### PR TITLE
feat(core-cli): Add UI demo utilities and box example

### DIFF
--- a/libs/core-cli/examples/box.d
+++ b/libs/core-cli/examples/box.d
@@ -1,0 +1,122 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "box"
+    dependency "sparkles:core-cli" version="*"
+    targetPath "build"
++/
+
+import std.algorithm : map, joiner;
+import std.conv : to;
+
+import sparkles.core_cli.ui.box : drawBox, BoxProps;
+import sparkles.core_cli.ui.demo : Section, runDemo;
+import sparkles.core_cli.ui.table : drawTable;
+import sparkles.core_cli.term_style : Style, stylize, styleSample;
+import sparkles.core_cli.term_style : stb = stylizedTextBuilder;
+import sparkles.core_cli.prettyprint : prettyPrint, PrettyPrintOptions;
+
+struct Config
+{
+    string host;
+    int port;
+    bool ssl;
+    string[] endpoints;
+}
+
+struct Server
+{
+    string name;
+    string ip;
+    int port;
+}
+
+struct Cluster
+{
+    string name;
+    Server[] servers;
+    bool active;
+}
+
+void main()
+{
+    runDemo(
+        header: "drawBox Demo - All Features",
+        content: [
+            Section(
+                header: "Simple Box",
+                content: ["1"]
+                    .drawBox("1"),
+            ),
+            Section(
+                header: "Box with Styled Content",
+                content: [
+                    "Status:    ".stylize(Style.bold) ~ "Running".stylize(Style.green),
+                    "Mode:      ".stylize(Style.bold) ~ "Production".stylize(Style.yellow),
+                    "Health:    ".stylize(Style.bold) ~ "Healthy".stylize(Style.brightGreen),
+                    "Uptime:    ".stylize(Style.bold) ~ "3 days, 14 hours".stylize(Style.cyan),
+                ].drawBox("Status"),
+            ),
+            Section(
+                header: "Box without Left Border",
+                content: ["This is line number 1", "This is line number 2", "This is line number 3"]
+                    .drawBox("No Border", BoxProps(omitLeftBorder: true)),
+            ),
+            Section(
+                header: "Box with Embedded Table",
+                content: [
+                    ["Name", "Age", "Role"],
+                    ["Alice", "30", "Engineer"],
+                    ["Bob", "25", "Designer"],
+                    ["Carol", "35", "Manager"],
+                ].drawTable.drawBox("Team"),
+            ),
+            Section(
+                header: "Box with prettyPrint Output",
+                content: Config(
+                    host: "localhost",
+                    port: 8080,
+                    ssl: true,
+                    endpoints: ["/api", "/health", "/metrics"],
+                ).prettyPrint(PrettyPrintOptions(softMaxWidth: 0)).drawBox("Config"),
+            ),
+            Section(
+                header: "Dashboard Example",
+                content: [
+                    ["Metric".stylize(Style.bold), "Value".stylize(Style.bold), "Status".stylize(Style.bold)],
+                    ["CPU Usage", "45%", "OK".stylize(Style.green)],
+                    ["Memory", "2.1 GB", "OK".stylize(Style.green)],
+                    ["Disk", "89%", "Warning".stylize(Style.yellow)],
+                    ["Network", "1.2 Gbps", "OK".stylize(Style.green)],
+                ].drawTable.drawBox("Metrics"),
+            ),
+            Section(
+                header: "Color Palette Box",
+                content: [
+                    "Foreground Colors:".stylize(Style.bold),
+                    "  " ~ [Style.red, Style.green, Style.yellow, Style.blue, Style.magenta, Style.cyan]
+                        .map!styleSample.joiner(" ").to!string,
+                    "",
+                    "Bright Colors:".stylize(Style.bold),
+                    "  " ~ [Style.brightRed, Style.brightGreen, Style.brightYellow, Style.brightBlue]
+                        .map!styleSample.joiner(" ").to!string,
+                    "",
+                    "Styles:".stylize(Style.bold),
+                    "  " ~ [Style.bold, Style.dim, Style.italic, Style.underline, Style.strikethrough]
+                        .map!styleSample.joiner(" ").to!string,
+                ].drawBox("Styles"),
+            ),
+            Section(
+                header: "Complex Data Structure",
+                content: Cluster(
+                    name: "Production",
+                    servers: [
+                        Server("web-01", "192.168.1.10", 80),
+                        Server("web-02", "192.168.1.11", 80),
+                        Server("db-01", "192.168.1.20", 5432),
+                    ],
+                    active: true,
+                ).prettyPrint(PrettyPrintOptions(softMaxWidth: 60)).drawBox("Cluster"),
+            ),
+        ],
+    );
+}

