### PR TITLE
Fix the 'unstyle' function and apply it for calculating table column widths

### DIFF
--- a/libs/core-cli/src/sparkles/core_cli/term_unstyle.d
+++ b/libs/core-cli/src/sparkles/core_cli/term_unstyle.d
@@ -5,8 +5,8 @@ module sparkles.core_cli.term_unstyle;
 auto unstyle(R)(R range)
 {
     import std.regex : regex, replaceAll;
-    const re = "\x1B\\[([0-9]{1,2}(;[0-9]{1,2})*)?[m|K]";
-    return range.replaceAll(regex(re), "");
+    const pattern = regex(`\x1B\[[0-9;]*[A-Za-z]`);
+    return range.replaceAll(pattern, "");
 }
 
 unittest

--- a/libs/core-cli/src/sparkles/core_cli/term_unstyle.d
+++ b/libs/core-cli/src/sparkles/core_cli/term_unstyle.d
@@ -9,6 +9,29 @@ auto unstyle(R)(R range)
     return range.replaceAll(pattern, "");
 }
 
+version (unittest)
+{
+    import std.traits : EnumMembers;
+    import sparkles.core_cli.term_style : Style, stylize;
+
+    alias Seq(T...) = T;
+
+    alias nonColorStyles = Seq!(Style.bold, Style.dim, Style.italic,
+        Style.underline, Style.inverse, Style.strikethrough);
+    static immutable colorStyles = [EnumMembers!Style[9 .. $]];
+
+    @safe string[] styleInAllPossibleWays(string text)
+    {
+        string[] table;
+        foreach (i, color; colorStyles)
+            static foreach (j; 0 .. nonColorStyles.length)
+                table ~= text
+                    .stylize(nonColorStyles[j])
+                    .stylize(color);
+        return table;
+    }
+}
+
 unittest
 {
     import sparkles.core_cli.term_style : stylizedTextBuilder;
@@ -28,6 +51,12 @@ unittest
     );
 
     assert(styledText.payload.unstyle == "Format me");
+
+    const text = "42";
+    const table = styleInAllPossibleWays(text);
+
+    foreach (el; table)
+        assert(el.unstyle == text);
 }
 
 size_t unstyledLength(R)(R range)

--- a/libs/core-cli/src/sparkles/core_cli/term_unstyle.d
+++ b/libs/core-cli/src/sparkles/core_cli/term_unstyle.d
@@ -30,7 +30,7 @@ unittest
     assert(styledText.payload.unstyle == "Format me");
 }
 
-size_t unstyledLenght(R)(R range)
+size_t unstyledLength(R)(R range)
 {
     import std.range : walkLength;
     return range.unstyle.walkLength;

--- a/libs/core-cli/src/sparkles/core_cli/ui/box.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/box.d
@@ -5,7 +5,7 @@ import std.algorithm.searching : maxElement;
 import std.range : walkLength, repeat;
 import std.format : format;
 
-import sparkles.core_cli.term_unstyle : unstyledLenght;
+import sparkles.core_cli.term_unstyle : unstyledLength;
 
 struct BoxProps
 {
@@ -25,8 +25,8 @@ struct BoxProps
 
 string drawBox(string[] content, string title, BoxProps props = BoxProps.init)
 {
-    const outputWidth = content.map!(x => x.unstyledLenght).maxElement;
-    const titleWidth = title.unstyledLenght;
+    const outputWidth = content.map!(x => x.unstyledLength).maxElement;
+    const titleWidth = title.unstyledLength;
 
     const prefix = props.omitLeftBorder ? ""d : props.verticalLine ~ " "d;
     const prefixLen = prefix.length;
@@ -41,7 +41,7 @@ string drawBox(string[] content, string title, BoxProps props = BoxProps.init)
 
     foreach (line; content)
     {
-        const rightPadLen = outputWidth - line.unstyledLenght;
+        const rightPadLen = outputWidth - line.unstyledLength;
         result ~= "%s%s%s %s\n".format(prefix, line, ' '.repeat(rightPadLen), props.verticalLine);
     }
 

--- a/libs/core-cli/src/sparkles/core_cli/ui/table.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/table.d
@@ -7,6 +7,7 @@ import std.range : walkLength, repeat, iota;
 import std.format : format;
 
 import sparkles.core_cli.ui.box : BoxProps;
+import sparkles.core_cli.term_unstyle : unstyledLength;
 
 bool hasRectangularShape(T)(const T[][] array)
 {
@@ -36,7 +37,7 @@ in (hasRectangularShape(cells))
 {
     return cells[0].length
         .iota
-        .map!(col => cells.map!(row => row[col].length).maxElement())
+        .map!(col => cells.map!(row => unstyledLength(row[col])).maxElement())
         .array;
 }
 


### PR DESCRIPTION
## Summary

Fix the `unstyle` function to correctly strip all ANSI escape codes and use it for calculating table/box column widths.

### Changes

1. **Fix regex pattern in `term_unstyle`** - The original pattern `\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[m|K]` didn't match all ANSI sequences. Updated to `\x1B\[[0-9;]*[A-Za-z]` which handles all SGR codes.

2. **Add comprehensive unittest for `unstyle`** - Tests all style combinations (bold, dim, italic, underline, inverse, strikethrough) with all colors to ensure proper stripping.

3. **Use `unstyledLength` in table/box** - Apply `unstyledLength` when calculating column widths so styled content aligns correctly.

4. **Fix typo `unstyledLenght` → `unstyledLength`** - Corrected the function name typo.

### Code style fixes

- Replace `import std;` with specific imports
- Add space after `static foreach`

## Test Plan

- [x] All unit tests pass (`dub test :core-cli`)
- [x] New unittest verifies `unstyle` works with all style combinations