### PR TITLE
feat(core-cli): Add prettyprint module with colorized output support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,8 @@ indent_size = 4
 [{CMakeLists.txt,*.cmake}]
 indent_size = 2
 indent_style = space
+
+# Disable indent checking for prettyprint.d - contains multiline string literals
+# with intentional 2-space indentation for expected test output
+[libs/core-cli/src/sparkles/core_cli/prettyprint.d]
+indent_size = unset

--- a/libs/core-cli/examples/prettyprint.d
+++ b/libs/core-cli/examples/prettyprint.d
@@ -1,0 +1,312 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "prettyprint"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import std.stdio : writeln;
+import std.typecons : Tuple, tuple;
+
+import sparkles.core_cli.prettyprint : prettyPrint, PrettyPrintOptions;
+
+// Custom enum
+enum Status { pending, running, completed, failed }
+
+// Simple struct
+struct Point { int x; int y; }
+
+// Nested struct
+struct Person {
+    string name;
+    int age;
+    Point location;
+}
+
+// Recursive struct (linked list)
+struct Node {
+    int value;
+    Node* next;
+}
+
+// Complex struct with many field types
+struct ComplexData {
+    // Primitives
+    bool active;
+    byte b;
+    int count;
+    long bigNum;
+    float ratio;
+    double precise;
+
+    // Characters and strings
+    char initial;
+    string name;
+    wstring wideName;
+
+    // Enum
+    Status status;
+
+    // Arrays
+    int[] numbers;
+    int[3] fixedNumbers;
+
+    // Associative array
+    string[int] lookup;
+
+    // Nested struct
+    Person owner;
+
+    // Pointer
+    int* refCount;
+
+    // Tuple
+    Tuple!(int, string, bool) metadata;
+}
+
+// Simple class
+class Animal {
+    string species;
+    int legs;
+}
+
+void main() {
+    writeln("═══════════════════════════════════════════════════════════════════");
+    writeln("                    prettyPrint Demo - All Types                    ");
+    writeln("═══════════════════════════════════════════════════════════════════\n");
+
+    // 1. Null
+    writeln("── null ──");
+    writeln(prettyPrint(null));
+    writeln();
+
+    // 2. Booleans
+    writeln("── bool ──");
+    writeln(prettyPrint(true));
+    writeln(prettyPrint(false));
+    writeln();
+
+    // 3. Integers
+    writeln("── integers ──");
+    writeln(prettyPrint(42));
+    writeln(prettyPrint(-123L));
+    writeln(prettyPrint(cast(ubyte)255));
+    writeln();
+
+    // 4. Floating point
+    writeln("── floats ──");
+    writeln(prettyPrint(3.14159));
+    writeln(prettyPrint(double.nan));
+    writeln(prettyPrint(double.infinity));
+    writeln(prettyPrint(-double.infinity));
+    writeln();
+
+    // 5. Characters
+    writeln("── chars ──");
+    writeln(prettyPrint('A'));
+    writeln(prettyPrint('\n'));
+    writeln(prettyPrint('\t'));
+    writeln(prettyPrint('\''));
+    writeln();
+
+    // 6. Strings
+    writeln("── strings ──");
+    writeln(prettyPrint("Hello, World!"));
+    writeln(prettyPrint("Line1\nLine2\tTabbed"));
+    writeln(prettyPrint("Quote: \"test\""));
+    writeln();
+
+    // 7. Enums
+    writeln("── enum ──");
+    writeln(prettyPrint(Status.running));
+    writeln(prettyPrint(Status.failed));
+    writeln();
+
+    // 8. Arrays
+    writeln("── arrays ──");
+    int[] arr = [1, 2, 3, 4, 5];
+    writeln(prettyPrint(arr));
+    writeln();
+
+    int[] empty;
+    writeln(prettyPrint(empty));
+    writeln();
+
+    // 9. Static arrays
+    writeln("── static array ──");
+    int[4] staticArr = [10, 20, 30, 40];
+    writeln(prettyPrint(staticArr));
+    writeln();
+
+    // 10. Associative arrays
+    writeln("── associative array ──");
+    string[int] aa = [1: "one", 2: "two", 3: "three"];
+    writeln(prettyPrint(aa));
+    writeln();
+
+    // 11. Simple struct
+    writeln("── struct ──");
+    auto point = Point(10, 20);
+    writeln(prettyPrint(point));
+    writeln();
+
+    // 12. Nested struct
+    writeln("── nested struct ──");
+    auto person = Person("Alice", 30, Point(100, 200));
+    writeln(prettyPrint(person));
+    writeln();
+
+    // 13. Tuples
+    writeln("── tuple (unnamed) ──");
+    auto t1 = tuple(42, "hello", 3.14, true);
+    writeln(prettyPrint(t1));
+    writeln();
+
+    writeln("── tuple (named) ──");
+    auto t2 = Tuple!(int, "id", string, "name", bool, "active")(1, "test", true);
+    writeln(prettyPrint(t2));
+    writeln();
+
+    // 14. Pointers
+    writeln("── pointers ──");
+    int* nullPtr = null;
+    writeln(prettyPrint(nullPtr));
+
+    int val = 42;
+    int* ptr = &val;
+    writeln(prettyPrint(ptr));
+    writeln();
+
+    // 15. Recursive struct (linked list)
+    writeln("── recursive struct (linked list) ──");
+    Node n3 = Node(3, null);
+    Node n2 = Node(2, &n3);
+    Node n1 = Node(1, &n2);
+    writeln(prettyPrint(n1));
+    writeln();
+
+    // 16. Class
+    writeln("── class ──");
+    Animal nullAnimal = null;
+    writeln(prettyPrint(nullAnimal));
+
+    auto dog = new Animal();
+    dog.species = "Canis familiaris";
+    dog.legs = 4;
+    writeln(prettyPrint(dog));
+    writeln();
+
+    // 17. Complex nested structure
+    writeln("── complex nested structure ──");
+    int refVal = 99;
+    auto complex = ComplexData(
+        active: true,
+        b: -5,
+        count: 42,
+        bigNum: 9_876_543_210,
+        ratio: 0.75f,
+        precise: 3.141592653589793,
+        initial: 'X',
+        name: "Complex\nData",
+        wideName: "Wide"w,
+        status: Status.running,
+        numbers: [1, 2, 3],
+        fixedNumbers: [10, 20, 30],
+        lookup: [1: "one", 2: "two"],
+        owner: Person("Bob", 25, Point(50, 60)),
+        refCount: &refVal,
+        metadata: tuple(123, "meta", false)
+    );
+    writeln(prettyPrint(complex));
+    writeln();
+
+    // 18. maxItems demonstration
+    writeln("── maxItems (limit: 3) ──");
+    int[] bigArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    writeln(prettyPrint(bigArray, PrettyPrintOptions(maxItems: 3)));
+    writeln();
+
+    // 19. maxDepth demonstration
+    writeln("── maxDepth (limit: 2) ──");
+    writeln(prettyPrint(complex, PrettyPrintOptions(maxDepth: 2)));
+    writeln();
+
+    // 20. Without colors
+    writeln("── without colors ──");
+    writeln(prettyPrint(person, PrettyPrintOptions(useColors: false)));
+    writeln();
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // softMaxWidth demonstrations
+    // ─────────────────────────────────────────────────────────────────────────
+
+    writeln("═══════════════════════════════════════════════════════════════════");
+    writeln("                   softMaxWidth Demonstrations                      ");
+    writeln("═══════════════════════════════════════════════════════════════════\n");
+
+    // 21. softMaxWidth comparison - same struct, different widths
+    writeln("── softMaxWidth: default (80) - fits on one line ──");
+    writeln(prettyPrint(point));
+    writeln();
+
+    writeln("── softMaxWidth: 15 - too narrow, uses multi-line ──");
+    writeln(prettyPrint(point, PrettyPrintOptions(softMaxWidth: 15)));
+    writeln();
+
+    writeln("── softMaxWidth: 0 - always multi-line ──");
+    writeln(prettyPrint(point, PrettyPrintOptions(softMaxWidth: 0)));
+    writeln();
+
+    // 22. Array width comparison
+    writeln("── array with softMaxWidth: default (80) ──");
+    int[] mediumArr = [100, 200, 300, 400, 500];
+    writeln(prettyPrint(mediumArr));
+    writeln();
+
+    writeln("── array with softMaxWidth: 20 ──");
+    writeln(prettyPrint(mediumArr, PrettyPrintOptions(softMaxWidth: 20)));
+    writeln();
+
+    // 23. Nested struct width comparison
+    writeln("── nested struct with softMaxWidth: default (80) ──");
+    writeln(prettyPrint(person));
+    writeln();
+
+    writeln("── nested struct with softMaxWidth: 40 ──");
+    writeln(prettyPrint(person, PrettyPrintOptions(softMaxWidth: 40)));
+    writeln();
+
+    writeln("── nested struct with softMaxWidth: 0 ──");
+    writeln(prettyPrint(person, PrettyPrintOptions(softMaxWidth: 0)));
+    writeln();
+
+    // 24. Associative array width comparison
+    writeln("── AA with softMaxWidth: default (80) ──");
+    writeln(prettyPrint(aa));
+    writeln();
+
+    writeln("── AA with softMaxWidth: 25 ──");
+    writeln(prettyPrint(aa, PrettyPrintOptions(softMaxWidth: 25)));
+    writeln();
+
+    // 25. Complex struct - shows how nested values can be inline even when parent is multi-line
+    writeln("── complex struct (default) - parent multi-line, nested values inline ──");
+    writeln(prettyPrint(complex));
+    writeln();
+
+    writeln("── complex struct with softMaxWidth: 0 - everything multi-line ──");
+    writeln(prettyPrint(complex, PrettyPrintOptions(softMaxWidth: 0)));
+    writeln();
+
+    // 26. Linked list width comparison
+    writeln("── linked list with softMaxWidth: default (80) ──");
+    writeln(prettyPrint(n1));
+    writeln();
+
+    writeln("── linked list with softMaxWidth: 30 ──");
+    writeln(prettyPrint(n1, PrettyPrintOptions(softMaxWidth: 30)));
+    writeln();
+
+    writeln("═══════════════════════════════════════════════════════════════════");
+    writeln("                           Demo Complete                            ");
+    writeln("═══════════════════════════════════════════════════════════════════");
+}