--- a/libs/core-cli/examples/header.d
+++ b/libs/core-cli/examples/header.d
@@ -1,0 +1,37 @@
+#!/usr/bin/env dub
+
+/+ dub.sdl:
+name "header"
+dependency "sparkles:core-cli" version="*"
+targetPath "build"
++/
+
+import sparkles.core_cli.ui.header;
+import std.stdio : writeln;
+
+void main()
+{
+    // Simple divider (default style)
+    writeln("Default divider:");
+    "Section Title".drawHeader.writeln;
+    writeln();
+
+    // Custom line character
+    writeln("Double line divider:");
+    "Important".drawHeader(HeaderProps(lineChar: '═')).writeln;
+    writeln();
+
+    // Fixed width divider
+    writeln("Fixed width (40 chars):");
+    "Centered".drawHeader(HeaderProps(width: 40)).writeln;
+    writeln();
+
+    // Banner style
+    writeln("Banner style:");
+    "Main Title".drawHeader(HeaderProps(style: HeaderStyle.banner, width: 30)).writeln;
+    writeln();
+
+    // Banner with auto width
+    writeln("Banner (auto width):");
+    "Auto Width Banner".drawHeader(HeaderProps(style: HeaderStyle.banner)).writeln;
+}

--- a/libs/core-cli/examples/table.d
+++ b/libs/core-cli/examples/table.d
@@ -1,114 +1,103 @@
 #!/usr/bin/env dub
-
 /+ dub.sdl:
-name "table"
-dependency "sparkles:core-cli" version="*"
-targetPath "build"
+    name "table"
+    dependency "sparkles:core-cli" version="*"
+    targetPath "build"
 +/
 
+import sparkles.core_cli.ui.demo : Section, runDemo;
 import sparkles.core_cli.ui.table : drawTable;
 import sparkles.core_cli.term_style : Style, stylize;
