### PR TITLE
docs: Add VitePress documentation site

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,8 @@ indent_style = space
 # with intentional 2-space indentation for expected test output
 [libs/core-cli/src/sparkles/core_cli/prettyprint.d]
 indent_size = unset
+
+# Disable indent checking for markdown - code blocks may have intentional
+# spacing for visual output examples
+[*.md]
+indent_size = unset

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,82 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "package.json"
+      - "package-lock.json"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build VitePress site
+        run: npm run docs:build
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs/.vitepress/dist --project-name=sparkles-docs --branch=${{ github.head_ref || 'main' }}
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
+            const body = `📄 Docs preview deployed to: ${deploymentUrl}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes('Docs preview deployed to:'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ __dummy.html
 
 # Code coverage
 *.lst
+
+# Node.js / VitePress
+node_modules/
+docs/.vitepress/dist/
+docs/.vitepress/cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ Detailed guidelines are in `docs/guidelines/`:
 - **[Code Style](docs/guidelines/code-style.md)** — Formatting, naming, module layout, imports
 - **[Functional & Declarative Programming](docs/guidelines/functional-declarative-programming-guidelines.md)** — Range pipelines, UFCS, purity, lazy evaluation
 - **[Design by Introspection](docs/guidelines/design-by-introspection-01-guidelines.md)** — Capability traits, optional primitives, shell-with-hooks pattern
-- **[Interpolated Expression Sequences](docs/guidelines/ies.md)** — IES syntax, metadata processing, context-aware encoding
+- **[Interpolated Expression Sequences](docs/guidelines/interpolated-expression-sequences.md)** — IES syntax, metadata processing, context-aware encoding
+- **[DDoc](docs/guidelines/ddoc.md)** — Documentation comments, sections, macros, cross-referencing
 
 ## Building and Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Detailed guidelines are in `docs/guidelines/`:
 - **[Code Style](docs/guidelines/code-style.md)** — Formatting, naming, module layout, imports
 - **[Functional & Declarative Programming](docs/guidelines/functional-declarative-programming-guidelines.md)** — Range pipelines, UFCS, purity, lazy evaluation
 - **[Design by Introspection](docs/guidelines/design-by-introspection-01-guidelines.md)** — Capability traits, optional primitives, shell-with-hooks pattern
+- **[Interpolated Expression Sequences](docs/guidelines/ies.md)** — IES syntax, metadata processing, context-aware encoding
 
 ## Building and Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,7 @@ Follow the conventional commits format:
 - `chore` - Maintenance tasks
 - `build` - Build system changes
 - `ci` - CI/CD changes
+- `docs` - Documentation changes
 
 ### Scopes
 
@@ -288,6 +289,7 @@ Follow the conventional commits format:
 - `test-utils` - For test-utils package changes
 - `dub` - For dub configuration changes
 - `nix` - For Nix configuration changes
+- `guidelines` - For documentation guidelines changes
 
 ### Examples
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,62 @@
+import { defineConfig } from "vitepress";
+
+export default defineConfig({
+  title: "Sparkles",
+  description: "D library for building CLI applications",
+  base: "/",
+
+  // Ignore links to .d source files referenced from docs
+  ignoreDeadLinks: [/\.d$/],
+
+  themeConfig: {
+    nav: [
+      { text: "Docs", link: "/overview" },
+      { text: "API", link: "/api/" },
+    ],
+
+    sidebar: [
+      {
+        text: "Overview",
+        items: [{ text: "core-cli Package", link: "/overview" }],
+      },
+      {
+        text: "Guidelines",
+        items: [
+          {
+            text: "Functional & Declarative Programming",
+            link: "/guidelines/functional-declarative-programming-guidelines",
+          },
+          {
+            text: "Design by Introspection",
+            items: [
+              {
+                text: "Intro",
+                link: "/guidelines/design-by-introspection-00-intro",
+              },
+              {
+                text: "Guidelines",
+                link: "/guidelines/design-by-introspection-01-guidelines",
+              },
+            ],
+          },
+          {
+            text: "Interpolated Expression Sequences",
+            link: "/guidelines/interpolated-expression-sequences",
+          },
+          { text: "DDoc", link: "/guidelines/ddoc" },
+          {
+            text: "Code Style",
+            items: [
+              { text: "Overview", link: "/guidelines/code-style" },
+              { text: "Appendix: Official DStyle", link: "/guidelines/dstyle" },
+            ],
+          },
+        ],
+      },
+    ],
+
+    socialLinks: [
+      { icon: "github", link: "https://github.com/PetarKirov/sparkles" },
+    ],
+  },
+});

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,32 @@
+:root {
+  --vp-sidebar-width: 340px;
+
+  --vp-c-brand-1: #d63452;
+  --vp-c-brand-2: #e95e67;
+  --vp-c-brand-3: #a93a58;
+  --vp-c-brand-soft: rgba(214, 52, 82, 0.14);
+
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(
+    135deg,
+    #532360,
+    #a93a58,
+    #d63452,
+    #e95e67,
+    #f7b360
+  );
+
+  --vp-home-hero-image-background-image: linear-gradient(
+    135deg,
+    #532360 30%,
+    #d63452 70%
+  );
+  --vp-home-hero-image-filter: blur(56px);
+}
+
+.dark {
+  --vp-c-brand-1: #e95e67;
+  --vp-c-brand-2: #f7b360;
+  --vp-c-brand-3: #d63452;
+  --vp-c-brand-soft: rgba(233, 94, 103, 0.14);
+}

--- a/docs/.vitepress/theme/index.mts
+++ b/docs/.vitepress/theme/index.mts
@@ -1,0 +1,4 @@
+import DefaultTheme from "vitepress/theme";
+import "./custom.css";
+
+export default DefaultTheme;

--- a/docs/guidelines/code-style.md
+++ b/docs/guidelines/code-style.md
@@ -170,3 +170,40 @@ auto result = createWidget(
     resizable: false,
 );
 ```
+
+## Interpolated Expression Sequences ([DIP1036](https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1036.md))
+
+Use IES (`i"..."`) when interspersing string literals with expressions. Preference order:
+
+1. **IES** — Type-safe, enables context-aware encoding
+2. **`std.format`** — When format specifiers are needed (`%08x`, `%.2f`)
+3. **Manual concatenation** — Avoid
+
+```d
+import std.conv : text;
+import std.stdio : writeln;
+
+string name = "Alice";
+int count = 42;
+
+// Good: IES with writeln (no allocation)
+writeln(i"Hello, $(name)! Count: $(count)");
+
+// Good: IES converted to string
+string msg = i"Hello, $(name)! Count: $(count)".text;
+
+// Good: std.format when format specifiers needed
+import std.format : format;
+string hex = format!"Value: 0x%08X"(count);
+
+// Avoid: manual concatenation
+string bad = "Hello, " ~ name ~ "! Count: " ~ count.to!string;
+```
+
+**Key rules:**
+
+- IES produces a tuple, not a string — use `.text` or pass to IES-accepting functions
+- Prefer `writeln(i"...")` over `writeln(i"...".text)` to avoid allocation
+- For security-sensitive contexts (SQL, HTML, URLs), use dedicated IES-processing functions that escape interpolated values
+
+See [Interpolated Expression Sequences](interpolated-expression-sequences.md) for complete patterns including safe SQL queries, HTML templates, and structured logging.

--- a/docs/guidelines/code-style.md
+++ b/docs/guidelines/code-style.md
@@ -24,7 +24,7 @@ See [DDoc](ddoc.md) for documentation comment syntax and conventions.
 
 ### Imports
 
-Group imports in this order:
+Group imports in this order, separated by a single empty line between groups:
 
 1. `core.*` modules (DRuntime)
 2. `std.*` modules (Phobos)

--- a/docs/guidelines/code-style.md
+++ b/docs/guidelines/code-style.md
@@ -20,6 +20,8 @@ Organize D modules in this order:
 
 Unit tests for a specific function or type should follow that declaration directly.
 
+See [DDoc](ddoc.md) for documentation comment syntax and conventions.
+
 ### Imports
 
 Group imports in this order:

