### PR TITLE
Fix column width calculation in `drawTable`

### DIFF
--- a/libs/core-cli/examples/table.d
+++ b/libs/core-cli/examples/table.d
@@ -6,22 +6,26 @@ dependency "sparkles:core-cli" version="*"
 targetPath "build"
 +/
 
-import sparkles.core_cli.ui.table;
-import sparkles.core_cli.ui.box : BoxProps;
+import sparkles.core_cli.ui.table : drawTable;
+import sparkles.core_cli.term_style : Style, stylize;
 import std.stdio : writeln;
 
 void main()
 {
+    writeln("═══════════════════════════════════════════════════════════════");
+    writeln("                    drawTable Examples");
+    writeln("═══════════════════════════════════════════════════════════════\n");
+
     // Simple single-cell table
-    writeln("Single cell:");
+    writeln("1. Single cell:");
     drawTable([["Hello"]]).writeln;
 
     // Single row with multiple columns
-    writeln("Single row:");
+    writeln("2. Single row:");
     drawTable([["Name", "Age", "City"]]).writeln;
 
     // Multiple rows and columns
-    writeln("User data:");
+    writeln("3. Basic table:");
     drawTable([
         ["Name", "Age", "City"],
         ["Alice", "30", "New York"],
@@ -30,7 +34,7 @@ void main()
     ]).writeln;
 
     // Varying column widths
-    writeln("Varying widths:");
+    writeln("4. Varying column widths:");
     drawTable([
         ["ID", "Description", "Status"],
         ["1", "Short", "OK"],
@@ -38,12 +42,73 @@ void main()
         ["3", "Medium length", "Failed"]
     ]).writeln;
 
-    // Numeric data
-    writeln("Numeric data:");
+    // =========================================================================
+    // STYLED CONTENT EXAMPLES - Tests ANSI escape code handling
+    // =========================================================================
+
+    writeln("═══════════════════════════════════════════════════════════════");
+    writeln("                    Styled Content Tests");
+    writeln("═══════════════════════════════════════════════════════════════\n");
+
+    // Styled headers
+    writeln("5. Bold headers:");
     drawTable([
-        ["Product", "Price", "Qty", "Total"],
-        ["Widget", "$10.00", "5", "$50.00"],
-        ["Gadget", "$25.50", "2", "$51.00"],
-        ["Gizmo", "$5.25", "10", "$52.50"]
+        ["Name".stylize(Style.bold), "Status".stylize(Style.bold), "Priority".stylize(Style.bold)],
+        ["Task 1", "Done", "High"],
+        ["Task 2", "In Progress", "Medium"],
+        ["Task 3", "Pending", "Low"]
     ]).writeln;
+
+    // Color-coded status
+    writeln("6. Color-coded status (tests alignment with different escape code lengths):");
+    drawTable([
+        ["Metric".stylize(Style.bold), "Value".stylize(Style.bold), "Status".stylize(Style.bold)],
+        ["CPU Usage", "45%", "OK".stylize(Style.green)],
+        ["Memory", "78%", "Warning".stylize(Style.yellow)],
+        ["Disk", "92%", "Critical".stylize(Style.red)],
+        ["Network", "12%", "OK".stylize(Style.green)]
+    ]).writeln;
+
+    // Mixed styles - the key test for proper alignment
+    writeln("7. Mixed styles (short styled vs long unstyled):");
+    drawTable([
+        ["Status", "Description"],
+        ["OK".stylize(Style.green), "Everything is working fine"],
+        ["WARN".stylize(Style.yellow), "Some issues detected"],
+        ["FAIL".stylize(Style.red), "Critical failure"]
+    ]).writeln;
+
+    // Multiple styles per cell
+    writeln("8. Multiple styles combined:");
+    drawTable([
+        ["Type".stylize(Style.bold).stylize(Style.underline).stylize(Style.cyan), "Message".stylize(Style.bold).stylize(Style.underline).stylize(Style.cyan)],
+        ["INFO".stylize(Style.blue).stylize(Style.bold), "Application started".stylize(Style.dim)],
+        ["DEBUG".stylize(Style.magenta).stylize(Style.dim).stylize(Style.italic), "Loading configuration...".stylize(Style.italic)],
+        ["ERROR".stylize(Style.red).stylize(Style.bold).stylize(Style.inverse), "Connection failed!".stylize(Style.red).stylize(Style.bold)]
+    ]).writeln;
+
+    // Styled content in all cells
+    writeln("9. Fully styled table:");
+    drawTable([
+        [
+            "Server".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
+            "Status".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
+            "Load".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
+        ],
+        ["web-01".stylize(Style.brightGreen).stylize(Style.bold), "UP".stylize(Style.green).stylize(Style.inverse), "23%".stylize(Style.green)],
+        ["web-02".stylize(Style.brightGreen).stylize(Style.bold), "UP".stylize(Style.green).stylize(Style.inverse), "45%".stylize(Style.yellow).stylize(Style.bold)],
+        ["db-01".stylize(Style.brightRed).stylize(Style.bold).stylize(Style.strikethrough), "DOWN".stylize(Style.red).stylize(Style.inverse).stylize(Style.bold), "0%".stylize(Style.dim).stylize(Style.italic)]
+    ]).writeln;
+
+    // Edge case: very short styled text next to long unstyled
+    writeln("10. Alignment stress test (short styled vs long unstyled):");
+    drawTable([
+        ["A".stylize(Style.red), "This is a very long description that should align properly"],
+        ["OK".stylize(Style.green), "Short"],
+        ["WARN".stylize(Style.yellow), "Medium length text here"]
+    ]).writeln;
+
+    writeln("═══════════════════════════════════════════════════════════════");
+    writeln("If all tables above have properly aligned columns, the fix works!");
+    writeln("═══════════════════════════════════════════════════════════════");
 }


### PR DESCRIPTION
## Summary

Fix column alignment in `drawTable` when cells contain ANSI escape codes (colors, bold, etc.).

**The problem:** The original implementation used `format()` with width specifiers for padding, which counted ANSI escape code bytes as visible characters, causing misaligned columns.

**The fix:** Use `unstyledLength` to calculate the visual width of each cell, then manually pad with spaces.

### Changes

- **table.d**: Replace `format()` padding with manual padding based on `unstyledLength`
- **table.d**: Add unit test for styled content alignment
- **examples/table.d**: Add comprehensive styled content examples for visual verification

### Screenshot

Screenshot of the "Styled Content Tests" section from `./libs/core-cli/examples/table.d`:

<img width="665" height="1100" alt="image" src="https://github.com/user-attachments/assets/255d4b65-53b2-4398-95f9-2388cda2c5f4" />

## Test Plan

- [x] All existing unit tests pass (`dub test :core-cli`)
- [x] New `drawTable.styledContent` test verifies alignment with styled cells
- [x] Visual verification via `./libs/core-cli/examples/table.d`