-import std.stdio : writeln;
 
 void main()
 {
-    writeln("═══════════════════════════════════════════════════════════════");
-    writeln("                    drawTable Examples");
-    writeln("═══════════════════════════════════════════════════════════════\n");
-
-    // Simple single-cell table
-    writeln("1. Single cell:");
-    drawTable([["Hello"]]).writeln;
-
-    // Single row with multiple columns
-    writeln("2. Single row:");
-    drawTable([["Name", "Age", "City"]]).writeln;
-
-    // Multiple rows and columns
-    writeln("3. Basic table:");
-    drawTable([
-        ["Name", "Age", "City"],
-        ["Alice", "30", "New York"],
-        ["Bob", "25", "San Francisco"],
-        ["Charlie", "35", "Chicago"]
-    ]).writeln;
-
-    // Varying column widths
-    writeln("4. Varying column widths:");
-    drawTable([
-        ["ID", "Description", "Status"],
-        ["1", "Short", "OK"],
-        ["2", "A much longer description here", "Pending"],
-        ["3", "Medium length", "Failed"]
-    ]).writeln;
-
-    // =========================================================================
-    // STYLED CONTENT EXAMPLES - Tests ANSI escape code handling
-    // =========================================================================
-
-    writeln("═══════════════════════════════════════════════════════════════");
-    writeln("                    Styled Content Tests");
-    writeln("═══════════════════════════════════════════════════════════════\n");
-
-    // Styled headers
-    writeln("5. Bold headers:");
-    drawTable([
-        ["Name".stylize(Style.bold), "Status".stylize(Style.bold), "Priority".stylize(Style.bold)],
-        ["Task 1", "Done", "High"],
-        ["Task 2", "In Progress", "Medium"],
-        ["Task 3", "Pending", "Low"]
-    ]).writeln;
-
-    // Color-coded status
-    writeln("6. Color-coded status (tests alignment with different escape code lengths):");
-    drawTable([
-        ["Metric".stylize(Style.bold), "Value".stylize(Style.bold), "Status".stylize(Style.bold)],
-        ["CPU Usage", "45%", "OK".stylize(Style.green)],
-        ["Memory", "78%", "Warning".stylize(Style.yellow)],
-        ["Disk", "92%", "Critical".stylize(Style.red)],
-        ["Network", "12%", "OK".stylize(Style.green)]
-    ]).writeln;
-
-    // Mixed styles - the key test for proper alignment
-    writeln("7. Mixed styles (short styled vs long unstyled):");
-    drawTable([
-        ["Status", "Description"],
-        ["OK".stylize(Style.green), "Everything is working fine"],
-        ["WARN".stylize(Style.yellow), "Some issues detected"],
-        ["FAIL".stylize(Style.red), "Critical failure"]
-    ]).writeln;
-
-    // Multiple styles per cell
-    writeln("8. Multiple styles combined:");
-    drawTable([
-        ["Type".stylize(Style.bold).stylize(Style.underline).stylize(Style.cyan), "Message".stylize(Style.bold).stylize(Style.underline).stylize(Style.cyan)],
-        ["INFO".stylize(Style.blue).stylize(Style.bold), "Application started".stylize(Style.dim)],
-        ["DEBUG".stylize(Style.magenta).stylize(Style.dim).stylize(Style.italic), "Loading configuration...".stylize(Style.italic)],
-        ["ERROR".stylize(Style.red).stylize(Style.bold).stylize(Style.inverse), "Connection failed!".stylize(Style.red).stylize(Style.bold)]
-    ]).writeln;
-
-    // Styled content in all cells
-    writeln("9. Fully styled table:");
-    drawTable([
-        [
-            "Server".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
-            "Status".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
-            "Load".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
+    runDemo(
+        header: "drawTable Demo - All Features",
+        content: [
+            Section(
+                header: "Single Cell",
+                content: [["Hello"]].drawTable,
+            ),
+            Section(
+                header: "Single Row",
+                content: [["Name", "Age", "City"]].drawTable,
+            ),
+            Section(
+                header: "Basic Table",
+                content: [
+                    ["Name", "Age", "City"],
+                    ["Alice", "30", "New York"],
+                    ["Bob", "25", "San Francisco"],
+                    ["Charlie", "35", "Chicago"],
+                ].drawTable,
+            ),
+            Section(
+                header: "Varying Column Widths",
+                content: [
+                    ["ID", "Description", "Status"],
+                    ["1", "Short", "OK"],
+                    ["2", "A much longer description here", "Pending"],
+                    ["3", "Medium length", "Failed"],
+                ].drawTable,
+            ),
+            Section(
+                header: "Bold Headers",
+                content: [
+                    ["Name".stylize(Style.bold), "Status".stylize(Style.bold), "Priority".stylize(Style.bold)],
+                    ["Task 1", "Done", "High"],
+                    ["Task 2", "In Progress", "Medium"],
+                    ["Task 3", "Pending", "Low"],
+                ].drawTable,
+            ),
+            Section(
+                header: "Color-Coded Status",
+                content: [
+                    ["Metric".stylize(Style.bold), "Value".stylize(Style.bold), "Status".stylize(Style.bold)],
+                    ["CPU Usage", "45%", "OK".stylize(Style.green)],
+                    ["Memory", "78%", "Warning".stylize(Style.yellow)],
+                    ["Disk", "92%", "Critical".stylize(Style.red)],
+                    ["Network", "12%", "OK".stylize(Style.green)],
+                ].drawTable,
+            ),
+            Section(
+                header: "Mixed Styles",
+                content: [
+                    ["Status", "Description"],
+                    ["OK".stylize(Style.green), "Everything is working fine"],
+                    ["WARN".stylize(Style.yellow), "Some issues detected"],
+                    ["FAIL".stylize(Style.red), "Critical failure"],
+                ].drawTable,
+            ),
+            Section(
+                header: "Multiple Styles Combined",
+                content: [
+                    ["Type".stylize(Style.bold).stylize(Style.underline).stylize(Style.cyan), "Message".stylize(Style.bold).stylize(Style.underline).stylize(Style.cyan)],
+                    ["INFO".stylize(Style.blue).stylize(Style.bold), "Application started".stylize(Style.dim)],
+                    ["DEBUG".stylize(Style.magenta).stylize(Style.dim).stylize(Style.italic), "Loading configuration...".stylize(Style.italic)],
+                    ["ERROR".stylize(Style.red).stylize(Style.bold).stylize(Style.inverse), "Connection failed!".stylize(Style.red).stylize(Style.bold)],
+                ].drawTable,
+            ),
+            Section(
+                header: "Fully Styled Table",
+                content: [
+                    [
+                        "Server".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
+                        "Status".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
+                        "Load".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
+                    ],
+                    ["web-01".stylize(Style.brightGreen).stylize(Style.bold), "UP".stylize(Style.green).stylize(Style.inverse), "23%".stylize(Style.green)],
+                    ["web-02".stylize(Style.brightGreen).stylize(Style.bold), "UP".stylize(Style.green).stylize(Style.inverse), "45%".stylize(Style.yellow).stylize(Style.bold)],
+                    ["db-01".stylize(Style.brightRed).stylize(Style.bold).stylize(Style.strikethrough), "DOWN".stylize(Style.red).stylize(Style.inverse).stylize(Style.bold), "0%".stylize(Style.dim).stylize(Style.italic)],
+                ].drawTable,
+            ),
+            Section(
+                header: "Alignment Stress Test",
+                content: [
+                    ["A".stylize(Style.red), "This is a very long description that should align properly"],
+                    ["OK".stylize(Style.green), "Short"],
+                    ["WARN".stylize(Style.yellow), "Medium length text here"],
+                ].drawTable,
+            ),
         ],
-        ["web-01".stylize(Style.brightGreen).stylize(Style.bold), "UP".stylize(Style.green).stylize(Style.inverse), "23%".stylize(Style.green)],
-        ["web-02".stylize(Style.brightGreen).stylize(Style.bold), "UP".stylize(Style.green).stylize(Style.inverse), "45%".stylize(Style.yellow).stylize(Style.bold)],
-        ["db-01".stylize(Style.brightRed).stylize(Style.bold).stylize(Style.strikethrough), "DOWN".stylize(Style.red).stylize(Style.inverse).stylize(Style.bold), "0%".stylize(Style.dim).stylize(Style.italic)]
-    ]).writeln;
-
-    // Edge case: very short styled text next to long unstyled
-    writeln("10. Alignment stress test (short styled vs long unstyled):");
-    drawTable([
-        ["A".stylize(Style.red), "This is a very long description that should align properly"],
-        ["OK".stylize(Style.green), "Short"],
-        ["WARN".stylize(Style.yellow), "Medium length text here"]
-    ]).writeln;
-
-    writeln("═══════════════════════════════════════════════════════════════");
-    writeln("If all tables above have properly aligned columns, the fix works!");
-    writeln("═══════════════════════════════════════════════════════════════");
+    );
 }

--- a/libs/core-cli/src/sparkles/core_cli/ui/box.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/box.d
@@ -1,5 +1,6 @@
 module sparkles.core_cli.ui.box;
 
+import std.algorithm.comparison : max;
 import std.algorithm.iteration : map;
 import std.algorithm.searching : maxElement;
 import std.range : walkLength, repeat;
@@ -25,17 +26,20 @@ struct BoxProps
 
 string drawBox(string[] content, string title, BoxProps props = BoxProps.init)
 {
-    const outputWidth = content.map!(x => x.unstyledLength).maxElement;
-    const titleWidth = title.unstyledLength;
-
     const prefix = props.omitLeftBorder ? ""d : props.verticalLine ~ " "d;
     const prefixLen = prefix.length;
+
+    // Minimum width to fit: ╭──╼ {title} ╾─╮ (overhead = 9) and bottom: ╰──────────╯ (overhead = 10)
+    const titleWidth = title.unstyledLength;
+    const minWidth = max(titleWidth + 9, 10) - prefixLen;
+    const contentWidth = content.map!(x => x.unstyledLength).maxElement;
+    const outputWidth = max(contentWidth, minWidth);
 
     auto topLine = props.horizontalLine.repeat(outputWidth + prefixLen - titleWidth - 7);
     auto bottomLine = props.horizontalLine.repeat(outputWidth + prefixLen - 10);
 
     auto top = "╭──╼ %s ╾%s─╮".format(title, topLine);
-    auto bottom = "╰────────%s──╯".format(bottomLine);
+    auto bot = "╰────────%s──╯".format(bottomLine);
 
     string result = top ~ '\n';
 
@@ -45,11 +49,180 @@ string drawBox(string[] content, string title, BoxProps props = BoxProps.init)
         result ~= "%s%s%s %s\n".format(prefix, line, ' '.repeat(rightPadLen), props.verticalLine);
     }
 
-    result ~= bottom;
+    result ~= bot;
 
     return result;
 }
 