--- a/docs/guidelines/ddoc.md
+++ b/docs/guidelines/ddoc.md
@@ -1,0 +1,842 @@
+# D Developer Guidelines: DDoc
+
+## Introduction
+
+DDoc is D's built-in documentation generator. It extracts specially formatted comments from source code and produces formatted output (typically HTML). Unlike external tools such as Doxygen or Javadoc, DDoc is integrated into the D compiler itself and invoked via `dmd -D`.
+
+DDoc's design goals favor documentation that reads well in source code, requires minimal markup, avoids repeating information the compiler already knows, and does not depend on embedded HTML.
+
+This document establishes guidelines for writing effective DDoc comments across D projects. It covers comment syntax, section conventions, formatting features, macro usage, cross-referencing, and common pitfalls.
+
+---
+
+## Complete Example
+
+Before diving into the details, here is a fully documented module showing all the key elements in context — module-level documentation, function documentation with all standard sections, cross-references, and a documented unittest:
+
+```d
+/**
+Spatial utility functions for 2D geometry.
+
+This module provides distance and proximity calculations
+for points in two-dimensional Euclidean space.
+
+See_Also:
+    $(MREF geometry, threedim) for 3D equivalents
+
+Source: $(SRC geometry/twodim.d)
+Copyright: © 2025 Project Authors
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
+Authors: $(HTTP example.com, Jane Developer)
+
+Macros:
+    SRC = $(LINK2 https://github.com/example/geom/blob/main/$0, $0)
+*/
+module geometry.twodim;
+
+import std.math : sqrt, isClose;
+
+/**
+Computes the Euclidean distance between two points in 2D space.
+
+Uses the standard distance formula: `sqrt((x2-x1)² + (y2-y1)²)`.
+Returns `0.0` when the two points are identical.
+
+Params:
+    x1 = x-coordinate of the first point
+    y1 = y-coordinate of the first point
+    x2 = x-coordinate of the second point
+    y2 = y-coordinate of the second point
+
+Returns: The Euclidean distance as a `double`.
+
+Throws: Nothing.
+
+See_Also: $(LREF manhattanDistance)
+*/
+@safe pure nothrow @nogc
+double euclideanDistance(double x1, double y1, double x2, double y2)
+{
+    return sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+    assert(euclideanDistance(0, 0, 3, 4).isClose(5.0));
+    assert(euclideanDistance(1, 1, 1, 1).isClose(0.0));
+}
+
+/**
+Computes the Manhattan distance between two points.
+
+Params:
+    x1 = x-coordinate of the first point
+    y1 = y-coordinate of the first point
+    x2 = x-coordinate of the second point
+    y2 = y-coordinate of the second point
+
+Returns: The sum of absolute differences along each axis.
+
+See_Also: $(LREF euclideanDistance)
+*/
+@safe pure nothrow @nogc
+double manhattanDistance(double x1, double y1, double x2, double y2)
+{
+    import std.math : abs = fabs;
+    return abs(x2 - x1) + abs(y2 - y1);
+}
+
+/// ditto
+@safe pure nothrow @nogc
+double manhattanDistance(int x1, int y1, int x2, int y2)
+{
+    import std.math : abs;
+    return abs(x2 - x1) + abs(y2 - y1);
+}
+
+///
+@safe pure nothrow @nogc
+unittest
+{
+    assert(manhattanDistance(1.0, 1.0, 4.0, 5.0).isClose(7.0));
+    assert(manhattanDistance(0, 0, 3, 4) == 7);
+}
+```
+
+The rest of this document explains each element shown above in detail.
+
+Note how the module comment defines a `SRC` macro so that `Source:` links use a short, readable invocation. In practice, define such project-level macros in a shared `.ddoc` file passed on the command line (e.g., `project.ddoc`) rather than repeating the definition in every module.
+
+---
+
+## Comment Forms
+
+DDoc recognizes three comment forms:
+
+```d
+/// Single-line documentation comment.
+
+/** Multi-line block documentation comment. */
+
+/++ Multi-line nesting block documentation comment. +/
+```
+
+**Guideline:** Prefer block comments (`/**` or `/++`) for multi-line documentation. Use `///` only for `ditto` comments or very short annotations. Do not use more than two leading `*` or `+` characters in the opening delimiter.
+
+```d
+// ✅ Good
+/**
+This function returns the sum of two integers.
+*/
+int sum(int a, int b) { return a + b; }
+
+/// ditto
+int sum(long a, long b) { return cast(int)(a + b); }
+
+// ❌ Bad — excessive opening stars
+/***********************************
+ * Don't do this in new code.
+ */
+```
+
+### Leading Margin Characters
+
+Extra `*` or `+` characters on the left margin are stripped automatically and are not part of the documentation. The D Style recommends that documentation comments should **not** have leading stars on each line. Phobos enforces this, and it is good practice in all D code:
+
+```d
+// ✅ Good — no leading stars
+/**
+Checks whether a number is positive.
+Zero is not considered positive.
+*/
+
+// ❌ Avoid
+/**
+ * Checks whether a number is positive.
+ * Zero is not considered positive.
+ */
+```
+
+---
+
+## Comment Placement and Association
+
+Each documentation comment is associated with a declaration. The rules are:
+
+1. A comment on its own line (or with only whitespace to the left) documents the **next** declaration.
+2. A comment on the same line to the **right** of a declaration documents that declaration.
+3. Multiple comments applying to the same declaration are concatenated.
+4. A comment preceding the `module` declaration documents the entire module.
+5. A declaration with **no** documentation comment may be omitted from output entirely. Add an empty comment (`///`) to force inclusion.
+
+```d
+/// Documentation for `a`. `b` has no documentation and may not appear.
+int a;
+int b;
+
+/** Documentation for both `c` and `d`. */
+int c;
+/** ditto */
+int d;
+
+int e; /// Documentation for `e`.
+```
+
+### The `ditto` Keyword
+
+If a documentation comment consists solely of the word `ditto`, it reuses the documentation of the previous declaration at the same scope. This is useful for overloads and closely related symbols:
+
+```d
+/// Converts the value to a string representation.
+string toString(int value) { /* ... */ }
+/// ditto
+string toString(float value) { /* ... */ }
+```
+
+### When Not to Use DDoc Comments
+
+Do not use DDoc comments for overrides unless the overriding function does something different (as far as the caller is concerned) than the overridden function. DDoc comment blocks are also overkill for nested functions and function literals — use ordinary comments for those instead.
+
+---
+
+## Section Structure
+
+A DDoc comment is divided into a sequence of sections. Sections are identified by a name followed by a colon (`:`) as the first non-blank content on a line. Section names are case-insensitive.
+
+Note: Section names starting with `http://` or `https://` are not recognized as section names. This was a historical source of bugs (fixed in DMD 2.076) where bare URLs at the start of a line could be mistakenly parsed as section headers.
+
+### Summary
+
+The first section is the **Summary** — the first paragraph up to the first blank line or named section. Keep it to one line when possible. The Summary is optional but strongly recommended.
+
+### Description
+
+Everything after the Summary and before the first named section is the **Description**. It consists of one or more paragraphs. A Description requires a Summary to precede it.
+
+```d
+/**
+Brief one-line summary of what this function does.
+
+More detailed description follows after the blank line.
+This can span multiple paragraphs.
+
+Second paragraph of description.
+*/
+```
+
+### Named Sections
+
+Named sections follow the Summary and Description. None are required, but certain sections are expected by convention.
+
+---
+
+## Standard Sections
+
+These sections are recognized by DDoc and have conventional meanings:
+
+| Section       | Purpose                                                    |
+| ------------- | ---------------------------------------------------------- |
+| `Params:`     | Documents function parameters (special syntax — see below) |
+| `Returns:`    | Describes the return value                                 |
+| `Throws:`     | Lists exceptions thrown and under what conditions          |
+| `See_Also:`   | References to related symbols or URLs                      |
+| `Examples:`   | Usage examples (prefer documented unittests instead)       |
+| `Bugs:`       | Known bugs or limitations                                  |
+| `Deprecated:` | Explanation and migration path for deprecated symbols      |
+| `Authors:`    | Author(s) of the declaration                               |
+| `License:`    | License information                                        |
+| `Standards:`  | Applicable standards or specifications                     |
+| `History:`    | Revision history                                           |
+| `Version:`    | Current version of the declaration                         |
+| `Date:`       | Date of the current revision                               |
+| `Copyright:`  | Copyright notice (special behavior on module declarations) |
+
+### Params Section
+
+The `Params:` section uses special syntax. Each parameter starts on a new line with the parameter name followed by `=`:
+
+```d
+/**
+Computes the weighted average.
+
+Params:
+    values = the input array of values
+    weights = corresponding weights for each value;
+              must have the same length as `values`
+
+Returns: The weighted arithmetic mean.
+
+Throws: `RangeError` if `values` is empty.
+
+See_Also: $(LREF simpleAverage), $(LREF geometricMean)
+*/
+double weightedAverage(double[] values, double[] weights) { /* ... */ }
+```
+
+**Guideline:** Text in sections that spans more than one line should be indented by one additional level relative to the section header.
+
+**Warning:** The compiler will issue a warning if a `Params:` section lists a parameter name that does not match any actual function parameter. It also warns if the format `param = description` is not followed. Pay attention to these warnings — they indicate documentation/code drift.
+
+---
+
+## Documentation Requirements
+
+### Minimum Coverage
+
+Every public declaration should have a documentation comment. At minimum, every public function should have:
+
+1. A **Summary** line
+2. A **`Params:`** section (if the function takes parameters)
+3. A **`Returns:`** section (if the function returns non-`void`)
+
+Do not redundantly document a `void` return. Phobos enforces these requirements via CI; adopting them in your own projects is strongly recommended.
+
+```d
+/**
+Checks whether a number is positive.
+`0` is not considered positive.
+
+Params:
+    number = the number to check
+
+Returns: `true` if the number is positive, `false` otherwise.
+
+See_Also: $(LREF isNegative)
+*/
+bool isPositive(int number)
+{
+    return number > 0;
+}
+```
+
+### Module-Level Documentation
+
+The documentation comment preceding the `module` declaration documents the entire module. Use this to describe the module's purpose, provide usage guidance, and set module-level macros or copyright information.
+
+```d
+/**
+Provides mathematical utility functions for statistical analysis.
+
+This module contains functions for computing means, variances,
+and other descriptive statistics.
+
+Copyright: © 2025 Project Authors
+License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0)
+Authors: $(HTTP example.com, Jane Developer)
+*/
+module stats.descriptive;
+```
+
+When the `Copyright:` section appears on a module declaration, its content is assigned to the `COPYRIGHT` macro for use elsewhere in the documentation.
+
+---
+
+## Embedded Code
+
+### Code Blocks
+
+Delimit D code examples with at least three hyphens (`---`), backticks (`` ` ``), or tildes (`~`). The code receives automatic syntax highlighting. Use exactly three dashes (`---`) as the conventional delimiter:
+
+```d
+/**
+Sorts the range in ascending order.
+
+Examples:
+---
+auto arr = [3, 1, 2];
+arr.sort();
+assert(arr == [1, 2, 3]);
+---
+*/
+```
+
+To embed code in another language without D syntax highlighting, add a language identifier after the opening delimiter:
+
+````d
+/++
+Interoperates with C++ containers.
+
+``` cpp
+#include <vector>
+std::vector<int> v = {1, 2, 3};
+````
+
++/
+
+````
+
+Note: When your code block needs to contain `/* ... */` comments, use the `/++ ... +/` comment form so the block comment inside the code does not prematurely close the documentation comment.
+
+### Inline Code
+
+Use backticks for inline code references, similar to Markdown:
+
+```d
+/// Returns `true` if `a == b`.
+bool equal(int a, int b) { return a == b; }
+````
+
+Text inside backticks is wrapped in the `$(DDOC_BACKQUOTED)` macro and rendered as an inline code span. Macros are still expanded inside backticks. To include a literal backtick, use the `$(BACKTICK)` macro.
+
+**Warning:** Because macros are expanded inside backticks, writing `` `i"Hello $(name)"` `` in DDoc prose will cause `$(name)` to be processed as a macro and silently vanish. To show IES syntax literally in inline code, escape the dollar sign: `` `i"Hello $(DOLLAR)$(LPAREN)name$(RPAREN)"` ``. Alternatively, use a `---` code block where no macro expansion occurs.
+
+---
+
+## Documented Unit Tests
+
+DDoc can extract unit test bodies as usage examples. A documented unittest is a `unittest` block immediately preceded by a `///` comment:
+
+```d
+/**
+Returns the absolute value of `x`.
+
+Params:
+    x = input value
+
+Returns: The absolute value.
+*/
+int myAbs(int x)
+{
+    return x < 0 ? -x : x;
+}
+
+///
+unittest
+{
+    assert(myAbs(-5) == 5);
+    assert(myAbs(3) == 3);
+    assert(myAbs(0) == 0);
+}
+```
+
+The compiler inserts the unittest body into the `Examples:` section of the preceding declaration's documentation. This approach is strongly preferred over manually written `Examples:` sections because the examples are compiled and tested, preventing documentation from drifting out of sync with the code.
+
+### Best Practices for Documented Unittests
+
+Write documented unittests so they are self-contained: include any required `import` statements inside the unittest block rather than relying on module-level imports. This ensures the examples remain valid when extracted for documentation.
+
+Annotate unittest blocks with appropriate attributes to verify the documented function's attribute compliance:
+
+```d
+///
+@safe pure nothrow @nogc
+unittest
+{
+    assert(myFunc(42) == expected);
+}
+```
+
+Avoid placing unittest blocks inside templates. They generate a new unittest for each instantiation, which wastes compilation time and can produce confusing test output. Place tests outside of the template instead.
+
+### IES in Documented Unittests
+
+IES `$(expr)` syntax inside `i"..."` string literals is **safe** in documented unittests. The compiler's lexer tokenizes `i"..."` as a string literal before DDoc processes the source text, so `$(expr)` inside IES is preserved literally in the generated Examples section — it is not expanded as a DDoc macro.
+
+However, `$(...)` in the `///` comment text preceding the unittest IS processed as a DDoc macro. Use `$(DOLLAR)$(LPAREN)...$(RPAREN)` escaping there.
+
+```d
+/// This documented unittest uses IES safely.
+/// Note: `$(DOLLAR)$(LPAREN)name$(RPAREN)` in this comment must be escaped,
+/// but inside the unittest body it needs no escaping.
+@safe
+unittest
+{
+    string name = "Alice";
+    auto greeting = i"Hello, $(name)!".text;  // $(name) preserved in docs
+    assert(greeting == "Hello, Alice!");
+}
+```
+
+---
+
+## Formatting Features
+
+### Text Emphasis
+
+Wrap text in `*` for emphasis and `**` for strong emphasis:
+
+```d
+/// This is *emphasized* and this is **strongly emphasized**.
+```
+
+Underscores (`_`) are **not** used for emphasis in DDoc (unlike Markdown) because they conflict with `snake_case` identifiers and underscore prefix processing.
+
+### Identifier Emphasis
+
+DDoc automatically emphasizes identifiers that are function parameters or names in scope at the associated declaration. To prevent unintended emphasis, prefix an identifier with `_` (the underscore is stripped from output):
+
+```d
+/**
+The _function parameter `x` is documented here.
+Mentioning `x` in the description highlights it automatically.
+*/
+void compute(int x) { }
+```
+
+Be careful with identifiers beginning with underscores in code examples within documentation comments — they can trigger unintended emphasis or DDoc errors.
+
+### Headings
+
+Use `#` characters (one to six) to create headings within long documentation sections:
+
+```d
+/**
+# Overview
+General description.
+
+## Details
+More specific information.
+*/
+```
+
+### Links
+
+DDoc supports four link styles:
+
+```d
+/**
+1. Reference links: [Object] or [ref]
+2. Inline links: [D Language](https://dlang.org)
+3. Bare URLs: https://dlang.org
+4. Images: ![alt text](https://dlang.org/images/d3.png)
+
+[ref]: https://dlang.org "The D Language Website"
+*/
+```
+
+Reference links that match a D symbol in scope generate hyperlinks to that symbol's documentation automatically. If a reference label matches both a D symbol and an explicit reference definition, the explicit definition takes precedence.
+
+### Lists
+
+Start ordered lists with a number and period. Start unordered lists with `-`, `*`, or `+`:
+
+```d
+/**
+Steps:
+1. Initialize the buffer
+2. Process each element
+3. Flush results
+
+Features:
+- Fast allocation
+- Cache-friendly layout
+*/
+```
+
+**Caveat:** Inside `/** ... */` comments, a leading `*` on a line is consumed as part of the comment delimiter. Use `-` for unordered lists inside `/** ... */` comments, or use double `**` if the list marker must be an asterisk. The same caveat applies to `+` inside `/++ ... +/` comments.
+
+### Tables
+
+Tables follow a Markdown-like syntax with header, delimiter, and data rows separated by `|`:
+
+```d
+/**
+| Type    | Size   |
+| ------- | -----: |
+| `int`   | 4      |
+| `long`  | 8      |
+*/
+```
+
+Use `:` in the delimiter row for alignment: left (`---`), right (`---:`), or center (`:---:`).
+
+### Block Quotes
+
+Prefix lines with `>` for quoted material:
+
+```d
+/**
+> Design is not just what it looks like.
+> Design is how it works.
+*/
+```
+
+Lines directly following a quoted line are considered part of the quote. Insert a blank line to end the quote.
+
+---
+
+## Cross-Referencing with Macros
+
+Effective cross-referencing is critical for usable documentation. DDoc and the standard library define a set of macros for linking between symbols and modules.
+
+### Intra-Module Links
+
+Use `$(LREF symbol)` to link to another symbol in the same module:
+
+```d
+/**
+See_Also: $(LREF isNegative), $(LREF abs)
+*/
+```
+
+`LREF` generates an anchor link within the current page: `<a href="#symbol">symbol</a>`.
+
+### Cross-Module Links
+
+Use `$(REF symbol, package, module)` to link to a symbol in another module. Arguments after the first form the module path, passed as comma-separated segments:
+
+```d
+/**
+See_Also: $(REF writeln, std, stdio)
+*/
+```
+
+The `REF` macro generates a link like `std_stdio.html#.writeln`. The argument order (symbol first, then module segments) may seem inverted but is dictated by DDoc's macro processing and the link format.
+
+For linking to a member of a type in another module, use dotted notation for the first argument:
+
+```d
+/**
+See_Also: $(REF File.writeln, std, stdio)
+*/
+```
+
+### Module Links
+
+Use `$(MREF std, module)` to link to a module itself (rather than a symbol within it):
+
+```d
+/**
+For I/O operations, see $(MREF std, stdio).
+*/
+```
+
+### External Links
+
+For links to external URLs, use `$(LINK2 url, display text)` or `$(LINK url)`:
+
+```d
+/**
+See the $(LINK2 https://dlang.org/spec/ddoc.html, DDoc specification).
+*/
+```
+
+For links to Phobos source files, use `$(PHOBOSSRC path)`:
+
+```d
+/**
+Source: $(PHOBOSSRC std/algorithm/searching.d)
+*/
+```
+
+### Linking Pitfalls
+
+Several recurring issues involve malformed DDoc links:
+
+- **Broken `LINK2` URLs**: Long URLs split across lines inside macros can break because DDoc treats line breaks inside macro arguments inconsistently. Keep URLs on a single line when possible.
+- **Wrong anchor format**: When using `REF` to link to a nested symbol (e.g., a struct member), use dots, not module segments: `$(REF MyStruct.myMethod, std, mymodule)`, not separate arguments for each level.
+- **`DOC_ROOT_` macros for external packages**: When linking to symbols in packages outside the current root package, DDoc prepends a `$(DOC_ROOT_pkg)` macro. Define these macros if you need cross-package links.
+
+---
+
+## Macros
+
+DDoc includes a text macro preprocessor. Macros are invoked with `$(NAME)` or `$(NAME arguments)` syntax.
+
+### Defining Macros
+
+Macros can be defined in a `Macros:` section at the end of a documentation comment, in `.ddoc` files passed on the command line, or in the compiler configuration file:
+
+```d
+/**
+Macros:
+    MYLINK = <a href="$1">$2</a>
+    RED = <span style="color:red">$0</span>
+*/
+module mymodule;
+```
+
+### Macro Arguments
+
+| Syntax      | Meaning                              |
+| ----------- | ------------------------------------ |
+| `$0`        | All argument text                    |
+| `$1` … `$9` | Individual comma-separated arguments |
+| `$+`        | All arguments after the first        |
+
+### Escaping Commas in Arguments
+
+If an argument itself contains commas, they must be escaped. Two approaches work:
+
+1. Backslash-escape: `$(FOO one, two\, three, four)` — here `$2` is `two, three`.
+2. Wrapper macro: Define `ARGS=$0` and use `$(FOO one, $(ARGS two, three), four)`.
+
+### Key Predefined Macros
+
+DDoc provides predefined macros for formatting. Some frequently used ones:
+
+| Macro                | Purpose                          |
+| -------------------- | -------------------------------- |
+| `$(B text)`          | Bold                             |
+| `$(I text)`          | Italic                           |
+| `$(D code)`          | Inline D code formatting         |
+| `$(LINK url)`        | Clickable link                   |
+| `$(LINK2 url, text)` | Clickable link with display text |
+| `$(DDOC)`            | Overall output template          |
+| `$(BODY)`            | Generated document body          |
+| `$(TITLE)`           | Module name                      |
+
+### Standard Library Macros
+
+The Phobos documentation system defines additional macros (in `std.ddoc` and `dlang.org.ddoc`) that are available when building with the standard `.ddoc` files. These are commonly used in D projects beyond just Phobos itself:
+
+| Macro                     | Purpose                           |
+| ------------------------- | --------------------------------- |
+| `$(LREF symbol)`          | Link to symbol in the same module |
+| `$(REF symbol, pkg, mod)` | Link to symbol in another module  |
+| `$(MREF pkg, mod)`        | Link to a module                  |
+| `$(HTTP url, text)`       | HTTP link (shorthand)             |
+| `$(PHOBOSSRC path)`       | Link to Phobos source on GitHub   |
+| `$(BUGZILLA id)`          | Link to a Bugzilla issue          |
+
+### Macro Precedence
+
+Macro definitions are resolved in this order (later definitions override earlier ones):
+
+1. Predefined macros
+2. Definitions from `DDOCFILE` in compiler configuration
+3. Definitions from `.ddoc` files on the command line
+4. Runtime definitions generated by DDoc
+5. Definitions from `Macros:` sections in source
+
+Macro names beginning with `D_` and `DDOC_` are reserved.
+
+---
+
+## Special Characters and Escaping
+
+### Character Entities
+
+Replace characters that have special meaning to the DDoc processor:
+
+| Character | Entity  |
+| --------- | ------- |
+| `<`       | `&lt;`  |
+| `>`       | `&gt;`  |
+| `&`       | `&amp;` |
+
+This is not necessary inside code sections or when the character is not followed by `#` or a letter.
+
+### Punctuation Escapes
+
+Escape ASCII punctuation with a backslash (`\`). Some characters produce predefined macros:
+
+| Character | Escape result     |
+| --------- | ----------------- |
+| `(`       | `$(LPAREN)`       |
+| `)`       | `$(RPAREN)`       |
+| `,`       | `$(COMMA)`        |
+| `$`       | `$(DOLLAR)`       |
+| `\\`      | Literal backslash |
+
+Backslashes inside code blocks are not treated as escapes. Backslashes before non-punctuation characters are included as-is (e.g., `C:\dmd2\bin` doesn't need escaping).
+
+---
+
+## Common Pitfalls
+
+These issues are recurring sources of bugs in D documentation. The compiler now warns about some of them, but awareness helps avoid surprises.
+
+### Unmatched Parentheses
+
+**This is the single most common DDoc issue.** DDoc's macro system depends on properly nested parentheses. An unmatched `)` or `(` in documentation text will corrupt the macro expansion of the entire section, potentially producing garbled output for the whole module page.
+
+The compiler will warn: `Ddoc: Stray ')'. This may cause incorrect Ddoc output. Use $(RPAREN) instead for unpaired right parentheses.`
+
+**Fix:** Use `$(LPAREN)` and `$(RPAREN)` for literal parentheses that are not matched, or backslash-escape them with `\(` and `\)`:
+
+```d
+/**
+The function signature is: `void foo$(LPAREN)$(RPAREN)`.
+Alternatively: `void foo\(\)`.
+*/
+```
+
+This also applies inside code examples if they are not properly delimited with `---` fences. Code between `---` delimiters is handled correctly; the issue arises when parentheses appear in running prose or in un-fenced code references.
+
+### Dollar Signs
+
+A bare `$` followed by `(` is interpreted as a macro invocation. To include a literal `$(`, escape the dollar sign: `\$(` or use `$(DOLLAR)`.
+
+Note: IES uses `\$` to produce a literal dollar sign inside `i"..."` strings. This is a lexer-level escape, independent of DDoc's `$(DOLLAR)` macro. The two mechanisms operate at different stages and do not interfere with each other.
+
+### Macro Expansion Limits
+
+DDoc has a recursion limit for macro expansion. If your documentation triggers more expansions than the limit (configurable but typically generous), the compiler will error: `DDoc macro expansion limit exceeded`. This usually indicates a circular macro definition or an extremely deeply nested set of macros. Simplify the macro hierarchy if this occurs.
+
+### Section Names Colliding with URLs
+
+Avoid starting a line with a URL that could be parsed as a section name. For instance, the text `https:` at the start of a line was historically parsed as a section header called `https`. Since DMD 2.076, `http://` and `https://` prefixes are correctly excluded from section name detection, but earlier compilers may still have this issue.
+
+### Asterisks and Plus Signs in List Items
+
+Inside `/** ... */` comments, leading `*` on any line is consumed as part of the comment delimiter. This means `* List item` becomes ` List item` (no bullet). Use `-` for unordered lists in `/** */` comments. The same applies to `+` in `/++ +/` comments.
+
+### Identifier Auto-Highlighting Surprises
+
+DDoc automatically emphasizes any identifier in documentation text that matches a parameter name or a symbol in scope. This can produce unexpected highlighting for common words that happen to be parameter names (e.g., a parameter named `value` or `result`). Prefix with `_` to suppress: `_value`.
+
+### IES `$(...)` in DDoc Comments
+
+IES and DDoc both use `$(...)` syntax. Their interaction depends on context:
+
+| Context                     | `$(...)` treated as                        | Safe for IES? |
+| --------------------------- | ------------------------------------------ | :-----------: |
+| `---` code block            | Literal code                               |      Yes      |
+| Documented unittest body    | Literal code (string literal token)        |      Yes      |
+| DDoc prose (no backticks)   | DDoc macro                                 |      No       |
+| Backtick inline code        | DDoc macro                                 |      No       |
+| Function body (not in DDoc) | N/A — DDoc never processes function bodies |      Yes      |
+
+When mentioning IES syntax in DDoc prose, always escape: write `$(DOLLAR)$(LPAREN)expr$(RPAREN)` to render as `$(expr)`. Inside `---` code blocks and documented unittest bodies, no escaping is needed.
+
+See [IES and DDoc Interaction](ddoc_ies_interaction.d) for the test program that verified these behaviors.
+
+---
+
+## General-Purpose Documentation with DDoc
+
+DDoc can also be used to process standalone documentation files (not D source code). If a `.d` file starts with the string `Ddoc`, it is treated as a documentation file rather than source code. The text from immediately after `Ddoc` to the end of the file (or any `Macros:` section) forms the document body. No automatic syntax highlighting is applied except within `---` delimited code blocks. Only macro processing occurs.
+
+Much of the dlang.org website itself is written this way — `.dd` files that start with `Ddoc` and use macros from `.ddoc` theme files for layout and styling.
+
+---
+
+## Appendix: IES and DDoc Interaction Test
+
+The file [ddoc_ies_interaction.d](ddoc_ies_interaction.d) tests 8 scenarios where IES `$(expr)` and DDoc `$(MACRO)` syntax could collide. Run it to verify behavior with your compiler version:
+
+```bash
+# Runtime verification
+dub run --single docs/guidelines/ddoc_ies_interaction.d
+
+# Generate DDoc HTML and inspect
+ldc2 -D -Dd=build/docs -preview=in -preview=dip1000 \
+  docs/guidelines/ddoc_ies_interaction.d
+```
+
+Key findings:
+
+| #   | Scenario                           | `$(...)` preserved? | Notes                                                                       |
+| --- | ---------------------------------- | :-----------------: | --------------------------------------------------------------------------- |
+| 1   | IES in documented unittest body    |         Yes         | `i"Hello $(name)"` in unittest code renders intact                          |
+| 2   | IES in `---` code block            |         Yes         | No macro expansion inside code fences                                       |
+| 3   | IES in backtick inline code        |         No          | `$(name)` inside backticks is macro-expanded and vanishes                   |
+| 4   | Bare `$(name)` in DDoc prose       |         No          | Undefined macros expand to empty string                                     |
+| 5   | DDoc macros + IES in function body |       Coexist       | DDoc never processes function bodies                                        |
+| 6   | Dollar escaping                    |        Works        | IES `\$` and DDoc `$(DOLLAR)` are independent mechanisms                    |
+| 7   | Chained/nested IES                 |         Yes         | Multiple `$(...)` in string literals all preserved                          |
+| 8   | Variables named `B`, `D`, `I`      |    In code: Yes     | IES `$(B)` in string literals is safe; `$(B)` in DDoc prose renders as bold |
+
+---
+
+## References
+
+- [DDoc Language Specification](https://dlang.org/spec/ddoc.html) — The authoritative reference for all DDoc syntax and processing rules.
+- [The D Style](https://dlang.org/dstyle.html) — Official coding and documentation style conventions for D.
+- [Documented Unit Tests](https://dlang.org/spec/unittest.html#documented-unittests) — Specification for auto-generated examples from unittests.
+- [Predefined Macro Definitions (source)](https://github.com/dlang/dmd/blob/master/compiler/src/dmd/res/default_ddoc_theme.ddoc) — Reference implementation of all predefined DDoc macros.
+- [Standard Library Macros (std_consolidated.ddoc)](https://github.com/dlang/dlang.org/blob/master/std_consolidated.ddoc) — Macro definitions for `LREF`, `REF`, `BUGZILLA`, and other standard library macros.
+- [dlang.org Macros (dlang.org.ddoc)](https://github.com/dlang/dlang.org/blob/master/dlang.org.ddoc) — Site-wide macro definitions including `REF`, `MREF`, and layout macros.

--- a/docs/guidelines/ddoc_ies_interaction.d
+++ b/docs/guidelines/ddoc_ies_interaction.d
@@ -1,0 +1,389 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "ddoc-ies-interaction"
+    dependency "sparkles:core-cli" version="*"
+    dflags "-preview=in" "-preview=dip1000"
++/
+
+/**
+Investigation of IES and DDoc `$(DOLLAR)$(LPAREN)...$(RPAREN)` syntax interaction.
+
+Both IES and DDoc use the dollar-paren syntax but for different purposes:
+
+$(UL
+    $(LI IES: `i"Hello $(DOLLAR)$(LPAREN)name$(RPAREN)"` — interpolation of D expressions)
+    $(LI DDoc: `$(DOLLAR)$(LPAREN)B bold$(RPAREN)` — macro expansion in documentation)
+)
+
+This module tests 8 interaction scenarios to reveal how the compiler
+handles `$(DOLLAR)$(LPAREN)...$(RPAREN)` in contexts where both systems could claim it.
+
+# Running This Test
+
+Compile and run:
+---
+dub run --single docs/guidelines/ddoc_ies_interaction.d
+---
+
+Generate DDoc and inspect the HTML output:
+---
+ldc2 -D -Dd=build/docs -preview=in -preview=dip1000 \
+    docs/guidelines/ddoc_ies_interaction.d
+---
+*/
+
+import std.conv : text;
+import std.stdio : writeln;
+
+
+// ---------------------------------------------------------------------------
+// Scenario 1: IES in documented unittest
+// ---------------------------------------------------------------------------
+
+/**
+Scenario 1: IES inside a documented unittest.
+
+When DDoc extracts a documented unittest body as an Example, it processes
+the source text through its macro expander. The `$(DOLLAR)$(LPAREN)name$(RPAREN)` inside
+`i"Hello $(DOLLAR)$(LPAREN)name$(RPAREN)"` appears as raw text to DDoc.
+
+If `name` is not a defined DDoc macro, it should expand to empty string,
+silently vanishing from the Example section in the generated HTML.
+
+Params:
+    person = the name to greet
+
+Returns: A greeting string.
+*/
+string greetPerson(string person) @safe pure
+{
+    return i"Hello, $(person)!".text;
+}
+
+/// Documented unittest — DDoc extracts this body as an Example.
+/// The `$(name)` inside `i"..."` will be visible to DDoc's macro expander.
+@safe unittest
+{
+    string name = "Alice";
+    auto result = greetPerson(name);
+    assert(result == "Hello, Alice!");
+
+    // This IES literal contains $(name) — DDoc may try to expand it
+    auto greeting = i"Welcome, $(name)!".text;
+    assert(greeting == "Welcome, Alice!");
+}
+
+
+// ---------------------------------------------------------------------------
+// Scenario 2: IES in `---` code blocks inside DDoc comments
+// ---------------------------------------------------------------------------
+
+/**
+Scenario 2: IES usage inside a DDoc `---` code block.
+
+Code inside `---` delimiters is NOT subject to DDoc macro expansion.
+This means `$(expr)` is preserved literally in the documentation output.
+
+---
+int cpu = 75;
+string status = "OK";
+auto msg = i"CPU: $(cpu)% Status: $(status)".text;
+assert(msg == "CPU: 75% Status: OK");
+---
+
+The `$(cpu)` and `$(status)` above should appear literally in generated
+docs because they are inside a `---` code block.
+
+Params:
+    cpuPercent = CPU usage percentage
+    status = current status string
+
+Returns: A formatted status string.
+*/
+string formatStatus(int cpuPercent, string status) @safe pure
+{
+    return i"CPU: $(cpuPercent)% Status: $(status)".text;
+}
+
+///
+@safe unittest
+{
+    assert(formatStatus(75, "OK") == "CPU: 75% Status: OK");
+    assert(formatStatus(100, "BUSY") == "CPU: 100% Status: BUSY");
+}
+
+
+// ---------------------------------------------------------------------------
+// Scenario 3: IES in backtick inline code in DDoc prose
+// ---------------------------------------------------------------------------
+
+/**
+Scenario 3: backtick inline code containing IES syntax.
+
+In DDoc, backtick content is wrapped in `$(DDOC_BACKQUOTED)`, but
+macros are still expanded inside backticks.
+
+So writing `i"Hello $(name)"` in prose should cause `$(name)` to be
+processed as a macro even inside backticks.
+
+The safe way to show IES in DDoc prose is to use a `---` code block,
+or escape: `i"Hello $(DOLLAR)$(LPAREN)name$(RPAREN)"`.
+
+Params:
+    person = the name to greet
+
+Returns: A greeting string.
+*/
+string greetSafe(string person) @safe pure
+{
+    return i"Greetings, $(person)!".text;
+}
+
+///
+@safe unittest
+{
+    assert(greetSafe("Bob") == "Greetings, Bob!");
+}
+
+
+// ---------------------------------------------------------------------------
+// Scenario 4: Bare $(name) in DDoc prose (no backticks, no code block)
+// ---------------------------------------------------------------------------
+
+/**
+Scenario 4: bare dollar-paren in DDoc prose.
+
+Writing $(name) without backticks or code blocks causes DDoc to
+interpret it as a macro invocation. Since `name` is not a defined
+DDoc macro, it expands to an empty string.
+
+Compare these in generated docs:
+
+$(UL
+    $(LI $(B This text is bold) — `B` is a predefined DDoc macro)
+    $(LI $(I This text is italic) — `I` is a predefined DDoc macro)
+    $(LI >$(name)< — undefined macro, should vanish)
+    $(LI >$(DOLLAR)$(LPAREN)name$(RPAREN)< — escaped, shows literal text)
+)
+
+Params:
+    person = the name to greet
+
+Returns: A farewell string.
+*/
+string farewell(string person) @safe pure
+{
+    return i"Goodbye, $(person)!".text;
+}
+
+///
+@safe unittest
+{
+    assert(farewell("Charlie") == "Goodbye, Charlie!");
+}
+
+
+// ---------------------------------------------------------------------------
+// Scenario 5: DDoc macros coexisting with IES in function body
+// ---------------------------------------------------------------------------
+
+/**
+Scenario 5: DDoc macros in comments, IES in function body.
+
+This function uses $(LREF greetPerson) internally. The $(D formatReport)
+function demonstrates that DDoc macros in comments and IES in the
+function body coexist without conflict.
+
+DDoc processes comments only — it never looks inside function bodies.
+The IES `$(DOLLAR)$(LPAREN)count$(RPAREN)` in the body is invisible to DDoc.
+
+Params:
+    person = the person to include in the report
+    count = the item count to report
+
+Returns: A formatted report string.
+
+See_Also: $(LREF greetPerson), $(LREF formatStatus)
+*/
+string formatReport(string person, int count) @safe pure
+{
+    auto greeting = i"$(person) has $(count) items".text;
+    return i"Report: $(greeting)".text;
+}
+
+///
+@safe unittest
+{
+    assert(formatReport("Dave", 5) == "Report: Dave has 5 items");
+}
+
+
+// ---------------------------------------------------------------------------
+// Scenario 6: Dollar sign escaping
+// ---------------------------------------------------------------------------
+
+/**
+Scenario 6: dollar sign escaping in IES vs DDoc.
+
+In IES, `\$` produces a literal dollar sign:
+---
+string price = i"Price: \$$(amount)".text;
+// With amount=42: "Price: $42"
+---
+
+In DDoc, use `$(DOLLAR)` for a literal dollar sign:
+$(UL
+    $(LI Literal dollar: $(DOLLAR))
+    $(LI Literal dollar-paren: $(DOLLAR)$(LPAREN))
+    $(LI Literal right paren: $(RPAREN))
+)
+
+To show IES syntax literally in DDoc prose, write
+`$(DOLLAR)$(LPAREN)expr$(RPAREN)` which renders as the literal text.
+
+Params:
+    amount = the price amount
+
+Returns: A price string with dollar sign.
+*/
+string formatPrice(int amount) @safe pure
+{
+    return i"Price: \$$(amount)".text;
+}
+
+///
+@safe unittest
+{
+    assert(formatPrice(42) == "Price: $42");
+    assert(formatPrice(0) == "Price: $0");
+}
+
+
+// ---------------------------------------------------------------------------
+// Scenario 7: Nested IES in documented unittests
+// ---------------------------------------------------------------------------
+
+/**
+Scenario 7: nested IES in documented unittests.
+
+Chained IES conversions produce multiple `$(DOLLAR)$(LPAREN)...$(RPAREN)` patterns
+in the unittest source text. When DDoc extracts this as an Example,
+its parenthesis-tracking macro expander encounters nested dollar-paren
+sequences from multiple IES literals.
+*/
+string nestedIes() @safe pure
+{
+    int val = 42;
+    auto inner = i"inner=$(val)".text;
+    return i"outer[$(inner)]".text;
+}
+
+/// Documented unittest with chained IES expressions.
+/// DDoc will see multiple `$(...)` patterns in the extracted source.
+@safe unittest
+{
+    int val = 42;
+    auto inner = i"inner=$(val)".text;
+    auto result = i"outer[$(inner)]".text;
+    assert(result == "outer[inner=42]");
+
+    // Chained IES conversions
+    string name = "Eve";
+    int count = 3;
+    auto part1 = i"$(name):".text;
+    auto part2 = i"$(part1) $(count) items".text;
+    assert(part2 == "Eve: 3 items");
+}
+
+
+// ---------------------------------------------------------------------------
+// Scenario 8: IES with expressions that look like DDoc macros
+// ---------------------------------------------------------------------------
+
+/**
+Scenario 8: variable names that collide with DDoc macro names.
+
+The variables `B`, `D`, and `I` are valid D identifiers, but
+`$(B text)` is the DDoc bold macro, `$(D code)` is inline code,
+and `$(I text)` is italic.
+
+In a documented unittest, DDoc extracts source text and applies
+macro expansion. The text `i"$(B)"` contains `$(B)` which DDoc
+will interpret as the bold macro with empty content.
+*/
+string ambiguousNames() @safe pure
+{
+    string B = "bold-var";
+    string D = "code-var";
+    string I = "italic-var";
+    return i"B=$(B) D=$(D) I=$(I)".text;
+}
+
+/// Documented unittest where variable names match DDoc macro names.
+/// In generated docs, `$(B)`, `$(D)`, and `$(I)` in the IES literals
+/// may be expanded as DDoc macros instead of appearing as source code.
+@safe unittest
+{
+    string B = "bold-value";
+    string D = "code-value";
+    string I = "italic-value";
+
+    // These IES expressions use variables named B, D, I
+    // which are also DDoc macro names
+    auto result = i"B=$(B) D=$(D) I=$(I)".text;
+    assert(result == "B=bold-value D=code-value I=italic-value");
+
+    // Single-letter variable that is NOT a DDoc macro
+    string X = "x-value";
+    auto safe = i"X=$(X)".text;
+    assert(safe == "X=x-value");
+}
+
+
+// ---------------------------------------------------------------------------
+// Main — run all scenarios and print results
+// ---------------------------------------------------------------------------
+
+void main()
+{
+    writeln("=== IES / DDoc Interaction Test ===");
+    writeln();
+
+    writeln("--- Scenario 1: IES in documented unittest ---");
+    writeln("  greetPerson(\"Alice\") = ", greetPerson("Alice"));
+    writeln();
+
+    writeln("--- Scenario 2: IES in ---code block--- documented function ---");
+    writeln("  formatStatus(75, \"OK\") = ", formatStatus(75, "OK"));
+    writeln();
+
+    writeln("--- Scenario 3: IES in backtick-documented function ---");
+    writeln("  greetSafe(\"Bob\") = ", greetSafe("Bob"));
+    writeln();
+
+    writeln("--- Scenario 4: Bare $(name) in DDoc prose ---");
+    writeln("  farewell(\"Charlie\") = ", farewell("Charlie"));
+    writeln();
+
+    writeln("--- Scenario 5: DDoc macros + IES body ---");
+    writeln("  formatReport(\"Dave\", 5) = ", formatReport("Dave", 5));
+    writeln();
+
+    writeln("--- Scenario 6: Dollar sign escaping ---");
+    writeln("  formatPrice(42) = ", formatPrice(42));
+    writeln();
+
+    writeln("--- Scenario 7: Nested IES ---");
+    writeln("  nestedIes() = ", nestedIes());
+    writeln();
+
+    writeln("--- Scenario 8: DDoc macro-like variable names ---");
+    writeln("  ambiguousNames() = ", ambiguousNames());
+    writeln();
+
+    writeln("=== All runtime tests passed ===");
+    writeln();
+    writeln("To generate DDoc and inspect the interaction:");
+    writeln("  ldc2 -D -Dd=build/docs -preview=in -preview=dip1000 \\");
+    writeln("    docs/guidelines/ddoc_ies_interaction.d");
+}

--- a/docs/guidelines/interpolated-expression-sequences.md
+++ b/docs/guidelines/interpolated-expression-sequences.md
@@ -18,6 +18,7 @@ Key benefits:
 
 - **[Code Style][code-style]** — Formatting, naming, and syntax conventions
 - **[Functional & Declarative Programming][functional-declarative]** — Range pipelines, output ranges, purity
+- **[DDoc][ddoc]** — Documentation comments; `$(...)` syntax overlap with IES
 
 ---
 

--- a/docs/guidelines/interpolated-expression-sequences.md
+++ b/docs/guidelines/interpolated-expression-sequences.md
@@ -1,0 +1,793 @@
+# D Developer Guidelines: Interpolated Expression Sequences (IES)
+
+## Overview
+
+Interpolated expression sequences (IES) embed D expressions directly in string literals using `$(expr)` syntax. Unlike simple string interpolation in other languages, D's IES preserves **metadata** about each component—literal text segments and expression source code—enabling context-aware processing at compile time.
+
+Key benefits:
+
+- **Type safety** — Functions receive actual typed values, not stringified text
+- **Metadata preservation** — Libraries can distinguish literals from dynamic values
+- **Context-aware encoding** — Apply URL encoding, HTML escaping, or SQL parameterization based on context
+- **Compile-time validation** — Validate structure (HTML tags, SQL syntax) before runtime
+- **Zero overhead** — Compile-time string generation has no runtime cost
+
+---
+
+## Relationship to Other Guidelines
+
+- **[Code Style][code-style]** — Formatting, naming, and syntax conventions
+- **[Functional & Declarative Programming][functional-declarative]** — Range pipelines, output ranges, purity
+
+---
+
+## Quick Reference
+
+```d
+// IES is written with the i"..." prefix. It does NOT produce a string.
+// It produces a compile-time sequence of typed segments.
+
+import core.interpolation;  // auto-imported when IES is used, but explicit is clearer
+
+string name = "Alice";
+int count = 42;
+
+// Convert to string explicitly
+import std.conv : text;
+string greeting = i"Hello, $(name)! You have $(count) items.".text;
+
+// Pass directly to functions that accept IES (no allocation)
+import std.stdio : writeln;
+writeln(i"Hello, $(name)! You have $(count) items.");
+
+// WRONG — IES does not implicitly convert to string
+// string s = i"Hello, $(name)";  // COMPILE ERROR
+```
+
+---
+
+## 1. IES Literal Syntax
+
+IES has three literal forms. All use `$(expr)` for interpolation.
+
+### Syntax Forms
+
+| Form                           | Delimiter     | Escapes?                     | `$(...)` interpolation? |
+| ------------------------------ | ------------- | ---------------------------- | ----------------------- |
+| [`i"..."`](#double-quoted-ies) | Double quotes | Yes (`\n`, `\t`, `\$`, etc.) | Yes                     |
+| [`` i`...` ``](#wysiwyg-ies)   | Backticks     | No                           | Yes                     |
+| [`iq{...}`](#token-ies)        | `iq{` `}`     | No                           | Yes                     |
+
+**Note:** IES literals do NOT support character width suffixes (no `i"..."w` or `i"..."d`).
+
+### Double-Quoted IES {#double-quoted-ies}
+
+Standard form. Supports escape sequences (`\n`, `\t`, `\\`, `\$`, etc.).
+
+```d
+string msg = i"Name:\t$(name)\nCount:\t$(count)".text;
+// \$ produces a literal $ character
+string price = i"Price: \$$(amount)".text;
+```
+
+A bare `$` NOT followed by `(` is treated as a literal `$` — no escape needed:
+
+```d
+string s = i"costs $5 but $(variable) is interpolated".text;
+```
+
+### Wysiwyg IES {#wysiwyg-ies}
+
+Backtick-delimited. No escape sequences are recognized. What you type is what you get.
+
+```d
+string raw = i`no escapes here: \n is literal, $(expr) is interpolated`.text;
+```
+
+### Token IES {#token-ies}
+
+Must contain valid D tokens. No escape sequences. Useful for embedding D code fragments.
+
+```d
+auto tokens = iq{$(expr) + $(other)};
+```
+
+---
+
+## 2. Converting IES to a String {#converting-ies-to-a-string}
+
+IES does not implicitly convert to `string`. This is a deliberate safety decision to prevent injection vulnerabilities.
+
+### Using `std.conv.text` (Simple Cases)
+
+```d
+import std.conv : text;
+
+string name = "Alice";
+string result = i"Hello, $(name)!".text;
+assert(result == "Hello, Alice!");
+```
+
+### Using `std.stdio.writeln` (Direct Output, No Allocation)
+
+```d
+import std.stdio : writeln;
+writeln(i"Value: $(x)");  // No string allocation — writes segments directly
+```
+
+### @nogc Considerations
+
+`.text` allocates via GC. For @nogc code, write to output ranges instead (see [Output Range Integration](#output-range-integration)).
+
+**Rule:** Prefer passing IES directly to functions that accept it natively (like `writeln`) over converting to `string` first. This avoids unnecessary allocation and enables type-safe processing.
+
+---
+
+## 3. What IES Produces {#what-ies-produces}
+
+An IES literal is **not a string**. The compiler transforms it into a **sequence** of typed segments. Every IES sequence has this structure:
+
+```text
+InterpolationHeader, ...segments..., InterpolationFooter
+```
+
+Each segment is one of:
+
+| Segment Type                    | What It Represents                  | `toString()` Returns |
+| ------------------------------- | ----------------------------------- | -------------------- |
+| `InterpolationHeader`           | Start sentinel                      | `""` (empty)         |
+| `InterpolatedLiteral!"text"`    | Literal string portion              | The literal text     |
+| `InterpolatedExpression!"code"` | Source text of next expression      | `""` (empty)         |
+| _(the actual value)_            | The runtime value of the expression | _(its own type)_     |
+| `InterpolationFooter`           | End sentinel                        | `""` (empty)         |
+
+### Concrete Expansion Example
+
+```d
+string name = "Alice";
+int count = 3;
+auto ies = i"$(name) has $(count) items.";
+
+// The compiler expands this to a sequence equivalent to:
+// (
+//   InterpolationHeader(),
+//   InterpolatedExpression!"name"(),   // source text of expression
+//   name,                              // actual value: "Alice"
+//   InterpolatedLiteral!" has "(),     // literal text between expressions
+//   InterpolatedExpression!"count"(),  // source text of expression
+//   count,                             // actual value: 3
+//   InterpolatedLiteral!" items."(),   // trailing literal text
+//   InterpolationFooter()
+// )
+```
+
+### Key Properties
+
+- `InterpolatedLiteral` carries its string as a **compile-time template parameter**, accessible via `.toString()` or `is` expression.
+- `InterpolatedExpression` carries the source code of the expression as a **compile-time template parameter**, accessible via `.expression` enum.
+- The actual runtime values appear **directly in the sequence** after their corresponding `InterpolatedExpression`.
+- `core.interpolation` types are automatically imported when IES is used, but explicit `import core.interpolation;` is recommended for clarity in library code.
+- None of these structs carry runtime state.
+
+### Security: Why IES Does Not Convert to String Implicitly
+
+This segment structure is the foundation of IES's security model. Because each segment carries its type, library functions can distinguish trusted literals from untrusted values.
+
+The type system distinguishes between **literal text** (trusted, from source code) and **interpolated values** (untrusted, from variables). This is a critical safety property.
+
+#### The Problem with Naive String Building
+
+```d
+// Dangerous: manual string concatenation has no type-level safety
+string query = "SELECT * FROM users WHERE name = '" ~ userInput ~ "'";
+// If userInput = "'; DROP TABLE users; --" -> SQL injection
+```
+
+#### The IES Advantage
+
+A library function receiving an IES can inspect each segment's type at compile time:
+
+```d
+// The library sees:
+//   InterpolatedLiteral!"SELECT * FROM users WHERE name = '"  -> trusted literal
+//   InterpolatedExpression!"userInput"                         -> marker
+//   userInput                                                  -> UNTRUSTED value: escape it!
+//   InterpolatedLiteral!"'"                                    -> trusted literal
+```
+
+This enables the library to automatically apply context-appropriate escaping (SQL parameterization, HTML encoding, URL encoding, shell escaping) without any effort from the caller.
+
+#### Use Cases Enabled by This Design
+
+| Domain         | What the library does with interpolated values |
+| -------------- | ---------------------------------------------- |
+| SQL            | Parameterized queries (bind variables)         |
+| HTML           | HTML-entity encoding                           |
+| URLs           | Percent-encoding                               |
+| Shell commands | Shell escaping                                 |
+| Logging        | Structured field extraction                    |
+| i18n/l10n      | Reorderable message parameters                 |
+
+**Rule:** Library authors SHOULD provide IES-accepting overloads rather than requiring callers to use `.text`. This preserves safety and avoids unnecessary allocation.
+
+**Rule:** Library authors MUST NOT `mixin()` the string from `InterpolatedExpression`. It comes from a different scope and will fail. The string is informational only.
+
+---
+
+## 4. Writing Functions That Accept IES {#writing-functions-that-accept-ies}
+
+### Recommended Pattern: Variadic Template with Header/Footer Guards
+
+```d
+import core.interpolation;
+
+void processIES(Sequence...)(
+    InterpolationHeader,
+    Sequence data,
+    InterpolationFooter
+)
+{
+    // Process `data` here.
+    // `data` contains interleaved InterpolatedLiteral, InterpolatedExpression,
+    // and actual values.
+}
+
+// Usage:
+string name = "Alice";
+processIES(i"Hello, $(name)!");
+```
+
+The `InterpolationHeader`/`InterpolationFooter` parameters act as type-level guards that ensure the function is only called with an IES, and they delimit the interpolation boundary.
+
+### Iterating Over Segments at Compile Time
+
+```d
+import core.interpolation;
+import std.array : appender;
+
+string iesConcat(Sequence...)(InterpolationHeader, Sequence data, InterpolationFooter)
+{
+    import std.conv : to;
+    auto result = appender!string;
+
+    static foreach (item; data)
+    {
+        // InterpolatedLiteral — a literal string fragment
+        static if (is(typeof(item) == InterpolatedLiteral!str, string str))
+        {
+            result ~= str;
+        }
+        // InterpolatedExpression — skip (it's metadata only)
+        else static if (is(typeof(item) == InterpolatedExpression!code, string code))
+        {
+            // `code` contains the source text, e.g. "name"
+            // Typically skip this; it's informational only.
+        }
+        // Actual runtime value
+        else
+        {
+            result ~= to!string(item);
+        }
+    }
+    return result[];
+}
+```
+
+### Compile-Time Template Parameter Usage
+
+IES can also be passed as template arguments, enabling compile-time processing including types:
+
+```d
+import core.interpolation;
+
+template processAtCompileTime(InterpolationHeader header, Sequence...)
+{
+    static assert(Sequence[$ - 1] == InterpolationFooter());
+    // Process Sequence at compile time...
+}
+
+alias result = processAtCompileTime!(i"Type is: $(int)");
+```
+
+### Output Range Integration
+
+The patterns above use `appender!string` as the output sink. For `@nogc` contexts or streaming output, the same approach works with output ranges.
+
+#### Writing to Output Ranges
+
+```d
+import core.interpolation;
+import std.conv : to;
+import std.range.primitives : isOutputRange, put;
+
+void writeInterpolated(Writer, Args...)(
+    ref Writer w,
+    InterpolationHeader,
+    Args args,
+    InterpolationFooter
+)
+if (isOutputRange!(Writer, char))
+{
+    static foreach (arg; args)
+    {
+        static if (is(typeof(arg) == InterpolatedLiteral!str, string str))
+            put(w, str);
+        else static if (is(typeof(arg) == InterpolatedExpression!expr, string expr))
+        {
+            // Skip metadata
+        }
+        else
+            put(w, arg.to!string);
+    }
+}
+```
+
+For a production implementation of this pattern, see the [`styled_template` module][styled-template-src], where [`writeStyled()`][styled-template-src] processes IES into styled terminal output via an output range.
+
+#### @nogc with SmallBuffer
+
+For @nogc contexts, use `SmallBuffer` and avoid `.to!string`:
+
+```d
+import core.interpolation;
+import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+// Usage
+SmallBuffer!(char, 256) buf;
+// Custom @nogc IES processing with integer-to-string conversion
+// that doesn't allocate...
+```
+
+---
+
+## 5. Complete Patterns
+
+The patterns in this section are adapted from Adam D. Ruppe's [interpolation-examples][interpolation-examples] repository, which demonstrates real-world IES use cases.
+
+### Pattern: Safe SQL Query Builder
+
+```d
+import core.interpolation;
+
+struct SafeQuery
+{
+    string sql;
+    string[] params;
+}
+
+SafeQuery buildQuery(Sequence...)(InterpolationHeader, Sequence data, InterpolationFooter)
+{
+    import std.conv : to;
+    import std.array : appender;
+
+    auto sql = appender!string;
+    string[] params;
+
+    static foreach (item; data)
+    {
+        static if (is(typeof(item) == InterpolatedLiteral!str, string str))
+        {
+            sql ~= str;
+        }
+        else static if (is(typeof(item) == InterpolatedExpression!code, string code))
+        {
+            // skip expression metadata
+        }
+        else
+        {
+            sql ~= "?";
+            params ~= to!string(item);
+        }
+    }
+
+    return SafeQuery(sql[], params);
+}
+
+// Usage:
+string userName = "Alice'; DROP TABLE users; --";
+auto q = buildQuery(i"SELECT * FROM users WHERE name = $(userName)");
+assert(q.sql == "SELECT * FROM users WHERE name = ?");
+assert(q.params == ["Alice'; DROP TABLE users; --"]);
+```
+
+::: info Attribution
+Adapted from [`lib/sql.d`][interpolation-examples-sql] in Adam D. Ruppe's interpolation-examples. The original uses compile-time query construction with `execi()` for a real SQLite binding.
+:::
+
+### Pattern: HTML Template with Auto-Escaping
+
+```d
+import core.interpolation;
+import std.array : appender, replace;
+
+string htmlEscape(string s)
+{
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+            .replace("\"", "&quot;").replace("'", "&#39;");
+}
+
+string safeHtml(Sequence...)(InterpolationHeader, Sequence data, InterpolationFooter)
+{
+    auto result = appender!string;
+
+    static foreach (item; data)
+    {
+        static if (is(typeof(item) == InterpolatedLiteral!str, string str))
+        {
+            result ~= str;  // Trusted literal: pass through
+        }
+        else static if (is(typeof(item) == InterpolatedExpression!code, string code))
+        {
+            // skip
+        }
+        else static if (is(typeof(item) : string))
+        {
+            result ~= htmlEscape(item);  // Untrusted value: escape!
+        }
+        else
+        {
+            import std.conv : to;
+            result ~= htmlEscape(to!string(item));
+        }
+    }
+
+    return result[];
+}
+
+// Usage:
+string userInput = "<script>alert('xss')</script>";
+string html = safeHtml(i"<p>Hello, $(userInput)!</p>");
+// Result: <p>Hello, &lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;!</p>
+```
+
+::: info Attribution
+Adapted from [`lib/html.d`][interpolation-examples-html] in Adam D. Ruppe's interpolation-examples. The original includes compile-time HTML structure validation and returns a DOM `Element`.
+:::
+
+### Pattern: URL Encoding
+
+```d
+import core.interpolation;
+import std.array : appender;
+import std.conv : to;
+import std.uri : encodeComponent;
+
+string urlSafe(Args...)(InterpolationHeader, Args args, InterpolationFooter)
+{
+    auto result = appender!string;
+
+    static foreach (arg; args)
+    {
+        static if (is(typeof(arg) == InterpolatedLiteral!str, string str))
+            result ~= str;
+        else static if (is(typeof(arg) == InterpolatedExpression!expr, string expr))
+        {
+            // Skip metadata
+        }
+        else
+            result ~= encodeComponent(arg.to!string);
+    }
+
+    return result[];
+}
+
+// Usage
+auto query = "hello world & goodbye";
+auto url = urlSafe(i"https://example.com/search?q=$(query)");
+// Result: "https://example.com/search?q=hello%20world%20%26%20goodbye"
+```
+
+::: info Attribution
+Adapted from [`lib/url.d`][interpolation-examples-url] in Adam D. Ruppe's interpolation-examples. The original uses a state machine to apply context-appropriate encoding to different URL components.
+:::
+
+### Pattern: Structured Logging
+
+```d
+import core.interpolation;
+import std.conv : to;
+import std.array : appender;
+
+void logStructured(Sequence...)(InterpolationHeader, Sequence data, InterpolationFooter)
+{
+    auto message = appender!string;
+    string[string] fields;
+
+    static foreach (idx, item; data)
+    {
+        static if (is(typeof(item) == InterpolatedLiteral!str, string str))
+        {
+            message ~= str;
+        }
+        else static if (is(typeof(item) == InterpolatedExpression!code, string code))
+        {
+            // The next element in the sequence is the actual value.
+            // Store as a named field for structured logging.
+            fields[code] = to!string(data[idx + 1]);
+        }
+        else
+        {
+            message ~= to!string(item);
+        }
+    }
+
+    import std.stdio : writefln;
+    writefln!"msg=%s fields=%s"(message[], fields);
+}
+
+// Usage:
+string user = "Alice";
+int latency = 42;
+logStructured(i"Request from $(user) took $(latency)ms");
+// Output: msg=Request from Alice took 42ms fields=["user": "Alice", "latency": "42"]
+```
+
+::: info Attribution
+Inspired by the internationalization example ([`04-internationalization.d`][interpolation-examples-i18n]) in Adam D. Ruppe's interpolation-examples, which uses `InterpolatedExpression` to extract named parameters for reorderable message templates.
+:::
+
+### Real-World: `styled_template`
+
+The sparkles [`styled_template`][styled-template-src] module applies the same IES patterns shown above to build a styled terminal output system. Its core function, `writeStyled()`, accepts IES and writes ANSI-styled text to any output range:
+
+```d
+void writeStyled(Writer, Args...)(
+    ref Writer w,
+    InterpolationHeader,
+    Args args,
+    InterpolationFooter
+)
+{
+    import std.conv : to;
+    import std.range.primitives : put;
+
+    ParserContext ctx;
+
+    static foreach (arg; args)
+    {{
+        alias T = typeof(arg);
+        static if (is(T == InterpolatedLiteral!lit, string lit))
+        {
+            parseLiteral(w, lit, ctx);
+        }
+        else static if (is(T == InterpolatedExpression!code, string code))
+        {
+            // Skip expression metadata
+        }
+        else
+        {
+            // Output interpolated value - styles already active from block
+            put(w, arg.to!string);
+        }
+    }}
+}
+```
+
+The three-branch `static if` dispatch — literal, expression metadata, runtime value — is the same core pattern used in every example above. The difference is that `parseLiteral` interprets a `{style ...}` mini-language within literal segments to emit ANSI escape codes.
+
+Consumer-side examples:
+
+- [`libs/core-cli/examples/styled_template.d`][example-styled-template] — comprehensive demo of style syntax (colors, bold, nesting, negation)
+- [`libs/core-cli/examples/box.d`][example-box] — box drawing with styled IES content
+- [`libs/core-cli/examples/table.d`][example-table] — table rendering with styled headers
+- [`scripts/run_md_examples.d`][run-md-examples] — CLI status and progress output using IES
+
+---
+
+## 6. When to Use IES vs Alternatives
+
+### Use IES When
+
+- Building user-facing messages with embedded values
+- Context-aware encoding is needed (SQL, HTML, URLs)
+- You want compile-time metadata about the template structure
+- Passing to functions that process the sequence directly
+
+### Use `std.format` / `writef` When
+
+- You need format specifiers (`%08x`, `%.2f`, `%10s`)
+- Building strings for `printf`-style APIs
+- Maximum control over output formatting
+
+### Decision Matrix
+
+| Scenario                 | Recommendation            |
+| ------------------------ | ------------------------- |
+| CLI output messages      | IES with `writeln`        |
+| SQL queries              | IES with parameterization |
+| HTML generation          | IES with entity encoding  |
+| Hex/binary formatting    | `std.format`              |
+| Log messages with values | IES                       |
+| @nogc string building    | IES with output ranges    |
+
+---
+
+## 7. Common Mistakes {#common-mistakes}
+
+### Assigning IES Directly to a String
+
+```d
+string s = i"Hello, $(name)";  // COMPILE ERROR
+```
+
+**Fix:** Use `.text` or pass to an IES-accepting function:
+
+```d
+import std.conv : text;
+string s = i"Hello, $(name)".text;
+```
+
+### Trying to Mixin an InterpolatedExpression
+
+```d
+// Inside a library function processing IES:
+mixin(code);  // FAILS — wrong scope
+```
+
+**Fix:** Use the actual runtime value that follows the `InterpolatedExpression` in the sequence. Never mixin the expression string.
+
+### Assuming IES is a Single Value
+
+```d
+auto x = i"Hello $(name)";
+writeln(typeof(x).stringof);  // It's a sequence, not a string!
+```
+
+**Fix:** Understand that `x` is a sequence. Index it or pass it to a variadic function.
+
+### Forgetting that `$` Without `(` is Literal
+
+```d
+string s = i"costs $5".text;     // Fine — bare $ is literal
+string s = i"costs \$5".text;    // Also fine — \$ is explicit escape
+string s = i"$(price) USD".text; // Interpolation with $(...)
+```
+
+### Not Handling Empty InterpolatedExpression
+
+Library code should be robust against implementations that omit `InterpolatedExpression` or provide an empty string. Do not depend on it always being present:
+
+```d
+// Robust: handle both with and without InterpolatedExpression
+else static if (is(typeof(item) == InterpolatedExpression!code, string code))
+{
+    // May be empty or missing entirely — handle gracefully
+}
+```
+
+### IES Syntax in DDoc Comments
+
+IES and DDoc both use `$(...)` syntax. When writing DDoc comments that mention IES, the `$(expr)` in prose text will be interpreted as a DDoc macro:
+
+```d
+/**
+Use `i"Hello $(name)"` for interpolation.    ← $(name) vanishes!
+Use `i"Hello $(DOLLAR)$(LPAREN)name$(RPAREN)"` instead.  ← renders correctly
+*/
+```
+
+This does NOT affect actual IES code in function bodies or unittest bodies — only DDoc comment text. Inside `---` code blocks in DDoc comments, `$(...)` is preserved literally. See [DDoc Guidelines][ddoc-ies] for the full interaction rules.
+
+---
+
+## 8. Advanced Usage
+
+The following topics cover less common but powerful IES capabilities for library authors and advanced use cases.
+
+### Compile-Time Introspection
+
+All IES segment types support compile-time inspection:
+
+```d
+string name = "Alice";
+auto ies = i"Hello, $(name)!";
+
+// Type checks
+static assert(is(typeof(ies[0]) == InterpolationHeader));
+static assert(is(typeof(ies[$ - 1]) == InterpolationFooter));
+
+// Literal string access at compile time
+static assert(ies[1].toString() == "Hello, ");
+
+// Expression source text access at compile time
+static assert(ies[2].expression == "name");
+
+// Runtime value
+assert(ies[3] == "Alice");
+```
+
+#### Building Format Strings at Compile Time
+
+```d
+import core.interpolation;
+
+template makeFormatString(Args...)
+{
+    enum string makeFormatString = ()
+    {
+        string result;
+        static foreach (arg; Args)
+        {
+            static if (is(arg == InterpolatedLiteral!str, string str))
+                result ~= str;
+            else static if (is(arg == InterpolatedExpression!expr, string expr))
+            {
+                // Skip
+            }
+            else static if (is(arg == InterpolationHeader) || is(arg == InterpolationFooter))
+            {
+                // Skip
+            }
+            else
+                result ~= "%s";  // Placeholder for value
+        }
+        return result;
+    }();
+}
+
+// Validate at compile time with static assert
+enum fmt = makeFormatString!(typeof(i"Value: $(42)".expand));
+static assert(fmt == "Value: %s");
+```
+
+### IES and Nesting
+
+IES can nest. Each nested IES produces its own `InterpolationHeader`/`InterpolationFooter` pair. Library code processing IES should track nesting depth if it matters:
+
+```d
+auto nested = i"outer $(i"inner $(value)") end";
+// This produces nested Header/Footer pairs
+```
+
+---
+
+## 9. Quick-Reference Checklist
+
+- [ ] **IES produces a sequence, not a string.** Never assign to `string` directly. [→ §3](#what-ies-produces)
+- [ ] **Use `.text` for simple string conversion.** `import std.conv : text;` then `i"...".text`. [→ §2](#converting-ies-to-a-string)
+- [ ] **Use `writeln` for direct output.** It accepts IES natively with zero allocation. [→ §2](#converting-ies-to-a-string)
+- [ ] **Write IES-accepting functions** with the `(InterpolationHeader, Sequence data, InterpolationFooter)` signature pattern. [→ §4](#writing-functions-that-accept-ies)
+- [ ] **Distinguish literals from values** using `static if` with `is(typeof(item) == InterpolatedLiteral!str, string str)`. [→ §4](#writing-functions-that-accept-ies)
+- [ ] **Never mixin InterpolatedExpression.** The `.expression` member is informational only. [→ §7](#common-mistakes)
+- [ ] **Escape interpolated values, not literals** in security-sensitive contexts (SQL, HTML, URLs). [→ §3](#security-why-ies-does-not-convert-to-string-implicitly)
+- [ ] **Prefer IES-native overloads** over `.text` conversion in library APIs. [→ §3](#security-why-ies-does-not-convert-to-string-implicitly)
+- [ ] **`core.interpolation` is auto-imported** when IES is used, but import explicitly in library code for clarity. [→ §3](#key-properties)
+- [ ] **Handle missing/empty `InterpolatedExpression`** — don't assume it's always present. [→ §7](#common-mistakes)
+
+---
+
+## References
+
+- [D Spec: Interpolation Expression Sequences][d-spec-ies] — Language specification
+- [core.interpolation module][core-interpolation] — Runtime support types
+- [DIP1036 — String Interpolation][dip1036] — Design rationale
+- [Adam D. Ruppe's interpolation-examples][interpolation-examples] — Real-world IES use cases (SQL, HTML, URLs, i18n)
+
+<!-- Guidelines -->
+
+[code-style]: code-style.md
+[functional-declarative]: functional-declarative-programming-guidelines.md
+[ddoc]: ddoc.md
+[ddoc-ies]: ddoc.md#ies--in-ddoc-comments
+
+<!-- D language references -->
+
+[d-spec-ies]: https://dlang.org/spec/istring.html
+[core-interpolation]: https://dlang.org/phobos/core_interpolation.html
+[dip1036]: https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1036.md
+
+<!-- Adam D. Ruppe's interpolation-examples -->
+
+[interpolation-examples]: https://github.com/adamdruppe/interpolation-examples
+[interpolation-examples-sql]: https://github.com/adamdruppe/interpolation-examples/blob/master/lib/sql.d
+[interpolation-examples-html]: https://github.com/adamdruppe/interpolation-examples/blob/master/lib/html.d
+[interpolation-examples-url]: https://github.com/adamdruppe/interpolation-examples/blob/master/lib/url.d
+[interpolation-examples-i18n]: https://github.com/adamdruppe/interpolation-examples/blob/master/04-internationalization.d
+
+<!-- Sparkles source files -->
+
+[styled-template-src]: ../../libs/core-cli/src/sparkles/core_cli/styled_template.d
+[example-styled-template]: ../../libs/core-cli/examples/styled_template.d
+[example-box]: ../../libs/core-cli/examples/box.d
+[example-table]: ../../libs/core-cli/examples/table.d
+[run-md-examples]: ../../scripts/run_md_examples.d

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+---
+layout: home
+
+hero:
+  name: Sparkles
+  text: CLI Utilities for D
+  tagline: Terminal styling, pretty-printing, TUI components, and @nogc support for building beautiful command-line applications.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /overview
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/PetarKirov/sparkles
+
+features:
+  - title: core-cli
+    details: Terminal styling with ANSI colors, pretty-printing for any D type, UI components (tables, boxes, headers), and styled templates using Interpolated Expression Sequences.
+---

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,384 @@
+# core-cli Package Overview
+
+A D library providing utilities for building CLI applications with terminal styling, pretty-printing, UI components, and @nogc support.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Terminal Styling](#terminal-styling)
+- [Styled Templates (IES)](#styled-templates-ies)
+- [Pretty Printing](#pretty-printing)
+- [UI Components](#ui-components)
+  - [Tables](#tables)
+  - [Boxes](#boxes)
+  - [Headers](#headers)
+- [SmallBuffer (@nogc)](#smallbuffer-nogc)
+- [Running Examples](#running-examples)
+
+## Installation
+
+Add `sparkles:core-cli` as a dependency:
+
+::: code-group
+
+```sdl [dub.sdl]
+dependency "sparkles:core-cli" version="*"
+```
+
+```json [dub.json]
+"dependencies": {
+    "sparkles:core-cli": "*"
+}
+```
+
+:::
+
+## Terminal Styling
+
+The `term_style` module provides ANSI terminal colors and text attributes.
+
+### Style Enum
+
+Available styles include:
+
+- **Colors**: `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`
+- **Bright colors**: `brightRed`, `brightGreen`, `brightYellow`, etc.
+- **Background**: `bgRed`, `bgGreen`, `bgBlue`, etc.
+- **Attributes**: `bold`, `dim`, `italic`, `underline`, `strikethrough`, `inverse`
+
+### Basic Usage
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "styledemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.term_style : Style, stylize;
+
+void main()
+{
+    writeln("Error: ".stylize(Style.red) ~ "Something went wrong");
+    writeln("Success: ".stylize(Style.green) ~ "Operation completed");
+    writeln("Warning".stylize(Style.bold).stylize(Style.yellow));
+}
+```
+
+### Compile-Time Builder
+
+For CTFE-compatible styling, use `stylizedTextBuilder`:
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "builderdemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.term_style : stylizedTextBuilder;
+
+void main()
+{
+    // Chain multiple styles fluently
+    enum styledText = "Important".stylizedTextBuilder.bold.underline.red;
+    writeln(styledText);
+}
+```
+
+## Styled Templates (IES)
+
+The `styled_template` module provides a template syntax for applying terminal styles using D's Interpolated Expression Sequences (IES).
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "styledtemplatedemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import sparkles.core_cli.styled_template;
+
+void main()
+{
+    int cpu = 75;
+    styledWriteln(i"CPU: {red $(cpu)%} Status: {green OK}");
+}
+```
+
+### Syntax Reference
+
+::: v-pre
+
+| Syntax                     | Description                          |
+| -------------------------- | ------------------------------------ |
+| `{red text}`               | Apply single style                   |
+| `{bold.red text}`          | Chain multiple styles                |
+| `{bold outer {red inner}}` | Nested blocks (inner inherits outer) |
+| `{red text {~red normal}}` | Negation with `~` removes a style    |
+| `{{`                       | Escaped literal `{`                  |
+| `}}`                       | Escaped literal `}`                  |
+
+:::
+
+### Available Functions
+
+| Function                      | Description                                  |
+| ----------------------------- | -------------------------------------------- |
+| `styledText(i"...")`          | Returns styled string                        |
+| `styledWriteln(i"...")`       | Writes to stdout with newline                |
+| `styledWrite(i"...")`         | Writes to stdout without newline             |
+| `styled(i"...")`              | Returns lazy wrapper for deferred processing |
+| `writeStyled(writer, i"...")` | Writes to any output range                   |
+
+### More Examples
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "styledexamples"
+    dependency "sparkles:core-cli" version="*"
++/
+import sparkles.core_cli.styled_template;
+
+void main()
+{
+    // Chained styles
+    styledWriteln(i"{bold.italic.green Bold italic green text}");
+
+    // Nested with inheritance
+    styledWriteln(i"{bold Bold {red bold+red} back to bold}");
+
+    // Style negation
+    styledWriteln(i"{bold.red Both {~red just bold} both again}");
+
+    // Practical usage
+    string file = "main.d";
+    int errors = 3;
+    styledWriteln(i"{dim $(file):} {red.bold $(errors) errors}");
+
+    // Escaped braces for literals
+    styledWriteln(i"Use {{style text}} syntax");
+}
+```
+
+## Pretty Printing
+
+The `prettyprint` module formats any D type with syntax highlighting.
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "prettyprintdemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.prettyprint : prettyPrint, PrettyPrintOptions;
+
+struct Server { string host; int port; bool ssl; }
+
+void main()
+{
+    auto server = Server("localhost", 8080, true);
+    writeln(prettyPrint(server));
+
+    // Custom options
+    int[] numbers = [1, 2, 3, 4, 5];
+    writeln(prettyPrint(numbers, PrettyPrintOptions(useColors: false)));
+}
+```
+
+### PrettyPrintOptions
+
+| Option         | Default | Description                                            |
+| -------------- | ------- | ------------------------------------------------------ |
+| `indentStep`   | 2       | Spaces per indent level                                |
+| `maxDepth`     | 8       | Maximum recursion depth                                |
+| `maxItems`     | 32      | Max items shown for arrays/AAs                         |
+| `softMaxWidth` | 80      | Try single-line if output fits (0 = always multi-line) |
+| `useColors`    | true    | Enable ANSI colors                                     |
+
+## UI Components
+
+### Tables
+
+Render data as ASCII tables with Unicode box-drawing characters.
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "tabledemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.ui.table : drawTable;
+import sparkles.core_cli.term_style : Style, stylize;
+
+void main()
+{
+    string[][] data = [
+        ["Name".stylize(Style.bold), "Status".stylize(Style.bold)],
+        ["web-01", "Running".stylize(Style.green)],
+        ["web-02", "Stopped".stylize(Style.red)],
+    ];
+    writeln(drawTable(data));
+}
+```
+
+Output:
+
+```text
+╭────────┬─────────╮
+│ Name   │ Status  │
+├────────┼─────────┤
+│ web-01 │ Running │
+│ web-02 │ Stopped │
+╰────────┴─────────╯
+```
+
+### Boxes
+
+Draw bordered boxes around content with optional titles.
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "boxdemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.ui.box : drawBox;
+
+void main()
+{
+    writeln(["Line 1", "Line 2", "Line 3"].drawBox("My Box"));
+}
+```
+
+Output:
+
+```text
+╭──╼ My Box ╾───╮
+│ Line 1        │
+│ Line 2        │
+│ Line 3        │
+╰───────────────╯
+```
+
+#### Box with Footer
+
+Use `BoxProps` to add a footer to boxes:
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "boxfooterdemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.ui.box : drawBox, BoxProps;
+
+void main()
+{
+    writeln(["Processing..."].drawBox("Status", BoxProps(footer: "Press Q to cancel")));
+}
+```
+
+Output:
+
+```text
+╭──╼ Status ╾──────────────╮
+│ Processing...            │
+╰──╼ Press Q to cancel ╾───╯
+```
+
+### Headers
+
+Create section dividers and banners.
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "headerdemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.ui.header : drawHeader, HeaderProps, HeaderStyle;
+
+void main()
+{
+    // Divider style (default)
+    writeln("Configuration".drawHeader);
+
+    // Banner style
+    writeln("Main Section".drawHeader(HeaderProps(
+        style: HeaderStyle.banner,
+        width: 30
+    )));
+}
+```
+
+Output:
+
+```text
+── Configuration ──
+
+══════════════════════════════
+         Main Section
+══════════════════════════════
+```
+
+## SmallBuffer (@nogc)
+
+A `@nogc` container with Small Buffer Optimization (SBO). Stores small data inline, automatically switches to heap when capacity is exceeded.
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "smallbufferdemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+void main()
+{
+    // 64 chars inline, heap if exceeded
+    SmallBuffer!(char, 64) buf;
+
+    buf ~= "Hello";
+    buf ~= ' ';
+    buf ~= "World";
+
+    writeln(buf[]);  // "Hello World"
+    writeln("On heap: ", buf.onHeap);  // false
+}
+```
+
+### Key Features
+
+- **@nogc @safe**: No garbage collector allocations in hot paths
+- **Output range**: Works with `std.algorithm` and other range-based APIs
+- **Automatic growth**: Switches to heap allocation when needed
+- **Slicing**: Access elements via `buf[]` or `buf[start..end]`
+
+## Running Examples
+
+Examples in `libs/core-cli/examples/` are standalone runnable files:
+
+```bash
+# Run directly with dub
+dub run --single libs/core-cli/examples/prettyprint.d
+
+# Or make executable and run
+chmod +x libs/core-cli/examples/color.d
+./libs/core-cli/examples/color.d
+```
+
+Available examples:
+
+- `color.d` - Style and color palette showcase
+- `prettyprint.d` - Type formatting demonstration
+- `styled_template.d` - IES-based template styling
+- `table.d` - Table rendering variations
+- `box.d` - Box layouts with nested content
+- `header.d` - Header styles

--- a/libs/core-cli/examples/box.d
+++ b/libs/core-cli/examples/box.d
@@ -117,6 +117,26 @@ void main()
                     active: true,
                 ).prettyPrint(PrettyPrintOptions(softMaxWidth: 60)).drawBox("Cluster"),
             ),
+            Section(
+                header: "Box with Footer",
+                content: [
+                    "Build started at 14:32:01",
+                    "Compiling 42 modules...",
+                    "Linking executable...",
+                    "Build completed in 3.2s",
+                ].drawBox("Build Log", BoxProps(footer: "✓ Success".stylize(Style.green))),
+            ),
+            Section(
+                header: "Task Status with Footer",
+                content: [
+                    "Task:      ".stylize(Style.bold) ~ "Deploy to production",
+                    "Started:   ".stylize(Style.bold) ~ "2024-01-15 10:30",
+                    "Duration:  ".stylize(Style.bold) ~ "45 seconds",
+                ].drawBox(
+                    "deploy-v2.1.0".stylize(Style.cyan),
+                    BoxProps(footer: "✗ Failed".stylize(Style.red)),
+                ),
+            ),
         ],
     );
 }

--- a/libs/core-cli/examples/box.d
+++ b/libs/core-cli/examples/box.d
@@ -12,7 +12,7 @@ import sparkles.core_cli.ui.box : drawBox, BoxProps;
 import sparkles.core_cli.ui.demo : Section, runDemo;
 import sparkles.core_cli.ui.table : drawTable;
 import sparkles.core_cli.term_style : Style, stylize, styleSample;
-import sparkles.core_cli.term_style : stb = stylizedTextBuilder;
+import sparkles.core_cli.styled_template : styledText;
 import sparkles.core_cli.prettyprint : prettyPrint, PrettyPrintOptions;
 
 struct Config
@@ -50,10 +50,10 @@ void main()
             Section(
                 header: "Box with Styled Content",
                 content: [
-                    "Status:    ".stylize(Style.bold) ~ "Running".stylize(Style.green),
-                    "Mode:      ".stylize(Style.bold) ~ "Production".stylize(Style.yellow),
-                    "Health:    ".stylize(Style.bold) ~ "Healthy".stylize(Style.brightGreen),
-                    "Uptime:    ".stylize(Style.bold) ~ "3 days, 14 hours".stylize(Style.cyan),
+                    styledText(i"{bold Status:    }{green Running}"),
+                    styledText(i"{bold Mode:      }{yellow Production}"),
+                    styledText(i"{bold Health:    }{brightGreen Healthy}"),
+                    styledText(i"{bold Uptime:    }{cyan 3 days, 14 hours}"),
                 ].drawBox("Status"),
             ),
             Section(
@@ -82,25 +82,25 @@ void main()
             Section(
                 header: "Dashboard Example",
                 content: [
-                    ["Metric".stylize(Style.bold), "Value".stylize(Style.bold), "Status".stylize(Style.bold)],
-                    ["CPU Usage", "45%", "OK".stylize(Style.green)],
-                    ["Memory", "2.1 GB", "OK".stylize(Style.green)],
-                    ["Disk", "89%", "Warning".stylize(Style.yellow)],
-                    ["Network", "1.2 Gbps", "OK".stylize(Style.green)],
+                    [styledText(i"{bold Metric}"), styledText(i"{bold Value}"), styledText(i"{bold Status}")],
+                    ["CPU Usage", "45%", styledText(i"{green OK}")],
+                    ["Memory", "2.1 GB", styledText(i"{green OK}")],
+                    ["Disk", "89%", styledText(i"{yellow Warning}")],
+                    ["Network", "1.2 Gbps", styledText(i"{green OK}")],
                 ].drawTable.drawBox("Metrics"),
             ),
             Section(
                 header: "Color Palette Box",
                 content: [
-                    "Foreground Colors:".stylize(Style.bold),
+                    styledText(i"{bold Foreground Colors:}"),
                     "  " ~ [Style.red, Style.green, Style.yellow, Style.blue, Style.magenta, Style.cyan]
                         .map!styleSample.joiner(" ").to!string,
                     "",
-                    "Bright Colors:".stylize(Style.bold),
+                    styledText(i"{bold Bright Colors:}"),
                     "  " ~ [Style.brightRed, Style.brightGreen, Style.brightYellow, Style.brightBlue]
                         .map!styleSample.joiner(" ").to!string,
                     "",
-                    "Styles:".stylize(Style.bold),
+                    styledText(i"{bold Styles:}"),
                     "  " ~ [Style.bold, Style.dim, Style.italic, Style.underline, Style.strikethrough]
                         .map!styleSample.joiner(" ").to!string,
                 ].drawBox("Styles"),
@@ -124,17 +124,17 @@ void main()
                     "Compiling 42 modules...",
                     "Linking executable...",
                     "Build completed in 3.2s",
-                ].drawBox("Build Log", BoxProps(footer: "✓ Success".stylize(Style.green))),
+                ].drawBox("Build Log", BoxProps(footer: styledText(i"{green ✓ Success}"))),
             ),
             Section(
                 header: "Task Status with Footer",
                 content: [
-                    "Task:      ".stylize(Style.bold) ~ "Deploy to production",
-                    "Started:   ".stylize(Style.bold) ~ "2024-01-15 10:30",
-                    "Duration:  ".stylize(Style.bold) ~ "45 seconds",
+                    styledText(i"{bold Task:      }Deploy to production"),
+                    styledText(i"{bold Started:   }2024-01-15 10:30"),
+                    styledText(i"{bold Duration:  }45 seconds"),
                 ].drawBox(
-                    "deploy-v2.1.0".stylize(Style.cyan),
-                    BoxProps(footer: "✗ Failed".stylize(Style.red)),
+                    styledText(i"{cyan deploy-v2.1.0}"),
+                    BoxProps(footer: styledText(i"{red ✗ Failed}")),
                 ),
             ),
         ],

--- a/libs/core-cli/examples/styled_template.d
+++ b/libs/core-cli/examples/styled_template.d
@@ -1,0 +1,146 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "styled_template"
+    dependency "sparkles:core-cli" version="*"
+    targetPath "build"
++/
+
+import sparkles.core_cli.styled_template;
+import sparkles.core_cli.ui.box : drawBox;
+import sparkles.core_cli.ui.demo : Section, runDemo;
+
+void main()
+{
+    runDemo(
+        header: "styledTemplate Demo - IES Style Syntax",
+        content: [
+            Section(
+                header: "Single Style",
+                content: [
+                    styledText(i"{red This text is red}"),
+                    styledText(i"{green This text is green}"),
+                    styledText(i"{blue This text is blue}"),
+                    styledText(i"{yellow This text is yellow}"),
+                ].drawBox("Colors"),
+            ),
+            Section(
+                header: "Chained Styles",
+                content: [
+                    styledText(i"{bold.red Bold and red}"),
+                    styledText(i"{italic.cyan Italic and cyan}"),
+                    styledText(i"{underline.magenta Underlined magenta}"),
+                    styledText(i"{bold.italic.green Bold, italic, and green}"),
+                ].drawBox("Combined"),
+            ),
+            Section(
+                header: "Text Attributes",
+                content: [
+                    styledText(i"{bold Bold text}"),
+                    styledText(i"{dim Dim text}"),
+                    styledText(i"{italic Italic text}"),
+                    styledText(i"{underline Underlined text}"),
+                    styledText(i"{strikethrough Strikethrough text}"),
+                ].drawBox("Attributes"),
+            ),
+            Section(
+                header: "Background Colors",
+                content: [
+                    styledText(i"{bgRed White on red}"),
+                    styledText(i"{bgGreen Black on green}"),
+                    styledText(i"{bgBlue White on blue}"),
+                    styledText(i"{bgYellow.black Black on yellow}"),
+                ].drawBox("Backgrounds"),
+            ),
+            Section(
+                header: "Nested Blocks",
+                content: [
+                    styledText(i"{bold Bold {red with red} back to bold}"),
+                    styledText(i"{cyan Cyan {bold.underline bold underlined} just cyan}"),
+                    styledText(i"{dim Dim {brightWhite bright} dim again}"),
+                ].drawBox("Nesting"),
+            ),
+            Section(
+                header: "Style Negation",
+                content: [
+                    styledText(i"{bold.red Bold red {~red just bold} bold red again}"),
+                    styledText(i"{italic.underline Both {~italic underline only} both}"),
+                ].drawBox("Negation with ~"),
+            ),
+            Section(
+                header: "Complex Combinations",
+                content: complexExamples().drawBox("Advanced"),
+            ),
+            Section(
+                header: "With Interpolation",
+                content: interpolationExamples().drawBox("Variables"),
+            ),
+            Section(
+                header: "Escaped Braces",
+                content: [
+                    styledText(i"Use {{style text}} syntax for styling"),
+                    styledText(i"{bold Literal braces: {{these}} are not styles}"),
+                    styledText(i`JSON example: {{"key": "value"}}`),
+                ].drawBox("Escaping"),
+            ),
+            Section(
+                header: "Practical Examples",
+                content: practicalExamples().drawBox("Real World"),
+            ),
+        ],
+    );
+}
+
+string[] interpolationExamples()
+{
+    int cpu = 75;
+    int memory = 42;
+    string status = "running";
+    double temperature = 65.5;
+
+    return [
+        styledText(i"CPU: {red $(cpu)%}"),
+        styledText(i"Memory: {green $(memory)%}"),
+        styledText(i"Status: {bold.cyan $(status)}"),
+        styledText(i"Temp: {yellow $(temperature)}C"),
+    ];
+}
+
+string[] complexExamples()
+{
+    return [
+        // Deep nesting: 4 levels with style changes at each
+        styledText(i"{bold.italic.red L1:{~red.underline L2:{cyan L3:{~bold.~italic L4}L3}L2}L1}"),
+
+        // Multiple negations then restore
+        styledText(i"{bold.italic.underline ALL {~bold.~underline just italic} ALL again}"),
+
+        // Negation combined with addition
+        styledText(i"{bold.red start {~red.cyan swap colors} back to red}"),
+
+        // Three-level nesting with additions
+        styledText(i"{red outer {bold middle {underline.cyan inner} middle} outer}"),
+
+        // Style accumulation through levels
+        styledText(i"{bold B {italic BI {underline BIU {red BIUR} BIU} BI} B}"),
+
+        // Toggle effect: remove and re-add
+        styledText(i"{bold.red on {~bold off {bold on} off} on}"),
+    ];
+}
+
+string[] practicalExamples()
+{
+    string errorMsg = "Connection refused";
+    string filename = "config.json";
+    int line = 42;
+    int errors = 3;
+    int warnings = 7;
+
+    return [
+        styledText(i"{red.bold ERROR:} $(errorMsg)"),
+        styledText(i"{yellow WARNING:} Deprecated API usage"),
+        styledText(i"{green.bold SUCCESS:} Build completed"),
+        styledText(i"{dim $(filename):$(line)} - {red $(errors) errors}, {yellow $(warnings) warnings}"),
+        styledText(i"Press {bold.cyan q} to quit, {bold.cyan h} for help"),
+    ];
+}

--- a/libs/core-cli/examples/table.d
+++ b/libs/core-cli/examples/table.d
@@ -7,7 +7,7 @@
 
 import sparkles.core_cli.ui.demo : Section, runDemo;
 import sparkles.core_cli.ui.table : drawTable;
-import sparkles.core_cli.term_style : Style, stylize;
+import sparkles.core_cli.styled_template : styledText;
 
 void main()
 {
@@ -43,7 +43,7 @@ void main()
             Section(
                 header: "Bold Headers",
                 content: [
-                    ["Name".stylize(Style.bold), "Status".stylize(Style.bold), "Priority".stylize(Style.bold)],
+                    [styledText(i"{bold Name}"), styledText(i"{bold Status}"), styledText(i"{bold Priority}")],
                     ["Task 1", "Done", "High"],
                     ["Task 2", "In Progress", "Medium"],
                     ["Task 3", "Pending", "Low"],
@@ -52,50 +52,50 @@ void main()
             Section(
                 header: "Color-Coded Status",
                 content: [
-                    ["Metric".stylize(Style.bold), "Value".stylize(Style.bold), "Status".stylize(Style.bold)],
-                    ["CPU Usage", "45%", "OK".stylize(Style.green)],
-                    ["Memory", "78%", "Warning".stylize(Style.yellow)],
-                    ["Disk", "92%", "Critical".stylize(Style.red)],
-                    ["Network", "12%", "OK".stylize(Style.green)],
+                    [styledText(i"{bold Metric}"), styledText(i"{bold Value}"), styledText(i"{bold Status}")],
+                    ["CPU Usage", "45%", styledText(i"{green OK}")],
+                    ["Memory", "78%", styledText(i"{yellow Warning}")],
+                    ["Disk", "92%", styledText(i"{red Critical}")],
+                    ["Network", "12%", styledText(i"{green OK}")],
                 ].drawTable,
             ),
             Section(
                 header: "Mixed Styles",
                 content: [
                     ["Status", "Description"],
-                    ["OK".stylize(Style.green), "Everything is working fine"],
-                    ["WARN".stylize(Style.yellow), "Some issues detected"],
-                    ["FAIL".stylize(Style.red), "Critical failure"],
+                    [styledText(i"{green OK}"), "Everything is working fine"],
+                    [styledText(i"{yellow WARN}"), "Some issues detected"],
+                    [styledText(i"{red FAIL}"), "Critical failure"],
                 ].drawTable,
             ),
             Section(
                 header: "Multiple Styles Combined",
                 content: [
-                    ["Type".stylize(Style.bold).stylize(Style.underline).stylize(Style.cyan), "Message".stylize(Style.bold).stylize(Style.underline).stylize(Style.cyan)],
-                    ["INFO".stylize(Style.blue).stylize(Style.bold), "Application started".stylize(Style.dim)],
-                    ["DEBUG".stylize(Style.magenta).stylize(Style.dim).stylize(Style.italic), "Loading configuration...".stylize(Style.italic)],
-                    ["ERROR".stylize(Style.red).stylize(Style.bold).stylize(Style.inverse), "Connection failed!".stylize(Style.red).stylize(Style.bold)],
+                    [styledText(i"{bold.underline.cyan Type}"), styledText(i"{bold.underline.cyan Message}")],
+                    [styledText(i"{bold.blue INFO}"), styledText(i"{dim Application started}")],
+                    [styledText(i"{dim.italic.magenta DEBUG}"), styledText(i"{italic Loading configuration...}")],
+                    [styledText(i"{bold.inverse.red ERROR}"), styledText(i"{bold.red Connection failed!}")],
                 ].drawTable,
             ),
             Section(
                 header: "Fully Styled Table",
                 content: [
                     [
-                        "Server".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
-                        "Status".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
-                        "Load".stylize(Style.bold).stylize(Style.underline).stylize(Style.brightCyan),
+                        styledText(i"{bold.underline.brightCyan Server}"),
+                        styledText(i"{bold.underline.brightCyan Status}"),
+                        styledText(i"{bold.underline.brightCyan Load}"),
                     ],
-                    ["web-01".stylize(Style.brightGreen).stylize(Style.bold), "UP".stylize(Style.green).stylize(Style.inverse), "23%".stylize(Style.green)],
-                    ["web-02".stylize(Style.brightGreen).stylize(Style.bold), "UP".stylize(Style.green).stylize(Style.inverse), "45%".stylize(Style.yellow).stylize(Style.bold)],
-                    ["db-01".stylize(Style.brightRed).stylize(Style.bold).stylize(Style.strikethrough), "DOWN".stylize(Style.red).stylize(Style.inverse).stylize(Style.bold), "0%".stylize(Style.dim).stylize(Style.italic)],
+                    [styledText(i"{bold.brightGreen web-01}"), styledText(i"{inverse.green UP}"), styledText(i"{green 23%}")],
+                    [styledText(i"{bold.brightGreen web-02}"), styledText(i"{inverse.green UP}"), styledText(i"{bold.yellow 45%}")],
+                    [styledText(i"{bold.strikethrough.brightRed db-01}"), styledText(i"{bold.inverse.red DOWN}"), styledText(i"{dim.italic 0%}")],
                 ].drawTable,
             ),
             Section(
                 header: "Alignment Stress Test",
                 content: [
-                    ["A".stylize(Style.red), "This is a very long description that should align properly"],
-                    ["OK".stylize(Style.green), "Short"],
-                    ["WARN".stylize(Style.yellow), "Medium length text here"],
+                    [styledText(i"{red A}"), "This is a very long description that should align properly"],
+                    [styledText(i"{green OK}"), "Short"],
+                    [styledText(i"{yellow WARN}"), "Medium length text here"],
                 ].drawTable,
             ),
         ],

--- a/libs/core-cli/src/sparkles/core_cli/styled_template.d
+++ b/libs/core-cli/src/sparkles/core_cli/styled_template.d
@@ -1,0 +1,787 @@
+/**
+ * Style template processing for IES (Interpolated Expression Sequences).
+ *
+ * Provides a template syntax for applying terminal styles to IES strings:
+ * ---
+ * import sparkles.core_cli.styled_template;
+ *
+ * int cpu = 75;
+ * styledWriteln(i"CPU: {red $(cpu)%} Status: {green OK}");
+ * ---
+ *
+ * Supported syntax:
+ * - `{red text}` — Apply single style
+ * - `{bold.red text}` — Chain multiple styles
+ * - `{bold outer {red nested}}` — Nested blocks (inner inherits outer)
+ * - `{red text {~red normal}}` — Negation with `~` removes a style
+ * - `{{` — Escaped literal `{`
+ * - `}}` — Escaped literal `}`
+ */
+module sparkles.core_cli.styled_template;
+
+import core.interpolation;
+
+import sparkles.core_cli.term_style : Style;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Style Name Lookup
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parses a style name string to a Style enum value.
+/// Returns Style.none if the name is not recognized.
+@safe pure nothrow @nogc
+Style styleFromName(const(char)[] name)
+{
+    switch (name)
+    {
+        // Special
+        case "none": return Style.none;
+        case "reset": return Style.reset;
+
+        // Text attributes
+        case "bold": return Style.bold;
+        case "dim": return Style.dim;
+        case "italic": return Style.italic;
+        case "underline": return Style.underline;
+        case "inverse": return Style.inverse;
+        case "hidden": return Style.hidden;
+        case "strikethrough": return Style.strikethrough;
+
+        // Foreground colors
+        case "black": return Style.black;
+        case "red": return Style.red;
+        case "green": return Style.green;
+        case "yellow": return Style.yellow;
+        case "blue": return Style.blue;
+        case "magenta": return Style.magenta;
+        case "cyan": return Style.cyan;
+        case "white": return Style.white;
+        case "gray": return Style.gray;
+
+        // Bright foreground colors
+        case "brightRed": return Style.brightRed;
+        case "brightGreen": return Style.brightGreen;
+        case "brightYellow": return Style.brightYellow;
+        case "brightBlue": return Style.brightBlue;
+        case "brightMagenta": return Style.brightMagenta;
+        case "brightCyan": return Style.brightCyan;
+        case "brightWhite": return Style.brightWhite;
+
+        // Background colors
+        case "bgBlack": return Style.bgBlack;
+        case "bgRed": return Style.bgRed;
+        case "bgGreen": return Style.bgGreen;
+        case "bgYellow": return Style.bgYellow;
+        case "bgBlue": return Style.bgBlue;
+        case "bgMagenta": return Style.bgMagenta;
+        case "bgCyan": return Style.bgCyan;
+        case "bgWhite": return Style.bgWhite;
+        case "bgGray": return Style.bgGray;
+
+        // Bright background colors
+        case "bgBrightRed": return Style.bgBrightRed;
+        case "bgBrightGreen": return Style.bgBrightGreen;
+        case "bgBrightYellow": return Style.bgBrightYellow;
+        case "bgBrightBlue": return Style.bgBrightBlue;
+        case "bgBrightMagenta": return Style.bgBrightMagenta;
+        case "bgBrightCyan": return Style.bgBrightCyan;
+        case "bgBrightWhite": return Style.bgBrightWhite;
+
+        default: return Style.none;
+    }
+}
+
+///
+@("styleFromName.basic")
+@safe pure nothrow @nogc
+unittest
+{
+    assert(styleFromName("red") == Style.red);
+    assert(styleFromName("bold") == Style.bold);
+    assert(styleFromName("bgBlue") == Style.bgBlue);
+    assert(styleFromName("unknown") == Style.none);
+    assert(styleFromName("") == Style.none);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Style Stack for Nested Blocks
+// ─────────────────────────────────────────────────────────────────────────────
+
+private struct StyleState
+{
+    Style[8] styles;
+    size_t count;
+
+    /// Emit escape sequences for transition FROM parent TO this state
+    void emitOpenDiff(Writer)(ref Writer w, in StyleState parent) const
+    {
+        import sparkles.core_cli.text_writers : writeEscapeSeq;
+
+        // Close styles that were in parent but removed in this (negation)
+        foreach_reverse (i; 0 .. parent.count)
+            if (parent.styles[i] != Style.none && !hasStyle(parent.styles[i]))
+                writeEscapeSeq(w, parent.styles[i][1]);
+
+        // Open styles that are new in this (not in parent)
+        foreach (i; 0 .. count)
+            if (styles[i] != Style.none && !parent.hasStyle(styles[i]))
+                writeEscapeSeq(w, styles[i][0]);
+    }
+
+    /// Emit escape sequences for transition FROM this state back TO parent
+    void emitCloseDiff(Writer)(ref Writer w, in StyleState parent) const
+    {
+        import sparkles.core_cli.text_writers : writeEscapeSeq;
+
+        // Close styles that were added in this (not in parent)
+        foreach_reverse (i; 0 .. count)
+            if (styles[i] != Style.none && !parent.hasStyle(styles[i]))
+                writeEscapeSeq(w, styles[i][1]);
+
+        // Restore styles that were negated (in parent but not in this)
+        foreach (i; 0 .. parent.count)
+            if (parent.styles[i] != Style.none && !hasStyle(parent.styles[i]))
+                writeEscapeSeq(w, parent.styles[i][0]);
+    }
+
+    /// Emit opening escape sequences for all active styles
+    void emitOpen(Writer)(ref Writer w) const
+    {
+        emitOpenDiff(w, StyleState.init);
+    }
+
+    /// Emit closing escape sequences for all active styles (reverse order)
+    void emitClose(Writer)(ref Writer w) const
+    {
+        emitCloseDiff(w, StyleState.init);
+    }
+
+    /// Check if a style is currently active
+    bool hasStyle(Style s) const @nogc nothrow
+    {
+        foreach (i; 0 .. count)
+            if (styles[i] == s)
+                return true;
+        return false;
+    }
+
+    /// Add a style if not already present
+    void addStyle(Style s) @nogc nothrow
+    {
+        if (s != Style.none && !hasStyle(s) && count < styles.length)
+            styles[count++] = s;
+    }
+
+    /// Remove a style
+    void removeStyle(Style s) @nogc nothrow
+    {
+        size_t writeIdx = 0;
+        foreach (i; 0 .. count)
+        {
+            if (styles[i] != s)
+            {
+                if (writeIdx != i)
+                    styles[writeIdx] = styles[i];
+                writeIdx++;
+            }
+        }
+        count = writeIdx;
+    }
+
+    /// Check if any styles are active
+    bool empty() const @nogc nothrow
+    {
+        return count == 0;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parser Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+private enum ParseState
+{
+    normal,
+    styleName,
+    content
+}
+
+private struct ParserContext
+{
+    StyleState[16] styleStack;
+    size_t stackDepth;
+    ParseState state = ParseState.normal;
+    size_t styleNameStart;
+    size_t styleNameEnd;
+
+    void pushStyle(StyleState s) @nogc nothrow
+    {
+        if (stackDepth < styleStack.length)
+            styleStack[stackDepth++] = s;
+    }
+
+    void popStyle() @nogc nothrow
+    {
+        if (stackDepth > 0)
+            stackDepth--;
+    }
+
+    ref StyleState topStyle() return @nogc nothrow
+    {
+        return styleStack[stackDepth > 0 ? stackDepth - 1 : 0];
+    }
+
+    StyleState parentStyle() const @nogc nothrow
+    {
+        return stackDepth > 1 ? styleStack[stackDepth - 2] : StyleState.init;
+    }
+
+    bool hasStyles() const @nogc nothrow
+    {
+        return stackDepth > 0;
+    }
+}
+
+/// Parses a literal segment and writes styled output
+private void parseLiteral(Writer)(
+    ref Writer w,
+    const(char)[] literal,
+    ref ParserContext ctx
+)
+{
+    import std.range.primitives : put;
+
+    size_t i = 0;
+    while (i < literal.length)
+    {
+        const char c = literal[i];
+
+        final switch (ctx.state)
+        {
+            case ParseState.normal:
+                if (c == '{')
+                {
+                    // Check for escaped {{ -> literal {
+                    if (i + 1 < literal.length && literal[i + 1] == '{')
+                    {
+                        put(w, '{');
+                        i += 2;
+                        continue;
+                    }
+                    ctx.state = ParseState.styleName;
+                    ctx.styleNameStart = i + 1;
+                    ctx.styleNameEnd = i + 1;
+                }
+                else if (c == '}')
+                {
+                    // Check for escaped }} -> literal }
+                    if (i + 1 < literal.length && literal[i + 1] == '}')
+                    {
+                        put(w, '}');
+                        i += 2;
+                        continue;
+                    }
+                    put(w, c);
+                }
+                else
+                {
+                    put(w, c);
+                }
+                break;
+
+            case ParseState.styleName:
+                if (c == ' ')
+                {
+                    // End of style names, apply and switch to content
+                    auto spec = literal[ctx.styleNameStart .. ctx.styleNameEnd];
+                    applyStyleSpec(spec, ctx);
+                    // Only emit styles that are NEW (not inherited from parent)
+                    ctx.topStyle.emitOpenDiff(w, ctx.parentStyle);
+                    ctx.state = ParseState.content;
+                }
+                else if (c == '}')
+                {
+                    // Empty block like {} - treat as literal
+                    put(w, '{');
+                    put(w, '}');
+                    ctx.state = ParseState.normal;
+                }
+                else
+                {
+                    // Accumulate style name
+                    ctx.styleNameEnd = i + 1;
+                }
+                break;
+
+            case ParseState.content:
+                if (c == '{')
+                {
+                    // Check for escaped {{ -> literal {
+                    if (i + 1 < literal.length && literal[i + 1] == '{')
+                    {
+                        put(w, '{');
+                        i += 2;
+                        continue;
+                    }
+                    // Nested block
+                    ctx.state = ParseState.styleName;
+                    ctx.styleNameStart = i + 1;
+                    ctx.styleNameEnd = i + 1;
+                }
+                else if (c == '}')
+                {
+                    // Check for escaped }} -> literal }
+                    if (i + 1 < literal.length && literal[i + 1] == '}')
+                    {
+                        put(w, '}');
+                        i += 2;
+                        continue;
+                    }
+                    // End of block - close only styles that were added in this block
+                    ctx.topStyle.emitCloseDiff(w, ctx.parentStyle);
+                    ctx.popStyle();
+                    ctx.state = ctx.hasStyles ? ParseState.content : ParseState.normal;
+                }
+                else
+                {
+                    put(w, c);
+                }
+                break;
+        }
+        i++;
+    }
+}
+
+/// Parses style specification like "bold.red" or "~red.bold"
+private void applyStyleSpec(const(char)[] spec, ref ParserContext ctx)
+{
+    // Create new style state based on parent (or empty if root)
+    StyleState newState = ctx.hasStyles ? ctx.topStyle : StyleState.init;
+
+    // Parse dot-separated style names
+    size_t start = 0;
+    foreach (i, c; spec)
+    {
+        if (c == '.')
+        {
+            if (i > start)
+                applyStylePart(spec[start .. i], newState);
+            start = i + 1;
+        }
+    }
+    // Handle last part
+    if (start < spec.length)
+        applyStylePart(spec[start .. $], newState);
+
+    ctx.pushStyle(newState);
+}
+
+private void applyStylePart(const(char)[] part, ref StyleState state)
+{
+    if (part.length == 0)
+        return;
+
+    bool negate = part[0] == '~';
+    const(char)[] styleName = negate ? part[1 .. $] : part;
+
+    Style s = styleFromName(styleName);
+    if (s != Style.none)
+    {
+        if (negate)
+            state.removeStyle(s);
+        else
+            state.addStyle(s);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core Processing Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Writes styled IES output to an output range.
+void writeStyled(Writer, Args...)(
+    ref Writer w,
+    InterpolationHeader,
+    Args args,
+    InterpolationFooter
+)
+{
+    import std.conv : to;
+    import std.range.primitives : put;
+
+    ParserContext ctx;
+
+    static foreach (arg; args)
+    {{
+        alias T = typeof(arg);
+        static if (is(T == InterpolatedLiteral!lit, string lit))
+        {
+            parseLiteral(w, lit, ctx);
+        }
+        else static if (is(T == InterpolatedExpression!code, string code))
+        {
+            // Skip expression metadata
+        }
+        else
+        {
+            // Output interpolated value - styles already active from block
+            put(w, arg.to!string);
+        }
+    }}
+}
+
+/// Returns styled IES as a string.
+string styledText(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.array : appender;
+
+    auto buf = appender!string;
+    writeStyled(buf, header, args, footer);
+    return buf[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lazy Wrapper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Lazy wrapper that defers styled processing until consumed.
+struct StyledText(Args...)
+{
+    Args args;
+
+    /// Convert to string (allocates)
+    string toString() const
+    {
+        import std.array : appender;
+        import std.conv : to;
+        import std.range.primitives : put;
+
+        auto buf = appender!string;
+        ParserContext ctx;
+
+        foreach (arg; args)
+        {
+            alias T = typeof(arg);
+            static if (is(T == InterpolatedLiteral!lit, string lit))
+            {
+                parseLiteral(buf, lit, ctx);
+            }
+            else static if (is(T == InterpolatedExpression!code, string code))
+            {
+                // Skip expression metadata
+            }
+            else static if (is(T == InterpolationHeader) || is(T == InterpolationFooter))
+            {
+                // Skip header/footer
+            }
+            else
+            {
+                // Output interpolated value - styles already active from block
+                put(buf, arg.to!string);
+            }
+        }
+        return buf[];
+    }
+
+    /// Callback-based toString for writeln compatibility
+    void toString(scope void delegate(const(char)[]) sink) const
+    {
+        sink(toString());
+    }
+}
+
+/// Returns a lazy wrapper that can be converted to string or written to output range.
+auto styled(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    // Store all components including header/footer
+    return StyledText!(InterpolationHeader, Args, InterpolationFooter)(header, args, footer);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// stdout/stderr Write Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Write styled IES to stdout.
+void styledWrite(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.stdio : stdout;
+
+    auto w = stdout.lockingTextWriter;
+    writeStyled(w, header, args, footer);
+}
+
+/// Write styled IES to stdout with newline.
+void styledWriteln(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.stdio : stdout;
+
+    auto w = stdout.lockingTextWriter;
+    writeStyled(w, header, args, footer);
+    w.put('\n');
+}
+
+/// Write styled IES to stderr.
+void styledWriteErr(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.stdio : stderr;
+
+    auto w = stderr.lockingTextWriter;
+    writeStyled(w, header, args, footer);
+}
+
+/// Write styled IES to stderr with newline.
+void styledWritelnErr(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.stdio : stderr;
+
+    auto w = stderr.lockingTextWriter;
+    writeStyled(w, header, args, footer);
+    w.put('\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+@("styled.singleStyle")
+unittest
+{
+    assert(styledText(i"{red error}") == "\x1b[31merror\x1b[39m");
+}
+
+@("styled.chainedStyles")
+unittest
+{
+    // bold.red applies both styles
+    auto result = styledText(i"{bold.red text}");
+    // Should have bold open, red open, text, red close, bold close
+    assert(result == "\x1b[1m\x1b[31mtext\x1b[39m\x1b[22m");
+}
+
+@("styled.withInterpolation")
+unittest
+{
+    int val = 42;
+    assert(styledText(i"Value: {green $(val)}") == "Value: \x1b[32m42\x1b[39m");
+}
+
+@("styled.nested")
+unittest
+{
+    // Nested: bold applies to all, red only to inner
+    auto result = styledText(i"{bold A {red B} C}");
+    // A gets bold, B gets bold+red (inherited), C gets bold (red removed)
+    // Expected: bold open, "A ", red open, "B", red close, " C", bold close
+    assert(result == "\x1b[1mA \x1b[31mB\x1b[39m C\x1b[22m");
+}
+
+@("styled.negation")
+unittest
+{
+    // ~red removes red, but bold remains
+    auto result = styledText(i"{bold.red styled {~red unbold}}");
+    // "styled" = bold+red, "unbold" = bold only (red removed)
+    assert(result.length > 0); // Basic sanity check
+    // Verify structure: should have reset codes
+    import std.algorithm.searching : canFind;
+    assert(result.canFind("\x1b[1m")); // bold on
+    assert(result.canFind("\x1b[31m")); // red on
+}
+
+/// Elaborate test combining chained styles, deep nesting, and negation.
+///
+/// This test verifies the complete style state machine by building up a complex
+/// hierarchy of styles and selectively removing/adding styles at each level.
+///
+/// Visual representation of the test case:
+/// ---
+/// {bold.italic.red                           ← Level 1: bold + italic + red
+///     "A"
+///     {~red.underline                        ← Level 2: bold + italic + underline (red removed)
+///         "B"
+///         {cyan                              ← Level 3: bold + italic + underline + cyan
+///             "C"
+///             {~bold.~italic                 ← Level 4: underline + cyan (bold & italic removed)
+///                 "D"
+///             }                              ← Back to Level 3: bold + italic + underline + cyan
+///             "E"
+///         }                                  ← Back to Level 2: bold + italic + underline
+///         "F"
+///     }                                      ← Back to Level 1: bold + italic + red
+///     "G"
+/// }
+/// ---
+///
+/// Expected escape sequence flow:
+/// - [1m[3m[31m  → bold on, italic on, red on
+/// - "A"
+/// - [39m[4m     → red off, underline on
+/// - "B"
+/// - [36m        → cyan on
+/// - "C"
+/// - [23m[22m    → italic off, bold off (reverse order of parent array)
+/// - "D"
+/// - [1m[3m      → bold on, italic on (restore)
+/// - "E"
+/// - [39m        → cyan off
+/// - "F"
+/// - [24m[31m    → underline off, red on (restore)
+/// - "G"
+/// - [39m[23m[22m → red off, italic off, bold off
+@("styled.complexNestingWithNegation")
+unittest
+{
+    auto result = styledText(
+        i"{bold.italic.red A{~red.underline B{cyan C{~bold.~italic D}E}F}G}"
+    );
+
+    // Verify the exact escape sequence
+    // Note: styles are closed in reverse order of their position in the style array
+    assert(result ==
+        "\x1b[1m\x1b[3m\x1b[31m" ~  // bold, italic, red ON
+        "A" ~
+        "\x1b[39m" ~                // red OFF (negated)
+        "\x1b[4m" ~                 // underline ON (added)
+        "B" ~
+        "\x1b[36m" ~                // cyan ON (added)
+        "C" ~
+        "\x1b[23m\x1b[22m" ~        // italic OFF, bold OFF (reverse order)
+        "D" ~
+        "\x1b[1m\x1b[3m" ~          // bold ON, italic ON (restored)
+        "E" ~
+        "\x1b[39m" ~                // cyan OFF (exiting cyan block)
+        "F" ~
+        "\x1b[24m" ~                // underline OFF (exiting underline block)
+        "\x1b[31m" ~                // red ON (restored from negation)
+        "G" ~
+        "\x1b[39m\x1b[23m\x1b[22m"  // red OFF, italic OFF, bold OFF
+    );
+}
+
+/// Test negation restores parent styles correctly when multiple styles are negated.
+@("styled.multipleNegationRestore")
+unittest
+{
+    // Negate two styles, then exit - both should be restored
+    // Parent: [bold, italic, underline], Child negates: bold, underline
+    // Close order is reverse of array position: underline (idx 2), then bold (idx 0)
+    auto result = styledText(i"{bold.italic.underline outer {~bold.~underline inner} outer}");
+
+    assert(result ==
+        "\x1b[1m\x1b[3m\x1b[4m" ~   // bold, italic, underline ON
+        "outer " ~
+        "\x1b[24m\x1b[22m" ~        // underline OFF, bold OFF (reverse order)
+        "inner" ~
+        "\x1b[1m\x1b[4m" ~          // bold ON, underline ON (restored)
+        " outer" ~
+        "\x1b[24m\x1b[23m\x1b[22m"  // underline OFF, italic OFF, bold OFF
+    );
+}
+
+/// Test adding new styles in nested block while parent has styles.
+@("styled.nestedStyleAddition")
+unittest
+{
+    // Parent has bold, child adds underline and cyan
+    auto result = styledText(i"{bold parent {underline.cyan child} parent}");
+
+    assert(result ==
+        "\x1b[1m" ~                 // bold ON
+        "parent " ~
+        "\x1b[4m\x1b[36m" ~         // underline ON, cyan ON (new styles)
+        "child" ~
+        "\x1b[39m\x1b[24m" ~        // cyan OFF, underline OFF
+        " parent" ~
+        "\x1b[22m"                  // bold OFF
+    );
+}
+
+/// Test three levels of nesting with style additions at each level.
+@("styled.threeLevelNesting")
+unittest
+{
+    auto result = styledText(i"{red L1 {bold L2 {underline L3} L2} L1}");
+
+    assert(result ==
+        "\x1b[31m" ~      // red ON
+        "L1 " ~
+        "\x1b[1m" ~       // bold ON
+        "L2 " ~
+        "\x1b[4m" ~       // underline ON
+        "L3" ~
+        "\x1b[24m" ~      // underline OFF
+        " L2" ~
+        "\x1b[22m" ~      // bold OFF
+        " L1" ~
+        "\x1b[39m"        // red OFF
+    );
+}
+
+/// Test negation combined with addition in same block.
+@("styled.negationWithAddition")
+unittest
+{
+    // Start with bold+red, then remove red but add cyan
+    auto result = styledText(i"{bold.red start {~red.cyan middle} end}");
+
+    assert(result ==
+        "\x1b[1m\x1b[31m" ~  // bold ON, red ON
+        "start " ~
+        "\x1b[39m" ~         // red OFF (negated)
+        "\x1b[36m" ~         // cyan ON (added)
+        "middle" ~
+        "\x1b[39m" ~         // cyan OFF
+        "\x1b[31m" ~         // red ON (restored)
+        " end" ~
+        "\x1b[39m\x1b[22m"   // red OFF, bold OFF
+    );
+}
+
+@("styled.escapedOpenBrace")
+unittest
+{
+    // {{ produces literal {
+    assert(styledText(i"Use {{style}} syntax") == "Use {style} syntax");
+}
+
+@("styled.escapedCloseBrace")
+unittest
+{
+    // }} produces literal } inside styled block
+    assert(styledText(i"{red hey}} still red}") == "\x1b[31mhey} still red\x1b[39m");
+}
+
+@("styled.escapedBracesInContent")
+unittest
+{
+    // {{ and }} inside a styled block
+    assert(styledText(i"{bold use {{braces}}}") == "\x1b[1muse {braces}\x1b[22m");
+}
+
+@("styled.noStyle")
+unittest
+{
+    assert(styledText(i"plain text") == "plain text");
+}
+
+@("styled.emptyBlock")
+unittest
+{
+    // Empty {} should be treated as literal
+    assert(styledText(i"test {} here") == "test {} here");
+}
+
+@("styled.multipleBlocks")
+unittest
+{
+    auto result = styledText(i"{red error} and {green success}");
+    assert(result == "\x1b[31merror\x1b[39m and \x1b[32msuccess\x1b[39m");
+}
+
+@("styled.lazyWrapper")
+unittest
+{
+    int val = 99;
+    auto lazy_ = styled(i"Test: {blue $(val)}");
+    assert(lazy_.toString == "Test: \x1b[34m99\x1b[39m");
+}

--- a/nix/shells/default.nix
+++ b/nix/shells/default.nix
@@ -20,6 +20,9 @@ pkgs.mkShell {
     pkgs.dub
 
     pkgs.mold
+
+    # Documentation site
+    pkgs.nodejs
   ]
   ++ lib.optionals (system == "x86_64-linux") [
     pkgs.dmd

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3979 @@
+{
+  "name": "sparkles-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sparkles-docs",
+      "devDependencies": {
+        "vitepress": "^1.6.4",
+        "wrangler": "^4.63.0"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.14.0.tgz",
+      "integrity": "sha512-cZfj+1Z1dgrk3YPtNQNt0H9Rr67P8b4M79JjUKGS0d7/EbFbGxGgSu6zby5f22KXo3LT0LZa4O2c6VVbupJuDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.48.0.tgz",
+      "integrity": "sha512-n17WSJ7vazmM6yDkWBAjY12J8ERkW9toOqNgQ1GEZu/Kc4dJDJod1iy+QP5T/UlR3WICgZDi/7a/VX5TY5LAPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.48.0.tgz",
+      "integrity": "sha512-v5bMZMEqW9U2l40/tTAaRyn4AKrYLio7KcRuHmLaJtxuJAhvZiE7Y62XIsF070juz4MN3eyvfQmI+y5+OVbZuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.48.0.tgz",
+      "integrity": "sha512-7H3DgRyi7UByScc0wz7EMrhgNl7fKPDjKX9OcWixLwCj7yrRXDSIzwunykuYUUO7V7HD4s319e15FlJ9CQIIFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.48.0.tgz",
+      "integrity": "sha512-tXmkB6qrIGAXrtRYHQNpfW0ekru/qymV02bjT0w5QGaGw0W91yT+53WB6dTtRRsIrgS30Al6efBvyaEosjZ5uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.48.0.tgz",
+      "integrity": "sha512-4tXEsrdtcBZbDF73u14Kb3otN+xUdTVGop1tBjict+Rc/FhsJQVIwJIcTrOJqmvhtBfc56Bu65FiVOnpAZCxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.48.0.tgz",
+      "integrity": "sha512-unzSUwWFpsDrO8935RhMAlyK0Ttua/5XveVIwzfjs5w+GVBsHgIkbOe8VbBJccMU/z1LCwvu1AY3kffuSLAR5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.48.0.tgz",
+      "integrity": "sha512-RB9bKgYTVUiOcEb5bOcZ169jiiVW811dCsJoLT19DcbbFmU4QaK0ghSTssij35QBQ3SCOitXOUrHcGgNVwS7sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.48.0.tgz",
+      "integrity": "sha512-rhoSoPu+TDzDpvpk3cY/pYgbeWXr23DxnAIH/AkN0dUC+GCnVIeNSQkLaJ+CL4NZ51cjLIjksrzb4KC5Xu+ktw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.48.0.tgz",
+      "integrity": "sha512-aSe6jKvWt+8VdjOaq2ERtsXp9+qMXNJ3mTyTc1VMhNfgPl7ArOhRMRSQ8QBnY8ZL4yV5Xpezb7lAg8pdGrrulg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.48.0.tgz",
+      "integrity": "sha512-p9tfI1bimAaZrdiVExL/dDyGUZ8gyiSHsktP1ZWGzt5hXpM3nhv4tSjyHtXjEKtA0UvsaHKwSfFE8aAAm1eIQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.48.0.tgz",
+      "integrity": "sha512-XshyfpsQB7BLnHseMinp3fVHOGlTv6uEHOzNK/3XrEF9mjxoZAcdVfY1OCXObfwRWX5qXZOq8FnrndFd44iVsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.48.0.tgz",
+      "integrity": "sha512-Q4XNSVQU89bKNAPuvzSYqTH9AcbOOiIo6AeYMQTxgSJ2+uvT78CLPMG89RIIloYuAtSfE07s40OLV50++l1Bbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.48.0.tgz",
+      "integrity": "sha512-ZgxV2+5qt3NLeUYBTsi6PLyHcENQWC0iFppFZekHSEDA2wcLdTUjnaJzimTEULHIvJuLRCkUs4JABdhuJktEag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.12.0.tgz",
+      "integrity": "sha512-NK4vN+2Z/GbfGS4BamtbbVk1rcu5RmqaYGiyHJQrA09AoxdZPHDF3W/EhgI0YSK8p3vRo/VNCtbSJFPON7FWMQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "^1.20260115.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260205.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260205.0.tgz",
+      "integrity": "sha512-ToOItqcirmWPwR+PtT+Q4bdjTn/63ZxhJKEfW4FNn7FxMTS1Tw5dml0T0mieOZbCpcvY8BdvPKFCSlJuI8IVHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260205.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260205.0.tgz",
+      "integrity": "sha512-402ZqLz+LrG0NDXp7Hn7IZbI0DyhjNfjAlVenb0K3yod9KCuux0u3NksNBvqJx0mIGHvVR4K05h+jfT5BTHqGA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260205.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260205.0.tgz",
+      "integrity": "sha512-rz9jBzazIA18RHY+osa19hvsPfr0LZI1AJzIjC6UqkKKphcTpHBEQ25Xt8cIA34ivMIqeENpYnnmpDFesLkfcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260205.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260205.0.tgz",
+      "integrity": "sha512-jr6cKpMM/DBEbL+ATJ9rYue758CKp0SfA/nXt5vR32iINVJrb396ye9iat2y9Moa/PgPKnTrFgmT6urUmG3IUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260205.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260205.0.tgz",
+      "integrity": "sha512-SMPW5jCZYOG7XFIglSlsgN8ivcl0pCrSAYxCwxtWvZ88whhcDB/aISNtiQiDZujPH8tIo2hE5dEkxW7tGEwc3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.70",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.70.tgz",
+      "integrity": "sha512-CYNRCgN6nBTjN4dNkrBCjHXNR2e4hQihdsZUs/afUNFOWLSYjfihca4EFN05rRvDk4Xoy2n8tym6IxBZmcn+Qg==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
+      "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
+      "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/shared": "3.5.27",
+        "entities": "^7.0.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.27.tgz",
+      "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
+      "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@vue/compiler-core": "3.5.27",
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.27.tgz",
+      "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.27.tgz",
+      "integrity": "sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.27.tgz",
+      "integrity": "sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.27",
+        "@vue/shared": "3.5.27"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.27.tgz",
+      "integrity": "sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.27",
+        "@vue/runtime-core": "3.5.27",
+        "@vue/shared": "3.5.27",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.27.tgz",
+      "integrity": "sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.27",
+        "@vue/shared": "3.5.27"
+      },
+      "peerDependencies": {
+        "vue": "3.5.27"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
+      "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.48.0.tgz",
+      "integrity": "sha512-aD8EQC6KEman6/S79FtPdQmB7D4af/etcRL/KwiKFKgAE62iU8c5PeEQvpvIcBPurC3O/4Lj78nOl7ZcoazqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.14.0",
+        "@algolia/client-abtesting": "5.48.0",
+        "@algolia/client-analytics": "5.48.0",
+        "@algolia/client-common": "5.48.0",
+        "@algolia/client-insights": "5.48.0",
+        "@algolia/client-personalization": "5.48.0",
+        "@algolia/client-query-suggestions": "5.48.0",
+        "@algolia/client-search": "5.48.0",
+        "@algolia/ingestion": "1.48.0",
+        "@algolia/monitoring": "1.48.0",
+        "@algolia/recommend": "5.48.0",
+        "@algolia/requester-browser-xhr": "5.48.0",
+        "@algolia/requester-fetch": "5.48.0",
+        "@algolia/requester-node-http": "5.48.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260205.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260205.0.tgz",
+      "integrity": "sha512-jG1TknEDeFqcq/z5gsOm1rKeg4cNG7ruWxEuiPxl3pnQumavxo8kFpeQC6XKVpAhh2PI9ODGyIYlgd77sTHl5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.18.2",
+        "workerd": "1.20260205.0",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.28.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
+      "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
+      "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.27",
+        "@vue/compiler-sfc": "3.5.27",
+        "@vue/runtime-dom": "3.5.27",
+        "@vue/server-renderer": "3.5.27",
+        "@vue/shared": "3.5.27"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260205.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260205.0.tgz",
+      "integrity": "sha512-CcMH5clHwrH8VlY7yWS9C/G/C8g9czIz1yU3akMSP9Z3CkEMFSoC3GGdj5G7Alw/PHEeez1+1IrlYger4pwu+w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260205.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20260205.0",
+        "@cloudflare/workerd-linux-64": "1.20260205.0",
+        "@cloudflare/workerd-linux-arm64": "1.20260205.0",
+        "@cloudflare/workerd-windows-64": "1.20260205.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.63.0.tgz",
+      "integrity": "sha512-+R04jF7Eb8K3KRMSgoXpcIdLb8GC62eoSGusYh1pyrSMm/10E0hbKkd7phMJO4HxXc6R7mOHC5SSoX9eof30Uw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.12.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.0",
+        "miniflare": "4.20260205.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260205.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260205.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sparkles-docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.4",
+    "wrangler": "^4.63.0"
+  }
+}

--- a/scripts/run_md_examples.d
+++ b/scripts/run_md_examples.d
@@ -1,0 +1,297 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "run_md_examples"
+    dependency "sparkles:core-cli" version="*"
++/
+
+/++
+Extracts and runs dub single-file examples from markdown files.
+
+This script parses markdown files to find code blocks that represent
+dub single-file programs, executes them, and reports results.
+
+Usage:
+---
+./run_md_examples.d <markdown-file>
+---
+
+The script looks for D code blocks starting with:
+---
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "example-name"
++/
+---
++/
+
+// std.* modules
+import std.algorithm : canFind, countUntil, filter, map, startsWith;
+import std.array : array, join;
+import std.conv : text, to;
+import std.file : exists, mkdirRecurse, readText, remove, tempDir, write;
+import std.path : baseName, buildPath;
+import std.process : execute;
+import std.stdio : stderr, writeln;
+import std.string : indexOf, lineSplitter, strip;
+
+// sparkles packages
+import sparkles.core_cli.term_style : Style, stylize;
+import sparkles.core_cli.ui.box : BoxProps, drawBox;
+import sparkles.core_cli.ui.header : drawHeader, HeaderProps, HeaderStyle;
+
+// === Types ===
+
+struct Example
+{
+    string name;
+    string code;
+}
+
+// === Main Entry Point ===
+
+int main(string[] args)
+{
+    auto mdFile = parseArgs(args);
+    if (mdFile is null)
+        return 1;
+
+    auto examples = extractExamples(mdFile.readText);
+
+    if (examples.length == 0)
+    {
+        writeln("No runnable examples found.".stylize(Style.yellow));
+        return 0;
+    }
+
+    i"Running $(examples.length) example(s) from $(mdFile)".text
+        .drawHeader(HeaderProps(style: HeaderStyle.banner, width: 60))
+        .writeln("\n");
+
+    int failures = 0;
+    foreach (i, example; examples)
+    {
+        auto progress = i"[$(i + 1)/$(examples.length)]".text;
+        if (!runExample(example, progress))
+            failures++;
+        writeln();
+    }
+
+    displaySummary(examples.length, failures);
+
+    return failures > 0 ? 1 : 0;
+}
+
+// === Core Functions ===
+
+/// Extracts dub single-file examples from markdown content.
+@safe pure
+Example[] extractExamples(string content)
+{
+    Example[] examples;
+    auto lines = content.lineSplitter.array;
+
+    for (size_t i = 0; i < lines.length; i++)
+    {
+        // Look for ```d code fence
+        if (!lines[i].strip.startsWith("```d"))
+            continue;
+
+        // Find end of code block
+        auto endIdx = lines[i + 1 .. $].countUntil!(l => l.strip.startsWith("```"));
+        if (endIdx < 0)
+            continue;
+
+        auto codeLines = lines[i + 1 .. i + 1 + endIdx];
+
+        if (!isDubSingleFileBlock(codeLines))
+            continue;
+
+        auto name = extractExampleName(codeLines);
+        examples ~= Example(name, codeLines.join("\n"));
+        i += endIdx;
+    }
+
+    return examples;
+}
+
+/// Runs a single example and displays results.
+bool runExample(in Example example, string progress)
+{
+    // Write to temp file
+    auto tmpDir = buildPath(tempDir, "md-examples");
+    mkdirRecurse(tmpDir);
+    auto tmpFile = buildPath(tmpDir, example.name ~ ".d");
+
+    tmpFile.write(example.code);
+    scope(exit) if (tmpFile.exists) tmpFile.remove();
+
+    // Run with dub
+    auto result = execute(["dub", "run", "--single", tmpFile]);
+
+    // Format and display
+    auto header = formatExampleHeader(example, progress);
+    auto outputLines = result.output.lineSplitter
+        .filter!(l => !isDubNoise(l))
+        .map!(l => l.to!string)
+        .array;
+
+    displayResultBox(outputLines, header, result.status == 0);
+
+    return result.status == 0;
+}
+
+/// Checks if a line is dub build noise that should be filtered.
+@safe pure nothrow @nogc
+bool isDubNoise(const(char)[] line)
+{
+    auto stripped = line.strip;
+    if (stripped.length == 0)
+        return false; // Keep empty lines
+
+    // Simple patterns
+    if (line.canFind("Up-to-date") || line.canFind("up to date"))
+        return true;
+    if (line.canFind("Starting Performing"))
+        return true;
+    if (line.canFind("Linking "))
+        return true;
+    if (line.canFind("Finished "))
+        return true;
+    if (line.canFind("--force"))
+        return true;
+
+    // Context-dependent patterns
+    if (line.canFind("Building ") && line.canFind("configuration"))
+        return true;
+    if (line.canFind("Running ") && line.canFind("md-examples"))
+        return true;
+
+    return false;
+}
+
+// === Private Helpers ===
+
+/// Checks if code lines represent a dub single-file program.
+@safe pure nothrow @nogc
+private bool isDubSingleFileBlock(const(char[])[] codeLines)
+{
+    if (codeLines.length < 4)
+        return false;
+    if (!codeLines[0].strip.startsWith("#!/usr/bin/env dub"))
+        return false;
+    if (!codeLines[1].strip.startsWith("/+ dub.sdl:"))
+        return false;
+    return true;
+}
+
+/// Extracts the example name from dub.sdl header lines.
+@safe pure
+private string extractExampleName(const(char[])[] codeLines)
+{
+    foreach (line; codeLines[2 .. $])
+    {
+        auto stripped = line.strip;
+        if (stripped.startsWith("name "))
+            return parseQuotedName(stripped);
+        if (stripped.startsWith("+/"))
+            break;
+    }
+    return "unnamed";
+}
+
+/// Parses a name from a line like: name "example-name"
+@safe pure
+private string parseQuotedName(const(char)[] line)
+in (line.length > 0, "Line cannot be empty")
+{
+    auto start = line.indexOf('"');
+    if (start < 0)
+        return "unnamed";
+
+    auto rest = line[start + 1 .. $];
+    auto end = rest.indexOf('"');
+    if (end < 0)
+        return "unnamed";
+
+    return rest[0 .. end].idup;
+}
+
+/// Formats the header line for an example run.
+@safe pure
+private string formatExampleHeader(in Example example, string progress)
+{
+    auto cmd = i"dub run --single $(example.name).d".text;
+    return progress.stylize(Style.dim) ~ " " ~
+        example.name.stylize(Style.cyan) ~ " › ".stylize(Style.dim) ~
+        cmd.stylize(Style.dim);
+}
+
+/// Formats output lines for display, truncating if necessary.
+@safe pure
+private string[] formatOutputLines(string[] lines, size_t maxLines = 8)
+in (maxLines > 1, "maxLines must be at least 2 for truncation indicator")
+{
+    if (lines.length == 0)
+        return ["(no output)".stylize(Style.dim)];
+
+    if (lines.length > maxLines)
+        return lines[0 .. maxLines - 1] ~ ["...".stylize(Style.dim)];
+
+    return lines;
+}
+
+/// Displays the result box for an example run.
+private void displayResultBox(string[] outputLines, string header, bool success)
+{
+    auto footer = success
+        ? "✓ passed".stylize(Style.green)
+        : "✗ FAILED".stylize(Style.red);
+
+    outputLines
+        .formatOutputLines
+        .drawBox(header, BoxProps(footer: footer))
+        .writeln;
+}
+
+/// Validates command-line arguments.
+/// Returns the markdown file path or null on error.
+private string parseArgs(string[] args)
+{
+    if (args.length < 2)
+    {
+        stderr.writeln("Usage: ".stylize(Style.bold), args[0].baseName, " <markdown-file>");
+        return null;
+    }
+
+    const mdFile = args[1];
+    if (!mdFile.exists)
+    {
+        stderr.writeln("Error: ".stylize(Style.red), "File not found: ", mdFile);
+        return null;
+    }
+
+    return mdFile;
+}
+
+/// Displays the results summary.
+private void displaySummary(size_t total, size_t failures)
+{
+    writeln();
+    auto passed = total - failures;
+    auto resultText = i"$(passed)/$(total) passed".text;
+
+    if (failures == 0)
+    {
+        writeln([
+            "✓ ".stylize(Style.green) ~ "All examples passed!",
+            resultText.stylize(Style.dim),
+        ].drawBox("Results".stylize(Style.green)));
+    }
+    else
+    {
+        writeln([
+            "✗ ".stylize(Style.red) ~ i"$(failures) example(s) failed".text,
+            resultText.stylize(Style.dim),
+        ].drawBox("Results".stylize(Style.red)));
+    }
+}

--- a/scripts/run_md_examples.d
+++ b/scripts/run_md_examples.d
@@ -31,11 +31,11 @@ import std.conv : text, to;
 import std.file : exists, mkdirRecurse, readText, remove, tempDir, write;
 import std.path : baseName, buildPath;
 import std.process : execute;
-import std.stdio : stderr, writeln;
+import std.stdio : writeln;
 import std.string : indexOf, lineSplitter, strip;
 
 // sparkles packages
-import sparkles.core_cli.term_style : Style, stylize;
+import sparkles.core_cli.styled_template : styledText, styledWriteln, styledWritelnErr;
 import sparkles.core_cli.ui.box : BoxProps, drawBox;
 import sparkles.core_cli.ui.header : drawHeader, HeaderProps, HeaderStyle;
 
@@ -59,7 +59,7 @@ int main(string[] args)
 
     if (examples.length == 0)
     {
-        writeln("No runnable examples found.".stylize(Style.yellow));
+        styledWriteln(i"{yellow No runnable examples found.}");
         return 0;
     }
 
@@ -217,25 +217,20 @@ in (line.length > 0, "Line cannot be empty")
 }
 
 /// Formats the header line for an example run.
-@safe pure
 private string formatExampleHeader(in Example example, string progress)
 {
-    auto cmd = i"dub run --single $(example.name).d".text;
-    return progress.stylize(Style.dim) ~ " " ~
-        example.name.stylize(Style.cyan) ~ " › ".stylize(Style.dim) ~
-        cmd.stylize(Style.dim);
+    return styledText(i"{dim $(progress)} {cyan $(example.name)} {dim › dub run --single $(example.name).d}");
 }
 
 /// Formats output lines for display, truncating if necessary.
-@safe pure
 private string[] formatOutputLines(string[] lines, size_t maxLines = 8)
 in (maxLines > 1, "maxLines must be at least 2 for truncation indicator")
 {
     if (lines.length == 0)
-        return ["(no output)".stylize(Style.dim)];
+        return [styledText(i"{dim (no output)}")];
 
     if (lines.length > maxLines)
-        return lines[0 .. maxLines - 1] ~ ["...".stylize(Style.dim)];
+        return lines[0 .. maxLines - 1] ~ [styledText(i"{dim ...}")];
 
     return lines;
 }
@@ -244,8 +239,8 @@ in (maxLines > 1, "maxLines must be at least 2 for truncation indicator")
 private void displayResultBox(string[] outputLines, string header, bool success)
 {
     auto footer = success
-        ? "✓ passed".stylize(Style.green)
-        : "✗ FAILED".stylize(Style.red);
+        ? styledText(i"{green ✓ passed}")
+        : styledText(i"{red ✗ FAILED}");
 
     outputLines
         .formatOutputLines
@@ -259,14 +254,14 @@ private string parseArgs(string[] args)
 {
     if (args.length < 2)
     {
-        stderr.writeln("Usage: ".stylize(Style.bold), args[0].baseName, " <markdown-file>");
+        styledWritelnErr(i"{bold Usage:} $(args[0].baseName) <markdown-file>");
         return null;
     }
 
     const mdFile = args[1];
     if (!mdFile.exists)
     {
-        stderr.writeln("Error: ".stylize(Style.red), "File not found: ", mdFile);
+        styledWritelnErr(i"{red Error:} File not found: $(mdFile)");
         return null;
     }
 
@@ -278,20 +273,19 @@ private void displaySummary(size_t total, size_t failures)
 {
     writeln();
     auto passed = total - failures;
-    auto resultText = i"$(passed)/$(total) passed".text;
 
     if (failures == 0)
     {
         writeln([
-            "✓ ".stylize(Style.green) ~ "All examples passed!",
-            resultText.stylize(Style.dim),
-        ].drawBox("Results".stylize(Style.green)));
+            styledText(i"{green ✓} All examples passed!"),
+            styledText(i"{dim $(passed)/$(total) passed}"),
+        ].drawBox(styledText(i"{green Results}")));
     }
     else
     {
         writeln([
-            "✗ ".stylize(Style.red) ~ i"$(failures) example(s) failed".text,
-            resultText.stylize(Style.dim),
-        ].drawBox("Results".stylize(Style.red)));
+            styledText(i"{red ✗} $(failures) example(s) failed"),
+            styledText(i"{dim $(passed)/$(total) passed}"),
+        ].drawBox(styledText(i"{red Results}")));
     }
 }


### PR DESCRIPTION
## Summary
- Set up VitePress documentation site with custom theme, organized sidebar (nested Code Style and Design by Introspection sections), and landing page
- Add GitHub Actions workflow for deploying docs to GitHub Pages
- Add core-cli package overview, DDoc guidelines, IES guidelines, and code style docs
- Add styled template IES processing, drawBox footer support, and markdown example runner

## Test plan
- [ ] Verify `npm run docs:dev` serves the site locally
- [ ] Confirm sidebar navigation works with nested sections
- [ ] Verify GitHub Pages deployment workflow triggers on docs changes