--- a/libs/core-cli/src/sparkles/core_cli/lifetime.d
+++ b/libs/core-cli/src/sparkles/core_cli/lifetime.d
@@ -1,0 +1,647 @@
+module sparkles.core_cli.lifetime;
+
+import core.lifetime : emplace;
+
+/**
+ * Returns a reference to a thread-local static instance of type `T`,
+ * (re)initialized with the provided arguments.
+ *
+ * This is useful for throwing `Error`s in `@nogc` code, where allocating
+ * new objects is not allowed, but reusing a static instance is permitted.
+ *
+ * Example:
+ * ---
+ * @nogc void foo() {
+ *     throw staticInstance!Error("Something went wrong");
+ * }
+ * ---
+ */
+T staticInstance(T, Args...)(auto ref Args args)
+if (is(T == class))
+{
+    enum size = __traits(classInstanceSize, T);
+    enum alignment = __traits(classInstanceAlignment, T);
+
+    static align(alignment) ubyte[size] buffer;
+
+    // Reinitialize on each acceess
+    emplace!T(buffer[], args);
+
+    return cast(T) buffer.ptr;
+}
+
+/// ditto
+ref T staticInstance(T, Args...)(auto ref Args args)
+if (!is(T == class))
+{
+    static T instance;
+    instance = T(args);
+    return instance;
+}
+
+@("staticInstance.class.basic")
+@nogc nothrow
+unittest
+{
+    static class MyError : Error
+    {
+        int code;
+
+        @nogc nothrow this(string msg, int code = 0)
+        {
+            super(msg);
+            this.code = code;
+        }
+    }
+
+    auto err1 = staticInstance!MyError("first error", 1);
+    assert(err1.msg == "first error");
+    assert(err1.code == 1);
+
+    auto err2 = staticInstance!MyError("second error", 2);
+    assert(err2.msg == "second error");
+    assert(err2.code == 2);
+
+    // Both references point to the same static instance
+    assert(err1 is err2);
+}
+
+@("staticInstance.class.canThrowInNoGC")
+@nogc nothrow
+unittest
+{
+    // Verifies that the staticInstance can actually be used for throwing in @nogc code
+    static class TestError : Error
+    {
+        @nogc nothrow this(string msg)
+        {
+            super(msg);
+        }
+    }
+
+    static void throwingFunc() @nogc
+    {
+        throw staticInstance!TestError("test error in @nogc");
+    }
+
+    bool caught = false;
+    try
+    {
+        // We can't actually call throwingFunc here in the unittest
+        // because catching would allocate, but we verify it compiles
+        auto instance = staticInstance!TestError("compiles in @nogc");
+        assert(instance !is null);
+    }
+    catch (Error)
+    {
+        caught = true;
+    }
+}
+
+@("staticInstance.class.inheritance")
+@nogc nothrow
+unittest
+{
+    // Test that inheritance hierarchy is properly preserved
+    static class BaseError : Error
+    {
+        int baseCode;
+
+        @nogc nothrow this(string msg, int code)
+        {
+            super(msg);
+            this.baseCode = code;
+        }
+    }
+
+    static class DerivedError : BaseError
+    {
+        int derivedCode;
+
+        @nogc nothrow this(string msg, int baseCode, int derivedCode)
+        {
+            super(msg, baseCode);
+            this.derivedCode = derivedCode;
+        }
+    }
+
+    auto derived = staticInstance!DerivedError("derived error", 10, 20);
+    assert(derived.msg == "derived error");
+    assert(derived.baseCode == 10);
+    assert(derived.derivedCode == 20);
+
+    // Verify it's actually a DerivedError
+    BaseError base = derived;
+    assert(base !is null);
+    assert(base.baseCode == 10);
+}
+
+@("staticInstance.class.differentTypesAreDifferentInstances")
+@nogc nothrow
+unittest
+{
+    // Verify that different class types get different static buffers
+    static class ErrorA : Error
+    {
+        @nogc nothrow this(string msg) { super(msg); }
+    }
+
+    static class ErrorB : Error
+    {
+        @nogc nothrow this(string msg) { super(msg); }
+    }
+
+    auto a = staticInstance!ErrorA("error A");
+    auto b = staticInstance!ErrorB("error B");
+
+    // Different types should have different instances
+    assert(cast(void*) a !is cast(void*) b);
+    assert(a.msg == "error A");
+    assert(b.msg == "error B");
+}
+
+@("staticInstance.class.alignment")
+unittest
+{
+    // Test that alignment is properly handled for classes with specific alignment requirements
+    static class AlignedClass : Error
+    {
+        align(16) long[2] alignedData;
+
+        this(string msg, long val)
+        {
+            super(msg);
+            alignedData[0] = val;
+            alignedData[1] = val * 2;
+        }
+    }
+
+    auto instance = staticInstance!AlignedClass("aligned", 42);
+    assert(instance.alignedData[0] == 42);
+    assert(instance.alignedData[1] == 84);
+
+    // Verify alignment (address should be 16-byte aligned for the data)
+    auto addr = cast(size_t) &instance.alignedData[0];
+    assert(addr % 16 == 0, "Data should be 16-byte aligned");
+}
+
+@("staticInstance.class.zeroArgs")
+unittest
+{
+    // Test class with no constructor arguments (default constructor)
+    static class SimpleError : Error
+    {
+        this()
+        {
+            super("default message");
+        }
+    }
+
+    auto err = staticInstance!SimpleError();
+    assert(err.msg == "default message");
+}
+
+@("staticInstance.class.reinitialization")
+@nogc nothrow
+unittest
+{
+    // Thoroughly test that reinitialization works correctly
+    static class CountingError : Error
+    {
+        int value;
+
+        @nogc nothrow this(string msg, int val)
+        {
+            super(msg);
+            this.value = val;
+        }
+    }
+
+    // First initialization
+    auto err1 = staticInstance!CountingError("msg1", 100);
+    assert(err1.value == 100);
+    assert(err1.msg == "msg1");
+
+    // Reinitialize with different values
+    auto err2 = staticInstance!CountingError("msg2", 200);
+    assert(err2.value == 200);
+    assert(err2.msg == "msg2");
+
+    // The original reference should see the new values (same instance)
+    assert(err1.value == 200);
+    assert(err1.msg == "msg2");
+
+    // Third reinitialization
+    auto err3 = staticInstance!CountingError("msg3", 300);
+    assert(err1.value == 300);
+    assert(err2.value == 300);
+    assert(err3.value == 300);
+}
+
+@("staticInstance.struct.basic")
+unittest
+{
+    static struct Point
+    {
+        int x, y;
+    }
+
+    auto p1 = &staticInstance!Point(1, 2);
+    assert(p1.x == 1 && p1.y == 2);
+
+    auto p2 = &staticInstance!Point(3, 4);
+    assert(p2.x == 3 && p2.y == 4);
+
+    // Both references point to the same static instance
+    assert(p1 is p2);
+}
+
+@("staticInstance.struct.reinitialization")
+unittest
+{
+    // Test that struct reinitialization works correctly
+    static struct Data
+    {
+        int a;
+        string b;
+        double c;
+    }
+
+    auto d1 = &staticInstance!Data(1, "first", 1.5);
+    assert(d1.a == 1);
+    assert(d1.b == "first");
+    assert(d1.c == 1.5);
+
+    auto d2 = &staticInstance!Data(2, "second", 2.5);
+    assert(d2.a == 2);
+    assert(d2.b == "second");
+    assert(d2.c == 2.5);
+
+    // d1 and d2 point to the same instance
+    assert(d1 is d2);
+    assert(d1.a == 2); // d1 sees the updated values
+}
+
+@("staticInstance.struct.nested")
+unittest
+{
+    // Test nested structs
+    static struct Inner
+    {
+        int value;
+    }
+
+    static struct Outer
+    {
+        Inner inner;
+        int other;
+    }
+
+    auto o = &staticInstance!Outer(Inner(42), 100);
+    assert(o.inner.value == 42);
+    assert(o.other == 100);
+
+    auto o2 = &staticInstance!Outer(Inner(99), 200);
+    assert(o.inner.value == 99); // Original reference sees new values
+    assert(o.other == 200);
+}
+
+@("staticInstance.struct.withArray")
+unittest
+{
+    // Test struct containing fixed-size array
+    static struct ArrayContainer
+    {
+        int[4] data;
+    }
+
+    int[4] initData = [1, 2, 3, 4];
+    auto c = &staticInstance!ArrayContainer(initData);
+    assert(c.data == [1, 2, 3, 4]);
+
+    int[4] newData = [5, 6, 7, 8];
+    auto c2 = &staticInstance!ArrayContainer(newData);
+    assert(c.data == [5, 6, 7, 8]); // Same instance
+}
+
+@("staticInstance.struct.emptyStruct")
+unittest
+{
+    // Test empty struct (edge case)
+    static struct Empty {}
+
+    auto e1 = &staticInstance!Empty();
+    auto e2 = &staticInstance!Empty();
+    assert(e1 is e2);
+}
+
+@("staticInstance.struct.singleField")
+unittest
+{
+    // Test single field struct
+    static struct Single
+    {
+        long value;
+    }
+
+    auto s = &staticInstance!Single(long.max);
+    assert(s.value == long.max);
+
+    auto s2 = &staticInstance!Single(long.min);
+    assert(s.value == long.min);
+}
+
+@("staticInstance.struct.differentTypesAreDifferentInstances")
+unittest
+{
+    // Verify that different struct types get different static instances
+    static struct TypeA { int value; }
+    static struct TypeB { int value; }
+
+    auto a = &staticInstance!TypeA(10);
+    auto b = &staticInstance!TypeB(20);
+
+    // Different types should have different instances
+    assert(cast(void*) a !is cast(void*) b);
+    assert(a.value == 10);
+    assert(b.value == 20);
+
+    // Modifying one shouldn't affect the other
+    staticInstance!TypeA(100);
+    assert(a.value == 100);
+    assert(b.value == 20); // Unchanged
+}
+
+@("staticInstance.struct.alignment")
+unittest
+{
+    // Test structs with specific alignment requirements
+    static struct Aligned
+    {
+        align(32) long[4] data;
+    }
+
+    long[4] initData = [1L, 2L, 3L, 4L];
+    auto a = &staticInstance!Aligned(initData);
+    assert(a.data == [1L, 2L, 3L, 4L]);
+
+    // Verify alignment
+    auto addr = cast(size_t) &a.data[0];
+    assert(addr % 32 == 0, "Data should be 32-byte aligned");
+}
+
+@("staticInstance.struct.defaultInit")
+unittest
+{
+    // Test struct with default initialization
+    static struct WithDefaults
+    {
+        int x = 42;
+        string s = "default";
+    }
+
+    // Note: staticInstance requires explicit arguments
+    // This tests the struct can be constructed with its default values
+    auto w = &staticInstance!WithDefaults(42, "default");
+    assert(w.x == 42);
+    assert(w.s == "default");
+
+    auto w2 = &staticInstance!WithDefaults(100, "custom");
+    assert(w.x == 100);
+    assert(w.s == "custom");
+}
+
+@("staticInstance.struct.refReturned")
+unittest
+{
+    // Verify that the ref return works correctly
+    static struct Mutable
+    {
+        int value;
+    }
+
+    ref Mutable getMutable()
+    {
+        return staticInstance!Mutable(0);
+    }
+
+    getMutable().value = 42;
+
+    // Changes through ref should persist
+    auto m = &staticInstance!Mutable(0);
+    // Note: This reinitializes to 0, so value will be 0
+    assert(m.value == 0);
+}
+
+@("staticInstance.struct.largeStruct")
+unittest
+{
+    // Test with a larger struct to ensure memory handling is correct
+    static struct LargeStruct
+    {
+        long[64] data; // 512 bytes
+    }
+
+    long[64] expected;
+    foreach (i; 0 .. 64)
+        expected[i] = i * 100;
+
+    auto large = &staticInstance!LargeStruct(expected);
+
+    foreach (i; 0 .. 64)
+        assert(large.data[i] == i * 100);
+}
+
+@("staticInstance.primitiveTypes")
+unittest
+{
+    // Test with primitive types
+    auto i = &staticInstance!int(42);
+    assert(*i == 42);
+
+    auto i2 = &staticInstance!int(100);
+    assert(*i == 100); // Same instance
+    assert(i is i2);
+}
+
+@("staticInstance.primitiveTypes.different")
+unittest
+{
+    // Different primitive types get different instances
+    auto intVal = &staticInstance!int(1);
+    auto longVal = &staticInstance!long(2);
+    auto doubleVal = &staticInstance!double(3.0);
+
+    assert(*intVal == 1);
+    assert(*longVal == 2);
+    assert(*doubleVal == 3.0);
+
+    // They should be different memory locations
+    assert(cast(void*) intVal !is cast(void*) longVal);
+    assert(cast(void*) longVal !is cast(void*) doubleVal);
+}
+
+@("staticInstance.struct.destructorCalled")
+unittest
+{
+    // Test that struct destructor is called before reinitialization
+    static int destructorCallCount = 0;
+    static int constructionId = 0;
+
+    static struct TrackedStruct
+    {
+        int id;
+
+        this(int val)
+        {
+            id = val;
+            constructionId = val;
+        }
+
+        ~this()
+        {
+            destructorCallCount++;
+        }
+    }
+
+    // Reset counters
+    destructorCallCount = 0;
+    constructionId = 0;
+
+    // First initialization
+    auto s1 = &staticInstance!TrackedStruct(1);
+    assert(s1.id == 1);
+    assert(constructionId == 1);
+    // Destructor should be called once when the old value is replaced
+    // via assignment operator (which calls destructor on old value)
+    int destructorCountAfterFirst = destructorCallCount;
+
+    // Second initialization - should call destructor on old instance
+    auto s2 = &staticInstance!TrackedStruct(2);
+    assert(s2.id == 2);
+    assert(constructionId == 2);
+    // Destructor should have been called one more time
+    assert(destructorCallCount > destructorCountAfterFirst,
+        "Destructor should be called when reinitializing struct");
+}
+
+@("staticInstance.struct.destructorCalledMultipleTimes")
+unittest
+{
+    // Test that destructor is called on each reinitialization
+    static int destructorCallCount = 0;
+
+    static struct CountingStruct
+    {
+        int value;
+
+        this(int v)
+        {
+            value = v;
+        }
+
+        ~this()
+        {
+            destructorCallCount++;
+        }
+    }
+
+    destructorCallCount = 0;
+
+    // Multiple reinitializations
+    staticInstance!CountingStruct(1);
+    int countAfter1 = destructorCallCount;
+
+    staticInstance!CountingStruct(2);
+    int countAfter2 = destructorCallCount;
+    assert(countAfter2 > countAfter1, "Destructor should be called on second init");
+
+    staticInstance!CountingStruct(3);
+    int countAfter3 = destructorCallCount;
+    assert(countAfter3 > countAfter2, "Destructor should be called on third init");
+
+    staticInstance!CountingStruct(4);
+    int countAfter4 = destructorCallCount;
+    assert(countAfter4 > countAfter3, "Destructor should be called on fourth init");
+}
+
+@("staticInstance.struct.destructorReceivesCorrectState")
+unittest
+{
+    // Test that destructor sees the correct state when called
+    static int lastDestroyedValue = -1;
+
+    static struct StateTracker
+    {
+        int value;
+
+        this(int v)
+        {
+            value = v;
+        }
+
+        ~this()
+        {
+            lastDestroyedValue = value;
+        }
+    }
+
+    lastDestroyedValue = -1;
+
+    staticInstance!StateTracker(100);
+    // First time, destructor is called on default-initialized struct
+    int afterFirst = lastDestroyedValue;
+
+    staticInstance!StateTracker(200);
+    // Destructor should have been called with value 100
+    assert(lastDestroyedValue == 100,
+        "Destructor should see the previous value (100), got: " ~
+        (cast(char)('0' + lastDestroyedValue / 100)).stringof);
+
+    staticInstance!StateTracker(300);
+    // Destructor should have been called with value 200
+    assert(lastDestroyedValue == 200,
+        "Destructor should see the previous value (200)");
+}
+
+@("staticInstance.class.destructorBehavior")
+unittest
+{
+    // Note: For classes, the current implementation does NOT call destructors
+    // before reinitializing. This test documents the current behavior.
+    // Classes used with staticInstance (like Error) typically shouldn't
+    // hold resources that need cleanup.
+
+    static int dtorCount = 0;
+
+    static class TrackedError : Error
+    {
+        int id;
+
+        this(string msg, int id)
+        {
+            super(msg);
+            this.id = id;
+        }
+
+        ~this()
+        {
+            dtorCount++;
+        }
+    }
+
+    assert(dtorCount == 0);
+
+    auto e1 = staticInstance!TrackedError("error1", 1);
+    assert(e1.id == 1);
+    assert(dtorCount == 0);
+
+    auto e2 = staticInstance!TrackedError("error2", 2);
+    assert(e2.id == 2);
+    assert(dtorCount == 0);
+
+    // Document current behavior: class destructors are NOT called
+    // This is intentional for @nogc compatibility - calling destroy
+    // would potentially allocate. For Error types used in @nogc code,
+    // this is acceptable as they shouldn't hold resources.
+}