+/// Overload that accepts a single string and splits it into lines internally.
+string drawBox(string content, string title, BoxProps props = BoxProps.init)
+{
+    import std.array : array;
+    import std.string : lineSplitter;
+
+    return drawBox(content.lineSplitter.array, title, props);
+}
+
+@("drawBox.basic.singleLine")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    assert(["Hello"].drawBox("T") == `
+        ╭──╼ T ╾───╮
+        │ Hello    │
+        ╰──────────╯`.outdent(2));
+}
+
+@("drawBox.basic.multiLine")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    assert(["Line 1", "Line 2", "Line 3"].drawBox("Title") == `
+        ╭──╼ Title ╾───╮
+        │ Line 1       │
+        │ Line 2       │
+        │ Line 3       │
+        ╰──────────────╯`.outdent(2));
+}
+
+@("drawBox.basic.varyingLineWidths")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    assert(["Short", "A longer line", "Mid"].drawBox("Box") == `
+        ╭──╼ Box ╾──────╮
+        │ Short         │
+        │ A longer line │
+        │ Mid           │
+        ╰───────────────╯`.outdent(2));
+}
+
+@("drawBox.width.contentWiderThanTitle")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    assert(["This is a very long content line"].drawBox("T") == `
+        ╭──╼ T ╾───────────────────────────╮
+        │ This is a very long content line │
+        ╰──────────────────────────────────╯`.outdent(2));
+}
+
+@("drawBox.width.titleWiderThanContent")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    // This tests the fix for the underflow bug
+    assert(["Hi"].drawBox("Long Title Here") == `
+        ╭──╼ Long Title Here ╾───╮
+        │ Hi                     │
+        ╰────────────────────────╯`.outdent(2));
+}
+
+@("drawBox.width.minimalContent")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    // Single character content and title - tests minimum box size
+    assert(["x"].drawBox("T") == `
+        ╭──╼ T ╾───╮
+        │ x        │
+        ╰──────────╯`.outdent(2));
+}
+
+@("drawBox.width.emptyTitle")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    assert(["Content"].drawBox("") == `
+        ╭──╼  ╾────╮
+        │ Content  │
+        ╰──────────╯`.outdent(2));
+}
+
+@("drawBox.props.omitLeftBorder")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    assert(["Line 1", "Line 2"].drawBox("Title", BoxProps(omitLeftBorder: true)) == `
+        ╭──╼ Title ╾───╮
+        Line 1         │
+        Line 2         │
+        ╰──────────────╯`.outdent(2));
+}
+
+@("drawBox.props.omitLeftBorderWithLongTitle")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    // When omitLeftBorder is true, prefix is empty, affecting minWidth calculation
+    assert(["Hi"].drawBox("Very Long Title", BoxProps(omitLeftBorder: true)) == `
+        ╭──╼ Very Long Title ╾───╮
+        Hi                       │
+        ╰────────────────────────╯`.outdent(2));
+}
+
+@("drawBox.styled.contentWithAnsiCodes")
+@system unittest
+{
+    import sparkles.core_cli.term_style : Style, stylize;
+
+    // ANSI codes should not affect box width calculation
+    auto styledContent = "Hello".stylize(Style.bold);
+    assert([styledContent].drawBox("T") ==
+        "╭──╼ T ╾───╮\n" ~
+        "│ \x1b[1mHello\x1b[22m    │\n" ~
+        "╰──────────╯");
+}
+
+@("drawBox.styled.titleWithAnsiCodes")
+@system unittest
+{
+    import sparkles.core_cli.term_style : Style, stylize;
+
+    // Styled title should not affect width calculation
+    auto styledTitle = "Title".stylize(Style.cyan);
+    assert(["Content here"].drawBox(styledTitle) ==
+        "╭──╼ \x1b[36mTitle\x1b[39m ╾───╮\n" ~
+        "│ Content here │\n" ~
+        "╰──────────────╯");
+}
+
+@("drawBox.overload.singleString")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    // Test the single-string overload that splits on newlines
+    assert("Line 1\nLine 2".drawBox("T") == `
+        ╭──╼ T ╾───╮
+        │ Line 1   │
+        │ Line 2   │
+        ╰──────────╯`.outdent(2));
+}
+
+@("drawBox.overload.singleStringMultipleNewlines")
+@system unittest
+{
+    import sparkles.test_utils.string : outdent;
+
+    assert("A\nBB\nCCC".drawBox("X") == `
+        ╭──╼ X ╾───╮
+        │ A        │
+        │ BB       │
+        │ CCC      │
+        ╰──────────╯`.outdent(2));
+}
+
+// Legacy test using test files
 unittest
 {
     import std.algorithm.iteration : each;

--- a/libs/core-cli/src/sparkles/core_cli/ui/demo.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/demo.d
@@ -1,0 +1,77 @@
+/++
+Demo runner utilities for showcasing UI components.
+
+Provides a structured way to display multiple sections with headers,
+useful for examples and demonstrations.
++/
+module sparkles.core_cli.ui.demo;
+
+import std.stdio : writeln;
+
+import sparkles.core_cli.ui.header : drawHeader, HeaderProps, HeaderStyle;
+
+@safe:
+
+/// A section in a demo with a header and content.
+struct Section
+{
+    string header;
+    string content;
+}
+
+/// Configuration for demo rendering.
+struct DemoProps
+{
+    size_t width = 67;
+    string endTitle = "Demo Complete";
+}
+
+/// Runs a demo by printing a header banner, sections, and closing banner.
+///
+/// Params:
+///   header = The demo header shown in the opening banner
+///   content = Array of sections to display
+///   props = Configuration options
+///
+/// Example:
+/// ---
+/// runDemo(
+///     header: "My Demo",
+///     content: [
+///         Section(header: "First", content: "Some content here"),
+///         Section(header: "Second", content: "More content"),
+///     ],
+/// );
+/// ---
+void runDemo(string header, Section[] content, DemoProps props = DemoProps.init)
+{
+    header.drawHeader(HeaderProps(style: HeaderStyle.banner, width: props.width)).writeln("\n");
+
+    foreach (section; content)
+    {
+        section.header.drawHeader.writeln;
+        section.content.writeln("\n");
+    }
+
+    props.endTitle.drawHeader(HeaderProps(style: HeaderStyle.banner, width: props.width)).writeln;
+}
+
+/// Section initialization
+@("demo.Section.init")
+@safe pure nothrow @nogc
+unittest
+{
+    const section = Section(header: "Title", content: "Body text");
+    assert(section.header == "Title");
+    assert(section.content == "Body text");
+}
+
+/// DemoProps defaults
+@("demo.DemoProps.defaults")
+@safe pure nothrow @nogc
+unittest
+{
+    const props = DemoProps.init;
+    assert(props.width == 67);
+    assert(props.endTitle == "Demo Complete");
+}

--- a/libs/core-cli/src/sparkles/core_cli/ui/header.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/header.d
@@ -1,0 +1,118 @@
+/++
+Section header rendering utilities.
+
+Provides functions to draw styled section headers in terminal applications,
+supporting divider and banner styles.
++/
+module sparkles.core_cli.ui.header;
+
+import std.conv : to;
+import std.range : repeat;
+
+import sparkles.core_cli.term_unstyle : unstyledLenght;
+
+@safe:
+
+/// Header display style.
+enum HeaderStyle
+{
+    divider, // ── Title ──
+    banner, // Full-width centered title with top/bottom lines
+}
+
+/// Configuration options for header rendering.
+struct HeaderProps
+{
+    HeaderStyle style = HeaderStyle.divider;
+    dchar lineChar = '─';
+    dchar bannerLineChar = '═';
+    size_t width = 0; // 0 = auto
+    size_t titlePadding = 1; // spaces around title in divider
+}
+
+/// Draw a section header.
+///
+/// Params:
+///   title = The header title text
+///   props = Rendering options
+/// Returns:
+///   Formatted header string
+///
+/// Examples:
+/// ---
+/// // Simple divider
+/// "Section".drawHeader.writeln;
+/// // Output: ── Section ──
+///
+/// // Banner style
+/// "Main Title".drawHeader(HeaderProps(style: HeaderStyle.banner, width: 40)).writeln;
+/// ---
+string drawHeader(string title, HeaderProps props = HeaderProps.init)
+{
+    final switch (props.style)
+    {
+        case HeaderStyle.divider: return drawDivider(title, props);
+        case HeaderStyle.banner: return drawBanner(title, props);
+    }
+}
+
+/// Default divider style
+@("header.drawHeader.defaultDivider")
+unittest
+{
+    assert("Title".drawHeader == "── Title ──");
+}
+
+/// Custom line character
+@("header.drawHeader.customLineChar")
+unittest
+{
+    assert("Test".drawHeader(HeaderProps(lineChar: '═')) == "══ Test ══");
+}
+
+/// Banner style with fixed width
+@("header.drawHeader.bannerStyle")
+unittest
+{
+    const result = "Demo".drawHeader(HeaderProps(style: HeaderStyle.banner, width: 20));
+    assert(result == "════════════════════\n        Demo        \n════════════════════");
+}
+
+/// Fixed width divider
+@("header.drawHeader.fixedWidth")
+unittest
+{
+    const result = "X".drawHeader(HeaderProps(width: 11));
+    assert(result == "──── X ────");
+}
+
+private string drawDivider(string title, HeaderProps props)
+{
+    const titleLen = title.unstyledLenght;
+    const padding = ' '.repeat(props.titlePadding).to!string;
+
+    size_t totalWidth = props.width;
+    if (totalWidth == 0)
+        totalWidth = 4 + props.titlePadding * 2 + titleLen; // 2 chars each side minimum
+
+    const remaining = totalWidth - titleLen - props.titlePadding * 2;
+    const leftLen = remaining / 2;
+    const rightLen = remaining - leftLen;
+
+    return props.lineChar.repeat(leftLen).to!string
+        ~ padding ~ title ~ padding
+        ~ props.lineChar.repeat(rightLen).to!string;
+}
+
+private string drawBanner(string title, HeaderProps props)
+{
+    const titleLen = title.unstyledLenght;
+    const totalWidth = props.width > 0 ? props.width : titleLen + 20;
+
+    const line = props.bannerLineChar.repeat(totalWidth).to!string;
+    const leftPad = (totalWidth - titleLen) / 2;
+    const rightPad = totalWidth - titleLen - leftPad;
+    const titleLine = ' '.repeat(leftPad).to!string ~ title ~ ' '.repeat(rightPad).to!string;
+
+    return line ~ '\n' ~ titleLine ~ '\n' ~ line;
+}

--- a/libs/core-cli/src/sparkles/core_cli/ui/header.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/header.d
@@ -9,7 +9,7 @@ module sparkles.core_cli.ui.header;
 import std.conv : to;
 import std.range : repeat;
 
-import sparkles.core_cli.term_unstyle : unstyledLenght;
+import sparkles.core_cli.term_unstyle : unstyledLength;
 
 @safe:
 
@@ -88,7 +88,7 @@ unittest
 
 private string drawDivider(string title, HeaderProps props)
 {
-    const titleLen = title.unstyledLenght;
+    const titleLen = title.unstyledLength;
     const padding = ' '.repeat(props.titlePadding).to!string;
 
     size_t totalWidth = props.width;
@@ -106,7 +106,7 @@ private string drawDivider(string title, HeaderProps props)
 
 private string drawBanner(string title, HeaderProps props)
 {
-    const titleLen = title.unstyledLenght;
+    const titleLen = title.unstyledLength;
     const totalWidth = props.width > 0 ? props.width : titleLen + 20;
 
     const line = props.bannerLineChar.repeat(totalWidth).to!string;


### PR DESCRIPTION
## Summary
- Add `header` module with divider and banner styles for consistent UI headers
- Add `demo` module with `Section` and `runDemo` for showcasing UI components
- Add `box.d` example demonstrating drawBox with tables, prettyPrint, and styled content
- Refactor `table.d` example to use the new runDemo pattern
- Fix underflow bug in drawBox when title is wider than content
- Fix typo: `unstyledLenght` → `unstyledLength`
- Refactor `styleName` using switch with static foreach

## Screenshot of `./libs/core-cli/examples/box.d`
<img width="652" height="973" alt="image" src="https://github.com/user-attachments/assets/cec1118b-0a44-45b8-b5ed-6436cbf62183" />
<img width="652" height="793" alt="image" src="https://github.com/user-attachments/assets/3acf9628-5f03-43bd-ad9e-4ec8856eeae1" />

## Test plan
- [x] Run `dub build :core-cli` to verify compilation
- [x] Run `./libs/core-cli/examples/box.d` to see the box demo
- [x] Run `./libs/core-cli/examples/table.d` to see the updated table demo
- [x] Run `dub test :core-cli` to verify all tests pass