### PR TITLE
feat(core-cli): Add OSC 8 hyperlinks for type names in prettyPrint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ See [Code Style Guide](docs/guidelines/code-style.md#expression-based-contracts-
 Use named arguments for struct initialization (see [Code Style Guide](docs/guidelines/code-style.md#named-arguments-dip1030)):
 
 ```d
-auto opts = PrettyPrintOptions(
+auto opts = PrettyPrintOptions!void(
     indentStep: 2,
     maxDepth: 8,
     maxItems: 32,
@@ -307,10 +307,10 @@ chore(nix): Update flake inputs
 Many utilities work with output ranges for flexibility:
 
 ```d
-ref Writer prettyPrint(T, Writer)(
+ref Writer prettyPrint(T, Writer, Hook)(
     in T value,
     return ref Writer writer,
-    PrettyPrintOptions opt = PrettyPrintOptions()
+    in PrettyPrintOptions!Hook opt = PrettyPrintOptions!void()
 )
 {
     prettyPrintImpl(value, writer, opt, 0);

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ void main()
         active: true,
     );
 
-    writeln(prettyPrint(cluster, PrettyPrintOptions(useColors: false)));
+    writeln(prettyPrint(cluster, PrettyPrintOptions!void(useColors: false)));
 }
 ```
 
@@ -151,14 +151,17 @@ Cluster(
 Options via `PrettyPrintOptions`:
 
 ```d
-prettyPrint(value, PrettyPrintOptions(
+prettyPrint(value, PrettyPrintOptions!void(
     indentStep: 2,       // spaces per indent level
     maxDepth: 8,         // recursion limit
     maxItems: 32,        // max array/AA items shown
     softMaxWidth: 80,    // single-line threshold
     useColors: true,     // ANSI color output
+    useOscLinks: false,  // OSC 8 hyperlinks on type names
 ));
 ```
+
+The `SourceUriHook` template parameter controls the URI scheme for OSC 8 hyperlinks. Use `SchemeHook!"code"` for VS Code, `EditorDetectHook` for auto-detection from `$EDITOR`/`$VISUAL`, or implement a custom hook via [Design by Introspection](docs/guidelines/design-by-introspection-01-guidelines.md).
 
 ### Terminal Styling
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -184,11 +184,19 @@ void main()
 
     // Custom options
     int[] numbers = [1, 2, 3, 4, 5];
-    writeln(prettyPrint(numbers, PrettyPrintOptions(useColors: false)));
+    writeln(prettyPrint(numbers, PrettyPrintOptions!void(useColors: false)));
 }
 ```
 
 ### PrettyPrintOptions
+
+`PrettyPrintOptions` is a struct template parameterized on `SourceUriHook`:
+
+```d
+PrettyPrintOptions!void(...)              // default: file:// URIs
+PrettyPrintOptions!(SchemeHook!"code")    // VS Code URIs
+PrettyPrintOptions!EditorDetectHook       // auto-detect from $EDITOR/$VISUAL
+```
 
 | Option         | Default | Description                                            |
 | -------------- | ------- | ------------------------------------------------------ |
@@ -197,6 +205,22 @@ void main()
 | `maxItems`     | 32      | Max items shown for arrays/AAs                         |
 | `softMaxWidth` | 80      | Try single-line if output fits (0 = always multi-line) |
 | `useColors`    | true    | Enable ANSI colors                                     |
+| `useOscLinks`  | false   | Wrap type names in OSC 8 hyperlinks to source location |
+
+#### Source URI Hooks
+
+The `SourceUriHook` template parameter controls the URI scheme for OSC 8 hyperlinks on type names. Available hooks from `sparkles.core_cli.source_uri`:
+
+| Hook                  | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `void` (default)      | `file://` URIs with absolute paths               |
+| `SchemeHook!"code"`   | VS Code (`vscode://`) URIs                       |
+| `SchemeHook!"cursor"` | Cursor editor URIs                               |
+| `SchemeHook!"idea"`   | JetBrains IDE URIs                               |
+| `SchemeHook!"subl"`   | Sublime Text URIs                                |
+| `EditorDetectHook`    | Auto-detects from `$VISUAL`/`$EDITOR` at runtime |
+
+Custom hooks implement `static void writeSourceUri(string path, size_t line, size_t col, Writer)(ref Writer w)` — source location is passed as template parameters for CTFE evaluation.
 
 ## UI Components
 

--- a/libs/core-cli/examples/box.d
+++ b/libs/core-cli/examples/box.d
@@ -77,7 +77,7 @@ void main()
                     port: 8080,
                     ssl: true,
                     endpoints: ["/api", "/health", "/metrics"],
-                ).prettyPrint(PrettyPrintOptions(softMaxWidth: 0)).drawBox("Config"),
+                ).prettyPrint(PrettyPrintOptions!void(softMaxWidth: 0)).drawBox("Config"),
             ),
             Section(
                 header: "Dashboard Example",
@@ -115,7 +115,7 @@ void main()
                         Server("db-01", "192.168.1.20", 5432),
                     ],
                     active: true,
-                ).prettyPrint(PrettyPrintOptions(softMaxWidth: 60)).drawBox("Cluster"),
+                ).prettyPrint(PrettyPrintOptions!void(softMaxWidth: 60)).drawBox("Cluster"),
             ),
             Section(
                 header: "Box with Footer",

--- a/libs/core-cli/examples/prettyprint.d
+++ b/libs/core-cli/examples/prettyprint.d
@@ -8,6 +8,7 @@ import std.stdio : writeln;
 import std.typecons : Tuple, tuple;
 
 import sparkles.core_cli.prettyprint : prettyPrint, PrettyPrintOptions;
+import sparkles.core_cli.source_uri : EditorDetectHook, SchemeHook;
 
 // Custom enum
 enum Status { pending, running, completed, failed }
@@ -41,7 +42,6 @@ struct ComplexData {
     // Characters and strings
     char initial;
     string name;
-    wstring wideName;
 
     // Enum
     Status status;
@@ -196,7 +196,7 @@ void main() {
     writeln();
 
     // 17. Complex nested structure
-    writeln("── complex nested structure ──");
+    writeln("── complex nested structure (with OSC 8 hyperlinks) ──");
     int refVal = 99;
     auto complex = ComplexData(
         active: true,
@@ -207,7 +207,6 @@ void main() {
         precise: 3.141592653589793,
         initial: 'X',
         name: "Complex\nData",
-        wideName: "Wide"w,
         status: Status.running,
         numbers: [1, 2, 3],
         fixedNumbers: [10, 20, 30],
@@ -216,23 +215,23 @@ void main() {
         refCount: &refVal,
         metadata: tuple(123, "meta", false)
     );
-    writeln(prettyPrint(complex));
+    writeln(prettyPrint(complex, PrettyPrintOptions!void(useOscLinks: true)));
     writeln();
 
     // 18. maxItems demonstration
     writeln("── maxItems (limit: 3) ──");
     int[] bigArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    writeln(prettyPrint(bigArray, PrettyPrintOptions(maxItems: 3)));
+    writeln(prettyPrint(bigArray, PrettyPrintOptions!void(maxItems: 3)));
     writeln();
 
     // 19. maxDepth demonstration
     writeln("── maxDepth (limit: 2) ──");
-    writeln(prettyPrint(complex, PrettyPrintOptions(maxDepth: 2)));
+    writeln(prettyPrint(complex, PrettyPrintOptions!void(maxDepth: 2, useOscLinks: true)));
     writeln();
 
     // 20. Without colors
     writeln("── without colors ──");
-    writeln(prettyPrint(person, PrettyPrintOptions(useColors: false)));
+    writeln(prettyPrint(person, PrettyPrintOptions!void(useColors: false)));
     writeln();
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -249,11 +248,11 @@ void main() {
     writeln();
 
     writeln("── softMaxWidth: 15 - too narrow, uses multi-line ──");
-    writeln(prettyPrint(point, PrettyPrintOptions(softMaxWidth: 15)));
+    writeln(prettyPrint(point, PrettyPrintOptions!void(softMaxWidth: 15)));
     writeln();
 
     writeln("── softMaxWidth: 0 - always multi-line ──");
-    writeln(prettyPrint(point, PrettyPrintOptions(softMaxWidth: 0)));
+    writeln(prettyPrint(point, PrettyPrintOptions!void(softMaxWidth: 0)));
     writeln();
 
     // 22. Array width comparison
@@ -263,7 +262,7 @@ void main() {
     writeln();
 
     writeln("── array with softMaxWidth: 20 ──");
-    writeln(prettyPrint(mediumArr, PrettyPrintOptions(softMaxWidth: 20)));
+    writeln(prettyPrint(mediumArr, PrettyPrintOptions!void(softMaxWidth: 20)));
     writeln();
 
     // 23. Nested struct width comparison
@@ -272,11 +271,11 @@ void main() {
     writeln();
 
     writeln("── nested struct with softMaxWidth: 40 ──");
-    writeln(prettyPrint(person, PrettyPrintOptions(softMaxWidth: 40)));
+    writeln(prettyPrint(person, PrettyPrintOptions!void(softMaxWidth: 40)));
     writeln();
 
     writeln("── nested struct with softMaxWidth: 0 ──");
-    writeln(prettyPrint(person, PrettyPrintOptions(softMaxWidth: 0)));
+    writeln(prettyPrint(person, PrettyPrintOptions!void(softMaxWidth: 0)));
     writeln();
 
     // 24. Associative array width comparison
@@ -285,16 +284,16 @@ void main() {
     writeln();
 
     writeln("── AA with softMaxWidth: 25 ──");
-    writeln(prettyPrint(aa, PrettyPrintOptions(softMaxWidth: 25)));
+    writeln(prettyPrint(aa, PrettyPrintOptions!void(softMaxWidth: 25)));
     writeln();
 
     // 25. Complex struct - shows how nested values can be inline even when parent is multi-line
     writeln("── complex struct (default) - parent multi-line, nested values inline ──");
-    writeln(prettyPrint(complex));
+    writeln(prettyPrint(complex, PrettyPrintOptions!void(useOscLinks: true)));
     writeln();
 
     writeln("── complex struct with softMaxWidth: 0 - everything multi-line ──");
-    writeln(prettyPrint(complex, PrettyPrintOptions(softMaxWidth: 0)));
+    writeln(prettyPrint(complex, PrettyPrintOptions!void(softMaxWidth: 0, useOscLinks: true)));
     writeln();
 
     // 26. Linked list width comparison
@@ -303,7 +302,31 @@ void main() {
     writeln();
 
     writeln("── linked list with softMaxWidth: 30 ──");
-    writeln(prettyPrint(n1, PrettyPrintOptions(softMaxWidth: 30)));
+    writeln(prettyPrint(n1, PrettyPrintOptions!void(softMaxWidth: 30)));
+    writeln();
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // OSC 8 hyperlink demonstrations
+    // ─────────────────────────────────────────────────────────────────────────
+
+    writeln("═══════════════════════════════════════════════════════════════════");
+    writeln("                   OSC 8 Hyperlink Demonstrations                   ");
+    writeln("═══════════════════════════════════════════════════════════════════\n");
+
+    writeln("── struct with file:// hyperlinks (default) ──");
+    writeln(prettyPrint(person, PrettyPrintOptions!void(useOscLinks: true)));
+    writeln();
+
+    writeln("── struct with editor-detected hyperlinks ──");
+    writeln(prettyPrint(person, PrettyPrintOptions!EditorDetectHook(useOscLinks: true)));
+    writeln();
+
+    writeln("── struct with VS Code hyperlinks ──");
+    writeln(prettyPrint(person, PrettyPrintOptions!(SchemeHook!"code")(useOscLinks: true)));
+    writeln();
+
+    writeln("── enum with OSC 8 hyperlinks ──");
+    writeln(prettyPrint(Status.running, PrettyPrintOptions!void(useOscLinks: true)));
     writeln();
 
     writeln("═══════════════════════════════════════════════════════════════════");

--- a/libs/core-cli/src/sparkles/core_cli/source_uri.d
+++ b/libs/core-cli/src/sparkles/core_cli/source_uri.d
@@ -1,0 +1,333 @@
+/// Source URI generation for OSC 8 hyperlinks.
+///
+/// Provides path resolution, editor-specific URI schemes, and a hook interface
+/// for compile-time-configurable source location links. Uses Design by
+/// Introspection to let callers plug in custom URI writers.
+module sparkles.core_cli.source_uri;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Path Resolution
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Resolves a compiler-relative source path to an absolute path.
+///
+/// Uses `__FILE_FULL_PATH__` and `__FILE__` from the call site to derive
+/// the compiler's working directory, then resolves `path` against it.
+/// Works at compile time (CTFE) and at runtime.
+string resolveSourcePath(
+    string path,
+    string fullPath = __FILE_FULL_PATH__,
+    string relPath = __FILE__,
+) @safe pure
+{
+    import std.path : absolutePath;
+
+    // Already absolute — return as-is
+    if (path.length > 0 && path[0] == '/')
+        return path;
+
+    // Derive compiler working directory: strip relative suffix from full path
+    string base = fullPath[0 .. $ - relPath.length];
+    return absolutePath(path, base);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Editor Scheme Table
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct EditorScheme
+{
+    string name;
+    string function(string, size_t, size_t) pure uriFun;
+    immutable(string)[] aliases;
+}
+
+// ── URI format functions (IES-based, CTFE-evaluable) ────────────────────
+
+private string fileUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"file://$(path)#L$(line)".text;
+}
+
+private string vsCodeUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"vscode://file$(path):$(line):$(col)".text;
+}
+
+private string vsCodeInsidersUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"vscode-insiders://file$(path):$(line):$(col)".text;
+}
+
+private string cursorUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"cursor://file$(path):$(line):$(col)".text;
+}
+
+private string zedUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"zed://file$(path):$(line):$(col)".text;
+}
+
+private string jetBrainsUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"jetbrains://open?file=$(path)&line=$(line)&column=$(col)".text;
+}
+
+private string sublimeUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"subl://open?url=file://$(path)&line=$(line)&column=$(col)".text;
+}
+
+private string emacsUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"org-protocol://open-file?url=file://$(path)&line=$(line)&column=$(col)".text;
+}
+
+private string atomUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"atom://core/open/file?filename=$(path)&line=$(line)&column=$(col)".text;
+}
+
+private string lapceUri(string path, size_t line, size_t col) pure
+{
+    import std.conv : text;
+    return i"lapce://open?path=$(path)&line=$(line)&column=$(col)".text;
+}
+
+// ── Declarative scheme table ────────────────────────────────────────────
+
+enum editorSchemes = [
+    EditorScheme("VS Code",          &vsCodeUri,          ["code"]),
+    EditorScheme("VS Code Insiders", &vsCodeInsidersUri,  ["code-insiders"]),
+    EditorScheme("Cursor",           &cursorUri,          ["cursor"]),
+    EditorScheme("Zed",              &zedUri,             ["zed"]),
+    EditorScheme("IntelliJ IDEA",    &jetBrainsUri,       ["idea"]),
+    EditorScheme("GoLand",           &jetBrainsUri,       ["goland"]),
+    EditorScheme("CLion",            &jetBrainsUri,       ["clion"]),
+    EditorScheme("PyCharm",          &jetBrainsUri,       ["pycharm"]),
+    EditorScheme("RustRover",        &jetBrainsUri,       ["rustrover"]),
+    EditorScheme("WebStorm",         &jetBrainsUri,       ["webstorm"]),
+    EditorScheme("Sublime Text",     &sublimeUri,         ["subl", "sublime_text"]),
+    EditorScheme("Emacs",            &emacsUri,           ["emacs", "emacsclient"]),
+    EditorScheme("Atom",             &atomUri,            ["atom"]),
+    EditorScheme("Lapce",            &lapceUri,           ["lapce"]),
+    // Terminal editors — no custom URI scheme, fall back to file://
+    EditorScheme("Helix",            &fileUri,            ["helix", "hx"]),
+    EditorScheme("Neovim",           &fileUri,            ["nvim"]),
+    EditorScheme("Vim",              &fileUri,            ["vim", "vi"]),
+    EditorScheme("nano",             &fileUri,            ["nano"]),
+    EditorScheme("micro",            &fileUri,            ["micro"]),
+    EditorScheme("Kakoune",          &fileUri,            ["kak"]),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hook Interface and Capability Trait
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Hook protocol (optional primitive):
+///   `static void writeSourceUri(string path, size_t line, size_t col, Writer)(ref Writer w)`
+///
+/// `path`, `line`, `col` are compile-time values from `__traits(getLocation, T)`.
+template hasWriteSourceUri(Hook, Writer)
+{
+    enum bool hasWriteSourceUri = __traits(compiles, {
+        Writer w = Writer.init;
+        Hook.writeSourceUri!("/path", size_t(1), size_t(1))(w);
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hook Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Default fallback hook — produces `file://` URIs.
+struct FileUriHook
+{
+    static void writeSourceUri(string path, size_t line, size_t col, Writer)(ref Writer w)
+    {
+        import std.range.primitives : put;
+        enum uri = fileUri(path, line, col);  // CTFE
+        put(w, uri);
+    }
+}
+
+/// Compile-time hook for a specific editor, looked up by alias from the
+/// declarative table.
+///
+/// Usage: `PrettyPrintOptions!(SchemeHook!"code")(useOscLinks: true)`
+template SchemeHook(string editorAlias)
+{
+    struct SchemeHook
+    {
+        static void writeSourceUri(string path, size_t line, size_t col, Writer)(ref Writer w)
+        {
+            import std.range.primitives : put;
+            enum uri = findScheme(editorAlias).uriFun(path, line, col);  // CTFE
+            put(w, uri);
+        }
+    }
+}
+
+/// Runtime auto-detection from `$VISUAL`/`$EDITOR`.
+///
+/// Uses `static foreach` over `editorSchemes` to generate `switch` cases.
+/// Each case branch pre-computes its URI at CTFE — fully @nogc runtime writes.
+struct EditorDetectHook
+{
+    static void writeSourceUri(string path, size_t line, size_t col, Writer)(ref Writer w)
+    {
+        import std.range.primitives : put;
+
+        immutable editor = editorName();  // runtime: lazy-cached
+
+        // Generated from declarative table — each URI is CTFE-computed
+        switch (editor)
+        {
+            static foreach (scheme; editorSchemes)
+            {
+                static foreach (a; scheme.aliases)
+                    case a:
+                {
+                    enum uri = scheme.uriFun(path, line, col);  // CTFE!
+                    put(w, uri);                                 // @nogc
+                    return;
+                }
+            }
+            default:
+            {
+                enum uri = fileUri(path, line, col);  // CTFE fallback
+                put(w, uri);
+                return;
+            }
+        }
+    }
+
+    private static string editorName()
+    {
+        // Thread-local lazy cache
+        static string cached = null;
+        if (cached is null)
+        {
+            import std.path : baseName;
+            import std.process : environment;
+            cached = environment.get("VISUAL", environment.get("EDITOR", "")).baseName;
+        }
+        return cached;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+private EditorScheme findScheme(string editorAlias) pure
+{
+    foreach (scheme; editorSchemes)
+        foreach (a; scheme.aliases)
+            if (a == editorAlias)
+                return scheme;
+    return EditorScheme("Default", &fileUri, []);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// resolveSourcePath returns absolute paths unchanged.
+@("sourceUri.resolveSourcePath.absolute")
+@safe pure
+unittest
+{
+    assert(resolveSourcePath("/usr/local/src/main.d") == "/usr/local/src/main.d");
+}
+
+/// resolveSourcePath resolves relative paths against compiler CWD.
+@("sourceUri.resolveSourcePath.relative")
+@safe pure
+unittest
+{
+    enum resolved = resolveSourcePath(
+        "libs/core-cli/src/sparkles/core_cli/source_uri.d");
+    // Must be absolute
+    assert(resolved.length > 0 && resolved[0] == '/');
+    // Must end with the relative path
+    assert(resolved.length > 48
+        && resolved[$ - 48 .. $] == "libs/core-cli/src/sparkles/core_cli/source_uri.d");
+}
+
+/// resolveSourcePath works at compile time.
+@("sourceUri.resolveSourcePath.ctfe")
+@safe pure
+unittest
+{
+    enum absPath = resolveSourcePath("/already/absolute");
+    static assert(absPath == "/already/absolute");
+
+    enum relPath = resolveSourcePath("libs/core-cli/src/sparkles/core_cli/source_uri.d");
+    static assert(relPath.length > 0 && relPath[0] == '/');
+}
+
+/// FileUriHook produces file:// URIs.
+@("sourceUri.FileUriHook.writeSourceUri")
+@safe pure
+unittest
+{
+    import std.array : appender;
+    auto w = appender!string;
+    FileUriHook.writeSourceUri!("/home/user/project/main.d", size_t(42), size_t(5))(w);
+    assert(w[] == "file:///home/user/project/main.d#L42");
+}
+
+/// SchemeHook!"code" produces vscode:// URIs.
+@("sourceUri.SchemeHook.writeSourceUri")
+@safe pure
+unittest
+{
+    import std.array : appender;
+    auto w = appender!string;
+    SchemeHook!"code".writeSourceUri!("/home/user/project/main.d", size_t(10), size_t(3))(w);
+    assert(w[] == "vscode://file/home/user/project/main.d:10:3");
+}
+
+/// CTFE evaluation of uriFun from the table.
+@("sourceUri.editorSchemes.ctfeUri")
+@safe pure
+unittest
+{
+    // Verify a few schemes evaluate at CTFE
+    enum vsCode = editorSchemes[0].uriFun("/path/to/file.d", 1, 1);
+    static assert(vsCode == "vscode://file/path/to/file.d:1:1");
+
+    enum jetBrains = findScheme("idea").uriFun("/src/main.d", 10, 5);
+    static assert(jetBrains == "jetbrains://open?file=/src/main.d&line=10&column=5");
+}
+
+/// hasWriteSourceUri detects hooks with the protocol.
+@("sourceUri.hasWriteSourceUri.positive")
+@safe pure
+unittest
+{
+    import std.array : Appender;
+    static assert(hasWriteSourceUri!(FileUriHook, Appender!string));
+    static assert(hasWriteSourceUri!(SchemeHook!"code", Appender!string));
+}
+
+/// hasWriteSourceUri returns false for void and hookless types.
+@("sourceUri.hasWriteSourceUri.negative")
+@safe pure
+unittest
+{
+    import std.array : Appender;
+    static assert(!hasWriteSourceUri!(void, Appender!string));
+    static assert(!hasWriteSourceUri!(int, Appender!string));
+}


### PR DESCRIPTION
## Summary

- Wrap struct, class, and enum type names in clickable **OSC 8 terminal hyperlinks** pointing to their source definition via `__traits(getLocation, T)`
- `PrettyPrintOptions` is now a struct template parameterized on `SourceUriHook` for configurable URI schemes
- New `source_uri` module with `resolveSourcePath` (compiler-relative to absolute path resolution), a declarative editor scheme table (VS Code, JetBrains, Cursor, Sublime, Emacs, etc.), and three hook types:
  - `FileUriHook` — default `file://` URIs
  - `SchemeHook` — compile-time editor selection (e.g. `SchemeHook!"code"` for VS Code)
  - `EditorDetectHook` — runtime `$EDITOR`/`$VISUAL` detection

## Test plan

- [ ] `dub test :core-cli` passes
- [ ] Verify OSC 8 links render correctly in a supporting terminal (e.g. iTerm2, Windows Terminal, foot)
- [ ] Verify `useOscLinks: false` (default) produces no OSC sequences
- [ ] Check `SchemeHook` and `EditorDetectHook` resolve URIs for configured editors