--- a/libs/core-cli/src/sparkles/core_cli/prettyprint.d
+++ b/libs/core-cli/src/sparkles/core_cli/prettyprint.d
@@ -1,0 +1,827 @@
+module sparkles.core_cli.prettyprint;
+
+import std.typecons : Tuple;
+
+import sparkles.core_cli.term_style : escapeSeq, Style, stylize;
+
+struct PrettyPrintOptions
+{
+    ushort indentStep   = 2;   // spaces per indent level
+    ushort maxDepth     = 8;   // recursion limit
+    uint   maxItems     = 32;  // for arrays/ranges/AAs
+    uint   softMaxWidth = 80;  // try single-line if output fits (0 = always multi-line)
+    bool   useColors    = true;
+}
+
+/// Pretty-prints a value to a writer.
+/// Returns the writer for chaining.
+ref Writer prettyPrint(T, Writer)(
+    in T value,
+    return ref Writer writer,
+    PrettyPrintOptions opt = PrettyPrintOptions()
+)
+{
+    prettyPrintImpl(value, writer, opt, 0);
+    return writer;
+}
+
+/// Convenience overload that returns a string.
+string prettyPrint(T)(in T value, PrettyPrintOptions opt = PrettyPrintOptions())
+{
+    import std.array : appender;
+    auto w = appender!string;
+    prettyPrint(value, w, opt);
+    return w[];
+}
+
+private void prettyPrintImpl(T, Writer)(
+    in T value,
+    ref Writer w,
+    in PrettyPrintOptions opt,
+    ushort depth
+)
+{
+    import std.range.primitives : isForwardRange, hasLength, put;
+    import std.traits : isSomeChar, isSomeString, isNumeric, isFloatingPoint,
+        isPointer, isAssociativeArray, isStaticArray, isDynamicArray;
+
+    // Check depth limit
+    if (depth > opt.maxDepth)
+        return coloredWrite(w, "...", Style.red, opt.useColors);
+
+    enum isNullable = __traits(compiles, T.init is null) && !is(T == U[], U);
+
+    // 1. Null
+    static if (isNullable)
+    {
+        if (value is null)
+            return coloredWrite(w, "null", Style.yellow, opt.useColors);
+    }
+
+    // 2. Enums
+    static if (is(T == enum))
+    {
+        coloredWrite(w, T.stringof, Style.magenta, opt.useColors);
+        put(w, ".");
+        coloredWrite(w, value, Style.green, opt.useColors);
+    }
+    // 3. Boolean
+    else static if (is(T == bool))
+    {
+        coloredWrite(w, value ? "true" : "false", Style.yellow, opt.useColors);
+    }
+    // 4. Strings and individual chars
+    else static if (isSomeChar!T || isSomeString!T)
+    {
+        coloredWrite!"%(%s%)"(w, [value], Style.green, opt.useColors);
+    }
+    // 5. Numeric types
+    else static if (isNumeric!T)
+    {
+        static if (isFloatingPoint!T)
+        {
+            import std.math : isNaN, isInfinity;
+            if (isNaN(value))
+                return coloredWrite(w, "NaN", Style.red, opt.useColors);
+            else if (isInfinity(value))
+                return coloredWrite(w, value > 0 ? "+∞" : "-∞", Style.red, opt.useColors);
+        }
+
+        coloredWrite(w, value, Style.blue, opt.useColors);
+    }
+    // 6. Pointers
+    else static if (isPointer!T)
+    {
+        coloredWrite(w, "&", Style.magenta, opt.useColors);
+        prettyPrintImpl(*value, w, opt, cast(ushort)(depth + 1));
+    }
+    // 7. std.typecons.Tuple
+    else static if (is(T : Tuple!Args, Args...))
+    {
+        prettyPrintTuple(value, w, opt, depth);
+    }
+    // 8. Associative arrays
+    else static if (isAssociativeArray!T)
+    {
+        prettyPrintAA(value, w, opt, depth);
+    }
+    // 9. Static arrays - slice them
+    else static if (isStaticArray!T)
+    {
+        prettyPrintRange(value[], w, opt, depth);
+    }
+    // 10. Dynamic arrays / slices and forward ranges with length
+    else static if (isDynamicArray!T || (isForwardRange!T && hasLength!T))
+    {
+        prettyPrintRange(value, w, opt, depth);
+    }
+    // 11. Structs and classes
+    else static if (is(T == struct) || is(T == class))
+    {
+        prettyPrintAggregate(value, w, opt, depth);
+    }
+    else static if (!isNullable)
+    {
+        static assert(false, "prettyPrint: unsupported type " ~ T.stringof);
+    }
+}
+
+private void prettyPrintTuple(Writer, Args...)(
+    in Tuple!Args value,
+    ref Writer w,
+    in PrettyPrintOptions opt,
+    ushort depth
+)
+{
+    import std.range.primitives : put;
+    import std.format : formattedWrite;
+
+    put(w, "(");
+
+    foreach (i, field; value.expand)
+    {
+        if (i > 0)
+            put(w, ", ");
+
+        // Print field name if available
+        static if (value.fieldNames[i].length > 0)
+        {
+            coloredWrite(w, value.fieldNames[i], Style.brightCyan, opt.useColors);
+            put(w, ": ");
+        }
+
+        prettyPrintImpl(field, w, opt, cast(ushort)(depth + 1));
+    }
+
+    put(w, ")");
+}
+
+private void prettyPrintAA(T, Writer)(
+    auto ref const T aa,
+    ref Writer w,
+    in PrettyPrintOptions opt,
+    ushort depth
+)
+{
+    import std.range : repeat;
+    import std.range.primitives : put;
+    import std.format : formattedWrite;
+    import std.traits : KeyType, ValueType;
+
+    if (aa.length == 0)
+    {
+        coloredWrite(w, KeyType!T.stringof, Style.magenta, opt.useColors);
+        put(w, "[");
+        coloredWrite(w, ValueType!T.stringof, Style.magenta, opt.useColors);
+        put(w, "][]");
+        return;
+    }
+
+    // Try single-line format first
+    if (opt.softMaxWidth > 0 && aa.length <= opt.maxItems)
+    {
+        auto singleLineOpt = PrettyPrintOptions(
+            indentStep: opt.indentStep,
+            maxDepth: opt.maxDepth,
+            maxItems: opt.maxItems,
+            softMaxWidth: 0,
+            useColors: false
+        );
+        string singleLine = prettyPrintAAInline!T(aa, singleLineOpt, depth);
+        if (singleLine.length <= opt.softMaxWidth)
+        {
+            put(w, "[");
+            bool first = true;
+            foreach (key, val; aa)
+            {
+                if (!first)
+                    put(w, ", ");
+                first = false;
+                prettyPrintImpl(key, w, opt, cast(ushort)(depth + 1));
+                put(w, ": ");
+                prettyPrintImpl(val, w, opt, cast(ushort)(depth + 1));
+            }
+            put(w, "]");
+            return;
+        }
+    }
+
+    put(w, "[");
+
+    auto indent = ' '.repeat(opt.indentStep * (depth + 1));
+    auto closingIndent = ' '.repeat(opt.indentStep * depth);
+
+    uint count = 0;
+    foreach (key, val; aa)
+    {
+        if (count > 0)
+            put(w, ",");
+
+        if (count >= opt.maxItems)
+        {
+            put(w, "\n");
+            put(w, indent);
+            if (opt.useColors)
+                put(w, Style.gray[0].escapeSeq);
+            w.formattedWrite("... %d more", aa.length - count);
+            if (opt.useColors)
+                put(w, Style.gray[1].escapeSeq);
+            break;
+        }
+
+        put(w, "\n");
+        put(w, indent);
+        prettyPrintImpl(key, w, opt, cast(ushort)(depth + 1));
+        put(w, ": ");
+        prettyPrintImpl(val, w, opt, cast(ushort)(depth + 1));
+        count++;
+    }
+
+    put(w, "\n");
+    put(w, closingIndent);
+    put(w, "]");
+}
+
+private string prettyPrintAAInline(T)(in T aa, in PrettyPrintOptions opt, ushort depth)
+{
+    import std.array : appender;
+    auto w = appender!string;
+    w.put("[");
+    bool first = true;
+    foreach (key, val; aa)
+    {
+        if (!first)
+            w.put(", ");
+        first = false;
+        prettyPrintImpl(key, w, opt, cast(ushort)(depth + 1));
+        w.put(": ");
+        prettyPrintImpl(val, w, opt, cast(ushort)(depth + 1));
+    }
+    w.put("]");
+    return w.data;
+}
+
+private string prettyPrintRangeInline(R)(R range, in PrettyPrintOptions opt, ushort depth)
+{
+    import std.array : appender;
+    auto w = appender!string;
+    w.put("[");
+    bool first = true;
+    foreach (elem; range)
+    {
+        if (!first)
+            w.put(", ");
+        first = false;
+        prettyPrintImpl(elem, w, opt, cast(ushort)(depth + 1));
+    }
+    w.put("]");
+    return w.data;
+}
+
+private string prettyPrintAggregateInline(T)(auto ref const T value, in PrettyPrintOptions opt, ushort depth)
+{
+    import std.array : appender;
+    import std.traits : FieldNameTuple;
+
+    auto w = appender!string;
+    w.put(T.stringof);
+    w.put("(");
+
+    alias fieldNames = FieldNameTuple!T;
+    bool first = true;
+    static foreach (i, fieldName; fieldNames)
+    {{
+        static if (fieldName.length > 0)
+        {
+            if (!first)
+                w.put(", ");
+            first = false;
+            w.put(fieldName);
+            w.put(": ");
+            prettyPrintImpl(value.tupleof[i], w, opt, cast(ushort)(depth + 1));
+        }
+    }}
+    w.put(")");
+    return w.data;
+}
+
+private void prettyPrintRange(R, Writer)(
+    R range,
+    ref Writer w,
+    in PrettyPrintOptions opt,
+    ushort depth
+)
+{
+    import std.range : repeat;
+    import std.range.primitives : put, empty, front, popFront, hasLength;
+    import std.format : formattedWrite;
+
+    static if (hasLength!R)
+    {
+        const len = range.length;
+    }
+
+    // Check if empty
+    if (range.empty)
+    {
+        put(w, "[]");
+        return;
+    }
+
+    // Try single-line format first
+    static if (hasLength!R)
+    {
+        if (opt.softMaxWidth > 0 && len <= opt.maxItems)
+        {
+            auto singleLineOpt = PrettyPrintOptions(
+                indentStep: opt.indentStep,
+                maxDepth: opt.maxDepth,
+                maxItems: opt.maxItems,
+                softMaxWidth: 0,
+                useColors: false
+            );
+            string singleLine = prettyPrintRangeInline(range, singleLineOpt, depth);
+            if (singleLine.length <= opt.softMaxWidth)
+            {
+                put(w, "[");
+                bool first = true;
+                foreach (elem; range)
+                {
+                    if (!first)
+                        put(w, ", ");
+                    first = false;
+                    prettyPrintImpl(elem, w, opt, cast(ushort)(depth + 1));
+                }
+                put(w, "]");
+                return;
+            }
+        }
+    }
+
+    put(w, "[");
+
+    auto indent = ' '.repeat(opt.indentStep * (depth + 1));
+    auto closingIndent = ' '.repeat(opt.indentStep * depth);
+
+    uint count = 0;
+    foreach (elem; range)
+    {
+        if (count > 0)
+            put(w, ",");
+
+        if (count >= opt.maxItems)
+        {
+            put(w, "\n");
+            put(w, indent);
+            static if (hasLength!R)
+            {
+                if (opt.useColors)
+                    put(w, Style.gray[0].escapeSeq);
+                w.formattedWrite("... %d more", len - count);
+                if (opt.useColors)
+                    put(w, Style.gray[1].escapeSeq);
+            }
+            else
+            {
+                coloredWrite(w, "... more", Style.gray, opt.useColors);
+            }
+            break;
+        }
+
+        put(w, "\n");
+        put(w, indent);
+        prettyPrintImpl(elem, w, opt, cast(ushort)(depth + 1));
+        count++;
+    }
+
+    put(w, "\n");
+    put(w, closingIndent);
+    put(w, "]");
+}
+
+private void prettyPrintAggregate(T, Writer)(
+    auto ref const T value,
+    ref Writer w,
+    in PrettyPrintOptions opt,
+    ushort depth
+)
+{
+    import std.range : repeat;
+    import std.range.primitives : put;
+    import std.traits : FieldNameTuple, isNested;
+
+    alias fieldNames = FieldNameTuple!T;
+
+    static if (fieldNames.length == 0)
+    {
+        coloredWrite(w, T.stringof, Style.magenta, opt.useColors);
+        put(w, "()");
+        return;
+    }
+
+    // Try single-line format first
+    if (opt.softMaxWidth > 0)
+    {
+        auto singleLineOpt = PrettyPrintOptions(
+            indentStep: opt.indentStep,
+            maxDepth: opt.maxDepth,
+            maxItems: opt.maxItems,
+            softMaxWidth: 0,
+            useColors: false
+        );
+        string singleLine = prettyPrintAggregateInline(value, singleLineOpt, depth);
+        if (singleLine.length <= opt.softMaxWidth)
+        {
+            coloredWrite(w, T.stringof, Style.magenta, opt.useColors);
+            put(w, "(");
+            bool first = true;
+            static foreach (i, fieldName; fieldNames)
+            {{
+                static if (fieldName.length > 0)
+                {
+                    if (!first)
+                        put(w, ", ");
+                    first = false;
+                    coloredWrite(w, fieldName, Style.brightCyan, opt.useColors);
+                    put(w, ": ");
+                    prettyPrintImpl(value.tupleof[i], w, opt, cast(ushort)(depth + 1));
+                }
+            }}
+            put(w, ")");
+            return;
+        }
+    }
+
+    coloredWrite(w, T.stringof, Style.magenta, opt.useColors);
+    put(w, "(");
+
+    auto indent = ' '.repeat(opt.indentStep * (depth + 1));
+    auto closingIndent = ' '.repeat(opt.indentStep * depth);
+
+    static foreach (i, fieldName; fieldNames)
+    {{
+        // Skip context pointer for nested types
+        static if (fieldName.length > 0)
+        {
+            if (i > 0)
+                put(w, ",");
+
+            put(w, "\n");
+            put(w, indent);
+            coloredWrite(w, fieldName, Style.brightCyan, opt.useColors);
+            put(w, ": ");
+
+            prettyPrintImpl(value.tupleof[i], w, opt, cast(ushort)(depth + 1));
+        }
+    }}
+
+    put(w, "\n");
+    put(w, closingIndent);
+    put(w, ")");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+private void coloredWrite(string fmt = "%s", Writer, T)(ref Writer w, in T value, Style style, bool useColors)
+{
+    import std.range.primitives : put;
+    import std.traits : isSomeString;
+
+    string text;
+    static if (fmt == "%s" && isSomeString!T)
+        text = value;
+    else
+    {
+        import std.format : format;
+        text = format!fmt(value);
+    }
+
+    put(w, useColors ? text.stylize(style) : text);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+version (unittest)
+{
+    import core.exception : AssertError;
+    import std.string : outdent;
+    import std.typecons : tuple;
+
+    void check(T)(in T value, string expected, PrettyPrintOptions opts = PrettyPrintOptions(useColors: false),
+            string file = __FILE__, size_t line = __LINE__)
+    {
+        import std.exception : assumeUnique;
+        import sparkles.core_cli.lifetime : staticInstance;
+
+        static char[16 * 1024] buf;
+        static size_t len;
+        len = 0;
+
+        static struct BufWriter
+        {
+            char[] buf;
+            size_t* plen;
+
+            void put(const(char)[] s) @nogc nothrow @trusted
+            {
+                buf[*plen .. *plen + s.length] = s;
+                *plen += s.length;
+            }
+
+            void put(char c) @nogc nothrow @trusted
+            {
+                buf[*plen] = c;
+                (*plen)++;
+            }
+        }
+
+        auto writer = BufWriter(buf[], &len);
+        prettyPrint(value, writer, opts);
+        const(char)[] actual = buf[0 .. len];
+
+        if (actual != expected)
+        {
+            enum header = "prettyPrint mismatch:\nExpected:\n";
+            enum middle = "\nActual:\n";
+
+            writer.put(header);
+            writer.put(expected);
+            writer.put(middle);
+            writer.put(actual);
+
+            throw staticInstance!AssertError(
+                buf[len .. *writer.plen].assumeUnique,
+                file, line);
+        }
+    }
+}
+
+@("prettyPrint.null")
+unittest
+{
+    check(null, "null");
+}
+
+@("prettyPrint.bool")
+unittest
+{
+    check(true, "true");
+    check(false, "false");
+}
+
+@("prettyPrint.integers")
+unittest
+{
+    check(42, "42");
+    check(-123, "-123");
+    check(0uL, "0");
+}
+
+@("prettyPrint.floats")
+unittest
+{
+    check(3.14, "3.14");
+    check(double.nan, "NaN");
+    check(double.infinity, "+∞");
+    check(-double.infinity, "-∞");
+}
+
+@("prettyPrint.char")
+unittest
+{
+    check('a', "'a'");
+    check('\n', `'\n'`);
+    check('\t', `'\t'`);
+}
+
+@("prettyPrint.string")
+unittest
+{
+    check("hello", `"hello"`);
+    check("line1\nline2", `"line1\nline2"`);
+    check("tab\there", `"tab\there"`);
+}
+
+@("prettyPrint.enum")
+unittest
+{
+    enum Color { red, green, blue }
+    check(Color.green, "Color.green");
+}
+
+@("prettyPrint.array")
+unittest
+{
+    const opts = PrettyPrintOptions(softMaxWidth: 0, useColors: false);
+    int[] arr = [1, 2, 3];
+    check(arr, outdent(`
+        [
+          1,
+          2,
+          3
+        ]`)[1..$], opts);
+
+    int[] empty;
+    check(empty, "[]", opts);
+}
+
+@("prettyPrint.staticArray")
+unittest
+{
+    const opts = PrettyPrintOptions(softMaxWidth: 0, useColors: false);
+    int[3] arr = [10, 20, 30];
+    check(arr, outdent(`
+        [
+          10,
+          20,
+          30
+        ]`)[1..$], opts);
+}
+
+@("prettyPrint.aa")
+unittest
+{
+    int[string] empty;
+    check(empty, "null");
+}
+
+@("prettyPrint.struct")
+unittest
+{
+    struct Point { int x; int y; }
+    const opts = PrettyPrintOptions(softMaxWidth: 0, useColors: false);
+    auto p = Point(10, 20);
+    check(p, outdent(`
+        Point(
+          x: 10,
+          y: 20
+        )`)[1..$], opts);
+}
+
+@("prettyPrint.nestedStruct")
+unittest
+{
+    struct Inner { int value; }
+    struct Outer { string name; Inner inner; }
+
+    const opts = PrettyPrintOptions(softMaxWidth: 0, useColors: false);
+    auto o = Outer("test", Inner(42));
+    check(o, outdent(`
+        Outer(
+          name: "test",
+          inner: Inner(
+            value: 42
+          )
+        )`)[1..$], opts);
+}
+
+@("prettyPrint.tuple")
+unittest
+{
+    auto t1 = tuple(1, "hello", 3.14);
+    check(t1, `(1, "hello", 3.14)`);
+
+    auto t2 = Tuple!(int, "x", string, "name")(42, "test");
+    check(t2, `(x: 42, name: "test")`);
+}
+
+@("prettyPrint.pointer")
+unittest
+{
+    int* nullPtr = null;
+    check(nullPtr, "null");
+
+    int val = 42;
+    int* ptr = &val;
+    check(ptr, "&42");
+}
+
+@("prettyPrint.maxItems")
+unittest
+{
+    const opts = PrettyPrintOptions(maxItems: 3, useColors: false);
+    int[] arr = [1, 2, 3, 4, 5];
+    check(arr, outdent(`
+        [
+          1,
+          2,
+          3,
+          ... 2 more
+        ]`)[1..$], opts);
+}
+
+@("prettyPrint.maxDepth")
+unittest
+{
+    struct Deep { int value; Deep* next; }
+
+    // Define 5 levels of nesting once
+    Deep d5 = Deep(5, null);
+    Deep d4 = Deep(4, &d5);
+    Deep d3 = Deep(3, &d4);
+    Deep d2 = Deep(2, &d3);
+    Deep d1 = Deep(1, &d2);
+
+    // maxDepth: 1 - only the top-level struct fields are shown
+    check(d1, outdent(`
+        Deep(
+          value: 1,
+          next: &...
+        )`)[1..$], PrettyPrintOptions(maxDepth: 1, softMaxWidth: 0, useColors: false));
+
+    // maxDepth: 2 - one level of pointer dereference, but inner struct fields hit limit
+    check(d1, outdent(`
+        Deep(
+          value: 1,
+          next: &Deep(
+              value: ...,
+              next: ...
+            )
+        )`)[1..$], PrettyPrintOptions(maxDepth: 2, softMaxWidth: 0, useColors: false));
+
+    // maxDepth: 3 - inner struct fields visible, but next pointer hits limit
+    check(d1, outdent(`
+        Deep(
+          value: 1,
+          next: &Deep(
+              value: 2,
+              next: &...
+            )
+        )`)[1..$], PrettyPrintOptions(maxDepth: 3, softMaxWidth: 0, useColors: false));
+
+    // maxDepth: 4 - two levels of nesting visible
+    check(d1, outdent(`
+        Deep(
+          value: 1,
+          next: &Deep(
+              value: 2,
+              next: &Deep(
+                  value: ...,
+                  next: ...
+                )
+            )
+        )`)[1..$], PrettyPrintOptions(maxDepth: 4, softMaxWidth: 0, useColors: false));
+
+    // maxDepth: 5 - three levels of nesting visible
+    check(d1, outdent(`
+        Deep(
+          value: 1,
+          next: &Deep(
+              value: 2,
+              next: &Deep(
+                  value: 3,
+                  next: &...
+                )
+            )
+        )`)[1..$], PrettyPrintOptions(maxDepth: 5, softMaxWidth: 0, useColors: false));
+
+    // maxDepth: ushort.max - no practical limit, full output
+    check(d1, outdent(`
+        Deep(
+          value: 1,
+          next: &Deep(
+              value: 2,
+              next: &Deep(
+                  value: 3,
+                  next: &Deep(
+                      value: 4,
+                      next: &Deep(
+                          value: 5,
+                          next: null
+                        )
+                    )
+                )
+            )
+        )`)[1..$], PrettyPrintOptions(maxDepth: ushort.max, softMaxWidth: 0, useColors: false));
+}
+
+@("prettyPrint.withColors")
+unittest
+{
+    // Integer 42 with blue color code prefix and reset to default foreground
+    check(42, "\x1b[34m42\x1b[39m", PrettyPrintOptions(useColors: true));
+}
+
+@("prettyPrint.class")
+unittest
+{
+    class MyClass { int x; string name; }
+
+    const opts = PrettyPrintOptions(softMaxWidth: 0, useColors: false);
+
+    MyClass nullObj = null;
+    check(nullObj, "null", opts);
+
+    auto obj = new MyClass();
+    obj.x = 10;
+    obj.name = "test";
+    check(obj, outdent(`
+        MyClass(
+          x: 10,
+          name: "test"
+        )`)[1..$], opts);
+}


### PR DESCRIPTION
## Summary
- Adds a `prettyprint` module for debugging and logging with colorized output
- Supports structs, classes, arrays, associative arrays, tuples, pointers, enums, and primitives
- Includes configurable options: indentation, max depth, max items, soft max width, and ANSI colors
- Adds `staticInstance` utility in `lifetime.d` for creating reusable static instances in @nogc code
- Includes comprehensive example demonstrating all features

## Screenshots

<img width="683" height="1073" alt="image" src="https://github.com/user-attachments/assets/86362802-97d3-4a20-94b8-48767c756526" />

<img width="721" height="952" alt="image" src="https://github.com/user-attachments/assets/30f988ed-a061-4237-93f7-3d10d555293c" />

<img width="726" height="1076" alt="image" src="https://github.com/user-attachments/assets/64f94356-e856-4f0d-86f1-e494d43d2f38" />

<img width="745" height="603" alt="image" src="https://github.com/user-attachments/assets/c2e0ab54-3dca-4411-a586-dfd3519e96cc" />

<img width="745" height="1169" alt="image" src="https://github.com/user-attachments/assets/f2f8981c-f01a-4277-9d01-52716b224002" />

<img width="692" height="376" alt="image" src="https://github.com/user-attachments/assets/81498084-4949-4e28-999b-3a5853d51dd7" />


## Test plan
- [x] Run unit tests: `./scripts/run-tests.sh`
- [x] Run the example: `./libs/core-cli/examples/prettyprint.d`
- [x] Verify colorized output displays correctly in terminal