### PR TITLE
Add README, OSC 8 hyperlink component, and docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,6 +25,10 @@ indent_style = space
 [libs/core-cli/src/sparkles/core_cli/prettyprint.d]
 indent_size = unset
 
+# Test data files contain exact byte sequences — no trailing newline
+[libs/core-cli/test/data/**]
+insert_final_newline = unset
+
 # Disable indent checking for markdown - code blocks may have intentional
 # spacing for visual output examples
 [*.md]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,382 @@
+<p align="center">
+  <h1 align="center">sparkles</h1>
+  <p align="center">
+    <strong>A small D library for CLI applications</strong>
+  </p>
+  <p align="center">
+    Terminal styling, pretty-printing, UI components, and @nogc utilities
+  </p>
+  <p align="center">
+    <em>Early stage (v0.0.1) -- API may change</em>
+  </p>
+  <p align="center">
+    <a href="https://github.com/PetarKirov/sparkles/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/PetarKirov/sparkles/actions/workflows/ci.yml/badge.svg"></a>
+    <a href="https://code.dlang.org/packages/sparkles"><img alt="Dub version" src="https://img.shields.io/dub/v/sparkles.svg"></a>
+    <a href="https://code.dlang.org/packages/sparkles"><img alt="Dub downloads" src="https://img.shields.io/dub/dt/sparkles.svg"></a>
+    <a href="https://sparkles-docs.pages.dev/"><img alt="Docs" src="https://img.shields.io/badge/docs-sparkles--docs.pages.dev-blue"></a>
+    <a href="LICENSE"><img alt="BSL-1.0" src="https://img.shields.io/badge/license-BSL--1.0-blue.svg"></a>
+  </p>
+</p>
+
+---
+
+## Overview
+
+**sparkles:core-cli** is a collection of utilities for building command-line interfaces in D, with a focus on `@safe`, `@nogc`, `pure`, and `nothrow` compatibility.
+
+### What's Inside
+
+- **Styled Templates** -- Apply ANSI styles using D's Interpolated Expression Sequences (IES) with a concise `{style text}` syntax
+- **Pretty Printing** -- Colorized, type-aware formatting for any D type via compile-time introspection
+- **UI Components** -- Tables, boxes, and headers with Unicode box-drawing characters
+- **Terminal Styling** -- ANSI color and text attribute support with a fluent builder API
+- **SmallBuffer** -- A `@nogc` dynamic buffer with small buffer optimization (SBO)
+- **@nogc Utilities** -- `recycledInstance`, text writers, and output range interfaces
+
+## Quick Start
+
+Add sparkles to your `dub.sdl`:
+
+```sdl
+dependency "sparkles:core-cli" version="~>0.0.1"
+```
+
+Or `dub.json`:
+
+```json
+"dependencies": {
+    "sparkles:core-cli": "~>0.0.1"
+}
+```
+
+## Modules
+
+### Styled Templates
+
+Apply terminal styles using D's Interpolated Expression Sequences.
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_styled_templates"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import sparkles.core_cli.styled_template;
+
+void main()
+{
+    int cpu = 75;
+    styledWriteln(i"CPU: {red $(cpu)%} Status: {green OK}");
+    styledWriteln(i"{bold.red ERROR:} Connection refused");
+    styledWriteln(i"{cyan Outer {bold.underline inner} just cyan}");
+    styledWriteln(i"Press {bold.cyan q} to quit, {bold.cyan h} for help");
+}
+```
+
+```
+CPU: 75% Status: OK
+ERROR: Connection refused
+Outer inner just cyan
+Press q to quit, h for help
+```
+
+Syntax at a glance:
+
+| Syntax                      | Description                    |
+| --------------------------- | ------------------------------ |
+| `{red text}`                | Single style                   |
+| `{bold.red text}`           | Chained styles                 |
+| `{bold outer {red nested}}` | Nested blocks with inheritance |
+| `{red text {~red normal}}`  | Style negation with `~`        |
+| `{{` / `}}`                 | Escaped literal braces         |
+
+### Pretty Printing
+
+Format D values with syntax highlighting and structural indentation. Supports enums, booleans, strings, numerics, pointers, tuples, associative arrays, arrays, ranges, structs, and classes.
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_pretty_printing"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import std.stdio : writeln;
+
+import sparkles.core_cli.prettyprint;
+
+struct Server
+{
+    string name;
+    string ip;
+    int port;
+}
+
+struct Cluster
+{
+    string name;
+    Server[] servers;
+    bool active;
+}
+
+void main()
+{
+    auto cluster = Cluster(
+        name: "Production",
+        servers: [
+            Server("web-01", "192.168.1.10", 80),
+            Server("web-02", "192.168.1.11", 80),
+            Server("db-01", "192.168.1.20", 5432),
+        ],
+        active: true,
+    );
+
+    writeln(prettyPrint(cluster, PrettyPrintOptions(useColors: false)));
+}
+```
+
+```
+Cluster(
+  name: "Production",
+  servers: [
+    Server(name: "web-01", ip: "192.168.1.10", port: 80),
+    Server(name: "web-02", ip: "192.168.1.11", port: 80),
+    Server(name: "db-01", ip: "192.168.1.20", port: 5432)
+  ],
+  active: true
+)
+```
+
+Options via `PrettyPrintOptions`:
+
+```d
+prettyPrint(value, PrettyPrintOptions(
+    indentStep: 2,       // spaces per indent level
+    maxDepth: 8,         // recursion limit
+    maxItems: 32,        // max array/AA items shown
+    softMaxWidth: 80,    // single-line threshold
+    useColors: true,     // ANSI color output
+));
+```
+
+### Terminal Styling
+
+ANSI colors and text attributes via `stylize` and a fluent `stylizedTextBuilder`. Both work at runtime and at compile time (CTFE).
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_terminal_styling"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import std.stdio : writeln;
+
+import sparkles.core_cli.term_style;
+
+void main()
+{
+    // Runtime styling
+    writeln("Error: ".stylize(Style.red) ~ "something went wrong");
+
+    // Compile-time styling via fluent builder
+    enum title = "Important".stylizedTextBuilder(true).bold.underline.red;
+    writeln(title);
+}
+```
+
+```
+Error: something went wrong
+Important
+```
+
+### UI Components
+
+#### Tables
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_tables"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import std.stdio : writeln;
+
+import sparkles.core_cli.ui.table;
+
+void main()
+{
+    drawTable([
+        ["Name",    "Status",  "Load"],
+        ["web-01",  "UP",      "23%"],
+        ["web-02",  "UP",      "45%"],
+        ["db-01",   "DOWN",    "0%" ],
+    ]).writeln;
+}
+```
+
+```
+╭────────┬────────┬──────╮
+│ Name   │ Status │ Load │
+│ web-01 │ UP     │ 23%  │
+│ web-02 │ UP     │ 45%  │
+│ db-01  │ DOWN   │ 0%   │
+╰────────┴────────┴──────╯
+```
+
+#### Boxes
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_boxes"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import std.stdio : writeln;
+
+import sparkles.core_cli.ui.box;
+
+void main()
+{
+    drawBox(
+        ["Build started at 14:32:01",
+         "Compiling 42 modules...",
+         "Linking executable...",
+         "Build completed in 3.2s"],
+        "Build Log",
+        BoxProps(footer: "Success"),
+    ).writeln;
+}
+```
+
+```
+╭──╼ Build Log ╾────────────╮
+│ Build started at 14:32:01 │
+│ Compiling 42 modules...   │
+│ Linking executable...     │
+│ Build completed in 3.2s   │
+╰──╼ Success ╾──────────────╯
+```
+
+#### Headers
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_headers"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import std.stdio : writeln;
+
+import sparkles.core_cli.ui.header;
+
+void main()
+{
+    // Divider style:  ── Section Title ──
+    "Section Title".drawHeader.writeln;
+
+    // Banner style
+    "Main Title".drawHeader(HeaderProps(
+        style: HeaderStyle.banner,
+        lineChar: '═',
+        width: 40,
+    )).writeln;
+}
+```
+
+```
+── Section Title ──
+════════════════════════════════════════
+               Main Title
+════════════════════════════════════════
+```
+
+### SmallBuffer
+
+A `@nogc` dynamic array with small buffer optimization. Stores data inline up to a configurable threshold, then falls back to the heap via `pureMalloc`.
+
+```d
+import sparkles.core_cli.smallbuffer;
+
+@safe pure nothrow @nogc
+unittest {
+    SmallBuffer!(char, 64) buf;
+    buf ~= "Hello";
+    buf ~= ' ';
+    buf ~= "World";
+    assert(buf[] == "Hello World");
+    assert(!buf.onHeap);  // still using inline storage
+}
+```
+
+Works as an output range, so it composes with `std.algorithm`, `prettyPrint`, styled templates, and the rest of the library.
+
+### @nogc Utilities
+
+**`recycledInstance`** -- Reuse thread-local static instances for throwing errors in `@nogc` code:
+
+```d
+import sparkles.core_cli.lifetime;
+
+@nogc void validate(int x) {
+    if (x < 0)
+        throw recycledInstance!Error("value must be non-negative");
+}
+```
+
+**`text_writers`** -- Write integers, floats, escaped characters, and ANSI codes without GC allocation.
+
+**`term_unstyle`** -- Strip ANSI escape sequences from styled text.
+
+**`term_size`** -- Detect terminal window resizes via `SIGWINCH`.
+
+## Examples
+
+Runnable examples are in [`libs/core-cli/examples/`](libs/core-cli/examples/):
+
+```bash
+dub run --single libs/core-cli/examples/styled_template.d
+dub run --single libs/core-cli/examples/prettyprint.d
+dub run --single libs/core-cli/examples/table.d
+dub run --single libs/core-cli/examples/box.d
+dub run --single libs/core-cli/examples/header.d
+dub run --single libs/core-cli/examples/color.d
+```
+
+## Building & Testing
+
+```bash
+# Build
+dub build :core-cli
+
+# Run all tests
+./scripts/run-tests.sh
+
+# Test a specific sub-package
+dub test :core-cli
+
+# Run tests matching a pattern
+dub test :core-cli -- -i "SmallBuffer"
+
+# Verbose output with stack traces
+dub test :core-cli -- -v
+```
+
+The project uses a **Nix development shell** for reproducible builds:
+
+```bash
+nix develop -c dub build :core-cli
+nix develop -c ./scripts/run-tests.sh
+```
+
+## Documentation
+
+Documentation (work in progress) is available at **[sparkles-docs.pages.dev](https://sparkles-docs.pages.dev/)**.
+
+## License
+
+[Boost Software License 1.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 - **Styled Templates** -- Apply ANSI styles using D's Interpolated Expression Sequences (IES) with a concise `{style text}` syntax
 - **Pretty Printing** -- Colorized, type-aware formatting for any D type via compile-time introspection
-- **UI Components** -- Tables, boxes, and headers with Unicode box-drawing characters
+- **UI Components** -- Tables, boxes, headers, and OSC 8 hyperlinks
 - **Terminal Styling** -- ANSI color and text attribute support with a fluent builder API
 - **SmallBuffer** -- A `@nogc` dynamic buffer with small buffer optimization (SBO)
 - **@nogc Utilities** -- `recycledInstance`, text writers, and output range interfaces
@@ -295,6 +295,32 @@ void main()
 ════════════════════════════════════════
 ```
 
+#### OSC 8 Hyperlinks
+
+Make text clickable in terminal emulators that support [OSC 8](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda).
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_osc_link"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import std.stdio : writeln;
+
+import sparkles.core_cli.ui.osc_link;
+import sparkles.core_cli.term_style : Style;
+
+void main()
+{
+    // Plain clickable link
+    writeln(oscLink(text: "Example", uri: "https://example.com"));
+
+    // Styled clickable link (blue text)
+    writeln(oscLink(text: "D Language", uri: "https://dlang.org", style: Style.blue));
+}
+```
+
 ### SmallBuffer
 
 A `@nogc` dynamic array with small buffer optimization. Stores data inline up to a configurable threshold, then falls back to the heap via `pureMalloc`.
@@ -344,6 +370,7 @@ dub run --single libs/core-cli/examples/prettyprint.d
 dub run --single libs/core-cli/examples/table.d
 dub run --single libs/core-cli/examples/box.d
 dub run --single libs/core-cli/examples/header.d
+dub run --single libs/core-cli/examples/osc_link.d
 dub run --single libs/core-cli/examples/color.d
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,6 +12,7 @@ A D library providing utilities for building CLI applications with terminal styl
   - [Tables](#tables)
   - [Boxes](#boxes)
   - [Headers](#headers)
+  - [OSC 8 Hyperlinks](#osc-8-hyperlinks)
 - [SmallBuffer (@nogc)](#smallbuffer-nogc)
 - [Running Examples](#running-examples)
 
@@ -327,6 +328,46 @@ Output:
 ══════════════════════════════
 ```
 
+### OSC 8 Hyperlinks
+
+Make text clickable in terminal emulators that support [OSC 8](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda).
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "osclinkdemo"
+    dependency "sparkles:core-cli" version="*"
++/
+import std.stdio : writeln;
+import sparkles.core_cli.ui.osc_link : oscLink;
+import sparkles.core_cli.term_style : Style;
+
+void main()
+{
+    // Plain clickable link
+    writeln(oscLink(text: "Example", uri: "https://example.com"));
+
+    // Styled clickable link (blue text)
+    writeln(oscLink(text: "D Language", uri: "https://dlang.org", style: Style.blue));
+}
+```
+
+#### API
+
+| Function                     | Description                       |
+| ---------------------------- | --------------------------------- |
+| `oscLink(text, uri)`         | Wrap text in an OSC 8 hyperlink   |
+| `oscLink(text, uri, style)`  | Wrap styled text in an OSC 8 link |
+| `oscLinkOpenSeq(uri, props)` | Opening escape sequence only      |
+| `oscLinkCloseSeq(props)`     | Closing escape sequence only      |
+
+Configure via `OscLinkProps`:
+
+| Field        | Default             | Description                   |
+| ------------ | ------------------- | ----------------------------- |
+| `terminator` | `OscTerminator.bel` | BEL (`\x07`) or ST (`\x1b\\`) |
+| `id`         | `null`              | Optional link id for grouping |
+
 ## SmallBuffer (@nogc)
 
 A `@nogc` container with Small Buffer Optimization (SBO). Stores small data inline, automatically switches to heap when capacity is exceeded.
@@ -382,3 +423,4 @@ Available examples:
 - `table.d` - Table rendering variations
 - `box.d` - Box layouts with nested content
 - `header.d` - Header styles
+- `osc_link.d` - OSC 8 terminal hyperlinks

--- a/libs/core-cli/examples/osc_link.d
+++ b/libs/core-cli/examples/osc_link.d
@@ -1,0 +1,46 @@
+#!/usr/bin/env dub
+
+/+ dub.sdl:
+name "osc_link"
+dependency "sparkles:core-cli" version="*"
+targetPath "build"
++/
+
+import std.stdio : writeln;
+
+import sparkles.core_cli.ui.osc_link;
+import sparkles.core_cli.term_style : Style;
+
+void main()
+{
+    // Plain hyperlink
+    writeln("Visit: ", oscLink(text: "Example", uri: "https://example.com"));
+
+    // Styled hyperlink (blue text)
+    writeln("Docs:  ", oscLink(text: "D Language", uri: "https://dlang.org", style: Style.blue));
+
+    // Styled hyperlink (bold + underline)
+    writeln("Repo:  ", oscLink(text: "GitHub", uri: "https://github.com", style: Style.underline));
+
+    // With explicit id parameter
+    writeln("Home:  ", oscLink(text: "Homepage", uri: "https://example.com",
+        props: OscLinkProps(id: "home")));
+
+    // Using low-level open/close sequences directly
+    writeln(
+        oscLinkOpenSeq(uri: "https://dlang.org"),
+        "Click ",
+        "here".stylize(Style.bold),
+        oscLinkCloseSeq(),
+    );
+
+    // With ST terminator instead of BEL
+    writeln("ST:    ", oscLink(text: "ST link", uri: "https://example.com",
+        props: OscLinkProps(terminator: OscTerminator.st)));
+}
+
+private string stylize(string text, Style style)
+{
+    import sparkles.core_cli.term_style : stylize;
+    return text.stylize(style);
+}

--- a/libs/core-cli/src/sparkles/core_cli/ui/osc_link.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/osc_link.d
@@ -1,0 +1,172 @@
+/++
+OSC 8 terminal hyperlink rendering.
+
+Provides functions to wrap text in OSC 8 escape sequences, making it
+clickable in terminal emulators that support hyperlinks.
++/
+module sparkles.core_cli.ui.osc_link;
+
+import sparkles.core_cli.term_style : Style;
+
+@safe:
+
+/// OSC 8 sequence terminator style.
+enum OscTerminator
+{
+    bel, /// BEL character (`\x07`) — widely supported default.
+    st,  /// String Terminator (`\x1b\\`) — standard but less common.
+}
+
+/// Configuration for OSC 8 hyperlink rendering.
+struct OscLinkProps
+{
+    OscTerminator terminator = OscTerminator.bel;
+    string id = null; /// Optional link id parameter.
+}
+
+/// Returns the OSC 8 opening escape sequence for `uri`.
+pure nothrow
+string oscLinkOpenSeq(string uri, OscLinkProps props = OscLinkProps.init)
+{
+    const params = props.id !is null ? "id=" ~ props.id : "";
+    const term = props.terminator == OscTerminator.st ? "\x1b\\" : "\x07";
+    return "\x1b]8;" ~ params ~ ";" ~ uri ~ term;
+}
+
+/// Opening sequence uses BEL terminator by default.
+@("oscLink.oscLinkOpenSeq.bel")
+@safe pure nothrow unittest
+{
+    assert(oscLinkOpenSeq(uri: "https://example.com") == "\x1b]8;;https://example.com\x07");
+}
+
+/// Opening sequence with ST terminator.
+@("oscLink.oscLinkOpenSeq.st")
+@safe pure nothrow unittest
+{
+    assert(oscLinkOpenSeq(uri: "https://example.com", props: OscLinkProps(terminator: OscTerminator.st))
+        == "\x1b]8;;https://example.com\x1b\\");
+}
+
+/// Opening sequence with id parameter.
+@("oscLink.oscLinkOpenSeq.withId")
+@safe pure nothrow unittest
+{
+    assert(oscLinkOpenSeq(uri: "https://example.com", props: OscLinkProps(id: "link1"))
+        == "\x1b]8;id=link1;https://example.com\x07");
+}
+
+/// Returns the OSC 8 closing escape sequence.
+pure nothrow
+string oscLinkCloseSeq(OscLinkProps props = OscLinkProps.init)
+{
+    const term = props.terminator == OscTerminator.st ? "\x1b\\" : "\x07";
+    return "\x1b]8;;" ~ term;
+}
+
+/// Closing sequence uses BEL terminator by default.
+@("oscLink.oscLinkCloseSeq.bel")
+@safe pure nothrow unittest
+{
+    assert(oscLinkCloseSeq() == "\x1b]8;;\x07");
+}
+
+/// Closing sequence with ST terminator.
+@("oscLink.oscLinkCloseSeq.st")
+@safe pure nothrow unittest
+{
+    assert(oscLinkCloseSeq(props: OscLinkProps(terminator: OscTerminator.st)) == "\x1b]8;;\x1b\\");
+}
+
+/// Wraps `text` in an OSC 8 hyperlink to `uri`.
+pure nothrow
+string oscLink(string text, string uri, OscLinkProps props = OscLinkProps.init)
+{
+    return oscLinkOpenSeq(uri: uri, props: props) ~ text ~ oscLinkCloseSeq(props: props);
+}
+
+/// Plain hyperlink with BEL terminator.
+@("oscLink.oscLink.basic")
+@safe pure nothrow unittest
+{
+    assert(oscLink(text: "Click", uri: "https://example.com")
+        == "\x1b]8;;https://example.com\x07Click\x1b]8;;\x07");
+}
+
+/// Hyperlink with ST terminator.
+@("oscLink.oscLink.st")
+@safe pure nothrow unittest
+{
+    assert(oscLink(text: "Click", uri: "https://example.com", props: OscLinkProps(terminator: OscTerminator.st))
+        == "\x1b]8;;https://example.com\x1b\\Click\x1b]8;;\x1b\\");
+}
+
+/// Hyperlink with id parameter.
+@("oscLink.oscLink.withId")
+@safe pure nothrow unittest
+{
+    assert(oscLink(text: "Click", uri: "https://example.com", props: OscLinkProps(id: "foo"))
+        == "\x1b]8;id=foo;https://example.com\x07Click\x1b]8;;\x07");
+}
+
+/// Wraps styled `text` in an OSC 8 hyperlink to `uri`.
+///
+/// The SGR styling is applied inside the link, so terminal emulators
+/// render the styled text as a clickable hyperlink.
+pure nothrow
+string oscLink(string text, string uri, Style style, OscLinkProps props = OscLinkProps.init)
+{
+    import sparkles.core_cli.term_style : stylize;
+    return oscLinkOpenSeq(uri: uri, props: props) ~ text.stylize(style) ~ oscLinkCloseSeq(props: props);
+}
+
+/// Styled hyperlink with blue.
+@("oscLink.oscLink.styled")
+@safe pure nothrow unittest
+{
+    import sparkles.core_cli.term_style : stylize;
+
+    const result = oscLink(text: "Click", uri: "https://example.com", style: Style.blue);
+    assert(result == "\x1b]8;;https://example.com\x07" ~ "Click".stylize(Style.blue) ~ "\x1b]8;;\x07");
+}
+
+/// Styled hyperlink with id and ST terminator.
+@("oscLink.oscLink.styledWithProps")
+@safe pure nothrow unittest
+{
+    import sparkles.core_cli.term_style : stylize;
+
+    const result = oscLink(text: "Link", uri: "https://d-lang.org", style: Style.underline,
+        props: OscLinkProps(terminator: OscTerminator.st, id: "dlang"));
+    assert(result == "\x1b]8;id=dlang;https://d-lang.org\x1b\\" ~ "Link".stylize(Style.underline) ~ "\x1b]8;;\x1b\\");
+}
+
+/// `unstyledLength` works correctly with OSC links.
+@("oscLink.unstyledLength")
+@safe unittest
+{
+    import sparkles.core_cli.term_unstyle : unstyledLength;
+
+    assert(oscLink(text: "Click here", uri: "https://example.com").unstyledLength == 10);
+}
+
+/// Styled OSC link unstyled length counts only the visible text.
+@("oscLink.unstyledLength.styled")
+@safe unittest
+{
+    import sparkles.core_cli.term_unstyle : unstyledLength;
+
+    assert(oscLink(text: "Hello", uri: "https://example.com", style: Style.blue).unstyledLength == 5);
+}
+
+// Legacy test using test files
+@system unittest
+{
+    import sparkles.core_cli.test_utils : readFromTestDir;
+
+    // out0.txt: plain OSC 8 link with BEL terminator
+    assert(oscLink(text: "example", uri: "https://example.com") == readFromTestDir("out0.txt"));
+
+    // out1.txt: OSC 8 link with blue styling
+    assert(oscLink(text: "example", uri: "https://example.com", style: Style.blue) == readFromTestDir("out1.txt"));
+}

--- a/libs/core-cli/test/data/ui/osc_link/out0.txt
+++ b/libs/core-cli/test/data/ui/osc_link/out0.txt
@@ -1,0 +1,1 @@
+]8;;https://example.comexample]8;;

--- a/libs/core-cli/test/data/ui/osc_link/out1.txt
+++ b/libs/core-cli/test/data/ui/osc_link/out1.txt
@@ -1,0 +1,1 @@
+]8;;https://example.com[34mexample[39m]8;;

--- a/nix/checks/pre-commit.nix
+++ b/nix/checks/pre-commit.nix
@@ -4,5 +4,8 @@
     { ... }:
     {
       pre-commit.settings.hooks.rustfmt.enable = lib.mkForce false;
+
+      # Test data files contain exact byte sequences — no trailing newline
+      pre-commit.settings.hooks.end-of-file-fixer.excludes = [ "^libs/core-cli/test/data/" ];
     };
 }

--- a/scripts/run_md_examples.d
+++ b/scripts/run_md_examples.d
@@ -12,8 +12,16 @@ dub single-file programs, executes them, and reports results.
 
 Usage:
 ---
-./run_md_examples.d <markdown-file>
+./run_md_examples.d [--verify|--update] <markdown-file>
 ---
+
+Modes:
+
+$(LIST
+    $(ITEM Default — run examples and display results in boxes)
+    $(ITEM `--verify` — compare output against expected output blocks, report mismatches)
+    $(ITEM `--update` — rewrite the markdown file with actual output (golden snapshot update))
+)
 
 The script looks for D code blocks starting with:
 ---
@@ -22,40 +30,100 @@ The script looks for D code blocks starting with:
     name "example-name"
 +/
 ---
+
+When an output block (a bare fenced code block with no language tag) immediately
+follows a runnable code block, it is treated as the expected output for that example.
 +/
 
 // std.* modules
-import std.algorithm : canFind, countUntil, filter, map, startsWith;
+import std.algorithm : countUntil, filter, map, startsWith;
 import std.array : array, join;
 import std.conv : text, to;
 import std.file : exists, mkdirRecurse, readText, remove, tempDir, write;
 import std.path : baseName, buildPath;
 import std.process : execute;
 import std.stdio : writeln;
-import std.string : indexOf, lineSplitter, strip;
+import std.string : indexOf, lineSplitter, strip, stripRight;
 
 // sparkles packages
+import sparkles.core_cli.args : CliOption, HelpInfo, parseCliArgs;
 import sparkles.core_cli.styled_template : styledText, styledWriteln, styledWritelnErr;
+import sparkles.core_cli.term_unstyle : unstyle;
 import sparkles.core_cli.ui.box : BoxProps, drawBox;
 import sparkles.core_cli.ui.header : drawHeader, HeaderProps, HeaderStyle;
 
 // === Types ===
 
+struct CliParams
+{
+    @CliOption(`V|verify`, "Compare example output against expected output blocks in the markdown.")
+    bool verify;
+
+    @CliOption(`u|update`, "Rewrite the markdown file with actual example output.")
+    bool update;
+}
+
 struct Example
 {
     string name;
     string code;
+    string expectedOutput;
+    size_t codeBlockStart;
+    size_t codeBlockEnd;
+    size_t outputBlockStart;
+    size_t outputBlockEnd;
+}
+
+struct ExampleResult
+{
+    bool success;
+    string programOutput; // ANSI-stripped
+    string rawOutput;     // with ANSI codes for display
 }
 
 // === Main Entry Point ===
 
+/// `dub` has several verbosity flags that affect its diagnostic output
+/// (progress messages like "Building...", "Linking...", "Up-to-date...", etc.):
+///
+///   (default)   — prints all progress messages to stderr
+///   --quiet     — suppresses progress, still shows warnings and errors
+///   --vquiet    — suppresses everything including warnings (errors still shown)
+///
+/// Using `dub run --quiet --single <file>` eliminates the need for a heuristic
+/// noise filter: on success, only the program's stdout appears in the combined
+/// output; on failure, compiler errors are still reported.
+
 int main(string[] args)
 {
-    auto mdFile = parseArgs(args);
-    if (mdFile is null)
-        return 1;
+    const cli = args.parseCliArgs!CliParams(
+        HelpInfo(
+            "run_md_examples",
+            "Extract and run dub single-file examples from markdown files",
+        ),
+    );
 
-    auto examples = extractExamples(mdFile.readText);
+    if (cli.verify && cli.update)
+    {
+        styledWritelnErr(i"{red Error:} --verify and --update are mutually exclusive");
+        return 1;
+    }
+
+    if (args.length < 2)
+    {
+        styledWritelnErr(i"{bold Usage:} $(args[0].baseName) [--verify|--update] <markdown-file>");
+        return 1;
+    }
+
+    const mdFile = args[1];
+    if (!mdFile.exists)
+    {
+        styledWritelnErr(i"{red Error:} File not found: $(mdFile)");
+        return 1;
+    }
+
+    auto content = mdFile.readText;
+    auto examples = extractExamples(content);
 
     if (examples.length == 0)
     {
@@ -63,6 +131,118 @@ int main(string[] args)
         return 0;
     }
 
+    if (cli.verify)
+        return runVerifyMode(examples, mdFile);
+    else if (cli.update)
+        return runUpdateMode(examples, mdFile);
+    else
+        return runDefaultMode(examples, mdFile);
+}
+
+// === Core Functions ===
+
+/// Extracts dub single-file examples from markdown content,
+/// including any adjacent expected-output blocks.
+@safe pure
+Example[] extractExamples(string content)
+{
+    Example[] examples;
+    auto lines = content.lineSplitter.array;
+
+    for (size_t idx = 0; idx < lines.length; idx++)
+    {
+        // Look for ```d code fence
+        if (!lines[idx].strip.startsWith("```d"))
+            continue;
+
+        auto codeStart = idx;
+
+        // Find end of code block
+        auto endIdx = lines[idx + 1 .. $].countUntil!(l => l.strip.startsWith("```"));
+        if (endIdx < 0)
+            continue;
+
+        auto codeLines = lines[idx + 1 .. idx + 1 + endIdx];
+        auto codeEnd = idx + 1 + endIdx;
+
+        if (!isDubSingleFileBlock(codeLines))
+        {
+            idx = codeEnd;
+            continue;
+        }
+
+        auto name = extractExampleName(codeLines);
+
+        // Look for adjacent output block (bare ``` fence, no language tag)
+        string expectedOutput = null;
+        size_t outputStart = size_t.max;
+        size_t outputEnd = size_t.max;
+
+        auto searchStart = codeEnd + 1;
+        // Skip blank lines
+        while (searchStart < lines.length && lines[searchStart].strip.length == 0)
+            searchStart++;
+
+        if (searchStart < lines.length && lines[searchStart].strip == "```")
+        {
+            outputStart = searchStart;
+            auto outEndIdx = lines[searchStart + 1 .. $]
+                .countUntil!(l => l.strip.startsWith("```"));
+            if (outEndIdx >= 0)
+            {
+                outputEnd = searchStart + 1 + outEndIdx;
+                expectedOutput = lines[searchStart + 1 .. searchStart + 1 + outEndIdx]
+                    .join("\n");
+            }
+        }
+
+        examples ~= Example(
+            name: name,
+            code: codeLines.join("\n"),
+            expectedOutput: expectedOutput,
+            codeBlockStart: codeStart,
+            codeBlockEnd: codeEnd,
+            outputBlockStart: outputStart,
+            outputBlockEnd: outputEnd,
+        );
+
+        idx = (outputEnd != size_t.max) ? outputEnd : codeEnd;
+    }
+
+    return examples;
+}
+
+/// Runs a single example and returns its result.
+ExampleResult executeExample(in Example example)
+{
+    auto tmpDir = buildPath(tempDir, "md-examples");
+    mkdirRecurse(tmpDir);
+    auto tmpFile = buildPath(tmpDir, example.name ~ ".d");
+
+    tmpFile.write(example.code);
+    scope(exit) if (tmpFile.exists) tmpFile.remove();
+
+    auto result = execute(["dub", "run", "--quiet", "--single", tmpFile]);
+
+    // Strip ANSI codes, then trim trailing whitespace from each line
+    // so output matches what pre-commit hooks produce in markdown files.
+    auto cleaned = result.output.unstyle
+        .lineSplitter
+        .map!(l => l.stripRight)
+        .join("\n");
+
+    return ExampleResult(
+        success: result.status == 0,
+        programOutput: cleaned,
+        rawOutput: result.output,
+    );
+}
+
+// === Modes ===
+
+/// Default mode: run examples and display output in boxes.
+int runDefaultMode(Example[] examples, string mdFile)
+{
     i"Running $(examples.length) example(s) from $(mdFile)".text
         .drawHeader(HeaderProps(style: HeaderStyle.banner, width: 60))
         .writeln("\n");
@@ -71,102 +251,162 @@ int main(string[] args)
     foreach (i, example; examples)
     {
         auto progress = i"[$(i + 1)/$(examples.length)]".text;
-        if (!runExample(example, progress))
+        auto result = executeExample(example);
+        auto header = formatExampleHeader(example, progress);
+        auto outputLines = result.rawOutput.lineSplitter
+            .map!(l => l.to!string)
+            .array;
+
+        displayResultBox(outputLines, header, result.success);
+
+        if (!result.success)
             failures++;
         writeln();
     }
 
     displaySummary(examples.length, failures);
-
     return failures > 0 ? 1 : 0;
 }
 
-// === Core Functions ===
-
-/// Extracts dub single-file examples from markdown content.
-@safe pure
-Example[] extractExamples(string content)
+/// Verify mode: run examples, display output, and compare against expected output blocks.
+int runVerifyMode(Example[] examples, string mdFile)
 {
-    Example[] examples;
-    auto lines = content.lineSplitter.array;
+    i"Verifying $(examples.length) example(s) from $(mdFile)".text
+        .drawHeader(HeaderProps(style: HeaderStyle.banner, width: 60))
+        .writeln("\n");
 
-    for (size_t i = 0; i < lines.length; i++)
+    int failures = 0;
+    foreach (i, example; examples)
     {
-        // Look for ```d code fence
-        if (!lines[i].strip.startsWith("```d"))
+        auto progress = i"[$(i + 1)/$(examples.length)]".text;
+        auto header = formatExampleHeader(example, progress);
+        auto result = executeExample(example);
+        auto outputLines = result.rawOutput.lineSplitter
+            .map!(l => l.to!string)
+            .array;
+
+        if (!result.success)
+        {
+            failures++;
+            outputLines
+                .formatOutputLines(12)
+                .drawBox(header, BoxProps(footer: styledText(i"{red ✗ build failed}")))
+                .writeln;
+            writeln();
             continue;
+        }
 
-        // Find end of code block
-        auto endIdx = lines[i + 1 .. $].countUntil!(l => l.strip.startsWith("```"));
-        if (endIdx < 0)
+        if (example.expectedOutput is null)
+        {
+            outputLines
+                .formatOutputLines
+                .drawBox(header, BoxProps(footer: styledText(i"{green ✓ ran} {dim │} {yellow ⚠ no expected output}")))
+                .writeln;
+            writeln();
             continue;
+        }
 
-        auto codeLines = lines[i + 1 .. i + 1 + endIdx];
+        auto actual = result.programOutput.strip;
+        auto expected = example.expectedOutput.strip;
 
-        if (!isDubSingleFileBlock(codeLines))
-            continue;
-
-        auto name = extractExampleName(codeLines);
-        examples ~= Example(name, codeLines.join("\n"));
-        i += endIdx;
+        if (actual == expected)
+        {
+            outputLines
+                .formatOutputLines
+                .drawBox(header, BoxProps(footer: styledText(i"{green ✓ ran} {dim │} {green ✓ output matches}")))
+                .writeln;
+        }
+        else
+        {
+            failures++;
+            outputLines ~= "";
+            outputLines ~= styledText(i"{dim ─── expected ───}");
+            outputLines ~= expected.lineSplitter.map!(l => l.to!string).array;
+            outputLines
+                .formatOutputLines(24)
+                .drawBox(header, BoxProps(footer: styledText(i"{green ✓ ran} {dim │} {red ✗ output mismatch}")))
+                .writeln;
+        }
+        writeln();
     }
 
-    return examples;
+    displaySummary(examples.length, failures);
+    return failures > 0 ? 1 : 0;
 }
 
-/// Runs a single example and displays results.
-bool runExample(in Example example, string progress)
+/// Update mode: rewrite the markdown file with actual output.
+/// Processes examples in reverse order so line indices remain valid.
+int runUpdateMode(Example[] examples, string mdFile)
 {
-    // Write to temp file
-    auto tmpDir = buildPath(tempDir, "md-examples");
-    mkdirRecurse(tmpDir);
-    auto tmpFile = buildPath(tmpDir, example.name ~ ".d");
+    i"Updating $(examples.length) example(s) in $(mdFile)".text
+        .drawHeader(HeaderProps(style: HeaderStyle.banner, width: 60))
+        .writeln("\n");
 
-    tmpFile.write(example.code);
-    scope(exit) if (tmpFile.exists) tmpFile.remove();
+    auto lines = mdFile.readText.lineSplitter.array;
+    int failures = 0;
+    int updated = 0;
 
-    // Run with dub
-    auto result = execute(["dub", "run", "--single", tmpFile]);
+    foreach_reverse (i, example; examples)
+    {
+        auto result = executeExample(example);
 
-    // Format and display
-    auto header = formatExampleHeader(example, progress);
-    auto outputLines = result.output.lineSplitter
-        .filter!(l => !isDubNoise(l))
-        .map!(l => l.to!string)
-        .array;
+        if (!result.success)
+        {
+            failures++;
+            styledWriteln(i"  {red ✗} {cyan $(example.name)} — build failed, skipping");
+            continue;
+        }
 
-    displayResultBox(outputLines, header, result.status == 0);
+        auto actualOutput = result.programOutput.strip;
 
-    return result.status == 0;
-}
+        if (example.expectedOutput !is null && actualOutput == example.expectedOutput.strip)
+        {
+            styledWriteln(i"  {green ✓} {cyan $(example.name)} — output unchanged");
+            continue;
+        }
 
-/// Checks if a line is dub build noise that should be filtered.
-@safe pure nothrow @nogc
-bool isDubNoise(const(char)[] line)
-{
-    auto stripped = line.strip;
-    if (stripped.length == 0)
-        return false; // Keep empty lines
+        auto newOutputLines = ["```"]
+            ~ actualOutput.lineSplitter.map!(l => l.idup).array
+            ~ ["```"];
 
-    // Simple patterns
-    if (line.canFind("Up-to-date") || line.canFind("up to date"))
-        return true;
-    if (line.canFind("Starting Performing"))
-        return true;
-    if (line.canFind("Linking "))
-        return true;
-    if (line.canFind("Finished "))
-        return true;
-    if (line.canFind("--force"))
-        return true;
+        if (example.outputBlockStart != size_t.max)
+        {
+            // Replace existing output block
+            lines = lines[0 .. example.outputBlockStart]
+                ~ newOutputLines.map!(l => l.idup).array
+                ~ lines[example.outputBlockEnd + 1 .. $];
+            updated++;
+            styledWriteln(i"  {yellow ↻} {cyan $(example.name)} — output block updated");
+        }
+        else
+        {
+            // Insert new output block after code block
+            auto insertPos = example.codeBlockEnd + 1;
+            auto insertLines = [""] ~ newOutputLines;
+            lines = lines[0 .. insertPos]
+                ~ insertLines.map!(l => l.idup).array
+                ~ lines[insertPos .. $];
+            updated++;
+            styledWriteln(i"  {yellow +} {cyan $(example.name)} — output block inserted");
+        }
+    }
 
-    // Context-dependent patterns
-    if (line.canFind("Building ") && line.canFind("configuration"))
-        return true;
-    if (line.canFind("Running ") && line.canFind("md-examples"))
-        return true;
+    if (updated > 0)
+        mdFile.write(lines.join("\n") ~ "\n");
 
-    return false;
+    writeln();
+    if (updated > 0)
+        styledWriteln(i"{green ✓} Updated $(updated) output block(s) in $(mdFile)");
+    else
+        styledWriteln(i"{green ✓} All output blocks already up to date");
+
+    if (failures > 0)
+    {
+        styledWriteln(i"{red ✗} $(failures) example(s) failed to build");
+        return 1;
+    }
+
+    return 0;
 }
 
 // === Private Helpers ===
@@ -246,26 +486,6 @@ private void displayResultBox(string[] outputLines, string header, bool success)
         .formatOutputLines
         .drawBox(header, BoxProps(footer: footer))
         .writeln;
-}
-
-/// Validates command-line arguments.
-/// Returns the markdown file path or null on error.
-private string parseArgs(string[] args)
-{
-    if (args.length < 2)
-    {
-        styledWritelnErr(i"{bold Usage:} $(args[0].baseName) <markdown-file>");
-        return null;
-    }
-
-    const mdFile = args[1];
-    if (!mdFile.exists)
-    {
-        styledWritelnErr(i"{red Error:} File not found: $(mdFile)");
-        return null;
-    }
-
-    return mdFile;
 }
 
 /// Displays the results summary.


### PR DESCRIPTION
## Summary

- Add comprehensive README with project overview, module docs, runnable code examples, and badges
- Add `run_md_examples.d` script with `--verify` and `--update` modes to validate markdown code examples
- Add `osc_link` UI module for OSC 8 terminal hyperlinks with `oscLink`, `oscLinkOpenSeq`, `oscLinkCloseSeq` functions
- Extend `unstyle()` regex to strip OSC 8 escape sequences so `unstyledLength` works with hyperlinks
- Update `docs/overview.md` with OSC 8 section, API tables, and example listing
- Exclude test data directory from end-of-file-fixer and editorconfig final newline enforcement
- Use named arguments consistently across new code, examples, and existing examples (box.d, prettyprint.d)

## Test plan

- [x] `dub test :core-cli -- -i "oscLink" -v` — 17 tests pass
- [x] `dub test :core-cli -- -i "unstyle.oscLink" -v` — 5 tests pass
- [x] `./scripts/run-tests.sh` — full suite (149 + 4) passes, no regressions
- [x] `./scripts/run_md_examples.d --verify README.md` — 7/7 pass
- [x] `./scripts/run_md_examples.d --verify docs/overview.md` — 11/11 pass