### PR TITLE
docs: TUI library research — 13 libraries across 9 languages

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -114,6 +114,68 @@ export default defineConfig({
               },
             ],
           },
+          {
+            text: "TUI Libraries",
+            items: [
+              { text: "Catalog", link: "/research/tui-libraries/" },
+              {
+                text: "Ratatui (Rust)",
+                link: "/research/tui-libraries/ratatui",
+              },
+              {
+                text: "Ink (JavaScript)",
+                link: "/research/tui-libraries/ink",
+              },
+              {
+                text: "Textual (Python)",
+                link: "/research/tui-libraries/textual",
+              },
+              {
+                text: "Bubble Tea (Go)",
+                link: "/research/tui-libraries/bubbletea",
+              },
+              {
+                text: "Brick (Haskell)",
+                link: "/research/tui-libraries/brick",
+              },
+              {
+                text: "Notcurses (C)",
+                link: "/research/tui-libraries/notcurses",
+              },
+              {
+                text: "FTXUI (C++)",
+                link: "/research/tui-libraries/ftxui",
+              },
+              {
+                text: "Cursive (Rust)",
+                link: "/research/tui-libraries/cursive",
+              },
+              {
+                text: "Mosaic (Kotlin)",
+                link: "/research/tui-libraries/mosaic",
+              },
+              {
+                text: "Nottui (OCaml)",
+                link: "/research/tui-libraries/nottui",
+              },
+              {
+                text: "libvaxis (Zig)",
+                link: "/research/tui-libraries/libvaxis",
+              },
+              {
+                text: "tview (Go)",
+                link: "/research/tui-libraries/tview",
+              },
+              {
+                text: "ImTui (C++)",
+                link: "/research/tui-libraries/imtui",
+              },
+              {
+                text: "Comparison",
+                link: "/research/tui-libraries/comparison",
+              },
+            ],
+          },
         ],
       },
     ],

--- a/docs/research/tui-libraries/brick.md
+++ b/docs/research/tui-libraries/brick.md
@@ -1,0 +1,731 @@
+# Brick (Haskell)
+
+A declarative terminal user interface library for Haskell that lets developers build TUIs by writing pure functions to describe how the UI should look based on application state.
+
+| Field          | Value                                                                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Language       | Haskell                                                                                                                              |
+| License        | BSD-3-Clause                                                                                                                         |
+| Repository     | [github.com/jtdaugherty/brick](https://github.com/jtdaugherty/brick)                                                                 |
+| Documentation  | [Hackage](https://hackage.haskell.org/package/brick) / [User Guide](https://github.com/jtdaugherty/brick/blob/master/docs/guide.rst) |
+| Latest Version | ~2.10                                                                                                                                |
+| GitHub Stars   | ~1.7k                                                                                                                                |
+
+---
+
+## Overview
+
+### What It Solves
+
+Brick provides a high-level, declarative abstraction for building terminal user interfaces in Haskell. Rather than imperatively manipulating terminal cells, developers describe the UI as a pure function from application state to a list of widget layers. Brick handles rendering, diffing, layout computation, and the event loop internally.
+
+### Design Philosophy
+
+Brick is built on three core principles:
+
+1. **Pure functional rendering** -- the drawing function `appDraw` is a pure function from state `s` to `[Widget n]`. No IO is involved in describing what the UI looks like.
+2. **Declarative widget combinators** -- layouts are composed using combinators like `hBox`, `vBox`, `padLeft`, `hLimit`, `center`, and `viewport`. These compose cleanly, producing complex layouts from simple building blocks.
+3. **Typed application structure** -- the `App s e n` record type parameterizes the entire application over its state type, custom event type, and resource name type, giving the compiler full visibility into the application's structure.
+
+### History
+
+Brick was created by **Jonathan Daugherty** and is built on top of the **Vty** library (also by Daugherty). Vty handles the low-level terminal abstraction -- input parsing, output rendering, color support -- while Brick provides the higher-level widget, layout, and application architecture layers.
+
+The library has been under active development since around 2015 and is one of the most mature and well-documented TUI libraries in any language. It has comprehensive Haddock API documentation, a detailed user guide (`docs/guide.rst`), over 30 demo programs, and an FAQ. Over 50 known projects have been built with Brick, including terminal games, mail clients, file managers, and developer tools.
+
+---
+
+## Architecture
+
+### Application Type
+
+The central type in Brick is `App s e n`, a record parameterized over three type variables:
+
+- **`s`** -- the application state type
+- **`e`** -- the custom event type (for application-specific asynchronous events)
+- **`n`** -- the resource name type (used to identify viewports, extents, cursors, and mouse event targets)
+
+```haskell
+data App s e n =
+    App { appDraw         :: s -> [Widget n]
+        , appChooseCursor :: s -> [CursorLocation n] -> Maybe (CursorLocation n)
+        , appHandleEvent  :: BrickEvent n e -> EventM n s ()
+        , appStartEvent   :: EventM n s ()
+        , appAttrMap      :: s -> AttrMap
+        }
+```
+
+### Core Functions
+
+| Function          | Signature                                             | Purpose                                                         |
+| ----------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
+| `appDraw`         | `s -> [Widget n]`                                     | Pure function producing a list of widget layers (topmost first) |
+| `appHandleEvent`  | `BrickEvent n e -> EventM n s ()`                     | Monadic handler that modifies state in response to events       |
+| `appStartEvent`   | `EventM n s ()`                                       | One-time initialization at application startup                  |
+| `appChooseCursor` | `s -> [CursorLocation n] -> Maybe (CursorLocation n)` | Selects which cursor location to display                        |
+| `appAttrMap`      | `s -> AttrMap`                                        | Maps attribute names to visual attributes                       |
+
+### Rendering Model: Retained / Declarative
+
+Brick uses a **declarative, retained-style** rendering model. The application never directly manipulates terminal cells. Instead:
+
+1. `appDraw` produces a list of `Widget n` layers from the current state.
+2. Brick's rendering engine evaluates each widget's rendering function, threading layout constraints (available width, height) through the widget tree.
+3. Widgets produce `Result n` values containing Vty `Image`s, cursor positions, visibility requests, and border information.
+4. Brick composites the layers and hands the final `Image` to Vty for efficient terminal output with minimal repainting.
+
+### Event Loop
+
+Brick owns the event loop. The developer does not write a loop. The flow is:
+
+```
+startup -> appStartEvent -> render (appDraw) -> wait for event
+  -> appHandleEvent -> render -> wait for event -> ...
+  -> halt (terminates the loop)
+```
+
+After each event handler completes, three outcomes are possible:
+
+- **Default**: re-render the screen by calling `appDraw` again.
+- **`halt`**: stop the event loop and return the final state.
+- **`continueWithoutRedraw`**: skip re-rendering (optimization for events that do not change visible state).
+
+### EventM Monad
+
+In the current API (Brick 2.x), `appHandleEvent` operates in the `EventM n s ()` monad rather than returning a pure state transformation. `EventM` provides:
+
+- **`MonadState s`** -- full `mtl`-style state access (`get`, `put`, `modify`)
+- **Lens operations** -- via `microlens-mtl`, enabling `zoom`, `.=`, `%=` for focused state updates
+- **`liftIO`** -- for performing IO when needed (e.g., reading files)
+- **Scrolling requests** -- `hScrollBy`, `vScrollBy`, `vScrollPage`, `vScrollToBeginning`, etc.
+- **Extent lookups** -- querying rendered widget positions and sizes
+- **Vty handle access** -- for low-level terminal operations when necessary
+
+---
+
+## Terminal Backend
+
+### Vty (Virtual Terminal)
+
+Brick is built on top of **Vty**, a Haskell library described as "a high-level ncurses alternative." Vty handles all direct terminal interaction:
+
+| Capability       | Details                                                             |
+| ---------------- | ------------------------------------------------------------------- |
+| Color support    | True color (24-bit), 256 color, 16 color                            |
+| Input parsing    | Keyboard events, mouse events (normal and SGR extended mode)        |
+| Output rendering | Efficient buffered output, minimal terminal state changes           |
+| Unicode          | Full multi-column Unicode support (CJK, emoji), custom width tables |
+| Resize handling  | Automatic window resize detection and notification                  |
+| Paste mode       | Bracketed paste support                                             |
+| Refresh          | Automatic Ctrl-L screen refresh                                     |
+
+### Image Model
+
+Vty renders **Images** -- layers of characters with attributes (colors, styles). The rendering model minimizes the repaint area on each frame, "which virtually eliminates the flicker problems that plague ncurses programs." Images are composed using pure, compositional combinators before being flushed to the terminal.
+
+### Platform Support
+
+- **vty-unix** -- Unix/Linux backend using terminfo
+- **vty-windows** -- Windows backend
+- **vty-crossplatform** -- Selects the appropriate backend automatically
+
+Brick 2.0+ depends on `vty-crossplatform`, enabling support beyond Unix-like systems. Prior versions (1.x) were Unix-only.
+
+---
+
+## Layout System
+
+### Combinator-Based Layout
+
+Brick's layout system is entirely combinator-based. Widgets are composed using functions that express spatial relationships and constraints. There are no coordinates, no absolute positioning -- only relative, declarative composition.
+
+### Key Combinators
+
+| Combinator                    | Purpose                                 |
+| ----------------------------- | --------------------------------------- |
+| `hBox [w1, w2, ...]`          | Horizontal composition (left to right)  |
+| `vBox [w1, w2, ...]`          | Vertical composition (top to bottom)    |
+| `w1 <+> w2`                   | Infix horizontal composition            |
+| `w1 <=> w2`                   | Infix vertical composition              |
+| `padLeft n w`, `padRight n w` | Horizontal padding                      |
+| `padTop n w`, `padBottom n w` | Vertical padding                        |
+| `padAll n w`                  | Uniform padding on all sides            |
+| `padLeftRight n w`            | Horizontal padding on both sides        |
+| `padTopBottom n w`            | Vertical padding on both sides          |
+| `hLimit n w`                  | Constrain widget to at most `n` columns |
+| `vLimit n w`                  | Constrain widget to at most `n` rows    |
+| `hCenter w`, `vCenter w`      | Center horizontally / vertically        |
+| `center w`                    | Center in both dimensions               |
+| `fill c`                      | Fill available space with character `c` |
+| `viewport name type w`        | Create a named scrollable region        |
+
+### Widget Sizing: Greedy vs Fixed
+
+Every widget carries two `Size` values (horizontal and vertical), each being either `Fixed` or `Greedy`:
+
+```haskell
+data Size = Fixed | Greedy
+```
+
+- **`Fixed`** -- the widget uses the same amount of space regardless of how much is available. Examples: `str "hello"`, `hLimit 20 w`.
+- **`Greedy`** -- the widget expands to fill all available space. Examples: `fill ' '`, `vBox [...]`.
+
+The box layout algorithm uses these hints to allocate space:
+
+1. First, render all `Fixed` children and deduct their sizes from the available space.
+2. Then, divide the remaining space equally among `Greedy` children.
+
+This two-pass approach ensures fixed-size widgets always get their required space while greedy widgets share the remainder.
+
+### Multi-Panel Layout Example
+
+```haskell
+import Brick
+import Brick.Widgets.Border (border, borderWithLabel, hBorder, vBorder)
+import Brick.Widgets.Border.Style (unicode)
+import Brick.Widgets.Center (center, hCenter)
+
+-- | A three-panel layout: sidebar, main content, and a status bar.
+drawUI :: AppState -> [Widget Name]
+drawUI st = [ui]
+  where
+    ui = vBox
+        [ topPanel
+        , hBorder
+        , statusBar st
+        ]
+
+    topPanel = hBox
+        [ hLimit 25 (sidebar st)
+        , vBorder
+        , mainContent st
+        ]
+
+    sidebar st = borderWithLabel (str " Files ") $
+        padAll 1 $
+        vBox $ map (str . fileName) (st ^. fileList)
+
+    mainContent st = borderWithLabel (str " Editor ") $
+        padAll 1 $
+        viewport EditorViewport Vertical $
+        vBox $ map str (st ^. editorLines)
+
+    statusBar st = hBox
+        [ padLeftRight 1 $ str ("Line: " ++ show (st ^. cursorLine))
+        , fill ' '
+        , padLeftRight 1 $ str (st ^. statusMessage)
+        ]
+```
+
+This produces a layout like:
+
+```
++--- Files ---+|+--------- Editor ----------+
+|              ||                            |
+| main.hs     ||  module Main where         |
+| lib.hs      ||                            |
+| test.hs     ||  import Brick              |
+|              ||  import qualified ...      |
++--------------||                            |
+               |+----------------------------+
+─────────────────────────────────────────────
+ Line: 3                        Ready
+```
+
+The sidebar has a fixed width of 25 columns (`hLimit 25`). The main content area is greedy and takes the remaining space. The status bar uses `fill ' '` as a flexible spacer between the left and right items.
+
+---
+
+## Widget / Component System
+
+### The Widget Type
+
+```haskell
+data Widget n = Widget
+    { hSize  :: Size
+    , vSize  :: Size
+    , render :: RenderM n (Result n)
+    }
+```
+
+A `Widget n` is a rendering instruction carrying its size policies and a monadic rendering function. The `n` parameter is the resource name type used to identify viewports, extents, and mouse targets.
+
+### Result Type
+
+Rendering a widget produces a `Result`:
+
+```haskell
+data Result n = Result
+    { image              :: Graphics.Vty.Image
+    , cursors            :: [CursorLocation n]
+    , visibilityRequests :: [VisibilityRequest]
+    , extents            :: [Extent n]
+    , borders            :: BorderMap DynBorder
+    }
+```
+
+The `image` field contains the Vty `Image` (character grid with attributes). The other fields carry metadata about cursor positions, scrolling hints, clickable regions, and border connection information.
+
+### Built-In Widgets
+
+| Widget / Module         | Description                                          |
+| ----------------------- | ---------------------------------------------------- |
+| `str s`                 | Render a `String` (single line)                      |
+| `txt t`                 | Render `Text` (single line)                          |
+| `strWrap s`             | Render a `String` with word wrapping                 |
+| `txtWrap t`             | Render `Text` with word wrapping                     |
+| `withAttr an w`         | Apply attribute name `an` to widget `w`              |
+| `border w`              | Surround with a border                               |
+| `borderWithLabel lbl w` | Border with a label widget in the top edge           |
+| `hBorder`               | Horizontal line border                               |
+| `vBorder`               | Vertical line border                                 |
+| `table`                 | Table layout (`Brick.Widgets.Table`)                 |
+| `list`                  | Scrollable, selectable list (`Brick.Widgets.List`)   |
+| `dialog`                | Modal dialog with buttons (`Brick.Widgets.Dialog`)   |
+| `progressBar`           | Progress bar (`Brick.Widgets.ProgressBar`)           |
+| `edit` / `editor`       | Single/multi-line text editor (`Brick.Widgets.Edit`) |
+| `fileBrowser`           | File/directory browser (`Brick.Widgets.FileBrowser`) |
+
+### Custom Widgets
+
+Custom widgets are created using the `Widget` constructor, providing size policies and a rendering function:
+
+```haskell
+-- | A widget that draws a horizontal rule of a given character.
+horizontalRule :: Char -> Widget n
+horizontalRule ch = Widget Greedy Fixed $ do
+    ctx <- getContext
+    let w = ctx ^. availWidthL
+    render $ str (replicate w ch)
+
+-- | A widget that shows text with a colored bullet point.
+bulletItem :: AttrName -> String -> Widget n
+bulletItem bulletAttr text =
+    (withAttr bulletAttr (str "* ")) <+> strWrap text
+```
+
+The `getContext` function in `RenderM` provides the available width and height, the current attribute map, and the border style, enabling widgets to adapt to their layout context.
+
+### Forms Library (Brick.Forms)
+
+`Brick.Forms` provides a type-safe, validated form abstraction for structured input:
+
+```haskell
+data Form s e n
+
+-- Constructing a form from field descriptors
+mkForm :: UserInfo -> Form UserInfo e Name
+mkForm =
+    newForm [ editTextField (nameL) NameField (Just 1)
+            , editShowableField (ageL) AgeField
+            , editPasswordField (passwordL) PasswordField
+            , radioField (handednessL)
+                [ (LeftHanded,  LHField, "Left")
+                , (RightHanded, RHField, "Right")
+                , (Ambidextrous, AField,  "Ambidextrous")
+                ]
+            , checkboxField (ridesBikeL) BikeField "Do you ride a bike?"
+            ]
+
+-- In the event handler
+appHandleEvent (VtyEvent e) = zoom formL $ handleFormEvent (VtyEvent e)
+
+-- Accessing validated state
+let info = formState (st ^. form)
+```
+
+Forms handle focus management, tab ordering, validation, and rendering automatically. The `formState` accessor returns the current validated state of the form at any time.
+
+---
+
+## Styling
+
+### Attribute System
+
+Brick's styling system is based on **attribute maps** (`AttrMap`) that associate semantic **attribute names** (`AttrName`) with visual **attributes** (`Attr`).
+
+```haskell
+-- Attr contains: foreground color, background color, style modifiers
+data Attr = Attr
+    { attrStyle   :: MaybeDefault Style
+    , attrForeColor :: MaybeDefault Color
+    , attrBackColor :: MaybeDefault Color
+    , attrURL     :: Maybe String
+    }
+```
+
+### Defining Attributes
+
+```haskell
+-- Attribute names use <> (Monoid) for hierarchy
+baseAttr, headerAttr, selectedAttr, errorAttr :: AttrName
+baseAttr     = attrName "base"
+headerAttr   = attrName "header"
+selectedAttr = attrName "list" <> attrName "selected"
+errorAttr    = attrName "error"
+
+-- Build the attribute map with a global default and named overrides
+theAttrMap :: AttrMap
+theAttrMap = attrMap
+    (white `on` black)                -- global default: white on black
+    [ (headerAttr,   fg cyan `withStyle` bold)
+    , (selectedAttr, black `on` yellow)
+    , (errorAttr,    fg red `withStyle` bold)
+    , (listAttr,     fg white)
+    ]
+```
+
+### Attribute Inheritance
+
+Attribute names form a hierarchy via `<>`. When Brick looks up an attribute, it walks from the most specific name up to the global default, inheriting any properties (foreground, background, style) not explicitly set at the more specific level.
+
+For example, if `listAttr` sets only the foreground color, then `selectedAttr` (which is `listAttr <> attrName "selected"`) inherits the background from `listAttr`'s resolution, which in turn inherits from the global default.
+
+### Applying Attributes to Widgets
+
+```haskell
+drawUI :: AppState -> [Widget Name]
+drawUI st =
+    [ vBox
+        [ withAttr headerAttr $ str "=== My Application ==="
+        , str " "
+        , renderItems (st ^. items)
+        , str " "
+        , withAttr errorAttr $ str (st ^. errorMessage)
+        ]
+    ]
+
+renderItems :: [Item] -> Widget Name
+renderItems items = vBox
+    [ let attr = if selected then selectedAttr else listAttr
+      in withAttr attr $ str (itemLabel item)
+    | (i, item) <- zip [0..] items
+    , let selected = i == selectedIndex
+    ]
+```
+
+### Theme Support
+
+Brick includes a theming system (`Brick.Themes`) that enables user-customizable attribute maps. Themes can be serialized to INI-format configuration files, allowing end users to restyle an application without recompilation.
+
+---
+
+## Event Handling
+
+### BrickEvent Type
+
+```haskell
+data BrickEvent n e
+    = VtyEvent Event          -- Keyboard, mouse, resize from Vty
+    | AppEvent e              -- Custom application events
+    | MouseDown n Button [Modifier] Location  -- Widget-level mouse press
+    | MouseUp   n (Maybe Button) Location     -- Widget-level mouse release
+```
+
+- **`VtyEvent`** wraps the raw Vty `Event` type for keyboard input, terminal-level mouse events, and resize notifications.
+- **`AppEvent e`** carries custom events of the application's chosen type `e`, delivered via a `BChan` (bounded channel).
+- **`MouseDown`** / **`MouseUp`** are widget-level mouse events tagged with the resource name `n` of the widget that was clicked, enabling per-widget mouse handling.
+
+### Event Handler Pattern
+
+```haskell
+appHandleEvent :: BrickEvent Name CustomEvent -> EventM Name AppState ()
+appHandleEvent ev = case ev of
+    -- Keyboard events
+    VtyEvent (V.EvKey V.KEsc [])        -> halt
+    VtyEvent (V.EvKey (V.KChar 'q') []) -> halt
+    VtyEvent (V.EvKey V.KUp [])         -> modify $ \s -> s & selectedIndex %~ max 0 . subtract 1
+    VtyEvent (V.EvKey V.KDown [])       -> modify $ \s -> s & selectedIndex %~ min (length items - 1) . (+ 1)
+    VtyEvent (V.EvKey V.KEnter [])      -> do
+        st <- get
+        liftIO $ performAction (st ^. selectedItem)
+
+    -- Custom events from background threads
+    AppEvent (DataLoaded newData)        -> modify $ \s -> s & dataField .~ newData
+    AppEvent Tick                        -> modify $ \s -> s & counter %~ (+ 1)
+
+    -- Widget-level mouse click
+    MouseDown ListItem _ _ _            -> modify $ \s -> s & mouseClicked .~ True
+
+    -- Delegate to sub-widget handlers
+    VtyEvent e                          -> zoom editorL $ handleEditorEvent (VtyEvent e)
+
+    _                                   -> return ()
+```
+
+### Key Patterns
+
+- **`halt`** terminates the event loop and returns the final state to the caller.
+- **`modify`** / **`put`** update the application state within `EventM`.
+- **`zoom`** with a lens focuses the handler on a sub-component of the state, enabling delegation to widget-specific handlers like `handleEditorEvent` or `handleListEvent`.
+- Pattern matching on `VtyEvent (V.EvKey ...)` is the standard way to handle keyboard input.
+
+### Custom Events via BChan
+
+```haskell
+main :: IO ()
+main = do
+    chan <- newBChan 10  -- bounded channel, capacity 10
+
+    -- Background thread producing custom events
+    forkIO $ forever $ do
+        writeBChan chan Tick
+        threadDelay 1000000  -- 1 second
+
+    let app = App { ... }
+    initialState <- mkInitialState
+    finalState <- customMainWithDefaultVty (Just chan) app initialState
+    print finalState
+```
+
+The `BChan` (bounded channel) bridges background threads and the Brick event loop. Events written to the channel are delivered to `appHandleEvent` as `AppEvent` values, fully integrated with keyboard and mouse events.
+
+---
+
+## State Management
+
+### Single State Value
+
+Brick threads a single state value of type `s` through the entire application. This is the sole source of truth -- `appDraw` renders from it, `appHandleEvent` modifies it, and the final state is returned when the event loop terminates.
+
+```haskell
+data AppState = AppState
+    { _items         :: [Item]
+    , _selectedIndex :: Int
+    , _editor        :: Editor Text Name
+    , _statusMsg     :: String
+    , _counter       :: Int
+    }
+
+makeLenses ''AppState
+```
+
+### EventM and State Updates
+
+The `EventM n s` monad provides `MonadState s`, so state updates use standard `mtl` patterns:
+
+```haskell
+-- Direct update
+modify $ \s -> s { _counter = _counter s + 1 }
+
+-- Lens-based (recommended for complex state)
+counter %= (+ 1)
+selectedIndex .= 0
+editor %= applyEdit clearContents
+
+-- Zoom into sub-state for delegated handling
+zoom editor $ handleEditorEvent e
+```
+
+### Immutability by Default
+
+All state updates produce new values. Haskell's immutability guarantees that the rendering function always sees a consistent snapshot of the state. There is no possibility of partial updates or race conditions between rendering and event handling.
+
+### No Reactive System
+
+Brick does not have a reactive or observable system. There are no signals, subscriptions, or automatic propagation of changes. State changes are explicit: the event handler modifies the state, and the next render cycle uses the updated value. This simplicity is a deliberate design choice -- the entire state flow is visible in the event handler.
+
+### External Events via BChan
+
+For integrating with the outside world (network, timers, file watchers), the `BChan` (bounded channel) pattern is used. Background threads write events to the channel, and Brick delivers them as `AppEvent` values in the event handler, maintaining the single-threaded state update model.
+
+---
+
+## Extensibility & Ecosystem
+
+### Extension Libraries
+
+| Package               | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| **brick-skylighting** | Syntax highlighting via the Skylighting library |
+| **brick-tabular**     | Enhanced table widgets                          |
+| **brick-filetree**    | Directory tree browser widget                   |
+| **brick-panes**       | Overlay/pane management library                 |
+| **brick-calendar**    | Calendar widget                                 |
+
+### Built-In Extension Points
+
+- **Custom widgets** -- the `Widget` constructor is public; any function producing `Widget n` is a first-class citizen in layouts.
+- **Forms library** -- `Brick.Forms` provides high-level form construction with validation, built into the core package.
+- **Themes** -- `Brick.Themes` enables user-customizable styling via INI configuration files.
+- **File browser** -- `Brick.Widgets.FileBrowser` provides a ready-made file selection widget.
+
+### Community
+
+Brick has an active Haskell community with:
+
+- GitHub Discussions for Q&A
+- A `brick-users` Google Group / mailing list
+- Over 50 known projects built with Brick (games, mail clients, accounting tools, developer utilities)
+- 88+ contributors on GitHub
+- 30+ demo programs in the repository
+
+---
+
+## Strengths
+
+- **Pure functional elegance** -- rendering is a pure function from state to widgets, with no side effects. This makes the UI trivially testable and easy to reason about.
+- **Excellent combinator-based API** -- the layout combinators (`hBox`, `vBox`, `padLeft`, `hLimit`, `center`, `viewport`) compose cleanly and are highly expressive for a small API surface.
+- **Strong type safety** -- the `App s e n` type parameterization catches many errors at compile time. Resource names, custom events, and state are all statically typed.
+- **Comprehensive documentation** -- the user guide (`docs/guide.rst`) is one of the best pieces of library documentation in the Haskell ecosystem. The 30+ demo programs serve as a living reference.
+- **Good default layouts** -- the `Greedy` / `Fixed` sizing model produces sensible layouts without manual calculation. The box layout algorithm automatically distributes space.
+- **Forms library is excellent** -- `Brick.Forms` provides type-safe, validated forms with automatic focus management, a rare feature in TUI libraries at any level.
+- **Very composable** -- widgets, attributes, event handlers, and layout combinators all compose orthogonally. Complex UIs are built by snapping together small, well-understood pieces.
+- **Mature and stable** -- active development since ~2015, with a clean versioning history and thoughtful API evolution (e.g., the migration from pure update functions to `EventM`).
+- **Automatic border joining** -- adjacent border widgets automatically connect using appropriate intersection characters, a surprisingly difficult detail that Brick handles transparently.
+
+---
+
+## Weaknesses & Limitations
+
+- **Haskell learning curve** -- Brick requires familiarity with Haskell, lenses, monad transformers, and type-level programming. The barrier to entry is high for developers outside the Haskell ecosystem.
+- **Limited to Unix-like platforms historically** -- while Brick 2.0+ supports Windows via `vty-crossplatform`, the Unix backend (using terminfo) remains the primary and most battle-tested path.
+- **Performance overhead of immutable data structures** -- every state update allocates a new state value. For applications with very large state (e.g., large text buffers), this can introduce GC pressure.
+- **Debugging difficulty in pure functional style** -- tracing rendering issues through combinator composition and lazy evaluation can be challenging. There is no "inspect element" equivalent.
+- **Smaller widget ecosystem than some alternatives** -- compared to web-based TUI frameworks (Textual, Ink) or the Charm ecosystem (Bubble Tea + Bubbles + Lip Gloss), the number of pre-built widgets and community components is more limited.
+- **Less suitable for high-frequency updates** -- applications requiring very frequent re-renders (>30fps animations, real-time data visualization) may find the full re-render model and Haskell runtime overhead limiting.
+- **No built-in async/reactive primitives** -- unlike frameworks with reactive state management, all async integration requires manual `BChan` plumbing and explicit event handling.
+- **Lens dependency** -- effective use of Brick's state management strongly encourages (practically requires) the lens pattern, adding another conceptual layer.
+
+---
+
+## Lessons for D / Sparkles
+
+### Widget Combinators to UFCS Chains
+
+Brick's combinator composition:
+
+```haskell
+borderWithLabel (str " Files ") $ padAll 1 $ hLimit 25 $ vBox items
+```
+
+Maps naturally to D's UFCS chains:
+
+```d
+items
+    .vBox
+    .hLimit(25)
+    .padAll(1)
+    .borderWithLabel(" Files ")
+```
+
+D's UFCS provides the same left-to-right readability without Haskell's right-to-left `$` application, and with zero runtime overhead when the combinators are `@nogc` template functions returning widget structs by value.
+
+### AttrMap to Compile-Time D Map
+
+Brick's `AttrMap` with hierarchical attribute resolution could be implemented as a compile-time associative array in D using CTFE:
+
+```d
+enum Attr baseTheme = [
+    "header":   Attr(fg: Color.cyan, style: Style.bold),
+    "selected": Attr(fg: Color.black, bg: Color.yellow),
+    "error":    Attr(fg: Color.red, style: Style.bold),
+];
+```
+
+D's `enum` AA evaluated at compile time gives zero-runtime-cost theme definitions. Runtime theme loading could use the same `Attr[string]` type with runtime initialization.
+
+### Size Type (Greedy / Fixed) to D Enum or DbI Trait
+
+Brick's `Size` type:
+
+```haskell
+data Size = Fixed | Greedy
+```
+
+In D, this could be either a simple enum:
+
+```d
+enum SizePolicy { fixed, greedy }
+```
+
+Or a Design by Introspection capability trait, where widgets that expose `enum hPolicy = SizePolicy.greedy` are detected at compile time and handled differently by the layout algorithm:
+
+```d
+template isGreedyH(W) {
+    enum isGreedyH = __traits(hasMember, W, "hPolicy")
+        && W.hPolicy == SizePolicy.greedy;
+}
+```
+
+### Named Viewports
+
+Brick's viewport pattern -- named scrollable regions that persist scroll state across renders -- is directly useful for D. A D implementation could use string-based or enum-based names with a global viewport state registry:
+
+```d
+content
+    .vBox
+    .viewport("editor", ViewportType.vertical)
+    .vLimit(20)
+```
+
+### Forms from Struct Introspection
+
+Brick's `Form s e n` requires manual field-by-field form construction. D's compile-time introspection could auto-generate forms from struct definitions:
+
+```d
+struct UserInfo {
+    @Label("Name") string name;
+    @Label("Age") @Min(18) int age;
+    @Label("Password") @Password string password;
+    @Label("Handedness") Handedness handedness;
+    @Label("Rides bike") bool ridesBike;
+}
+
+// Auto-generated form with validation, focus, and rendering
+auto form = autoForm!UserInfo(initialValue);
+```
+
+D's `__traits(allMembers, ...)` and UDAs enable generating form fields, validation, and rendering at compile time with zero runtime reflection cost -- something Haskell achieves only through Template Haskell or GHC Generics.
+
+### Pure State Transitions
+
+Brick's `EventM` monad enforces structured state updates. D's `pure` attribute provides a similar guarantee:
+
+```d
+@safe pure nothrow
+AppState handleEvent(in AppState state, in Event event) {
+    // Guaranteed no global state mutation, no IO
+    return state.with!"selectedIndex"(state.selectedIndex + 1);
+}
+```
+
+D's `pure` functions cannot access mutable global state, providing a compile-time guarantee analogous to Haskell's separation of pure rendering from IO.
+
+### Template-Based Widget Composition
+
+Brick's type-safe widget composition translates to D's template system for zero-cost abstraction:
+
+```d
+auto ui = hBox(
+    sidebar.hLimit(25),
+    vBorder(),
+    mainContent,
+).border;
+```
+
+With D templates, the layout tree can be resolved at compile time. Widget types carry their size policies as template parameters, enabling the layout algorithm to specialize at compile time:
+
+```d
+struct HBox(Widgets...) {
+    enum hPolicy = allSatisfy!(isGreedyH, Widgets) ? SizePolicy.greedy : SizePolicy.fixed;
+    // ...
+}
+```
+
+---
+
+## References
+
+- **Repository**: <https://github.com/jtdaugherty/brick>
+- **User Guide**: <https://github.com/jtdaugherty/brick/blob/master/docs/guide.rst>
+- **Hackage (API docs)**: <https://hackage.haskell.org/package/brick>
+- **FAQ**: <https://github.com/jtdaugherty/brick/blob/master/docs/FAQ.md>
+- **Demo Programs**: <https://github.com/jtdaugherty/brick/tree/master/programs>
+- **Vty (terminal backend)**: <https://github.com/jtdaugherty/vty>
+- **Vty on Hackage**: <https://hackage.haskell.org/package/vty>
+- **brick-users mailing list**: <https://groups.google.com/group/brick-users>
+- **GitHub Discussions**: <https://github.com/jtdaugherty/brick/discussions>
+- **Changelog**: <https://github.com/jtdaugherty/brick/blob/master/CHANGELOG.md>
+- **Jonathan Daugherty's talk -- "Building Terminal User Interfaces in Haskell"**: Presented at various Haskell meetups; search for conference recordings.
+- **Samuel Tay -- "Brick Tutorial"**: <https://samtay.github.io/posts/introduction-to-brick>

--- a/docs/research/tui-libraries/bubbletea.md
+++ b/docs/research/tui-libraries/bubbletea.md
@@ -1,0 +1,995 @@
+# Bubble Tea (Go)
+
+A functional framework for building terminal user interfaces in Go, based on The Elm Architecture (Model-View-Update).
+
+| Field          | Value                                                              |
+| -------------- | ------------------------------------------------------------------ |
+| Language       | Go                                                                 |
+| License        | MIT                                                                |
+| Repository     | <https://github.com/charmbracelet/bubbletea>                       |
+| Documentation  | <https://github.com/charmbracelet/bubbletea/tree/master/tutorials> |
+| Latest Version | ~1.2.x (2025)                                                      |
+| GitHub Stars   | ~39k                                                               |
+
+---
+
+## Overview
+
+Bubble Tea is a Go framework for building terminal applications using The Elm Architecture (TEA), also known as Model-View-Update (MVU). It provides a simple, functional programming model where all state mutations are explicit, all rendering is a pure function of state, and all side effects are modeled as commands that produce messages.
+
+### What It Solves
+
+Building terminal UIs in Go traditionally involves low-level terminal manipulation, manual event loops, and ad hoc state management. Bubble Tea replaces this with a structured, testable architecture where the entire application lifecycle is expressed through three functions: `Init`, `Update`, and `View`.
+
+### Design Philosophy
+
+Bubble Tea directly adapts The Elm Architecture to the terminal:
+
+- **Unidirectional data flow** -- messages flow into `Update`, state flows out, `View` renders the state.
+- **No hidden state** -- the `Model` struct is the single source of truth.
+- **Side effects as values** -- I/O operations are represented as `Cmd` values, not imperative calls.
+- **Composition over inheritance** -- complex UIs are built by embedding sub-models and forwarding messages.
+
+### History and Ecosystem
+
+Bubble Tea was created by [Charm](https://charm.sh), a company building open-source tools and infrastructure for the terminal. It is the centerpiece of a broader ecosystem:
+
+| Project        | Role                                   | Repository                                                            |
+| -------------- | -------------------------------------- | --------------------------------------------------------------------- |
+| **Bubble Tea** | Application framework (MVU loop)       | [charmbracelet/bubbletea](https://github.com/charmbracelet/bubbletea) |
+| **Lip Gloss**  | Terminal styling and layout primitives | [charmbracelet/lipgloss](https://github.com/charmbracelet/lipgloss)   |
+| **Bubbles**    | Reusable UI components                 | [charmbracelet/bubbles](https://github.com/charmbracelet/bubbles)     |
+| **Wish**       | SSH server for Bubble Tea apps         | [charmbracelet/wish](https://github.com/charmbracelet/wish)           |
+| **Huh**        | Interactive forms and prompts          | [charmbracelet/huh](https://github.com/charmbracelet/huh)             |
+| **Gum**        | Shell scripting TUI utilities          | [charmbracelet/gum](https://github.com/charmbracelet/gum)             |
+| **Log**        | Colorful structured logging            | [charmbracelet/log](https://github.com/charmbracelet/log)             |
+| **Harmonica**  | Spring-based animations                | [charmbracelet/harmonica](https://github.com/charmbracelet/harmonica) |
+
+Bubble Tea is one of the most popular Go libraries for terminal UIs, significantly surpassing older projects like `tview` and `gocui` in adoption. It is used in production by Microsoft (Aztfy/Azure), CockroachDB, AWS (eks-node-viewer), Ubuntu (Authd), MinIO, NVIDIA, and Truffle Security.
+
+---
+
+## Architecture
+
+Bubble Tea implements a strict Model-View-Update (MVU) loop. The core abstraction is the `Model` interface:
+
+```go
+type Model interface {
+    // Init returns an initial command to execute when the program starts.
+    Init() Cmd
+
+    // Update is called when a message is received. It returns the updated
+    // model and an optional command to execute.
+    Update(Msg) (Model, Cmd)
+
+    // View renders the UI as a string based on the current model state.
+    View() string
+}
+```
+
+### The MVU Cycle
+
+```
+                 ┌─────────────────────┐
+                 │      Terminal        │
+                 │  (keyboard, mouse,   │
+                 │   resize, etc.)      │
+                 └────────┬────────────┘
+                          │ raw events
+                          ▼
+                 ┌─────────────────────┐
+                 │     tea.Msg          │
+                 │  (KeyMsg, MouseMsg,  │
+                 │   WindowSizeMsg,     │
+                 │   custom types)      │
+                 └────────┬────────────┘
+                          │
+                          ▼
+              ┌──────────────────────┐
+              │   Update(msg) →      │
+              │   (Model, Cmd)       │
+              └─────┬──────────┬─────┘
+                    │          │
+            new Model      tea.Cmd
+                    │          │
+                    ▼          ▼
+              ┌──────────┐  ┌──────────────┐
+              │  View()   │  │ Execute Cmd  │
+              │  → string │  │ → new Msg    │──┐
+              └─────┬─────┘  └──────────────┘  │
+                    │                           │
+                    ▼                           │
+              ┌──────────┐                      │
+              │ Render   │                      │
+              │ to term  │         loops back ──┘
+              └──────────┘
+```
+
+1. The framework collects terminal events and wraps them as `tea.Msg` values.
+2. `Update` receives each message, produces a new `Model` (Go struct value copy) and optionally a `Cmd`.
+3. `View` is called on the new model. It returns a string representation of the entire UI.
+4. The framework diffs the new view against the previous one and writes only the changes to the terminal.
+5. If `Update` returned a `Cmd`, the framework executes it asynchronously. When the command completes, it produces a new `Msg` that re-enters the cycle.
+
+### Msg
+
+`Msg` is the empty interface -- any Go value can be a message:
+
+```go
+type Msg interface{}
+```
+
+The framework provides built-in message types for terminal events (`KeyMsg`, `MouseMsg`, `WindowSizeMsg`, `FocusMsg`, `BlurMsg`), and applications define custom message types for their own domain events (HTTP responses, timer ticks, etc.).
+
+### Cmd
+
+A `Cmd` is a function that performs I/O and returns a `Msg`:
+
+```go
+type Cmd func() Msg
+```
+
+Commands are the only way to perform side effects in Bubble Tea. The framework executes them outside the MVU loop and feeds their results back as messages. A `nil` Cmd means "no side effect."
+
+Key built-in commands:
+
+```go
+// Quit the program
+func Quit() Msg { return QuitMsg{} }
+
+// Run multiple commands concurrently
+func Batch(cmds ...Cmd) Cmd
+
+// Run commands sequentially
+func Sequence(cmds ...Cmd) Cmd
+
+// Tick at a duration
+func Tick(d time.Duration, fn func(time.Time) Msg) Cmd
+
+// Synchronize with the system clock
+func Every(duration time.Duration, fn func(time.Time) Msg) Cmd
+
+// Set the terminal window title
+func SetWindowTitle(title string) Cmd
+
+// Query the terminal size
+func WindowSize() Cmd
+```
+
+### Program
+
+The `Program` is the runtime that drives the MVU loop:
+
+```go
+p := tea.NewProgram(initialModel, tea.WithAltScreen())
+finalModel, err := p.Run()
+```
+
+Programs can be configured with options and can receive external messages via `p.Send(msg)`.
+
+---
+
+## Terminal Backend
+
+Bubble Tea manages the terminal directly using ANSI escape sequences and Go's `os` package for TTY control, supplemented by the Charm `x/term` library.
+
+### Terminal Modes
+
+- **Raw mode** -- disables line buffering and echo so the framework receives individual keypresses.
+- **Alternate screen** -- uses the terminal's alternate screen buffer so the original scrollback is preserved. Enabled via `tea.WithAltScreen()`.
+- **Bracketed paste** -- enabled by default; detects pasted text vs. typed input. Disabled via `tea.WithoutBracketedPaste()`.
+- **Focus reporting** -- detects when the terminal window gains or loses focus. Enabled via `tea.WithReportFocus()`.
+
+### Mouse Support
+
+Two levels of mouse tracking are available:
+
+| Option                  | Events                                     | Compatibility |
+| ----------------------- | ------------------------------------------ | ------------- |
+| `WithMouseCellMotion()` | Click, release, wheel, drag (cell changes) | Broad         |
+| `WithMouseAllMotion()`  | All of the above plus hover / all motion   | Narrower      |
+
+Mouse events are parsed from both X10-encoded and SGR-encoded escape sequences. The `MouseMsg` struct provides:
+
+```go
+type MouseMsg struct {
+    X, Y           int
+    Shift, Alt, Ctrl bool
+    Action         MouseAction   // Press, Release, Motion
+    Button         MouseButton   // Left, Middle, Right, WheelUp, WheelDown, ...
+}
+```
+
+### Color Capabilities
+
+Color support is detected automatically and Lip Gloss handles degradation:
+
+- **True Color (24-bit)** -- full RGB via hex codes
+- **ANSI 256 (8-bit)** -- extended palette
+- **ANSI 16 (4-bit)** -- basic terminal colors
+- **No color** -- plain text fallback
+
+### Rendering
+
+The renderer operates at a configurable frame rate (default 60 FPS, max 120, set via `WithFPS()`). On each frame, the framework:
+
+1. Calls `View()` to get the full UI string.
+2. Diffs it against the previously rendered string.
+3. Writes only the changed lines to the terminal using cursor movement and line clearing escape sequences.
+
+This approach avoids flicker and minimizes I/O.
+
+### Platform Support
+
+- **Unix** (Linux, macOS, BSD) -- full support via POSIX TTY APIs.
+- **Windows** -- support via ConPTY (Windows Console Pseudo Terminal). Works in Windows Terminal, PowerShell, and cmd.exe.
+
+---
+
+## Layout System
+
+Bubble Tea has **no built-in layout system**. The `View()` function returns a plain string, and it is the developer's responsibility to compose that string. This is by design -- it keeps the core framework minimal.
+
+Layout is handled by **Lip Gloss**, which provides string measurement and joining utilities:
+
+### Measurement
+
+```go
+width := lipgloss.Width(renderedText)
+height := lipgloss.Height(renderedText)
+w, h := lipgloss.Size(renderedText)
+```
+
+These functions correctly account for ANSI escape sequences when measuring visible width and height.
+
+### Joining
+
+```go
+// Horizontal: align elements along their top, center, or bottom edges
+row := lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, rightPanel)
+
+// Vertical: align elements along their left, center, or right edges
+column := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+```
+
+### Placement
+
+```go
+// Place content within a region at a specific position
+output := lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, content)
+```
+
+### Multi-Panel Layout Example
+
+```go
+func (m model) View() string {
+    // Define styles
+    sidebarStyle := lipgloss.NewStyle().
+        Width(30).
+        Height(m.height - 2).
+        BorderStyle(lipgloss.RoundedBorder()).
+        BorderForeground(lipgloss.Color("63")).
+        Padding(1, 2)
+
+    contentStyle := lipgloss.NewStyle().
+        Width(m.width - 34).
+        Height(m.height - 2).
+        BorderStyle(lipgloss.RoundedBorder()).
+        BorderForeground(lipgloss.Color("63")).
+        Padding(1, 2)
+
+    statusStyle := lipgloss.NewStyle().
+        Width(m.width).
+        Background(lipgloss.Color("63")).
+        Foreground(lipgloss.Color("230")).
+        Padding(0, 1)
+
+    // Render panels
+    sidebar := sidebarStyle.Render(m.sidebarContent())
+    content := contentStyle.Render(m.mainContent())
+    status := statusStyle.Render(m.statusText())
+
+    // Compose layout: sidebar | content on top, status bar on bottom
+    top := lipgloss.JoinHorizontal(lipgloss.Top, sidebar, content)
+    return lipgloss.JoinVertical(lipgloss.Left, top, status)
+}
+```
+
+The manual string-composition approach is flexible but requires developers to handle sizing, overflow, and responsive behavior explicitly. There is no constraint solver or flexbox-style automatic layout.
+
+---
+
+## Widget/Component System
+
+The **Bubbles** library provides a collection of reusable components, each implemented as a Bubble Tea `Model`. Available bubbles:
+
+| Component    | Description                                  |
+| ------------ | -------------------------------------------- |
+| `textinput`  | Single-line text input with cursor, paste    |
+| `textarea`   | Multi-line text editor with scrolling        |
+| `list`       | Filterable, paginated list with fuzzy search |
+| `table`      | Tabular data display with column navigation  |
+| `viewport`   | Scrollable content pane (pager-like)         |
+| `spinner`    | Animated loading indicator                   |
+| `paginator`  | Page navigation (dot or numeric style)       |
+| `progress`   | Progress bar with optional animation         |
+| `filepicker` | File system browser and selector             |
+| `help`       | Auto-generated keybinding help view          |
+| `key`        | Keybinding definitions and matching          |
+| `timer`      | Countdown timer                              |
+| `stopwatch`  | Count-up stopwatch                           |
+| `cursor`     | Cursor blinking and style management         |
+
+### Composition Pattern
+
+Each bubble implements the `tea.Model` interface. Complex applications compose bubbles by embedding them as fields in a parent model and forwarding messages:
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/charmbracelet/bubbles/spinner"
+    "github.com/charmbracelet/bubbles/textinput"
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/charmbracelet/lipgloss"
+)
+
+type state int
+
+const (
+    stateInput state = iota
+    stateLoading
+    stateDone
+)
+
+type resultMsg string
+
+type model struct {
+    state   state
+    input   textinput.Model
+    spinner spinner.Model
+    result  string
+}
+
+func initialModel() model {
+    ti := textinput.New()
+    ti.Placeholder = "Enter a search query..."
+    ti.Focus()
+
+    sp := spinner.New()
+    sp.Spinner = spinner.Dot
+    sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+
+    return model{
+        state:   stateInput,
+        input:   ti,
+        spinner: sp,
+    }
+}
+
+func (m model) Init() tea.Cmd {
+    return tea.Batch(textinput.Blink, m.spinner.Tick)
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "ctrl+c":
+            return m, tea.Quit
+        case "enter":
+            if m.state == stateInput {
+                m.state = stateLoading
+                return m, doSearch(m.input.Value())
+            }
+        }
+
+    case resultMsg:
+        m.state = stateDone
+        m.result = string(msg)
+        return m, nil
+    }
+
+    var cmd tea.Cmd
+    switch m.state {
+    case stateInput:
+        m.input, cmd = m.input.Update(msg)
+    case stateLoading:
+        m.spinner, cmd = m.spinner.Update(msg)
+    }
+    return m, cmd
+}
+
+func (m model) View() string {
+    switch m.state {
+    case stateInput:
+        return fmt.Sprintf("Search:\n\n%s\n\n(enter to search, ctrl+c to quit)", m.input.View())
+    case stateLoading:
+        return fmt.Sprintf("%s Searching for %q...", m.spinner.View(), m.input.Value())
+    case stateDone:
+        return fmt.Sprintf("Result: %s\n\n(ctrl+c to quit)", m.result)
+    default:
+        return ""
+    }
+}
+
+func doSearch(query string) tea.Cmd {
+    return func() tea.Msg {
+        // Simulate an HTTP request or database query
+        return resultMsg("42 results found for: " + query)
+    }
+}
+
+func main() {
+    p := tea.NewProgram(initialModel())
+    if _, err := p.Run(); err != nil {
+        fmt.Println("Error:", err)
+    }
+}
+```
+
+Key composition principles:
+
+- **Embed sub-models** as struct fields in the parent model.
+- **Forward messages** to the appropriate sub-model in `Update`, capturing the returned `Cmd`.
+- **Delegate rendering** by calling each sub-model's `View()` and composing the strings.
+- **Use `tea.Batch`** to combine commands from multiple sub-models.
+
+---
+
+## Styling
+
+Styling in Bubble Tea is handled entirely by **Lip Gloss**, which provides a builder-pattern API with method chaining:
+
+```go
+var style = lipgloss.NewStyle().
+    Bold(true).
+    Italic(true).
+    Foreground(lipgloss.Color("#FAFAFA")).
+    Background(lipgloss.Color("#7D56F4")).
+    PaddingTop(2).
+    PaddingLeft(4).
+    PaddingBottom(2).
+    PaddingRight(4).
+    Width(40).
+    Align(lipgloss.Center).
+    BorderStyle(lipgloss.RoundedBorder()).
+    BorderForeground(lipgloss.Color("63"))
+
+output := style.Render("Hello, Bubble Tea!")
+```
+
+### Text Formatting
+
+```go
+lipgloss.NewStyle().Bold(true)
+lipgloss.NewStyle().Italic(true)
+lipgloss.NewStyle().Faint(true)
+lipgloss.NewStyle().Underline(true)
+lipgloss.NewStyle().Strikethrough(true)
+lipgloss.NewStyle().Blink(true)
+lipgloss.NewStyle().Reverse(true)
+```
+
+### Colors
+
+```go
+// ANSI 16 basic colors
+lipgloss.Color("5")        // magenta
+
+// ANSI 256 extended palette
+lipgloss.Color("86")       // aqua
+
+// True color (24-bit)
+lipgloss.Color("#FF6347")  // tomato red
+
+// Adaptive: different color for light vs. dark terminal backgrounds
+lipgloss.AdaptiveColor{Light: "236", Dark: "248"}
+
+// Complete: specify color for each profile level
+lipgloss.CompleteColor{
+    TrueColor: "#0000FF",
+    ANSI256:   "86",
+    ANSI:      "5",
+}
+```
+
+### Box Model
+
+Lip Gloss implements a CSS-inspired box model:
+
+```go
+style := lipgloss.NewStyle().
+    Padding(1, 2).           // vertical, horizontal
+    Margin(1, 2).            // vertical, horizontal
+    Width(40).               // minimum width
+    MaxWidth(60).            // maximum width
+    Height(10).              // minimum height
+    MaxHeight(20).           // maximum height
+    Align(lipgloss.Center).  // text alignment
+    BorderStyle(lipgloss.DoubleBorder()).
+    BorderForeground(lipgloss.Color("228"))
+```
+
+### Border Styles
+
+Built-in borders: `NormalBorder()`, `RoundedBorder()`, `ThickBorder()`, `DoubleBorder()`.
+
+Custom borders:
+
+```go
+lipgloss.Border{
+    Top: "._.:*:",  Bottom: "._.:*:",
+    Left: "|",      Right: "|",
+    TopLeft: "*",   TopRight: "*",
+    BottomLeft: "*", BottomRight: "*",
+}
+```
+
+### Style Composition
+
+```go
+// Copy a style (assignment copies all values)
+baseStyle := lipgloss.NewStyle().Padding(1, 2).Bold(true)
+headerStyle := baseStyle.Foreground(lipgloss.Color("99"))
+
+// Inherit unset values from a parent
+childStyle := lipgloss.NewStyle().
+    Foreground(lipgloss.Color("205")).
+    Inherit(parentStyle) // only copies rules not already set
+
+// Unset specific rules
+plain := style.UnsetBold().UnsetBackground()
+```
+
+### Tab Handling
+
+```go
+style.TabWidth(2)                    // render tabs as 2 spaces
+style.TabWidth(0)                    // remove tabs
+style.TabWidth(lipgloss.NoTabConversion) // preserve literal tabs
+```
+
+---
+
+## Event Handling
+
+All events in Bubble Tea are values of type `tea.Msg` dispatched to the `Update` function. There is no callback registration, event bus, or observer pattern -- just a switch statement on the message type.
+
+### Key Events
+
+```go
+type KeyMsg Key
+
+type Key struct {
+    Type  KeyType   // KeyRunes, KeyEnter, KeyCtrlC, KeyUp, KeyF1, ...
+    Runes []rune    // the character(s) for KeyRunes
+    Alt   bool      // whether Alt was held
+    Paste bool      // whether this came from a paste operation
+}
+```
+
+The `String()` method returns a human-readable representation: `"a"`, `"ctrl+c"`, `"alt+enter"`, `"up"`, `"f1"`, etc.
+
+### Mouse Events
+
+```go
+type MouseMsg struct {
+    X, Y           int
+    Shift, Alt, Ctrl bool
+    Action         MouseAction  // MouseActionPress, MouseActionRelease, MouseActionMotion
+    Button         MouseButton  // MouseButtonLeft, MouseButtonRight, MouseButtonWheelUp, ...
+}
+```
+
+### Window Size Events
+
+```go
+type WindowSizeMsg struct {
+    Width  int
+    Height int
+}
+```
+
+Sent when the terminal is resized (SIGWINCH on Unix). Also available on demand via `tea.WindowSize()`.
+
+### Focus Events
+
+When focus reporting is enabled (`tea.WithReportFocus()`):
+
+```go
+type FocusMsg struct{}
+type BlurMsg struct{}
+```
+
+### Comprehensive Update Example
+
+```go
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    switch msg := msg.(type) {
+
+    case tea.WindowSizeMsg:
+        m.width = msg.Width
+        m.height = msg.Height
+        return m, nil
+
+    case tea.KeyMsg:
+        switch msg.String() {
+        case "ctrl+c", "q":
+            return m, tea.Quit
+        case "up", "k":
+            m.cursor--
+            if m.cursor < 0 {
+                m.cursor = len(m.items) - 1
+            }
+        case "down", "j":
+            m.cursor++
+            if m.cursor >= len(m.items) {
+                m.cursor = 0
+            }
+        case "enter":
+            m.selected = m.cursor
+            return m, fetchDetails(m.items[m.cursor].ID)
+        }
+
+    case tea.MouseMsg:
+        if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
+            m.cursor = msg.Y - m.listOffset
+        }
+
+    case detailsMsg:
+        m.details = msg.Content
+        return m, nil
+
+    case errMsg:
+        m.err = msg.Err
+        return m, nil
+    }
+
+    return m, nil
+}
+```
+
+### Custom Messages and Commands
+
+Applications define their own message types and commands for domain-specific I/O:
+
+```go
+// Custom message types
+type detailsMsg struct{ Content string }
+type errMsg struct{ Err error }
+
+// Command that performs an HTTP request and returns a message
+func fetchDetails(id int) tea.Cmd {
+    return func() tea.Msg {
+        resp, err := http.Get(fmt.Sprintf("https://api.example.com/items/%d", id))
+        if err != nil {
+            return errMsg{err}
+        }
+        defer resp.Body.Close()
+        body, _ := io.ReadAll(resp.Body)
+        return detailsMsg{string(body)}
+    }
+}
+
+// Combining multiple commands
+return m, tea.Batch(
+    fetchDetails(m.selectedID),
+    spinner.Tick,
+    tea.WindowSize(),
+)
+```
+
+---
+
+## State Management
+
+### The Model IS the State
+
+In Bubble Tea, there is no separate state container, store, or reactive system. The `Model` struct is the complete application state. Every field that affects rendering or behavior lives in the model.
+
+```go
+type model struct {
+    items    []item
+    cursor   int
+    selected int
+    width    int
+    height   int
+    loading  bool
+    err      error
+
+    // Sub-model state
+    list     list.Model
+    viewport viewport.Model
+    spinner  spinner.Model
+}
+```
+
+### Immutable-Style Updates
+
+`Update` returns a _new_ `Model` value. In Go, this is a struct value copy (not a deep clone), so top-level fields are replaced but pointer-referenced data is shared. This is efficient for typical model sizes but requires care with slice and map mutations:
+
+```go
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    // m is a value copy -- mutations here don't affect the original
+    m.cursor++
+    return m, nil
+}
+```
+
+### No Global State
+
+There is no global mutable state, singleton store, or dependency injection. All state flows through the `Model`, and all mutations flow through `Update`. This makes applications:
+
+- **Testable** -- create a model, send messages, assert on the result.
+- **Predictable** -- given the same model and message, `Update` always produces the same result.
+- **Debuggable** -- the entire application state is visible in one struct.
+
+### Sub-Model Pattern
+
+Complex applications decompose state into sub-models:
+
+```go
+type model struct {
+    page     page
+    header   headerModel
+    sidebar  sidebarModel
+    content  contentModel
+    footer   footerModel
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+    var cmds []tea.Cmd
+    var cmd tea.Cmd
+
+    m.header, cmd = m.header.Update(msg)
+    cmds = append(cmds, cmd)
+
+    switch m.page {
+    case pageSidebar:
+        m.sidebar, cmd = m.sidebar.Update(msg)
+    case pageContent:
+        m.content, cmd = m.content.Update(msg)
+    }
+    cmds = append(cmds, cmd)
+
+    m.footer, cmd = m.footer.Update(msg)
+    cmds = append(cmds, cmd)
+
+    return m, tea.Batch(cmds...)
+}
+```
+
+Message routing is manual -- the parent decides which child receives which messages. There is no automatic focus management or message bus.
+
+---
+
+## Extensibility and Ecosystem
+
+### The Charm Ecosystem
+
+Bubble Tea sits at the center of a rich ecosystem of complementary libraries:
+
+| Library       | Purpose                                                    |
+| ------------- | ---------------------------------------------------------- |
+| **Lip Gloss** | Terminal styling: colors, borders, padding, layout joining |
+| **Bubbles**   | Pre-built UI components (inputs, lists, tables, spinners)  |
+| **Wish**      | Build SSH servers that serve Bubble Tea apps               |
+| **Huh**       | Interactive forms, prompts, and surveys                    |
+| **Gum**       | Shell-scriptable TUI components (no Go needed)             |
+| **Log**       | Colorful, structured, leveled logging                      |
+| **Harmonica** | Spring-based smooth animations                             |
+| **Pop**       | Email sending from the terminal                            |
+| **Mods**      | AI-powered terminal tools                                  |
+| **VHS**       | Record terminal GIFs from scripts                          |
+
+### Community
+
+The Charm ecosystem has a large and active community:
+
+- Active Discord server with thousands of members.
+- Extensive example repository with dozens of complete applications.
+- Third-party bubbles and middleware shared via Go modules.
+- Blog posts and conference talks covering patterns and best practices.
+
+### SSH Applications with Wish
+
+One of Bubble Tea's distinguishing features is Wish, which lets developers serve Bubble Tea applications over SSH:
+
+```go
+// A Bubble Tea app accessible via: ssh myapp.example.com
+s, _ := wish.NewServer(
+    wish.WithAddress("0.0.0.0:23234"),
+    wish.WithMiddleware(
+        bubbletea.Middleware(teaHandler),
+    ),
+)
+s.ListenAndServe()
+```
+
+This enables multi-user terminal applications, shared dashboards, and interactive tools accessible from any SSH client.
+
+---
+
+## Strengths
+
+- **Simple mental model** -- three functions (`Init`, `Update`, `View`) define the entire application lifecycle. No callbacks, no event registration, no lifecycle hooks beyond these three.
+- **Excellent documentation and examples** -- the repository includes a thorough tutorial, extensive examples, and the ecosystem has abundant community-written guides.
+- **Vibrant, cohesive ecosystem** -- Lip Gloss, Bubbles, Wish, Huh, and Gum are maintained by the same team, ensuring consistent APIs and design philosophy.
+- **Highly testable** -- testing is trivial because `Update` is a pure function of `(Model, Msg) -> (Model, Cmd)` and `View` is a pure function of `Model -> string`. No mocks needed for UI logic.
+- **SSH application support** -- Wish makes Bubble Tea unique among TUI frameworks by enabling network-accessible terminal applications with minimal additional code.
+- **Single binary deployment** -- Go's static compilation produces self-contained binaries with no runtime dependencies.
+- **Framerate-limited rendering** -- the renderer batches updates at up to 60 FPS, avoiding unnecessary redraws and terminal flicker.
+- **Cross-platform** -- works on Linux, macOS, and Windows (via ConPTY) without conditional compilation.
+- **Active maintenance** -- backed by a company (Charm) with a sustainable business model around terminal infrastructure.
+
+---
+
+## Weaknesses and Limitations
+
+- **String-based rendering loses structure** -- `View()` returns a flat string. The framework has no knowledge of widget boundaries, focus regions, or spatial relationships. Hit testing for mouse events must be implemented manually by tracking coordinates.
+- **No built-in layout engine** -- developers must manually calculate widths, heights, and positions. Lip Gloss provides joining utilities but not a constraint solver, flexbox, or grid system. Responsive layouts require explicit math.
+- **Go's type system limits expressiveness** -- the `Msg` type is `interface{}` (empty interface), so message dispatch requires type switches rather than exhaustive pattern matching. The compiler cannot verify that all message types are handled.
+- **Manual message routing in complex apps** -- parent models must explicitly forward messages to child models. There is no automatic propagation, focus-aware routing, or message middleware. This becomes verbose in deeply nested UIs.
+- **No built-in widget focus management** -- when composing multiple interactive bubbles (e.g., two text inputs), the developer must manually track which one is focused and route key events accordingly.
+- **Performance limited by string operations** -- the entire UI is rebuilt as a string on every update. For very large UIs, string concatenation and the subsequent diff become a bottleneck. There is no incremental rendering or virtual terminal buffer.
+- **No animation primitives in core** -- animations require manual tick commands and interpolation. Harmonica helps with easing but is a separate dependency.
+- **Shallow widget library** -- while Bubbles covers common cases, it lacks advanced components like trees, split panes, tab bars, modals, or rich text editors. Developers build these from scratch.
+- **Model value semantics in Go** -- returning a new `Model` value from `Update` copies the entire struct. For models with large slices or maps, this requires careful use of pointers to avoid performance issues, which partially undermines the immutable-style design.
+
+---
+
+## Lessons for D / Sparkles
+
+Bubble Tea's architecture offers several patterns that translate well to D, often with improvements enabled by D's richer type system and compile-time capabilities.
+
+### MVU Pattern with Immutable Structs and Pure Functions
+
+Bubble Tea's core loop maps directly to D idioms:
+
+```d
+// D's `pure` attribute enforces no hidden state access
+pure Model update(in Model m, in Msg msg) { ... }
+pure string view(in Model m) { ... }
+```
+
+D's `immutable` and `const` qualifiers provide stronger guarantees than Go's value semantics. A `pure` function that takes `in Model` (which is `scope const` with `-preview=in`) cannot modify or retain references to the model, making the MVU contract compiler-enforced rather than conventional.
+
+### Cmd/Msg with Sum Types
+
+Go uses the empty interface (`interface{}`) for messages and relies on type switches. D can use `SumType` or `std.variant.Algebraic` for exhaustive, compiler-checked message dispatch:
+
+```d
+import std.sumtype;
+
+alias Msg = SumType!(
+    KeyMsg,
+    MouseMsg,
+    WindowSizeMsg,
+    FetchResultMsg,
+    ErrorMsg,
+);
+
+// Compiler error if a case is missing
+Msg.match!(
+    (KeyMsg k)         => handleKey(model, k),
+    (MouseMsg m)       => handleMouse(model, m),
+    (WindowSizeMsg ws) => handleResize(model, ws),
+    (FetchResultMsg r) => handleResult(model, r),
+    (ErrorMsg e)       => handleError(model, e),
+);
+```
+
+Alternatively, template-based dispatch via Design by Introspection could allow compile-time resolution of message handlers based on capability traits.
+
+### View-as-String vs. Output Ranges
+
+Bubble Tea's biggest performance limitation is that `View()` returns a heap-allocated `string` that is then diffed. In D, the view function can write to an output range, avoiding allocation entirely:
+
+```d
+/// Renders the model's UI to an output range -- zero allocation.
+void view(Writer)(in Model m, ref Writer w)
+if (isOutputRange!(Writer, char))
+{
+    w.put("Items:\n");
+    foreach (i, item; m.items)
+    {
+        if (i == m.cursor)
+            w.put("> ");
+        else
+            w.put("  ");
+        w.put(item.name);
+        w.put('\n');
+    }
+}
+```
+
+This pattern is already established in Sparkles' `prettyPrint`, which writes to arbitrary output ranges including `SmallBuffer` for `@nogc` operation.
+
+### Lip Gloss Styling with UFCS Builder Chains
+
+Lip Gloss's method-chaining builder pattern maps directly to Sparkles' existing `stylizedTextBuilder` using UFCS and `opDispatch`:
+
+```go
+// Go / Lip Gloss
+lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205")).Render("Hello")
+```
+
+```d
+// D / Sparkles (already exists in term_style.d)
+"Hello".stylizedTextBuilder.bold.magenta
+```
+
+D's compile-time `opDispatch` resolves style names at compile time with zero runtime overhead, and `enum` evaluation enables CTFE for static style strings -- something Lip Gloss cannot do.
+
+### Bubble Composition with Template Mixins and DbI
+
+Bubble Tea's sub-model composition pattern (embed struct, forward messages, collect commands) can be expressed more powerfully in D using Design by Introspection:
+
+```d
+/// A widget that optionally supports focus, scrolling, and filtering
+/// based on what capabilities the underlying model provides.
+struct ComposedWidget(Models...)
+{
+    Models models;
+
+    void update(Msg msg)
+    {
+        static foreach (i, M; Models)
+        {
+            static if (__traits(hasMember, M, "update"))
+                models[i].update(msg);
+        }
+    }
+
+    void view(Writer)(ref Writer w)
+    {
+        static foreach (i, M; Models)
+        {
+            static if (__traits(hasMember, M, "view"))
+                models[i].view(w);
+        }
+    }
+}
+```
+
+This eliminates Bubble Tea's manual message forwarding boilerplate. The compiler generates the routing code based on the capabilities of each sub-model.
+
+### Testing Pattern with Output Ranges
+
+Bubble Tea's testability advantage (assert on model state and view string) becomes even stronger in D with output ranges:
+
+```d
+@("app.update.keyDown.movesCursor")
+@safe pure nothrow @nogc
+unittest
+{
+    auto m = initialModel();
+    m = update(m, KeyMsg(KeyType.down));
+    assert(m.cursor == 1);
+
+    SmallBuffer!(char, 1024) buf;
+    view(m, buf);
+    // buf[] contains the rendered view -- compare without allocation
+}
+```
+
+The combination of `pure`, `@nogc`, and `SmallBuffer` means UI tests run with zero allocation and can verify both state transitions and rendered output.
+
+---
+
+## References
+
+- **Repository**: <https://github.com/charmbracelet/bubbletea>
+- **Tutorial**: <https://github.com/charmbracelet/bubbletea/tree/master/tutorials>
+- **Examples**: <https://github.com/charmbracelet/bubbletea/tree/master/examples>
+- **Bubbles (components)**: <https://github.com/charmbracelet/bubbles>
+- **Lip Gloss (styling)**: <https://github.com/charmbracelet/lipgloss>
+- **Wish (SSH)**: <https://github.com/charmbracelet/wish>
+- **Huh (forms)**: <https://github.com/charmbracelet/huh>
+- **Gum (shell scripting)**: <https://github.com/charmbracelet/gum>
+- **Charm homepage**: <https://charm.sh>
+- **"The Elm Architecture" (original)**: <https://guide.elm-lang.org/architecture/>
+- **Charm blog**: <https://charm.sh/blog/>
+- **"Building a TUI with Bubble Tea" (talk)**: Various conference presentations by the Charm team

--- a/docs/research/tui-libraries/comparison.md
+++ b/docs/research/tui-libraries/comparison.md
@@ -1,0 +1,1035 @@
+# TUI Library Comparison & Design Recommendations
+
+A cross-library synthesis of thirteen TUI frameworks -- Ratatui (Rust), Ink (JavaScript), Textual (Python), Bubble Tea (Go), Brick (Haskell), Notcurses (C), FTXUI (C++), Cursive (Rust), Mosaic (Kotlin), Nottui (OCaml), libvaxis (Zig), tview (Go), and ImTui (C++) -- with concrete design recommendations for Sparkles.
+
+---
+
+## 1. Rendering Models Compared
+
+The thirteen libraries span five rendering paradigms: immediate mode, retained mode, functional DOM composition, incremental/reactive computation, and pure immediate-mode (ImGui). Each makes fundamentally different tradeoffs around state ownership, allocation patterns, and update granularity.
+
+### Immediate Mode
+
+**Ratatui**, **Bubble Tea**, and **libvaxis** use immediate-mode rendering. Every frame, the application rebuilds the entire UI description from scratch. There is no persistent widget tree or scene graph.
+
+**How the render cycle works:**
+
+- **Ratatui**: The application calls `terminal.draw(|frame| { ... })`. Inside the closure, widgets are constructed inline from application state and rendered into a `Buffer` (a flat `Vec<Cell>` grid). After the closure returns, the `Terminal` diffs the current buffer against the previous one and emits only changed cells to the backend. Widgets are consumed by value on render -- they do not persist between frames.
+
+- **Bubble Tea**: The `View()` method returns a plain `string` representing the entire UI. The framework diffs the new string against the previous one at the line level and overwrites only changed lines. There is no structured buffer -- just string comparison.
+
+- **libvaxis**: The application gets a `Window` (a view into the `Screen` back buffer), clears it, draws widgets into it via `writeCell()` and `print()`, then calls `render()`. Vaxis diffs the current `Screen` against `screen_last` (the front buffer) and emits only changed cells. The immediate-mode pattern is the same as Ratatui, but with Zig's explicit allocator passing at every allocation site.
+
+**Pros:**
+
+- Simple mental model: UI is always a function of current state
+- No stale widget state to manage
+- Zero persistent allocations for the widget tree
+- Naturally compatible with `pure` functions and `@nogc` rendering
+
+**Cons:**
+
+- Rebuilds the full UI every frame, even unchanged regions
+- No mechanism to skip unchanged subtrees without manual optimization
+- Bubble Tea's string-based approach loses spatial structure, making hit-testing and partial updates expensive
+
+**D suitability:** Excellent. Widgets as stack-allocated `struct` values, consumed within a single `draw` call, align perfectly with `@nogc` and output range patterns. Ratatui's `Buffer`-based approach maps directly to `SmallBuffer!(Cell, N)`. libvaxis's explicit allocator passing maps to D's `@nogc` attribute, which provides the same guarantee (no hidden allocation) enforced at compile time rather than by convention.
+
+### Retained Mode
+
+**Textual**, **Ink**, **Cursive**, and **tview** maintain persistent widget trees that survive across frames.
+
+**How the render cycle works:**
+
+- **Textual**: Maintains a DOM-like tree of `Widget` objects. When a `reactive` attribute changes, the widget is marked dirty. On the next frame, only dirty widgets are re-rendered. The compositor assembles output from Rich `Segment` objects, performing cuts, chops, occlusion, and composition to produce minimal terminal writes.
+
+- **Ink**: Uses React's `react-reconciler` to manage a virtual component tree. State changes trigger reconciliation (virtual tree diffing), then Yoga computes Flexbox layout, and the result is rendered to an ANSI string buffer. The framework patches the terminal by overwriting its output region.
+
+- **Cursive**: Maintains a persistent tree of `View` trait objects (`Box<dyn View>`). The framework owns the event loop, calls `required_size` / `layout` / `draw` on the tree, and routes events through the focused path. Views hold their own mutable state (scroll position, text content, selection index) and persist between frames. Named views can be accessed from callbacks via `call_on_name`.
+
+- **tview**: Maintains a tree of `Primitive` interface objects. `Application.Run()` owns the event loop, dispatching terminal events to the focused widget. On each event, the framework calls `Draw` on the entire tree -- tcell's internal diff layer optimizes actual terminal writes. Widgets own their state via getters/setters.
+
+**Pros:**
+
+- Partial updates: only dirty widgets are re-rendered (Textual, Ink)
+- Rich lifecycle hooks (mount, unmount, focus, effects)
+- CSS selectors and DOM queries for widget management (Textual)
+- Event bubbling through the tree
+- Built-in focus management (Cursive, tview) -- the framework tracks focus, routes input, and supports Tab/Shift-Tab navigation
+
+**Cons:**
+
+- Persistent heap allocations for the widget tree
+- Complex invalidation and dirty-tracking logic
+- GC pressure from retained objects (Python, JavaScript)
+- Virtual dispatch overhead for trait objects / interfaces (Cursive's `Box<dyn View>`, tview's `Primitive` interface)
+- Callback spaghetti in complex apps (Cursive, tview)
+- More complex state synchronization between app state and widget state
+
+**D suitability:** Mixed. A full retained DOM with GC-managed objects would fight D's `@nogc` philosophy. However, Textual's dirty-tracking compositor pattern is valuable -- it could be implemented with a flat cell-buffer approach rather than a GC object tree. Cursive's `View` trait maps to D interfaces (for heterogeneous trees) or template constraints (for static trees). tview's `Primitive` interface maps directly to D's Design by Introspection, with the advantage that D can check the contract at compile time rather than via Go's runtime duck typing.
+
+### Functional DOM Composition (FTXUI)
+
+**FTXUI** occupies a distinctive position: a two-tier architecture where the rendering layer is pure functional (immediate-mode elements) and the interaction layer is retained-mode (stateful components).
+
+**How the render cycle works:**
+
+The dom layer constructs an `Element` tree from functions (`text`, `hbox`, `vbox`, `border`, `gauge`). Elements are `shared_ptr<Node>` values -- new every frame, no mutation. The tree goes through a two-pass layout (bottom-up `ComputeRequirement`, top-down `SetBox`), then renders to a `Screen` pixel grid. The component layer wraps this: a `Component` produces an `Element` tree via `Render()`, handles events via `OnEvent()`, and participates in a focus tree. `ScreenInteractive` drives the loop, calling `Render()` each frame, diffing, and flushing.
+
+The pipe operator (`|`) enables decorator chaining: `text("hello") | bold | color(Color::Red) | border`. This is syntactic sugar for nested function application.
+
+**Pros:**
+
+- Clean separation: dom layer is pure functional, component layer adds only necessary statefulness
+- Pipe operator for left-to-right readability
+- Flexbox-inspired layout with full CSS flexbox semantics
+- Zero external dependencies
+
+**Cons:**
+
+- `shared_ptr` per node means heap allocation for every element every frame
+- No built-in async/concurrency model
+- No theming system
+
+**D suitability:** Excellent conceptual fit. FTXUI's pipe operator maps directly to D's UFCS -- `text("hello").bold.color(Color.red).border` -- as a built-in language feature with zero operator overloading. Elements can be `@nogc` struct values in `SmallBuffer`-backed trees instead of `shared_ptr` nodes. The dual dom/component architecture maps to `@nogc` pure element types + DbI-detected component capabilities.
+
+### Compose / Reactive Recomposition (Mosaic)
+
+**Mosaic** uses the Jetpack Compose compiler plugin and runtime, retargeted from Android views to terminal ANSI output.
+
+**How the render cycle works:**
+
+The Compose compiler plugin transforms `@Composable` functions at compile time, inserting change-detection guards and slot-table management code. During composition, the runtime records which `@Composable` functions read which snapshot state objects. When a `mutableStateOf` value changes, only the functions that read it are re-executed -- no virtual DOM diff, no full tree rebuild. A `MosaicNodeApplier` maps the abstract composition to a terminal node tree, which is measured, placed, and drawn to a `TextSurface` grid of styled pixels, then serialized as ANSI.
+
+**Pros:**
+
+- Compiler-powered recomposition: change detection inserted at compile time, not diffed at runtime
+- Automatic fine-grained dependency tracking via snapshot system
+- Familiar Compose/React mental model
+- Deep coroutine integration (`LaunchedEffect`, `snapshotFlow`)
+
+**Cons:**
+
+- Requires Kotlin and the Compose compiler plugin -- not portable to other languages
+- JVM startup overhead on JVM target
+- Limited built-in widgets (Text, Row, Column, Box, Spacer, Filler)
+- No focus management, no mouse support, no input field abstraction
+
+**D suitability:** The compiler-plugin mechanism is not replicable in D, but the _patterns_ are highly relevant. D's CTFE + mixin templates can generate change-detection boilerplate for struct fields. D's `Reactive!T` wrapper structs with `opDispatch` can approximate snapshot state. Modifier chains (`Modifier.width(10).padding(2).background(Color.Red)`) map directly to UFCS. The key lesson is that compile-time code generation for reactive state tracking is a powerful pattern that D can approximate through its own metaprogramming.
+
+### Incremental Computation / FRP (Nottui)
+
+**Nottui** uses incremental computation primitives where the UI is a reactive document with automatic dependency tracking.
+
+**How the render cycle works:**
+
+The core type is `'a Lwd.t` -- a reactive value that tracks dependencies in a DAG. Source nodes are `Lwd.var` (mutable reactive cells). Computed values use `Lwd.map`, `Lwd.map2`, `Lwd.bind` to compose reactive computations. The UI is a `Ui.t Lwd.t` -- a reactive value producing UI trees. On each frame, `Lwd.sample root` evaluates only damaged nodes (those whose transitive inputs changed). If nothing changed, sampling returns cached values at zero cost. There is no virtual DOM diff and no full redraw.
+
+**Pros:**
+
+- Automatic fine-grained reactivity -- dependencies tracked by the runtime, not declared by the programmer
+- Efficient sparse updates: O(k) where k = changed dependencies, not O(n) for the full tree
+- No virtual DOM overhead -- the dependency graph directly encodes what needs to update
+- Mathematically principled (Functor/Applicative/Monad)
+- Backend-agnostic core (Lwd works for terminal, web, and any other output)
+
+**Cons:**
+
+- Steep learning curve (monadic composition, OCaml type system)
+- Small ecosystem and community
+- `Lwd.bind` (dynamic graph rewiring) is more expensive than static edges
+- `Lwd.root` values must be explicitly released to avoid memory leaks
+
+**D suitability:** The incremental computation model is the most sophisticated update strategy among the thirteen libraries. For D, the key insight is that dependency-tracked incremental computation avoids both the O(n) full-redraw cost and the O(n) virtual-DOM-diff cost. A `Reactive!T` struct with automatic dependency registration during render passes can be implemented `@nogc` with a pre-allocated DAG -- no allocation, no diffing. This is the most promising path for high-performance partial updates in a `@nogc` context.
+
+### Pure Immediate-Mode / ImGui (ImTui)
+
+**ImTui** brings Dear ImGui's pure immediate-mode paradigm to the terminal. There are no widget objects, no retained tree, no callbacks. The UI is a sequence of function calls each frame.
+
+**How the render cycle works:**
+
+Each frame, the application calls ImGui functions (`Button`, `Text`, `SliderFloat`). ImGui accumulates draw geometry into draw lists. ImTui's text backend rasterizes triangles into a `TScreen` of packed 32-bit `TCell` values (character + foreground + background). The ncurses backend diffs current vs previous frame and writes only changed cells.
+
+Widget identity uses an ID stack (hashed string labels + window ID). The hot/active model tracks mouse hover and interaction state with zero widget objects -- just two IDs per frame.
+
+**Pros:**
+
+- Zero widget boilerplate -- a widget is a function call
+- UI code is maximally concise
+- Full Dear ImGui ecosystem (1000+ extensions)
+- No callback hell -- event handling is inline with rendering
+- State management is trivial -- application owns all state as plain variables
+- Entire render path can be `@nogc`
+
+**Cons:**
+
+- Pixel-to-character mapping loses precision
+- Limited to 256 ANSI colors
+- Cursor-based layout has no constraint solver or flexbox
+- No styled text (inline bold/color within a string)
+- No proper Unicode box-drawing characters
+
+**D suitability:** The widget-as-function pattern is maximally `@nogc`-friendly. D could offer an ImGui-like API layer for rapid prototyping with compile-time widget IDs via `__FILE__` and `__LINE__` template parameters (zero-cost, unlike ImGui's runtime string hashing). Push/pop style stacks map to D's `scope(exit)` guards, preventing the "forgot to pop" bugs common in C++ ImGui code. This would complement a more structured widget system as a rapid-development fast path.
+
+### Hybrid: Compositor with Planes (Notcurses)
+
+**Notcurses** uses a retained compositor model with manually managed planes.
+
+**How the render cycle works:**
+
+The application draws to `ncplane` surfaces (retained cell grids). On render, `ncpile_render()` composites all planes in z-order with alpha blending, producing a flattened cell grid. `ncpile_rasterize()` diffs against the previous frame and emits minimal escape sequences. The plane contents are retained and only need updating when they actually change, but the composition step runs across all visible planes every frame.
+
+**Pros:**
+
+- True alpha compositing between overlapping layers
+- Retained plane contents avoid unnecessary redraws of static elements
+- Cell-packed representation with inline glyph clusters avoids heap allocation
+- Thread-safe concurrent plane manipulation
+
+**Cons:**
+
+- Manual positioning and sizing of all planes
+- No automatic layout engine
+- Manual memory management for planes and cells
+
+**D suitability:** The plane compositor model maps well to D. Planes as `@nogc` structs with RAII cleanup via `~this()`, channel-based coloring via bitwise operations, and compositor output to `SmallBuffer` -- all align naturally.
+
+### Declarative Rebuild (Brick)
+
+**Brick** is a pure functional approach: `appDraw` is a pure function producing `[Widget n]` layers. The rendering engine evaluates each widget's rendering function, threading layout constraints through the tree. Widgets produce Vty `Image` values that are composited into the final frame. Unlike Textual and Ink, Brick re-evaluates the entire `appDraw` function on each event, making it a "declarative rebuild" rather than a persistent retained tree.
+
+**D suitability:** Strong. D's UFCS chains provide the same compositional expressiveness as Haskell's combinators, with left-to-right readability. D's `pure` attribute enforces the same side-effect-free guarantee.
+
+### Comparison Table
+
+| Aspect                | Ratatui                  | Bubble Tea           | Textual             | Ink                  | Brick                 | Notcurses             | FTXUI                                                | Cursive                                 | Mosaic                                   | Nottui                              | libvaxis                    | tview                    | ImTui                      |
+| --------------------- | ------------------------ | -------------------- | ------------------- | -------------------- | --------------------- | --------------------- | ---------------------------------------------------- | --------------------------------------- | ---------------------------------------- | ----------------------------------- | --------------------------- | ------------------------ | -------------------------- |
+| **Model**             | Immediate                | Immediate            | Retained (DOM)      | Retained (React)     | Declarative rebuild   | Retained (planes)     | Hybrid (functional DOM + retained components)        | Retained (view tree + callbacks)        | Reactive recomposition (compiler plugin) | Incremental computation (FRP/DAG)   | Immediate (double-buffered) | Retained (widget tree)   | Pure immediate (ImGui)     |
+| **Render target**     | Cell buffer              | String               | Rich Segments       | ANSI string          | Vty Image             | Cell grid             | Screen pixel grid                                    | Printer abstraction                     | TextSurface (TextPixel grid)             | Notty Image                         | Screen cell buffer          | tcell Screen             | TScreen (packed TCell)     |
+| **Diffing**           | Cell-level               | Line-level           | Region-level        | String patch         | Full recomposite      | Cell-level            | Cell-level (ScreenInteractive)                       | Full redraw                             | Differential ANSI encoding               | Incremental (only damaged nodes)    | Cell-level                  | Cell-level (via tcell)   | Cell-level                 |
+| **Partial update**    | No (full rebuild)        | No (full rebuild)    | Yes (dirty widgets) | Yes (reconciler)     | No (full rebuild)     | Yes (retained planes) | No (full element tree rebuild)                       | No (full redraw, `needs_relayout` hint) | Yes (snapshot-tracked recomposition)     | Yes (dependency-graph invalidation) | No (full rebuild)           | No (full tree Draw)      | No (full rebuild)          |
+| **Persistent state**  | None (widgets ephemeral) | None (string output) | Widget tree + CSS   | React component tree | None (pure rebuild)   | Plane cell grids      | Component tree (retained) + Element tree (ephemeral) | View tree (persistent)                  | Slot table (composition state)           | Lwd DAG (reactive variables)        | None (app-owned)            | Widget tree (persistent) | None (app-owned variables) |
+| **GC pressure**       | Zero                     | String alloc/frame   | High (Python)       | High (JS)            | Moderate (Haskell GC) | Zero (manual)         | Moderate (shared_ptr/frame)                          | Low (Rust ownership)                    | Moderate (JVM/native)                    | Low (OCaml GC, incremental)         | Zero (explicit allocator)   | Moderate (Go GC)         | Zero (C++ manual)          |
+| **@nogc feasibility** | High                     | Moderate             | Low                 | Low                  | N/A                   | High                  | Moderate (shared_ptr)                                | N/A (Rust)                              | Low (Kotlin/JVM)                         | Moderate (OCaml)                    | High                        | Moderate (Go GC)         | High                       |
+
+---
+
+## 2. Architecture Patterns Compared
+
+### Elm / MVU (Bubble Tea, partially Brick)
+
+Both Bubble Tea and Brick structure applications around a variant of The Elm Architecture:
+
+- **Bubble Tea**: Strict MVU via the `Model` interface with `Init() Cmd`, `Update(Msg) (Model, Cmd)`, and `View() string`. Side effects are modeled as `Cmd` values. The framework owns the event loop.
+- **Brick**: The `App s e n` record with `appDraw`, `appHandleEvent`, `appChooseCursor`, `appStartEvent`, and `appAttrMap`. While `appDraw` is pure, `appHandleEvent` uses the `EventM` monad for stateful updates with lens operations, making it less purely functional than Bubble Tea.
+
+**D alignment:** Strong. D's `pure` attribute enforces the no-side-effects contract at compile time. A `pure` `view` function taking `in Model` (which is `scope const` under `-preview=in`) provides a stronger guarantee than Go's convention-based immutability. D's `SumType` enables exhaustive, compiler-checked message dispatch -- a significant improvement over Go's `interface{}` type switches.
+
+### React / Component (Ink)
+
+Ink uses React's component model: function components with hooks (`useState`, `useEffect`, `useInput`), a virtual tree managed by `react-reconciler`, and Yoga for Flexbox layout.
+
+**D alignment:** Weak. React's component model is deeply tied to runtime reconciliation, closure-based hooks, and garbage collection. Translating hooks to D would lose the core benefits. However, the _concept_ of composable components with local state can be expressed through struct-based widgets with template parameters.
+
+### Pure Functional (Brick)
+
+Brick's pure functional core -- `appDraw :: s -> [Widget n]` -- is the cleanest expression of "UI as a function of state" in any of the thirteen libraries. Layout is entirely combinator-based (`hBox`, `vBox`, `padLeft`, `hLimit`), with no mutation.
+
+**D alignment:** Strong. D's UFCS chains provide the same compositional expressiveness as Haskell's combinators, with left-to-right readability. D's `pure` attribute enforces the same side-effect-free guarantee. The combinator approach maps directly to template functions returning widget structs by value.
+
+### CSS + Widget Tree (Textual)
+
+Textual mirrors web development: a DOM-like widget tree, TCSS stylesheets with selectors and pseudo-classes, message bubbling, reactive data binding, and async event handling.
+
+**D alignment:** Mixed. The CSS-like styling and selector system are powerful but deeply tied to runtime parsing and dynamic dispatch. D could implement a compile-time CSS DSL via CTFE, validating styles at compile time and producing zero-allocation style lookups. However, the full DOM + message-bubbling architecture adds complexity that may not be justified for a systems-oriented D library.
+
+### Functional DOM Composition (FTXUI)
+
+FTXUI's two-tier architecture separates pure functional rendering from stateful interaction. The dom layer builds Element trees from function calls. The component layer wraps Elements with event handling and mutable state. The pipe operator (`|`) enables decorator chaining.
+
+**D alignment:** Excellent. FTXUI's architecture maps remarkably well to D. The pipe operator IS D's UFCS -- `text("hello").bold.color(Color.blue).border` -- with zero operator overloading needed. The dual dom/component layers map to `@nogc` pure element types + DbI-detected component capabilities. FTXUI's `FlexboxConfig` struct maps to named-argument D structs with CTFE validation. The key improvement D offers: elements as `@nogc` value-type structs in `SmallBuffer` instead of `shared_ptr` heap nodes.
+
+### Callback-Based Retained Mode (Cursive, tview)
+
+Cursive and tview represent traditional desktop GUI toolkit architecture translated to the terminal: a retained widget tree with callback-driven event handling.
+
+- **Cursive**: Views form a persistent tree. The `View` trait provides `draw`, `required_size`, `layout`, and `on_event`. Named views are accessed by string via `call_on_name`. Callbacks receive `&mut Cursive` for tree manipulation. User data (`Box<dyn Any>`) stores application state.
+- **tview**: Primitives form a persistent tree. `Application.Run()` owns the event loop. `Flex` and `Grid` containers handle layout. Widgets own their state via getters/setters. `QueueUpdateDraw` serializes goroutine-to-UI communication.
+
+**D alignment:** The callback pattern maps to D delegates. However, callback spaghetti is a known weakness of both libraries. D could improve on this by offering an MVU alternative alongside callbacks. Cursive's named view access could be enhanced with compile-time indexed view trees using string template parameters. tview's `Primitive` interface maps to D's `isWidget` template constraint with static dispatch.
+
+### Compose / Reactive Recomposition (Mosaic)
+
+Mosaic uses Kotlin's Compose compiler plugin to transform `@Composable` functions into incremental tree-building code. The runtime's snapshot system tracks state reads and triggers minimal recomposition.
+
+**D alignment:** The compiler-plugin mechanism is language-specific, but the patterns translate. D's CTFE + mixin templates can generate change-detection logic for struct fields. A `mixin Reactive!(MyState)` could introspect fields and generate dirty-tracking code. Modifier chains map to UFCS. The constraint-based layout (`Row`, `Column`, `Box` with `MeasurePolicy`) maps to D template constraints and DbI.
+
+### Incremental Computation / FRP (Nottui/Lwd)
+
+Nottui's Lwd layer provides a general-purpose incremental computation engine. `Lwd.var` (mutable reactive cells) are source nodes. `Lwd.map`/`Lwd.map2`/`Lwd.bind` compose reactive computations into a DAG. Dependencies are tracked automatically -- no manual subscriptions, no observer pattern, no dirty flags.
+
+**D alignment:** Strong conceptual fit. D's template metaprogramming could create compile-time dependency graphs for static reactive relationships, with runtime `Reactive!T`-style tracking for dynamic state. The `get`/`peek` distinction (tracked read vs untracked read) is directly implementable. `Lwd_table` (reactive collections with incremental reduction) maps to a `ReactiveList!T` with incremental `reduce` operations -- valuable for log views and list widgets.
+
+### Pure Immediate-Mode / ImGui (ImTui)
+
+ImTui inherits Dear ImGui's paradigm: no widget objects, no retained tree, no callbacks. A widget is a function call that lays out, renders, and checks interaction in a single expression. The hot/active model tracks exactly two IDs for mouse interaction.
+
+**D alignment:** Excellent for `@nogc`. The entire pattern -- widget functions writing to a buffer, returning interaction state, with compile-time IDs via `__FILE__`/`__LINE__` -- is directly implementable in D with zero allocation. This makes an ideal rapid-prototyping layer.
+
+### comptime-Powered (libvaxis)
+
+libvaxis uses Zig's `comptime` pervasively: generic event types where `@hasField` determines at compile time which event categories to generate; duck-typed widgets where any type with the right methods works; compile-time table column generation via `@typeInfo` and `inline for`.
+
+**D alignment:** Direct. Zig's `comptime` and D's CTFE serve the same purpose. `@hasField` maps to `__traits(hasMember, ...)`. Zig's manual vtable construction (`*anyopaque` + function pointers) is what D's template constraints eliminate -- D achieves the same type erasure more ergonomically. libvaxis's explicit allocator passing maps to D's `@nogc` attribute enforcement. D can go further with string mixins and CTFE evaluation of arbitrary expressions.
+
+### App-Loop + Widgets (Ratatui)
+
+Ratatui is deliberately minimal: it provides widgets, layout, and buffered rendering but does not own the event loop or impose a state pattern.
+
+**D alignment:** Excellent. This "library, not framework" philosophy matches D's systems-programming ethos. The application controls the loop, widgets are value types rendered into a buffer, and the library handles only rendering concerns.
+
+### Imperative (Notcurses)
+
+Notcurses has no imposed architecture. The application creates planes, draws on them, handles input, and calls render. All state management is manual.
+
+**D alignment:** Natural. This is how most D terminal code would work without a framework. However, it provides no abstractions -- the burden is entirely on the application.
+
+### Recommendation for Sparkles
+
+**Primary: Ratatui's library-centric model with Brick-inspired pure combinators, FTXUI-inspired functional DOM composition via UFCS, Bubble Tea's MVU as an optional overlay, and Nottui-inspired incremental reactivity as a future optimization.**
+
+The core should be a rendering library (like Ratatui): `Buffer` + `Cell` + `Backend` + `Layout` + `Widget` trait. Applications control their own event loop. FTXUI's element-as-value pattern translates directly via UFCS decorator chains. For applications wanting more structure, an optional MVU module provides Bubble Tea-style `Model`/`update`/`view` scaffolding built on top of the core primitives.
+
+The combinator-based layout from Brick (via UFCS) should be the primary layout mechanism, with constraint-based layout available for advanced use cases. ImTui-style immediate-mode widget functions should be available as a rapid-prototyping fast path.
+
+For the future, Nottui's incremental computation model offers the most principled path to partial updates without virtual DOM diffing -- a `Reactive!T` system with dependency-tracked DAG propagation, implementable `@nogc` with pre-allocated graph nodes.
+
+---
+
+## 3. Layout Systems Compared
+
+| Aspect                 | Ratatui                          | Ink                      | Textual                       | Bubble Tea                     | Brick                  | Notcurses          | FTXUI                                                      | Cursive                                   | Mosaic                                          | Nottui                              | libvaxis                                 | tview                                       | ImTui                           |
+| ---------------------- | -------------------------------- | ------------------------ | ----------------------------- | ------------------------------ | ---------------------- | ------------------ | ---------------------------------------------------------- | ----------------------------------------- | ----------------------------------------------- | ----------------------------------- | ---------------------------------------- | ------------------------------------------- | ------------------------------- |
+| **Approach**           | Constraint solver (Cassowary)    | Flexbox (Yoga)           | CSS subset                    | String composition (Lip Gloss) | Combinators            | Manual positioning | Flexbox-inspired                                           | Constraint-based (required_size / layout) | Compose layout (Row/Column/Box + Constraints)   | Combinator-based reactive           | Manual windows + vxfw FlexRow/FlexColumn | Flex + Grid containers                      | Cursor-based procedural (ImGui) |
+| **Direction**          | Vertical/Horizontal              | Row/Column + nested flex | Horizontal/Vertical/Grid/Dock | Manual join                    | Horizontal/Vertical    | Absolute (y, x)    | hbox/vbox/flexbox                                          | LinearLayout (H/V)                        | Row/Column/Box                                  | join_x/join_y/join_z                | Manual child windows                     | FlexRow/FlexColumn                          | SameLine / default vertical     |
+| **Sizing**             | Length, %, Ratio, Min, Max, Fill | flexGrow/Shrink/Basis    | auto, fixed, %, fr            | Explicit Width/Height          | Fixed/Greedy two-pass  | Explicit rows/cols | flex/flex_grow/flex_shrink, size constraints               | required_size + weight                    | fillMaxWidth, width, requiredWidth, Constraints | layout_spec (w/h + stretch factors) | limit/unbounded                          | fixedSize + proportion                      | SetNextItemWidth, child regions |
+| **Flexbox**            | No                               | Full (Yoga)              | No                            | No                             | No                     | No                 | Full (FlexboxConfig: direction, wrap, justify, align, gap) | No                                        | Row/Column with Arrangement                     | No                                  | Basic (FlexRow/FlexColumn)               | Flex (proportion-based)                     | No                              |
+| **Grid**               | No                               | No                       | Yes (CSS Grid subset)         | No                             | No                     | No                 | gridbox (2D)                                               | No                                        | No                                              | No                                  | No                                       | Grid (responsive breakpoints)               | BeginTable (columnar)           |
+| **Nesting**            | Layout::split -> sub-layouts     | Arbitrary JSX nesting    | Widget tree with CSS          | Manual string joins            | Combinator composition | Plane hierarchy    | Arbitrary function nesting                                 | View tree nesting                         | Arbitrary @Composable nesting                   | Combinator composition              | Window.child() nesting                   | Flex/Grid nesting                           | BeginChild/EndChild nesting     |
+| **Constraint solving** | Yes (Cassowary)                  | Yes (Yoga)               | Yes (CSS-like)                | No                             | No (greedy/fixed)      | No                 | Yes (two-pass: ComputeRequirement + SetBox)                | Yes (required_size + layout two-pass)     | Yes (Compose Constraints + MeasurePolicy)       | No (stretch factors)                | No (manual)                              | No (proportional division)                  | No                              |
+| **Responsive**         | Re-split on resize               | Flexbox adapts           | CSS adapts                    | Manual                         | Greedy adapts          | Resize callbacks   | Flexbox adapts                                             | needs_relayout                            | Compose Constraints adapt                       | Stretch factors adapt               | Manual resize handling                   | Grid minGridWidth/minGridHeight breakpoints | Manual size calculation         |
+
+### Newly Notable Layout Patterns
+
+**FTXUI's Flexbox** is the most complete flexbox implementation among the thirteen libraries. Its `FlexboxConfig` brings CSS Flexbox semantics (direction, wrap, justify-content, align-items, align-content, gap) directly to the terminal. This is rare -- most TUI libraries offer only linear (hbox/vbox) layout. For D, `FlexboxConfig` maps to a named-argument struct with CTFE validation, and the layout solver operates as `@nogc pure nothrow` functions on stack-allocated node arrays.
+
+**tview's Grid with Responsive Breakpoints** provides CSS media query-like behavior via `minGridWidth` / `minGridHeight` parameters on grid items. Items are only shown when the terminal meets minimum size thresholds. This enables different layouts at different terminal sizes without imperative resize handling -- the declarative specification handles everything. D's CTFE could validate grid definitions at compile time while breakpoint evaluation happens at runtime.
+
+**Mosaic's Compose Layout** brings Android's constraint-based layout model to terminals. `Row`, `Column`, and `Box` composables with `Arrangement` (Start, End, Center, SpaceBetween, SpaceEvenly, SpaceAround, spacedBy) and `Alignment` provide sophisticated distribution. Custom layout via `MeasurePolicy` enables arbitrary measurement and placement. For D, the `MeasurePolicy` interface maps to template constraints and DbI.
+
+**Cursive's Two-Pass Protocol** (`required_size` + `layout`) is the classic desktop GUI approach. Each view reports its ideal size given constraints, then the framework assigns final sizes top-down. Weight-based flex distribution allows proportional sizing. This is simpler than flexbox but sufficient for dialog-heavy applications.
+
+**Nottui's Combinator-Based Reactive Layout** integrates layout with reactivity. Each `Ui.t` carries a `layout_spec` with stretch factors (`sw`, `sh`) controlling how extra space is distributed. The same combinators work with both plain `Ui.t` values and reactive `Ui.t Lwd.t` values. When a reactive variable changes, only the affected subtree's layout is recomputed.
+
+**libvaxis's Manual Layout** is the simplest: create child windows with explicit offsets and dimensions. The vxfw framework adds basic flex via `FlexRow`/`FlexColumn` with a two-pass algorithm (measure fixed children, distribute remainder proportionally). For D, this level of manual layout is the baseline -- always available, with higher-level abstractions layered on top.
+
+**ImTui's Cursor-Based Layout** is the most limited. ImGui's procedural cursor model (`Text` advances cursor down, `SameLine()` moves it right) has no constraint solver. Complex layouts require manual size calculations. However, `BeginChild`/`EndChild` provides scrollable sub-regions, and `BeginTable` provides columnar layout.
+
+### D Opportunities
+
+**Compile-time layout validation:** D's CTFE can validate layout constraints at compile time. Ratatui's `areas::<N>()` pattern catches count mismatches; D can go further by statically verifying that percentages sum to at most 100%, that exactly one Fill exists where required, and that min/max constraints are consistent:
+
+```d
+// Compile-time validated layout
+enum layout = Layout.vertical([
+    Constraint.length(3),      // header
+    Constraint.fill(1),        // body
+    Constraint.length(1),      // footer
+]);
+static assert(layout.constraints.length == 3);
+
+// Split returns fixed-size array -- count mismatch is a compile error
+auto areas = layout.split(frame.area);  // typeof(areas) == Rect[3]
+```
+
+**@nogc constraint solving:** A Cassowary solver operating on `SmallBuffer`-backed vectors could solve layout constraints without GC allocation, making the entire render path `@nogc`.
+
+**UFCS combinator chains:** Brick's combinator style maps directly to D UFCS, providing a fluent layout API with zero runtime overhead:
+
+```d
+auto sidebar = fileList
+    .vBox
+    .padAll(1)
+    .borderWithLabel(" Files ")
+    .hLimit(25);
+
+auto mainArea = hBox(sidebar, vBorder(), editor);
+```
+
+**FTXUI-style flexbox via UFCS:** FTXUI's flexbox layout maps to D named-argument structs:
+
+```d
+auto config = FlexboxConfig(
+    direction: Direction.row,
+    wrap: Wrap.wrap,
+    justifyContent: JustifyContent.spaceBetween,
+    alignItems: AlignItems.center,
+    gap: Gap(x: 1, y: 0),
+);
+
+auto layout = flexbox(children, config);
+```
+
+**Hybrid approach:** Use combinators (Brick-style) for most layouts, with an optional constraint solver (Ratatui-style) for complex responsive layouts, and FTXUI-style flexbox for CSS-familiar developers.
+
+---
+
+## 4. Widget Extensibility Compared
+
+### Widget Contracts
+
+| Library        | Contract                                                                                                              | Mechanism                                                           | Statefulness                                                             |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| **Ratatui**    | `Widget` trait: `fn render(self, area: Rect, buf: &mut Buffer)`                                                       | Rust trait (static dispatch)                                        | `StatefulWidget` trait with associated `State` type                      |
+| **Ink**        | React function component returning JSX                                                                                | Runtime reconciler                                                  | `useState`/`useReducer` hooks                                            |
+| **Textual**    | `Widget` class with `compose()` and/or `render()`                                                                     | Python class inheritance                                            | `reactive` descriptor attributes                                         |
+| **Bubble Tea** | `Model` interface: `Init() Cmd`, `Update(Msg) (Model, Cmd)`, `View() string`                                          | Go interface (dynamic dispatch)                                     | State embedded in Model struct                                           |
+| **Brick**      | `Widget n` type: `hSize`, `vSize`, `render :: RenderM n (Result n)`                                                   | Haskell data type + monadic render                                  | Via `EventM n s` monad and lenses                                        |
+| **Notcurses**  | No formal contract; draw on `ncplane`                                                                                 | C function calls on plane handles                                   | Plane retains cell state; `userptr` for app state                        |
+| **FTXUI**      | `Element` (shared_ptr\<Node\>) for dom; `ComponentBase` subclass for interaction                                      | Dual: pure function calls (dom) + virtual methods (components)      | Dom layer: stateless. Component layer: member variables + lambda capture |
+| **Cursive**    | `View` trait: `draw`, `required_size`, `layout`, `on_event`, `take_focus`                                             | Rust trait object (`Box<dyn View>`)                                 | View-internal state (each view owns its data)                            |
+| **Mosaic**     | `@Composable` function                                                                                                | Compiler plugin transforms functions into incremental tree-builders | `remember { mutableStateOf(...) }` snapshot state                        |
+| **Nottui**     | `Ui.t` value (atom, composition, event handler) wrapped in `Lwd.t` for reactivity                                     | Combinator composition of values                                    | `Lwd.var` reactive cells                                                 |
+| **libvaxis**   | Low-level: duck-typed `draw(Window)` convention. vxfw: `Widget` struct with `drawFn`/`eventHandler` function pointers | comptime duck typing (low-level) / manual vtable (vxfw)             | Application-owned structs                                                |
+| **tview**      | `Primitive` interface: `Draw`, `SetRect`, `GetRect`, `InputHandler`, `Focus`, `HasFocus`, `Blur`, `MouseHandler`      | Go interface (dynamic dispatch)                                     | Widgets own state via getters/setters                                    |
+| **ImTui**      | No widget contract. Widget = function call that writes to draw list and returns interaction state.                    | Immediate-mode function calls                                       | Application owns all state as plain variables                            |
+
+### Key Extensibility Patterns
+
+**FTXUI's Element/Component Duality** is particularly instructive. Elements (dom layer) are created by composing pure functions -- `text`, `hbox`, `vbox`, `border`. Components (interaction layer) produce Elements via `Render()` and handle events via `OnEvent()`. Custom components can subclass `ComponentBase` for complex interaction, or use `Renderer` lambdas for simple cases. The pipe operator composes decorators. For D, this duality maps to `@nogc` element structs (pure value types) + DbI-detected component capabilities.
+
+**Cursive's View Trait + ViewWrapper** provides two paths: implement `View` for full control, or use `ViewWrapper` (which delegates most methods to an inner view) for decorators. The `Canvas` closure-based view enables rapid prototyping without trait implementation. For D, `ViewWrapper` maps to `alias this` or mixin templates.
+
+**Mosaic's @Composable Functions** eliminate the widget class hierarchy entirely. Any `@Composable` function is a reusable component. State is held via `remember { mutableStateOf(...) }`. For D, composable functions returning element trees with UFCS modifiers achieve the same composition without a compiler plugin:
+
+```d
+auto statusBadge(string label, bool active) {
+    return row(
+        text(active ? "ON " : "OFF")
+            .bg(active ? Color.green : Color.red)
+            .pad(0, 1),
+        text(" " ~ label),
+    );
+}
+```
+
+**Nottui's Widget-as-Value** approach has no widget classes, no inheritance, no widget IDs. A `Ui.t` is constructed from primitives and composed with combinators. Reactivity comes from wrapping in `Lwd.t`. For D, this maps to struct values composed via UFCS, with optional `Reactive!T` wrapping for incremental updates.
+
+**libvaxis's comptime Duck Typing** is structurally identical to D's Design by Introspection. Any type with the right method signatures is a widget. The vxfw framework's manual vtable (`*anyopaque` + function pointers) is exactly what D's template constraints eliminate. D achieves the same polymorphism with `isWidget!T` and monomorphized code generation -- no manual vtable construction needed.
+
+**tview's Primitive Interface + Box Embedding** provides a rich base: every widget embeds `Box` for free border, title, padding, background, and focus highlight. For D, this maps to `mixin BoxBehavior` injecting border drawing, padding calculation, and focus tracking into any widget struct, or `alias this` for transparent delegation.
+
+**ImTui's No-Widget-Concept** is the radical alternative. A "custom widget" is just a function. For D, this means simple `@nogc` functions that write to a buffer and return interaction state -- the minimum possible widget API.
+
+### Mapping to D
+
+**Ratatui -> D template constraints (recommended for the core)**
+
+```d
+/// Any type with a `render(Rect, ref Buffer)` method is a widget.
+enum isWidget(T) = is(typeof((T w, Rect area, ref Buffer buf) {
+    w.render(area, buf);
+}));
+
+/// Stateful widgets also have an associated State type.
+enum isStatefulWidget(T) = isWidget!T
+    && is(T.State)
+    && is(typeof((T w, Rect area, ref Buffer buf, ref T.State s) {
+        w.render(area, buf, s);
+    }));
+```
+
+**FTXUI -> D UFCS element composition (recommended for ergonomics)**
+
+```d
+/// Elements as value types composed via UFCS.
+auto ui = vbox(
+    text("Dashboard").bold.cyan.hCenter,
+    separator(),
+    hbox(
+        gauge(0.73).color(Color.green).flex,
+        gauge(0.58).color(Color.yellow).flex,
+    ),
+).border;
+```
+
+**Brick -> D Design by Introspection for size policies**
+
+```d
+/// Widget optionally declares size policy via enum members.
+enum hasHPolicy(W) = is(typeof(W.hPolicy) == SizePolicy);
+SizePolicy getHPolicy(W)() {
+    static if (hasHPolicy!W) return W.hPolicy;
+    else return SizePolicy.greedy;
+}
+```
+
+**libvaxis -> D compile-time widget protocol (for zero-overhead generics)**
+
+```d
+/// Compile-time widget concept -- no interface, no vtable.
+enum isWidget(T) = __traits(hasMember, T, "draw")
+    && is(typeof((T w, Window win) { w.draw(win); }));
+
+/// Optional capabilities detected at compile time.
+enum isInteractiveWidget(T) = isWidget!T
+    && __traits(hasMember, T, "handleEvent");
+
+/// Dispatch events with optional handler.
+void dispatchEvent(W)(ref W widget, Event event) if (isWidget!W) {
+    static if (isInteractiveWidget!W)
+        widget.handleEvent(event);
+}
+```
+
+### Recommended Approach for D
+
+Use **template-based duck-typing** (like Ratatui's trait, but resolved at compile time via `isWidget`) as the core contract. Extend with **Design by Introspection** for optional capabilities:
+
+- `isWidget!T` -- core: has `render(Rect, ref Buffer)`
+- `isStatefulWidget!T` -- has associated `State` type
+- `hasHPolicy!T`, `hasVPolicy!T` -- declares size policy
+- `hasFocusable!T` -- can receive focus
+- `hasScrollable!T` -- supports scroll state
+
+This avoids virtual dispatch entirely. All widget calls are monomorphized at compile time. The `ref Buffer` parameter follows Sparkles' established output-range pattern.
+
+---
+
+## 5. Styling Approaches Compared
+
+| Library        | Mechanism                                                | Builder Pattern                                          | Color Support                   | Theme System                                   | Separation                           |
+| -------------- | -------------------------------------------------------- | -------------------------------------------------------- | ------------------------------- | ---------------------------------------------- | ------------------------------------ |
+| **Ratatui**    | `Style` struct + `Stylize` trait                         | `"hello".green().bold()`                                 | 16, 256, RGB                    | No built-in                                    | Style per Span/Line/Widget           |
+| **Ink**        | JSX props: `color`, `bold`                               | Component props                                          | Named, hex, RGB (chalk)         | No built-in                                    | Props on components                  |
+| **Textual**    | TCSS stylesheets + inline styles                         | CSS rule syntax                                          | Named, hex, RGB, HSL            | CSS variables (`$primary`)                     | External `.tcss` files               |
+| **Bubble Tea** | Lip Gloss `NewStyle()` builder                           | `NewStyle().Bold(true).Foreground(...)`                  | 16, 256, RGB + Adaptive         | No built-in                                    | Style objects at Render              |
+| **Brick**      | `AttrMap` with hierarchical `AttrName` keys              | `fg cyan \`withStyle\` bold`                             | 16, 256, RGB (Vty)              | `Brick.Themes` with INI serialization          | AttrMap separate, `withAttr` applies |
+| **Notcurses**  | Cell-level 64-bit channels + 16-bit style mask           | Imperative set functions                                 | 16, 256, RGB + alpha            | No built-in                                    | Per-cell on plane                    |
+| **FTXUI**      | Decorator functions + pipe operator                      | `text("hi") \| bold \| color(Color::Red) \| border`      | 16, 256, RGB, HSV, gradients    | No built-in                                    | Decorators wrap elements             |
+| **Cursive**    | Theme-based `Palette` with semantic color roles          | `update_theme(\|t\| { ... })`                            | 8, 256, RGB (auto-downgrade)    | Built-in (Palette + TOML loading + ThemedView) | Global theme + per-view overrides    |
+| **Mosaic**     | TextStyle bitmask + Color value class on Text params     | `TextStyle.Bold + TextStyle.Italic`                      | 16, 256, RGB (auto-downconvert) | No built-in                                    | Per-Text parameters                  |
+| **Nottui**     | Notty attributes (`A.fg red ++ A.st bold`)               | OCaml operator composition (`++`)                        | 8, 16, 256, 24-bit              | No built-in                                    | Per-cell in Notty images             |
+| **libvaxis**   | `Style` struct on `Cell`                                 | Struct literal: `.{ .fg = .{.rgb = ...}, .bold = true }` | 256, RGB                        | No built-in                                    | Per-cell Style struct                |
+| **tview**      | Tag-based inline text styling + programmatic tcell.Style | `"[red::b]text[-]"`                                      | 16, 256, RGB (via tcell)        | Global `tview.Styles` theme variable           | Tags in text + setter methods        |
+| **ImTui**      | ImGuiStyle struct (55 colors, 25 sizes) + Push/Pop stack | `PushStyleColor(idx, color)` / `PopStyleColor()`         | RGBA mapped to 256 ANSI         | Built-in (Dark/Light/Classic)                  | Global style + scoped overrides      |
+
+### Key Styling Patterns
+
+**FTXUI's Decorator Pipe** is the most compositional approach. Decorators are functions that wrap elements: `text("hi") | bold | color(Color::Red)`. The pipe operator is just `decorator(element)`. In D, this is UFCS: `text("hi").bold.color(Color.red)` -- identical semantics with no operator overloading.
+
+**Cursive's Theme System** is the most complete theming approach. A `Palette` maps 11 semantic roles (Background, Primary, Highlight, etc.) to concrete colors. Views reference roles via `ColorType::Palette(role)`, enabling runtime theme switching. TOML files define themes externally. `ThemedView` applies local theme overrides to subtrees. For D, the palette enum maps directly, and CTFE can parse TOML themes at compile time -- impossible in Rust.
+
+**tview's Tag-Based Styling** (`[red::b]Warning[-::-]`) embeds style information in text strings. While convenient for quick formatting, it requires runtime parsing and is limited to text content. For D, CTFE could parse these tags at compile time, producing pre-resolved style spans with zero runtime overhead.
+
+**ImTui's Push/Pop Style Stack** uses scoped overrides: `PushStyleColor(idx, color)` ... `PopStyleColor()`. The "forgot to pop" bug is common in C++ ImGui code. For D, `scope(exit)` guards or RAII structs prevent this class of bug entirely.
+
+**libvaxis's Style Struct** is the most minimal: a plain struct with boolean fields for attributes and union-tagged colors. No builder, no chain, no theme. For D, this direct struct approach is the natural `@nogc` representation for cell-level style storage.
+
+### Relation to Sparkles' Existing `term_style`
+
+Sparkles already has a `Style` enum with ANSI codes and a `stylizedTextBuilder` that supports UFCS-chain and CTFE styling:
+
+```d
+// Existing Sparkles pattern -- compile-time evaluated
+enum greeting = "Hello"
+    .stylizedTextBuilder(true)
+    .bold
+    .green;
+```
+
+This is closest to Ratatui's `Stylize` trait and FTXUI's pipe operator, but with the advantage of compile-time evaluation via `enum`.
+
+### Extension Path
+
+To support TUI widgets, the style system needs:
+
+1. **Structured `CellStyle` struct** (like Ratatui/libvaxis): Hold optional fg/bg colors and modifier flags, separate from ANSI string rendering.
+
+2. **RGB color support**: `Color.rgb(r, g, b)` and `Color.indexed(n)`, matching Ratatui's `Color` enum.
+
+3. **Incremental style application**: Applying a style patches only the fields it sets, enabling layered composition.
+
+4. **Attribute maps** (Brick/Cursive-inspired): Compile-time or runtime maps from semantic names to styles for themeable widgets. D's CTFE can parse theme TOML at compile time.
+
+5. **UFCS builder preserved**: `auto style = CellStyle.init.fg(Color.green).bold.bg(Color.black);`
+
+---
+
+## 6. Event Handling Compared
+
+### Architecture Summary
+
+| Library        | Model                                                        | Centralized?                                      | Keyboard                     | Mouse                              | Focus                                           | Async                             |
+| -------------- | ------------------------------------------------------------ | ------------------------------------------------- | ---------------------------- | ---------------------------------- | ----------------------------------------------- | --------------------------------- |
+| **Ratatui**    | Not provided (app's responsibility)                          | N/A                                               | Via backend                  | Via backend                        | Manual                                          | Via async runtime                 |
+| **Ink**        | Hooks (`useInput`, `useFocus`)                               | Distributed (per-component)                       | `useInput` hook              | Not supported                      | Built-in (`useFocus`)                           | React concurrent mode             |
+| **Textual**    | Message bubbling through DOM                                 | Centralized tree                                  | `on_key`, `BINDINGS`         | Full                               | CSS `:focus`                                    | asyncio-first                     |
+| **Bubble Tea** | All events as `Msg` to `Update`                              | Fully centralized                                 | `KeyMsg`                     | `MouseMsg`                         | Manual                                          | `Cmd` as async values             |
+| **Brick**      | `BrickEvent` to `appHandleEvent`                             | Fully centralized                                 | `VtyEvent`                   | Per-widget                         | `appChooseCursor`                               | `liftIO` in `EventM`              |
+| **Notcurses**  | Raw input API (`notcurses_get`)                              | App-controlled                                    | `ncinput` struct             | Full                               | Manual                                          | Thread-safe, app manages          |
+| **FTXUI**      | `OnEvent(Event) -> bool` on ComponentBase                    | Tree-based (focus path + bubbling)                | Event struct matching        | Full (click, scroll, motion, drag) | Built-in focus tree (ActiveChild)               | `Post()` for thread marshaling    |
+| **Cursive**    | Callbacks via `EventResult`                                  | Tree-based (focused path + bubbling + global)     | `Event` enum matching        | Via backends                       | Built-in (Tab/Shift-Tab, `take_focus`)          | `cb_sink()` channel injection     |
+| **Mosaic**     | `onKeyEvent` / `onPreviewKeyEvent` modifiers                 | Two-phase (preview down, bubble up)               | `KeyEvent` data class        | Not supported                      | Not built-in                                    | Coroutines (`LaunchedEffect`)     |
+| **Nottui**     | `keyboard_area` / `mouse_area` / `event_filter` wrappers     | Tree-based (propagation with Handled/Unhandled)   | Polymorphic variant matching | Full (click, drag, release, grab)  | Built-in                                        | Lwt for async                     |
+| **libvaxis**   | Tagged union event loop (`switch` on Event)                  | App-controlled                                    | `Key` struct                 | Full (SGR pixel precision)         | Manual (vxfw App provides basic tracking)       | Background thread + event queue   |
+| **tview**      | Callbacks (`SetInputCapture`, `SetChangedFunc`, etc.)        | Framework-managed (capture chain + focus routing) | `*tcell.EventKey`            | Full (click, drag, scroll)         | Built-in (framework tracks, Tab navigation)     | `QueueUpdateDraw` from goroutines |
+| **ImTui**      | Widget return values (`if (Button("OK"))`) + global IO state | None -- inline with rendering                     | `IsKeyPressed(key)`          | `io.MousePos`, `IsMouseClicked()`  | Hot/Active model (automatic, no explicit focus) | N/A (single-threaded frame loop)  |
+
+### Key Event Handling Patterns
+
+**Cursive's Callback-Based Events** use `EventResult` (Ignored or Consumed with optional callback). Events flow top-down through the focused path, then bubble up if ignored. Global callbacks catch unhandled events. The `OnEventView` wrapper adds per-view interception. The `cb_sink()` channel enables async injection from background threads. The pattern is familiar from desktop GUI toolkits but prone to callback spaghetti in complex applications.
+
+**tview's Framework-Managed Events** provide a capture chain: Application capture -> ancestor captures (top-down) -> focused widget's InputHandler. Widget-specific callbacks (`SetChangedFunc`, `SetSelectedFunc`, `SetDoneFunc`) provide semantic event handling. `QueueUpdateDraw` serializes goroutine-to-UI communication.
+
+**FTXUI's Component Event Handlers** use the `OnEvent(Event) -> bool` pattern on `ComponentBase`. Events propagate through the component tree: the deepest focused component handles first, bubbling up on `false`. The `CatchEvent` decorator intercepts events before they reach a component.
+
+**Mosaic's Two-Phase Propagation** mirrors Android: `onPreviewKeyEvent` fires top-down (preview/capture phase), `onKeyEvent` fires bottom-up (bubble phase). Returning `true` stops propagation. This is integrated with Kotlin coroutines for async side effects.
+
+**Nottui's Reactive Event Handlers** wrap widgets with `keyboard_area`, `mouse_area`, or `event_filter`. Handlers return `` `Handled `` or `` `Unhandled `` variants. Mouse areas support `` `Grab `` for drag capture. Events flow through the widget tree from root toward leaves.
+
+**libvaxis's Tagged Union Events** use Zig's exhaustive `switch` on a `union(enum)`. The `Loop` type is parameterized on the application's `Event` type -- `@hasField` at comptime determines which event categories to dispatch, generating zero code for undeclared variants. This is zero-cost event filtering.
+
+**ImTui's Inline Event Handling** is the simplest: `if (Button("Submit")) submitForm();`. No event propagation, no callbacks, no registration. The widget function checks interaction state at the call site. Item query functions (`IsItemHovered()`, `IsItemActive()`) provide additional state after any widget call.
+
+### Recommendation for Sparkles
+
+Follow Ratatui's approach: **do not own the event loop**. Provide event-related utilities (input parsing, key mapping, mouse event structures) but let the application control the loop. Use D's `SumType` for structured events with exhaustive matching:
+
+```d
+alias Event = SumType!(KeyEvent, MouseEvent, ResizeEvent, TickEvent);
+
+// Pure update function -- compiler-enforced
+@safe pure nothrow
+Model update(in Model model, in Event event) {
+    return event.match!(
+        (KeyEvent k)    => handleKey(model, k),
+        (MouseEvent m)  => handleMouse(model, m),
+        (ResizeEvent r) => handleResize(model, r),
+        (TickEvent t)   => handleTick(model, t),
+    );
+}
+```
+
+For libvaxis-inspired comptime event filtering, D can use `static if` on event type members:
+
+```d
+Event handleEvent(Event)(RawEvent raw) {
+    static if (__traits(hasMember, Event, "keyPress")) {
+        if (raw.isKeyPress)
+            return Event(Event.Kind.keyPress, raw.toKey);
+    }
+}
+```
+
+---
+
+## 7. Performance Characteristics
+
+### Allocation Patterns
+
+| Library        | Language GC     | Render-path allocations                          | Buffer type               | Widget lifetime                           |
+| -------------- | --------------- | ------------------------------------------------ | ------------------------- | ----------------------------------------- |
+| **Ratatui**    | None (Rust)     | `Vec<Cell>` reused across frames                 | Flat cell grid            | Ephemeral                                 |
+| **Bubble Tea** | Go GC           | String alloc per frame                           | String                    | Ephemeral                                 |
+| **Textual**    | Python GC       | Rich Segment objects per dirty widget            | Segment lists             | Persistent                                |
+| **Ink**        | JS GC           | React fiber tree + ANSI string                   | String buffer             | Persistent                                |
+| **Brick**      | Haskell GC      | Vty Image alloc per frame                        | Image (lazy)              | Ephemeral                                 |
+| **Notcurses**  | None (manual C) | Zero in common path (cells inline)               | Packed cell grid          | Persistent (planes)                       |
+| **FTXUI**      | None (C++)      | `shared_ptr<Node>` per element per frame         | Screen pixel grid         | Element: ephemeral. Component: persistent |
+| **Cursive**    | None (Rust)     | `Box<dyn View>` for view tree (persistent)       | Printer writes to backend | Persistent                                |
+| **Mosaic**     | JVM/Native GC   | Slot table + TextSurface per frame               | TextPixel grid            | Persistent (slot table)                   |
+| **Nottui**     | OCaml GC        | Incremental -- only damaged nodes recomputed     | Notty Image               | Persistent (DAG)                          |
+| **libvaxis**   | None (Zig)      | Explicit allocator; arena per frame in vxfw      | Screen cell buffer        | Ephemeral                                 |
+| **tview**      | Go GC           | Widget tree persistent; tcell cell buffer reused | tcell Screen              | Persistent                                |
+| **ImTui**      | None (C++)      | Zero (TScreen is flat array, reused)             | Packed TCell grid         | None (no widgets)                         |
+
+### Key Allocation Insights
+
+**libvaxis's allocator-aware pattern** is the most relevant for D. Every allocation site accepts a `std.mem.Allocator` parameter. The vxfw framework uses per-frame arena allocation for temporaries (formatted text, layout scratch), freed automatically at frame end. D's `@nogc` attribute provides the same guarantee at the type level -- the compiler ensures no hidden GC allocation rather than relying on the programmer to thread allocators correctly.
+
+**FTXUI's value-based elements** create `shared_ptr<Node>` for every element every frame. In D, elements as `@nogc` struct values stored in `SmallBuffer` eliminate this heap allocation entirely. For small-to-medium UIs (the common case in CLI tools), the entire Element tree fits in a `SmallBuffer` with no heap allocation at all.
+
+**ImTui's zero-widget-state** approach is the most allocation-friendly. The `TScreen` is a flat array of packed 32-bit `TCell` values (character + colors), reused across frames. There are no widget objects to allocate. The entire render path is just function calls writing to a fixed-size buffer. This is the theoretical minimum for allocation in a TUI framework.
+
+**Nottui's incremental computation** avoids the allocation problem differently: the reactive DAG is allocated once and reused. Updates touch only damaged nodes, so neither allocation nor computation scales with total UI size. The `Lwd_table` reactive collection tracks insertions/deletions incrementally. For D, a pre-allocated `DependencyGraph` with `SmallBuffer`-backed node arrays achieves the same pattern `@nogc`.
+
+**Mosaic's slot table** is a flat, gap-buffer-style array that stores composition state. While not zero-allocation (JVM/native GC manages the slot table), the design minimizes allocation by reusing slots across recompositions. For D, the lesson is that a flat, reusable buffer for composition state is more efficient than per-frame tree construction.
+
+### @nogc Feasibility
+
+| Approach                              | @nogc feasibility | Notes                                                                 |
+| ------------------------------------- | ----------------- | --------------------------------------------------------------------- |
+| **ImTui-style pure immediate**        | **Highest**       | Zero widget objects, flat buffer, function calls only                 |
+| **libvaxis-style explicit allocator** | **High**          | Arena per frame, explicit control at every site                       |
+| **Ratatui-style cell buffer**         | **High**          | `SmallBuffer!(Cell, N)` for typical screens                           |
+| **Notcurses-style planes**            | **High**          | Manual alloc with RAII; cell packing is naturally @nogc               |
+| **FTXUI-style functional DOM**        | **High in D**     | shared_ptr in C++, but elements as @nogc structs in D                 |
+| **Nottui-style incremental DAG**      | **High**          | Pre-allocated graph, no per-frame allocation                          |
+| **Brick-style pure rebuild**          | **Moderate**      | Compatible if output goes to cell buffer                              |
+| **Bubble Tea-style string render**    | **Moderate**      | `SmallBuffer!(char, N)` instead of heap string                        |
+| **Cursive-style retained view tree**  | **Low-Moderate**  | View tree requires allocation; `pureMalloc`-based allocators possible |
+| **tview-style retained widget tree**  | **Low-Moderate**  | Go GC manages widgets; D would need manual allocation                 |
+| **Textual-style retained DOM**        | **Low**           | Persistent object tree with dynamic dispatch                          |
+| **Mosaic-style Compose**              | **Low**           | Depends on compiler plugin + JVM/native runtime                       |
+| **Ink-style React reconciler**        | **Very low**      | Fundamentally depends on GC                                           |
+
+### Frame Diffing Strategies
+
+| Library        | Diffing unit      | Strategy                                                          |
+| -------------- | ----------------- | ----------------------------------------------------------------- |
+| **Ratatui**    | Cell              | Current vs previous buffer, cell-by-cell                          |
+| **Bubble Tea** | Line              | String output, line-by-line                                       |
+| **Textual**    | Region            | Compositor identifies dirty widget regions                        |
+| **Ink**        | Full output       | Overwrite entire output region                                    |
+| **Brick**      | Full image        | Vty diffs entire composed Image                                   |
+| **Notcurses**  | Cell              | Full compositor pass, then cell-by-cell diff                      |
+| **FTXUI**      | Cell              | ScreenInteractive diffs current vs previous                       |
+| **Cursive**    | Full              | Entire view tree re-laid-out and re-drawn per event               |
+| **Mosaic**     | Differential ANSI | Emit style codes only when pixel attributes change cell-to-cell   |
+| **Nottui**     | Incremental       | Only damaged nodes recomputed; Notty handles rendering            |
+| **libvaxis**   | Cell              | Screen vs screen_last, cell equality check with fast default path |
+| **tview**      | Cell              | tcell diffs new cell buffer vs previous                           |
+| **ImTui**      | Cell              | TScreen current vs screenPrev, row-by-row character comparison    |
+
+### Performance Ranking for D Implementation
+
+1. **ImTui-style flat buffer** -- Zero allocation, function calls to fixed buffer, cell-level diff. Theoretical minimum overhead.
+2. **Notcurses/libvaxis-style packed cells** -- Zero allocation in common path, cell-level diff, explicit memory control. Highest raw performance with retained planes.
+3. **Ratatui-style cell buffer** -- Near-zero allocation with `SmallBuffer`, cell-level diff, immediate-mode simplicity. Best balance of performance and ergonomics.
+4. **FTXUI-style functional DOM (in D)** -- Elements as `@nogc` structs in `SmallBuffer` instead of `shared_ptr`. Combines compositional elegance with zero allocation.
+5. **Nottui-style incremental DAG** -- Pre-allocated graph, O(k) updates for sparse changes. Best asymptotic performance for large, mostly-static UIs.
+6. **Brick-style pure rebuild** -- Compatible with `@nogc` if output goes to cell buffer.
+7. **Retained-mode (Cursive/tview adapted)** -- Requires allocation management but provides framework-level focus/layout.
+
+---
+
+## 8. Synthesis: Design Recommendations for Sparkles
+
+### Recommended Architecture
+
+**Adopt Ratatui's library-centric model as the core, enhanced with FTXUI-inspired functional DOM composition via UFCS, Brick's combinator API, Bubble Tea's MVU as an optional layer, Nottui-inspired incremental reactivity as an optimization path, and ImTui-style immediate-mode widget functions as a rapid-prototyping fast path.**
+
+The rationale:
+
+1. **Ratatui's approach is the most natural fit for D.** Widgets as value-type structs, rendered into a cell buffer via template-constrained `render` methods, consumed by value -- this maps directly to `@nogc` D idioms with zero virtual dispatch overhead. The library does not own the event loop, respecting the application's control.
+
+2. **FTXUI's functional DOM composition translates beautifully to D UFCS.** Where FTXUI writes `text("hello") | bold | color(Color::Red) | border`, D writes `text("hello").bold.color(Color.red).border`. No special pipe operator needed -- UFCS is built-in, works at compile time, and composes with any free function. Elements as `@nogc` struct values in `SmallBuffer` instead of `shared_ptr` nodes eliminate FTXUI's per-node heap allocation. This is arguably the single most important lesson: FTXUI proved the functional DOM pattern works for terminals; D's UFCS makes it even more natural.
+
+3. **Brick's combinators provide the layout vocabulary.** `items.vBox.hLimit(25).padAll(1).borderWithLabel("Files")` -- same composability as Haskell, better readability, zero runtime overhead.
+
+4. **Bubble Tea's MVU pattern maps to D's `pure` + `SumType`.** For applications wanting structured state management, an optional module provides `Model`/`update`/`view` scaffolding where `update` is `pure` (compiler-enforced) and messages are `SumType` (exhaustive matching).
+
+5. **Mosaic's Compose model inspires D CTFE-driven reactive patterns.** While D cannot replicate Kotlin's compiler plugin, it can approximate snapshot state with `Reactive!T` wrapper structs, generate change-detection logic via `mixin Reactive!(MyState)`, and use CTFE to validate composable function signatures. The key insight from Compose: compile-time code generation for reactive state tracking is more efficient than runtime virtual DOM diffing.
+
+6. **Nottui's incremental computation is the most principled update strategy.** For large UIs where full rebuilds are expensive, a `Reactive!T` system with dependency-tracked DAG propagation avoids both O(n) full redraws and O(n) virtual DOM diffs. The DAG can be pre-allocated and reused `@nogc`. This is the most promising path for high-performance partial updates.
+
+7. **libvaxis's comptime patterns are DIRECTLY applicable to D.** Zig's `comptime` and D's CTFE serve the same purpose. `@hasField` -> `__traits(hasMember, ...)`. comptime event filtering -> `static if` on event union members. Manual vtable construction -> D template constraints (more ergonomic). Explicit allocator passing -> `@nogc` attribute (compiler-enforced). libvaxis validates that D's language features are sufficient for a modern, zero-overhead TUI library.
+
+8. **ImTui proves pure immediate-mode works for complex UIs.** The hnterm Hacker News client is a production-quality terminal application built entirely with immediate-mode function calls. D can offer this as a rapid-prototyping layer with compile-time widget IDs (via `__FILE__`/`__LINE__` template parameters) and `scope(exit)` style guards.
+
+9. **Cursive and tview show retained-mode variants' strengths.** Built-in focus management, dialog stacking, and form handling reduce boilerplate for form-heavy applications. D could offer these as optional framework modules on top of the core rendering library, using D interfaces for runtime polymorphism where heterogeneous view trees are needed, alongside template-based static dispatch for known-at-compile-time trees.
+
+10. **Textual's dirty-tracking compositor is a valuable optimization.** A dirty-tracking layer on top of the cell buffer can skip re-rendering unchanged regions. This is an optimization, not a core architectural requirement.
+
+### Core Abstractions
+
+#### Widget Concept (Template-Based, DbI)
+
+```d
+/// Core widget concept: any type that can render to a Buffer.
+enum isWidget(T) = is(typeof((T w, Rect area, ref Buffer buf) {
+    w.render(area, buf);
+}));
+
+/// Extended: stateful widget with associated State type.
+enum isStatefulWidget(T) = isWidget!T
+    && is(T.State)
+    && is(typeof((T w, Rect area, ref Buffer buf, ref T.State s) {
+        w.render(area, buf, s);
+    }));
+
+/// DbI: optional size policy declaration.
+SizePolicy hPolicyOf(W)() {
+    static if (__traits(hasMember, W, "hPolicy"))
+        return W.hPolicy;
+    else
+        return SizePolicy.greedy;  // default: fill available space
+}
+```
+
+#### Layout System Approach
+
+Hybrid: Brick-style combinators as the primary API, FTXUI-style flexbox for CSS-familiar developers, optional Ratatui-style constraint solver for advanced responsive layouts.
+
+```d
+/// Combinator-based layout (primary, UFCS)
+auto ui = vBox(
+    "Dashboard".text.bold.cyan.hCenter,
+    hBorder(),
+    hBox(
+        sidebarWidget.hLimit(25),
+        vBorder(),
+        contentWidget,  // greedy: fills remaining space
+    ),
+    hBorder(),
+    statusLine.text,
+);
+
+/// FTXUI-style flexbox (CSS-familiar)
+auto config = FlexboxConfig(
+    direction: Direction.row,
+    justifyContent: JustifyContent.spaceBetween,
+    gap: Gap(x: 1, y: 0),
+);
+auto layout = flexbox(children, config);
+
+/// Constraint-based layout (advanced)
+auto [header, body, footer] = Layout.vertical([
+    Constraint.length(3),
+    Constraint.fill(1),
+    Constraint.length(1),
+]).split(frame.area);
+```
+
+#### Buffer / Rendering Pipeline
+
+```d
+@safe pure nothrow @nogc:
+
+/// A single terminal cell.
+struct Cell {
+    SmallBuffer!(char, 8) grapheme;  // inline for ASCII/BMP, spills for long EGCs
+    StyleFlags style;                // bold, italic, underline, etc.
+    Color fg = Color.default_;
+    Color bg = Color.default_;
+}
+
+/// A rectangular grid of cells.
+struct Buffer {
+    Rect area;
+    Cell[] cells;  // or SmallBuffer!(Cell, 80 * 24) for typical terminals
+
+    /// Write a styled string at position.
+    void setString(ushort x, ushort y, scope const(char)[] text, Style style) { ... }
+
+    /// Diff against previous frame, writing only changed cells to output.
+    void diff(scope const Buffer prev, Writer)(ref Writer output) { ... }
+}
+
+/// Terminal wraps double-buffering and backend communication.
+struct Terminal(B) if (isBackend!B) {
+    B backend;
+    Buffer current;
+    Buffer previous;
+
+    /// Render a frame: call the draw function, diff, flush.
+    void draw(scope void delegate(ref Frame) @nogc nothrow drawFn) {
+        auto frame = Frame(&this.current);
+        drawFn(frame);
+        current.diff(previous, backend);
+        backend.flush();
+        swap(current, previous);
+    }
+}
+```
+
+#### Style System (Extending Existing term_style)
+
+```d
+/// Structured style for cell-level storage (not ANSI strings).
+struct CellStyle {
+    Nullable!Color fg;
+    Nullable!Color bg;
+    Modifiers modifiers;  // bitflag: bold, italic, underline, etc.
+
+    /// Incremental patch: only overwrite fields that are set.
+    CellStyle patch(CellStyle other) const { ... }
+}
+
+/// Color with full range support.
+struct Color {
+    enum Type : ubyte { default_, ansi16, ansi256, rgb }
+    Type type;
+    ubyte r, g, b;
+
+    static Color rgb(ubyte r, ubyte g, ubyte b) { ... }
+    static Color indexed(ubyte n) { ... }
+}
+
+/// UFCS style builder (preserves existing Sparkles pattern).
+auto bold(CellStyle s) { return CellStyle(s.fg, s.bg, s.modifiers | Modifiers.bold); }
+auto fg(CellStyle s, Color c) { return CellStyle(Nullable!Color(c), s.bg, s.modifiers); }
+```
+
+#### Event System
+
+```d
+/// Structured event types with D SumType.
+struct KeyEvent {
+    dchar codepoint;
+    Modifiers modifiers;
+    KeyAction action;
+}
+
+struct MouseEvent {
+    ushort x, y;
+    MouseButton button;
+    MouseAction action;
+    Modifiers modifiers;
+}
+
+struct ResizeEvent {
+    ushort width, height;
+}
+
+alias Event = SumType!(KeyEvent, MouseEvent, ResizeEvent);
+
+/// Optional MVU layer built on core event types.
+@safe pure nothrow
+Model update(in Model model, in Event event) {
+    return event.match!(
+        (in KeyEvent k)    => handleKey(model, k),
+        (in MouseEvent m)  => handleMouse(model, m),
+        (in ResizeEvent r) => handleResize(model, r),
+    );
+}
+```
+
+#### Optional: Incremental Reactivity Layer (Nottui-inspired)
+
+```d
+/// A reactive value that tracks dependencies automatically.
+struct Reactive(T) {
+    private T _value;
+    private DependencyNode _node;
+
+    /// Read the value, registering a dependency on the current computation.
+    T get() @safe {
+        if (auto ctx = RenderContext.current)
+            ctx.registerDependency(&_node);
+        return _value;
+    }
+
+    /// Read without dependency tracking (for event handlers).
+    T peek() @safe pure nothrow @nogc { return _value; }
+
+    /// Set the value, invalidating all dependents.
+    void set(T newVal) @safe {
+        _value = newVal;
+        _node.invalidateDependents();
+    }
+}
+
+/// Incremental propagation -- only recompute damaged nodes.
+@safe @nogc nothrow
+void propagateChanges(DependencyGraph* graph) {
+    foreach (node; graph.damagedNodes) {
+        node.recompute();
+        node.markClean();
+    }
+}
+```
+
+### Incremental Path from Current Sparkles
+
+#### Phase 1: Buffer + Cell + Backend Abstraction
+
+**Goal:** Establish the foundational rendering primitives.
+
+- `Cell` struct: grapheme (SmallBuffer-based) + style + fg/bg color
+- `Buffer` struct: `Rect` + flat cell array with `setString`, `setCell`, `diff`
+- `Color` type: ANSI 16, 256, and RGB support
+- `CellStyle` struct: fg, bg, modifiers with incremental patching
+- `Backend` template constraint: `draw`, `flush`, `clear`, `size`
+- POSIX backend: alternate screen, raw mode, ANSI output
+- `TestBackend`: in-memory backend for deterministic testing
+- `Terminal(B)` struct: double-buffering, diffing, draw function
+
+This phase builds on the existing `term_style` module (extending it) and `SmallBuffer` (for cell graphemes and buffer storage).
+
+#### Phase 2: Layout Engine
+
+**Goal:** Provide composable layout primitives.
+
+- `Rect` struct: position + size, with arithmetic helpers
+- Brick-style combinators as UFCS functions: `hBox`, `vBox`, `hLimit`, `vLimit`, `padLeft`, `padAll`, `hCenter`, `vCenter`, `fill`
+- FTXUI-style flexbox: `FlexboxConfig` struct with direction, wrap, justify, align, gap
+- `SizePolicy` enum (Fixed/Greedy) with DbI detection
+- Two-pass layout algorithm: allocate Fixed children first, divide remainder among Greedy
+- Optional: Cassowary constraint solver for `Constraint.length`, `Constraint.fill`, `Constraint.percentage`
+- Layout result caching (thread-local, keyed on constraints + input area)
+
+#### Phase 3: Widget System
+
+**Goal:** Define the widget contract and provide built-in widgets.
+
+- `isWidget` template constraint
+- `isStatefulWidget` with associated `State` type
+- Built-in widgets: `Text`, `Paragraph` (with wrapping), `Block` (borders + title), `List`/`ListState`, `Table`/`TableState`, `Gauge`, `Separator`
+- FTXUI-style element composition: `text("hello").bold.border` via UFCS
+- Optional ImTui-style immediate-mode functions: `button(buf, "Submit")`, `sliderInt(buf, "Volume", &state.volume, 0, 100)`
+- `AttrMap` for semantic styling (Brick/Cursive-inspired): compile-time `enum` maps for themes
+- `Viewport` with named scrollable regions
+
+#### Phase 4: Event Loop + State Management
+
+**Goal:** Provide optional structured event handling and reactivity.
+
+- `Event` SumType: `KeyEvent`, `MouseEvent`, `ResizeEvent`, custom events
+- Input parsing module: raw terminal bytes to structured `Event` values (libvaxis-inspired direct query, no terminfo dependency)
+- Optional MVU module: `Model`/`update`/`view` scaffolding with `pure` enforcement
+- `Cmd` type for side effects (Bubble Tea-inspired)
+- Focus management utilities (Cursive/tview-inspired)
+- Optional `Reactive!T` layer with incremental dependency tracking (Nottui-inspired)
+
+### Open Questions
+
+#### Retained vs Immediate for D?
+
+**Recommendation: Immediate-mode as the default, with optional retained-mode and incremental-mode optimization paths.**
+
+Immediate mode is the natural fit for `@nogc` D: widgets are stack-allocated, consumed on render, with no persistent allocations. For large UIs where rebuilding everything is expensive, two optimization paths are available:
+
+1. **Dirty-tracking** (Textual-inspired): mark regions as clean and skip re-rendering.
+2. **Incremental computation** (Nottui-inspired): pre-allocated dependency DAG with O(k) updates for sparse changes.
+
+The core API should be immediate-mode -- it is simpler, easier to reason about, and aligns with D's zero-overhead philosophy.
+
+#### CSS-like DSL vs Pure D Combinators?
+
+**Recommendation: Pure D combinators as the primary API, with optional compile-time CSS parsing.**
+
+Combinators (Brick/FTXUI-style via UFCS) provide type safety, `@nogc` compatibility, and zero runtime parsing cost. A compile-time CSS parser (via CTFE `import(...)` + string processing) could be provided for developers who prefer external stylesheets, but it should not be the primary interface.
+
+#### Compile-time vs Runtime Layout?
+
+**Recommendation: Both, with compile-time as the fast path.**
+
+For layouts known at compile time (static dashboards, fixed-structure UIs), CTFE can pre-compute the entire layout into a `static immutable Rect[]`. For dynamic layouts (user-resizable panes, responsive designs), runtime constraint solving is necessary. The API should be the same in both cases.
+
+#### Should Sparkles Bind to Notcurses or Build from Scratch?
+
+**Recommendation: Build from scratch, informed by Notcurses' and libvaxis's design decisions.**
+
+Rationale:
+
+- **D's strengths are underutilized by a C binding.** A binding gives access to Notcurses' features but none of D's advantages: no `@nogc` enforcement, no UFCS, no CTFE validation, no template-based widgets.
+
+- **The core patterns are straightforward to implement.** Packed cell representation, double-buffered diffing, escape sequence generation -- libvaxis demonstrates these in ~5k lines of Zig, and the patterns translate directly to D.
+
+- **libvaxis validates the no-terminfo approach.** Direct escape sequence generation with runtime capability queries (as libvaxis does) is more reliable and simpler than depending on terminfo databases. D's seamless C interop enables fallback to terminfo for legacy terminals.
+
+- **Dependency cost.** Notcurses has a non-trivial build chain. Building from scratch in D keeps the dependency graph minimal.
+
+- **Selective borrowing.** Specific innovations should be adopted: inline glyph cluster packing (via `SmallBuffer!(char, 8)`), packed cell representation, Kitty keyboard protocol support, and synchronized output. These can be implemented natively in D.

--- a/docs/research/tui-libraries/cursive.md
+++ b/docs/research/tui-libraries/cursive.md
@@ -1,0 +1,1427 @@
+# Cursive (Rust)
+
+A Rust library for building terminal user interfaces using a retained-mode view tree with callback-driven event handling, inspired by traditional GUI toolkits like GTK and Qt.
+
+| Field          | Value                                     |
+| -------------- | ----------------------------------------- |
+| Language       | Rust                                      |
+| License        | MIT                                       |
+| Repository     | <https://github.com/gyscos/cursive>       |
+| Documentation  | <https://docs.rs/cursive/latest/cursive/> |
+| Latest Version | 0.21.1 (2024)                             |
+| GitHub Stars   | ~4.7k                                     |
+
+---
+
+## Overview
+
+Cursive is a retained-mode TUI framework for Rust that manages an in-memory view tree,
+owns the event loop, and handles layout and rendering on behalf of the application. The
+developer describes views (widgets), wires up callbacks, and calls `siv.run()` -- the
+framework takes care of the rest.
+
+**What it solves.** Building terminal interfaces typically requires managing escape
+sequences, raw input handling, screen buffering, layout computation, and focus traversal.
+Cursive provides all of this as a coherent framework: a view tree that the library lays
+out, draws, and dispatches events through. The application author works at the level of
+"add a dialog with two buttons" rather than "write cells into a buffer at coordinates."
+
+**Design philosophy.** Cursive is modeled after traditional desktop GUI toolkits. Views
+form a tree. Each view knows how to draw itself, report its size requirements, and handle
+events. The framework owns the event loop, calls `layout` on the tree, draws it to the
+backend, and routes input events through the focused path. Callbacks attached to views
+mutate the application by receiving `&mut Cursive` -- a mutable reference to the root
+application struct. This is fundamentally different from Ratatui, which gives you a buffer
+and says "draw." Cursive gives you a tree and says "describe."
+
+The three stated design goals are:
+
+1. **Ease of use.** Simple apps should be simple. Complex apps should be manageable.
+2. **Linux TTY compatibility.** Broad accessibility across terminal environments.
+3. **Flexibility.** Support simple UI scripts, complex real-time applications, and games.
+
+**Contrast with Ratatui.** Ratatui is a rendering _library_ with an immediate-mode model:
+the application owns the main loop, reconstructs all widgets every frame, and pushes them
+into a buffer. There is no retained state, no event routing, no layout negotiation. Cursive
+is a _framework_ with a retained-mode model: it owns the event loop, maintains a persistent
+view tree, negotiates layout via `required_size` / `layout` callbacks, and routes events
+through the tree. The tradeoff is that Ratatui offers maximum control and minimal overhead
+(ideal for dashboards and custom UIs), while Cursive offers higher-level abstractions and
+less boilerplate (ideal for dialog-heavy apps, form-driven tools, and menu systems).
+
+**History.** Cursive was created by Alexandre Bury (gyscos) and has been actively
+maintained since its inception. It predates Ratatui (and its predecessor `tui-rs`),
+establishing itself as the "other" major Rust TUI library. With 4,700+ stars, 259 forks,
+110+ contributors, and 1,779 commits, it has a stable and active community. The library
+is split into `cursive-core` (the framework logic, backend-agnostic) and `cursive` (the
+main crate that bundles backend support).
+
+---
+
+## Architecture
+
+### Retained-Mode View Tree
+
+Cursive maintains a **persistent tree of views** in memory. Views are trait objects
+(`Box<dyn View>`) arranged hierarchically. Container views (like `LinearLayout`, `Dialog`,
+`StackView`) hold child views. The framework walks this tree to compute layout, render
+frames, and dispatch events.
+
+This is the key architectural distinction from immediate-mode frameworks. The view tree
+_persists_ between frames. When the user presses a key, the framework routes the event
+through the existing tree -- it does not rebuild anything. Views maintain their own state
+(scroll position, text content, selection index) internally.
+
+```
+Cursive (root application)
+  |
+  +-- StackView (layer stack / screen)
+        |
+        +-- Layer 0: LinearLayout
+        |     +-- TextView
+        |     +-- EditView (named: "input")
+        |
+        +-- Layer 1: Dialog (modal popup)
+              +-- TextView
+              +-- [Ok] button
+              +-- [Cancel] button
+```
+
+### The `Cursive` Struct
+
+The `Cursive` struct is the root of the application. It holds:
+
+- The **screen stack** (a `StackView` of layers per screen, plus multiple screens)
+- **Global callbacks** (keyed on events)
+- **User data** (arbitrary application state, `Box<dyn Any>`)
+- A reference to the **callback sink** (for async event injection)
+- **Theme** configuration
+
+Key methods:
+
+```rust
+// Initialization
+let mut siv = cursive::default();         // Uses default backend (crossterm)
+let mut siv = cursive::crossterm();       // Explicit backend
+let mut siv = cursive::pancurses();       // Alternative backend
+
+// View management
+siv.add_layer(view);                      // Push a view onto the layer stack
+siv.add_fullscreen_layer(view);           // Push a fullscreen layer
+siv.pop_layer();                          // Remove the top layer
+
+// Named view access
+siv.call_on_name("input", |v: &mut EditView| {
+    v.set_content("hello");
+});
+
+// Global callbacks
+siv.add_global_callback('q', |s| s.quit());
+
+// User data
+siv.set_user_data(MyAppState::new());
+siv.with_user_data(|state: &mut MyAppState| {
+    state.counter += 1;
+});
+
+// Execution
+siv.run();                                // Start the event loop
+siv.quit();                               // Stop the event loop
+```
+
+### The `View` Trait
+
+The `View` trait is the core abstraction. Every UI element implements it:
+
+```rust
+pub trait View {
+    // Required: render the view using the provided Printer
+    fn draw(&self, printer: &Printer<'_, '_>);
+
+    // Provided: report minimum required size given a constraint
+    fn required_size(&mut self, constraint: XY<usize>) -> XY<usize> {
+        XY::new(1, 1)
+    }
+
+    // Provided: called after size is finalized, propagate to children
+    fn layout(&mut self, size: XY<usize>) { }
+
+    // Provided: handle an input event
+    fn on_event(&mut self, event: Event) -> EventResult {
+        EventResult::Ignored
+    }
+
+    // Provided: attempt to take focus from a direction
+    fn take_focus(&mut self, source: Direction) -> Result<EventResult, CannotFocus> {
+        Err(CannotFocus)
+    }
+
+    // Provided: does layout need recomputation?
+    fn needs_relayout(&self) -> bool { true }
+
+    // Provided: which sub-area should be visible when scrolled?
+    fn important_area(&self, view_size: XY<usize>) -> Rect {
+        Rect::from_size(XY::zero(), view_size)
+    }
+
+    // Provided: run a closure on a child matching a selector
+    fn call_on_any(&mut self, sel: &Selector<'_>, cb: &mut dyn FnMut(&mut dyn View)) { }
+
+    // Provided: move focus to a child matching a selector
+    fn focus_view(&mut self, sel: &Selector<'_>) -> Result<EventResult, ViewNotFound> {
+        Err(ViewNotFound)
+    }
+
+    // Provided: return the type name for debugging
+    fn type_name(&self) -> &'static str { ... }
+}
+```
+
+The protocol is:
+
+1. **Size negotiation:** The framework calls `required_size(constraint)` top-down. Each
+   view reports how much space it ideally needs.
+2. **Layout finalization:** The framework calls `layout(final_size)` top-down with the
+   allocated dimensions. Container views distribute space to children.
+3. **Drawing:** The framework calls `draw(&Printer)` on each view. The `Printer` handles
+   coordinate translation and clipping.
+4. **Event dispatch:** Input events are routed through `on_event`. Events bubble up if
+   a child returns `EventResult::Ignored`.
+
+### Layers and Screens
+
+Cursive uses a **layer stack** for modal overlays. Each `add_layer` call pushes a new view
+on top. Only the topmost layer receives input by default. This makes dialogs and popups
+trivial:
+
+```rust
+siv.add_layer(
+    Dialog::text("Are you sure?")
+        .button("Yes", |s| { /* ... */ s.pop_layer(); })
+        .button("No", |s| { s.pop_layer(); })
+);
+```
+
+The framework also supports **multiple screens** (entirely separate view stacks) via
+`add_screen()` and `set_screen(id)`. This is useful for multi-page wizards or mode
+switching.
+
+### Named Views
+
+Any view can be wrapped in a `NamedView` to make it addressable by string:
+
+```rust
+// Wrapping with a name (using the Nameable trait)
+let edit = EditView::new().with_name("username");
+
+// Accessing by name from a callback
+siv.call_on_name("username", |view: &mut EditView| {
+    let content = view.get_content();
+    // ...
+});
+```
+
+This is the primary mechanism for cross-view communication. Since callbacks only receive
+`&mut Cursive`, named views allow reaching into the tree to read or mutate specific views
+without traversing it manually.
+
+---
+
+## Terminal Backend
+
+Cursive abstracts the terminal through a backend trait. The backend handles raw terminal
+I/O: entering/exiting raw mode, writing cells, reading input events, and querying terminal
+size. The application selects a backend at compile time via Cargo features or at runtime
+via constructor functions.
+
+### Supported Backends
+
+| Backend         | Cargo Feature       | Platforms             | Notes                                          |
+| --------------- | ------------------- | --------------------- | ---------------------------------------------- |
+| Crossterm       | `crossterm-backend` | Windows, Linux, macOS | Default since v0.21. Pure Rust, no C deps.     |
+| Ncurses         | `ncurses-backend`   | Linux, macOS          | Was default before v0.21. Requires libncurses. |
+| Pancurses       | `pancurses-backend` | Linux, macOS, Windows | Wraps ncurses-rs/pdcurses-sys. Needs C libs.   |
+| Termion         | `termion-backend`   | Linux, macOS, Redox   | Pure Rust. Lightweight, Unix-focused.          |
+| BearLibTerminal | `blt-backend`       | Linux, Windows        | Graphical terminal emulator. For games.        |
+
+Backend selection in `Cargo.toml`:
+
+```toml
+[dependencies.cursive]
+version = "0.21"
+default-features = false
+features = ["termion-backend"]
+```
+
+### Backend-Specific Initialization
+
+```rust
+// Default backend (crossterm)
+let mut siv = cursive::default();
+
+// Explicit backends
+let mut siv = cursive::crossterm();
+let mut siv = cursive::pancurses();
+let mut siv = cursive::termion();
+
+// Runtime backend selection
+siv.run_with(|| {
+    cursive::backends::crossterm::Backend::init().unwrap()
+});
+```
+
+### Capabilities
+
+- **8-color palette:** Universally supported, including Linux TTY.
+- **Extended colors (256 / true color):** Supported on most terminal emulators. Cursive
+  auto-downgrades true color to the nearest available if the terminal cannot display it.
+- **Mouse support:** Available through crossterm, termion, and ncurses backends.
+- **UTF-8:** Required locale. Wide character support is present but described as "initial."
+- **Dummy backend:** A `DummyBackend` exists for testing without a real terminal.
+
+---
+
+## Layout System
+
+Cursive uses a **constraint-based layout protocol** modeled on the classic
+`required_size` / `layout` two-pass pattern from desktop GUI toolkits.
+
+### The Two-Pass Protocol
+
+1. **Measurement pass:** The framework asks each view "how much space do you need?" by
+   calling `required_size(constraint)`. The `constraint` parameter is the maximum available
+   space. Views return their ideal size. Container views query children, sum/max their
+   sizes, and report upward.
+
+2. **Layout pass:** The framework tells each view "here is your actual size" by calling
+   `layout(final_size)`. Container views distribute this space to children according to
+   their layout strategy (linear division, fixed sizes, weights).
+
+### Container Views
+
+**`LinearLayout`** -- Arranges children linearly (horizontal or vertical):
+
+```rust
+let layout = LinearLayout::vertical()
+    .child(TextView::new("Name:"))
+    .child(EditView::new().with_name("name"))
+    .child(TextView::new("Email:"))
+    .child(EditView::new().with_name("email"))
+    .child(DummyView)
+    .child(
+        LinearLayout::horizontal()
+            .child(Button::new("Ok", |s| s.quit()))
+            .child(DummyView)
+            .child(Button::new("Cancel", |s| s.quit()))
+    );
+```
+
+**Weight-based flex distribution:**
+
+```rust
+let layout = LinearLayout::vertical()
+    .child(Panel::new(TextView::new("Header")).full_width())
+    .weight(1)
+    .child(Panel::new(TextView::new("Main content area")).full_width())
+    .weight(3)
+    .child(Panel::new(TextView::new("Footer")).full_width())
+    .weight(1);
+```
+
+The `weight` method applies to the most recently added child. Children with higher
+weights receive proportionally more of the available space after fixed-size children
+are satisfied.
+
+**`ResizedView`** -- Applies size constraints (min, max, fixed, full):
+
+```rust
+// Fixed width
+let view = ResizedView::with_fixed_width(30, my_view);
+
+// Min and max constraints
+let view = ResizedView::with_min_width(10,
+    ResizedView::with_max_width(50, my_view)
+);
+
+// Full screen
+let view = ResizedView::with_full_screen(my_view);
+```
+
+**`BoxView`** -- Alias for `ResizedView` in older API. Same functionality.
+
+**`PaddedView`** -- Adds padding (margins) around a view:
+
+```rust
+let padded = PaddedView::lrtb(2, 2, 1, 1, my_view);  // left, right, top, bottom
+```
+
+**`Panel`** -- Draws a border with an optional title:
+
+```rust
+let panel = Panel::new(my_view).title("Settings");
+```
+
+**`ScrollView`** -- Wraps a view in a scrollable container:
+
+```rust
+let scrollable = ScrollView::new(long_text_view);
+// Or via the Scrollable trait:
+let scrollable = long_text_view.scrollable();
+```
+
+**`Layer`** -- Fills the background behind a view (used in modal stacks).
+
+**`StackView`** -- The internal view used by `Cursive` to manage the layer stack.
+Each screen is a `StackView`.
+
+### Non-Trivial Layout Example
+
+A form dialog with constrained layout:
+
+```rust
+use cursive::views::*;
+use cursive::view::Resizable;
+
+let form = Dialog::around(
+    LinearLayout::vertical()
+        .child(
+            LinearLayout::horizontal()
+                .child(TextView::new("Username: ").fixed_width(12))
+                .child(EditView::new().with_name("user").fixed_width(20))
+        )
+        .child(
+            LinearLayout::horizontal()
+                .child(TextView::new("Password: ").fixed_width(12))
+                .child(EditView::new().secret().with_name("pass").fixed_width(20))
+        )
+        .child(DummyView.fixed_height(1))
+        .child(
+            LinearLayout::horizontal()
+                .child(Checkbox::new().with_name("remember"))
+                .child(TextView::new(" Remember me"))
+        )
+)
+.title("Login")
+.button("Submit", |s| {
+    let user = s.call_on_name("user", |v: &mut EditView| {
+        v.get_content()
+    }).unwrap();
+    // ... handle submission
+})
+.button("Cancel", |s| s.quit())
+.fixed_width(40);
+```
+
+This produces:
+
+```
++-- Login -------------------------+
+| Username:  [__________________]  |
+| Password:  [__________________]  |
+|                                  |
+| [ ] Remember me                  |
+|                                  |
+|          <Submit> <Cancel>       |
++----------------------------------+
+```
+
+---
+
+## Widget / Component System
+
+Cursive provides a rich library of built-in views covering common UI patterns.
+
+### Text Views
+
+| View       | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| `TextView` | Displays static or dynamic text. Supports styled content. |
+| `TextArea` | Multi-line text editor with cursor movement.              |
+| `EditView` | Single-line text input. Supports secret mode, completion. |
+
+### Selection Views
+
+| View         | Description                                                |
+| ------------ | ---------------------------------------------------------- |
+| `SelectView` | Scrollable list with single selection. Supports callbacks. |
+| `RadioGroup` | Coordinates a group of `RadioButton` views.                |
+| `Checkbox`   | A toggleable checkbox.                                     |
+
+### Layout Views
+
+| View           | Description                                               |
+| -------------- | --------------------------------------------------------- |
+| `LinearLayout` | Horizontal or vertical arrangement with optional weights. |
+| `FixedLayout`  | Children at fixed positions (absolute layout).            |
+| `ListView`     | Labeled list of views (form-like, label + widget rows).   |
+| `StackView`    | Layer stack. Only the top layer is active.                |
+| `ScrollView`   | Wraps a view in a scrollable container.                   |
+
+### Dialog and Decoration
+
+| View             | Description                                         |
+| ---------------- | --------------------------------------------------- |
+| `Dialog`         | Titled container with content and action buttons.   |
+| `Panel`          | Border wrapper with optional title.                 |
+| `PaddedView`     | Adds padding (margins) around a child.              |
+| `ShadowView`     | Adds a drop shadow effect behind a child.           |
+| `Layer`          | Fills background behind a child (for modal stacks). |
+| `ResizedView`    | Constrains child size (fixed, min, max, full).      |
+| `HideableView`   | Wrapper that can show or hide its child.            |
+| `EnableableView` | Wrapper that can enable or disable its child.       |
+| `ThemedView`     | Applies a local theme override to its child.        |
+
+### Interactive Views
+
+| View          | Description                                         |
+| ------------- | --------------------------------------------------- |
+| `Button`      | Text label that triggers a callback on Enter/click. |
+| `ProgressBar` | Animated progress indicator.                        |
+| `SliderView`  | Horizontal or vertical value slider.                |
+| `Menubar`     | Top-of-screen menu bar with drop-down menus.        |
+
+### Utility Views
+
+| View            | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `NamedView`     | Wraps a view with a string name for `call_on_name`.  |
+| `OnEventView`   | Wraps a view to intercept or augment event handling. |
+| `OnLayoutView`  | Wraps a view to override the layout callback.        |
+| `FocusTracker`  | Detects focus gain/loss events.                      |
+| `CircularFocus` | Makes Tab/Shift-Tab wrap around within a container.  |
+| `Canvas`        | Closure-based custom view (no trait impl needed).    |
+| `DummyView`     | Empty spacer view.                                   |
+| `DebugView`     | Shows log output for debugging.                      |
+| `TrackedView`   | Remembers its position after layout.                 |
+| `LastSizeView`  | Remembers its size after layout.                     |
+| `GradientView`  | Applies a color gradient effect to a child.          |
+| `ScreensView`   | Switches between multiple screen states.             |
+
+### View Wrapping and Method Chaining
+
+Cursive uses **trait-based method chaining** to compose view wrappers concisely. Several
+extension traits add convenience methods to all views:
+
+```rust
+use cursive::view::{Resizable, Scrollable, Nameable};
+
+let view = EditView::new()
+    .with_name("input")       // Nameable: wraps in NamedView
+    .fixed_width(30)          // Resizable: wraps in ResizedView
+    .scrollable();            // Scrollable: wraps in ScrollView
+```
+
+These are equivalent to explicit wrapping:
+
+```rust
+let view = ScrollView::new(
+    ResizedView::with_fixed_width(30,
+        NamedView::new("input", EditView::new())
+    )
+);
+```
+
+The trait-based chaining reads left-to-right (innermost view first), matching the natural
+construction order. This pattern is one of Cursive's most ergonomic features.
+
+### Custom Views
+
+Implement the `View` trait to create custom views:
+
+```rust
+use cursive::event::{Event, EventResult, Key};
+use cursive::Printer;
+use cursive::Vec2;
+use cursive::view::View;
+
+struct CounterView {
+    count: i32,
+}
+
+impl CounterView {
+    fn new() -> Self {
+        CounterView { count: 0 }
+    }
+}
+
+impl View for CounterView {
+    fn draw(&self, printer: &Printer) {
+        printer.print((0, 0), &format!("Count: {}", self.count));
+    }
+
+    fn required_size(&mut self, _constraint: Vec2) -> Vec2 {
+        Vec2::new(20, 1)
+    }
+
+    fn on_event(&mut self, event: Event) -> EventResult {
+        match event {
+            Event::Char('+') => {
+                self.count += 1;
+                EventResult::consumed()
+            }
+            Event::Char('-') => {
+                self.count -= 1;
+                EventResult::consumed()
+            }
+            _ => EventResult::Ignored,
+        }
+    }
+
+    fn take_focus(&mut self, _: cursive::direction::Direction)
+        -> Result<EventResult, cursive::view::CannotFocus>
+    {
+        Ok(EventResult::consumed())
+    }
+}
+```
+
+For quick prototyping without implementing `View`, use `Canvas`:
+
+```rust
+use cursive::views::Canvas;
+
+let counter = Canvas::new(0i32)
+    .with_draw(|count: &i32, printer: &Printer| {
+        printer.print((0, 0), &format!("Count: {}", count));
+    })
+    .with_on_event(|count: &mut i32, event| match event {
+        Event::Char('+') => { *count += 1; EventResult::consumed() }
+        Event::Char('-') => { *count -= 1; EventResult::consumed() }
+        _ => EventResult::Ignored,
+    })
+    .with_required_size(|_, _| Vec2::new(20, 1));
+```
+
+### The `ViewWrapper` Trait
+
+For creating decorator views that mostly delegate to an inner view, `ViewWrapper`
+reduces boilerplate:
+
+```rust
+use cursive::view::{View, ViewWrapper};
+
+struct Bordered<V: View> {
+    inner: V,
+    border_char: char,
+}
+
+impl<V: View> ViewWrapper for Bordered<V> {
+    type V = V;
+
+    fn with_view<F, R>(&self, f: F) -> Option<R>
+    where F: FnOnce(&Self::V) -> R {
+        Some(f(&self.inner))
+    }
+
+    fn with_view_mut<F, R>(&mut self, f: F) -> Option<R>
+    where F: FnOnce(&mut Self::V) -> R {
+        Some(f(&mut self.inner))
+    }
+
+    // Override only the methods you need to customize.
+    // All other View methods delegate to the inner view automatically.
+}
+```
+
+The `wrap_impl!` macro can generate the `with_view` / `with_view_mut` boilerplate.
+
+---
+
+## Styling
+
+Cursive uses a **theme-based styling system**. Rather than attaching styles to individual
+views, the application defines a `Theme` with a `Palette` of named colors. Views reference
+palette colors by role (e.g., "primary text", "highlight"), and the theme resolves them to
+concrete terminal colors.
+
+### Theme Struct
+
+```rust
+pub struct Theme {
+    /// Whether shadows are drawn behind layers in a StackView.
+    pub shadow: bool,
+
+    /// How borders are drawn around views (Simple, Outset, None).
+    pub borders: BorderStyle,
+
+    /// The color palette mapping role names to colors.
+    pub palette: Palette,
+}
+```
+
+### Palette and PaletteColor
+
+The `Palette` maps semantic color roles to concrete colors:
+
+```rust
+pub enum PaletteColor {
+    Background,         // Application background
+    Shadow,             // Shadow behind layered views
+    View,               // View/widget background
+    Primary,            // Primary text color
+    Secondary,          // Secondary text color
+    Tertiary,           // Tertiary text color
+    TitlePrimary,       // Primary title text
+    TitleSecondary,     // Secondary title text
+    Highlight,          // Active/focused highlight
+    HighlightInactive,  // Inactive/unfocused highlight
+    HighlightText,      // Text within highlighted areas
+}
+```
+
+### Color Types
+
+```rust
+pub enum Color {
+    TerminalDefault,          // Inherit from terminal settings
+    Dark(BaseColor),          // 8 base colors (universal support)
+    Light(BaseColor),         // Light variants (most emulators)
+    Rgb(u8, u8, u8),          // 24-bit true color (auto-downgrade)
+    RgbLowRes(u8, u8, u8),   // 6x6x6 color cube (256-color palette)
+}
+
+pub enum BaseColor {
+    Black, Red, Green, Yellow, Blue, Magenta, Cyan, White,
+}
+```
+
+### ColorStyle and ColorType
+
+`ColorStyle` pairs a foreground and background color for a cell:
+
+```rust
+pub struct ColorStyle {
+    pub front: ColorType,
+    pub back: ColorType,
+}
+
+pub enum ColorType {
+    Color(Color),                // A concrete color
+    Palette(PaletteColor),       // Reference a palette role
+    InheritParent,               // Inherit from the parent view
+}
+```
+
+This indirection through `ColorType` means views can reference palette roles rather than
+hard-coding colors, enabling theme switching at runtime.
+
+### BorderStyle
+
+```rust
+pub enum BorderStyle {
+    Simple,   // Standard single-line borders (default)
+    Outset,   // 3D outset effect
+    None,     // No borders
+}
+```
+
+### Programmatic Theme Configuration
+
+```rust
+use cursive::theme::{BaseColor, BorderStyle, Color, PaletteColor, Theme};
+
+let mut siv = cursive::default();
+
+siv.update_theme(|theme| {
+    theme.shadow = false;
+    theme.borders = BorderStyle::Simple;
+    theme.palette[PaletteColor::Background] = Color::TerminalDefault;
+    theme.palette[PaletteColor::View] = Color::Dark(BaseColor::Black);
+    theme.palette[PaletteColor::Primary] = Color::Light(BaseColor::White);
+    theme.palette[PaletteColor::Highlight] = Color::Dark(BaseColor::Cyan);
+    theme.palette[PaletteColor::HighlightInactive] = Color::Dark(BaseColor::Blue);
+    theme.palette[PaletteColor::HighlightText] = Color::Dark(BaseColor::White);
+});
+```
+
+### TOML Theme Loading
+
+With the `toml` Cargo feature, themes can be loaded from files:
+
+```toml
+# theme.toml
+shadow = false
+borders = "simple"
+
+[colors]
+background = "black"
+view       = "#222222"
+primary    = "white"
+secondary  = "light cyan"
+tertiary   = "light magenta"
+title_primary   = "light yellow"
+title_secondary = "light blue"
+highlight       = "dark cyan"
+highlight_inactive = "dark blue"
+highlight_text  = "white"
+```
+
+```rust
+// Load at runtime
+siv.load_theme_file("theme.toml").expect("Failed to load theme");
+
+// Or from a string
+siv.load_toml(include_str!("theme.toml")).expect("Invalid theme");
+```
+
+### Per-View Theme Overrides
+
+The `ThemedView` wrapper applies a local theme to a subtree:
+
+```rust
+use cursive::views::ThemedView;
+
+let themed_panel = ThemedView::new(my_custom_theme, my_view);
+```
+
+### Built-In Themes
+
+Cursive provides two built-in themes:
+
+- **`Theme::retro()`** -- The default. Resembles classic dialog-based tools like GNU dialog.
+- **`Theme::terminal_default()`** -- Uses the terminal's native foreground/background colors.
+
+---
+
+## Event Handling
+
+Cursive is **callback-driven**. Events flow through the view tree, and views respond by
+returning `EventResult` values that may carry callbacks to execute.
+
+### Event Enum
+
+```rust
+pub enum Event {
+    // Character input
+    Char(char),
+    CtrlChar(char),
+    AltChar(char),
+
+    // Non-character keys (arrows, function keys, etc.)
+    Key(Key),
+    Shift(Key),
+    Alt(Key),
+    AltShift(Key),
+    Ctrl(Key),
+    CtrlShift(Key),
+    CtrlAlt(Key),
+
+    // System events
+    WindowResize,
+    FocusLost,
+    Refresh,
+
+    // Mouse events
+    Mouse { offset: Vec2, position: Vec2, event: MouseEvent },
+
+    // Unrecognized input sequences
+    Unknown(Vec<u8>),
+}
+```
+
+### EventResult
+
+```rust
+pub enum EventResult {
+    /// The event was not handled. The parent should try handling it.
+    Ignored,
+
+    /// The event was consumed. An optional callback may be attached.
+    Consumed(Option<Callback>),
+}
+```
+
+Convenience constructors:
+
+```rust
+EventResult::consumed()              // Consumed, no callback
+EventResult::with_cb(|s| s.quit())   // Consumed with a callback
+EventResult::Ignored                 // Not handled
+```
+
+### Event Flow
+
+Events flow **top-down through the focused path**, then **bubble up** if ignored:
+
+1. The framework receives an input event from the backend.
+2. It calls `on_event(event)` on the topmost layer's root view.
+3. Container views forward to their focused child.
+4. If a view returns `EventResult::Consumed(Some(cb))`, the callback is executed with
+   `&mut Cursive`.
+5. If a view returns `EventResult::Ignored`, the parent view gets a chance to handle it.
+6. If the event bubbles all the way up unhandled, global callbacks are checked.
+
+### Global Callbacks
+
+```rust
+let mut siv = cursive::default();
+
+// Quit on 'q' or Escape
+siv.add_global_callback('q', |s| s.quit());
+siv.add_global_callback(Key::Esc, |s| s.quit());
+
+// Ctrl+S to save
+siv.add_global_callback(Event::CtrlChar('s'), |s| {
+    // ... save logic ...
+});
+
+// Pre-event and post-event hooks
+siv.set_on_pre_event('q', |s| {
+    // Runs before the view tree processes the event
+});
+siv.set_on_post_event(Key::F1, |s| {
+    // Runs after the view tree processes the event
+    s.add_layer(Dialog::info("Help screen"));
+});
+```
+
+### Per-View Event Handling with OnEventView
+
+`OnEventView` wraps a view to intercept or augment its event handling:
+
+```rust
+use cursive::views::{OnEventView, TextView};
+use cursive::event::Key;
+
+let view = OnEventView::new(TextView::new("Press 'q' to quit"))
+    .on_event('q', |s| s.quit())
+    .on_event(Key::Esc, |s| s.quit());
+```
+
+The distinction between `on_event` and `on_pre_event`:
+
+- **`on_event`:** Triggers when the inner view _ignores_ the event (fallback handler).
+- **`on_pre_event`:** Triggers _before_ the inner view sees the event (interceptor).
+
+The `_inner` variants (`on_event_inner`, `on_pre_event_inner`) provide access to the
+wrapped view itself, enabling conditional handling based on view state:
+
+```rust
+let view = OnEventView::new(
+    SelectView::<String>::new()
+        .item_str("Alice")
+        .item_str("Bob")
+        .with_name("list")
+)
+.on_pre_event_inner(Key::Del, |siv, _event| {
+    // Access the inner NamedView -> SelectView to remove selected item
+    siv.get_mut().remove_item(
+        siv.get_mut().selected_id().unwrap_or(0)
+    );
+    Some(EventResult::consumed())
+});
+```
+
+### Callback-Driven Dialog Example
+
+```rust
+use cursive::views::{Dialog, EditView, TextView};
+use cursive::Cursive;
+
+fn main() {
+    let mut siv = cursive::default();
+
+    siv.add_layer(
+        Dialog::around(
+            EditView::new()
+                .on_submit(show_greeting)
+                .with_name("name")
+                .fixed_width(25)
+        )
+        .title("Enter your name")
+        .button("Ok", |s| {
+            let name = s.call_on_name("name", |v: &mut EditView| {
+                v.get_content()
+            }).unwrap();
+            show_greeting(s, &name);
+        })
+        .button("Quit", |s| s.quit())
+    );
+
+    siv.run();
+}
+
+fn show_greeting(s: &mut Cursive, name: &str) {
+    s.pop_layer();
+    s.add_layer(
+        Dialog::around(
+            TextView::new(format!("Hello, {}!", name))
+        )
+        .button("Ok", |s| s.quit())
+    );
+}
+```
+
+### Async Event Injection
+
+The `cb_sink()` method returns a channel sender for injecting callbacks from background
+threads:
+
+```rust
+let sink = siv.cb_sink().clone();
+
+std::thread::spawn(move || {
+    // ... long-running work ...
+    sink.send(Box::new(|s: &mut Cursive| {
+        s.add_layer(Dialog::info("Background work complete!"));
+    })).unwrap();
+});
+```
+
+This is the primary mechanism for communicating between async/threaded work and the UI.
+
+---
+
+## State Management
+
+### View-Internal State
+
+In Cursive's retained model, each view owns its own mutable state. An `EditView` holds its
+text buffer. A `SelectView` holds its items and selection index. A `ScrollView` holds its
+scroll offset. State persists between frames because the view tree persists.
+
+Views are mutated through `&mut self` in their `on_event` handler or externally through
+`call_on_name`:
+
+```rust
+// Mutate a view by name
+siv.call_on_name("counter", |view: &mut TextView| {
+    view.set_content("Updated text");
+});
+```
+
+### User Data
+
+For application-level state that does not belong to any specific view, Cursive provides a
+typed storage slot:
+
+```rust
+struct AppState {
+    logged_in: bool,
+    username: String,
+    items: Vec<String>,
+}
+
+siv.set_user_data(AppState {
+    logged_in: false,
+    username: String::new(),
+    items: vec![],
+});
+
+// Access from a callback
+siv.with_user_data(|state: &mut AppState| {
+    state.logged_in = true;
+    state.username = "admin".to_string();
+});
+
+// Or retrieve directly
+if let Some(state) = siv.user_data::<AppState>() {
+    println!("User: {}", state.username);
+}
+```
+
+The user data slot stores a single `Box<dyn Any>`. For multiple pieces of state, use a
+struct that groups them.
+
+### Shared Mutable State Across Callbacks
+
+Because each callback only receives `&mut Cursive`, sharing state between multiple
+callbacks requires one of:
+
+**Pattern 1: User data (recommended for global state)**
+
+```rust
+siv.set_user_data(0u32);  // Counter
+
+siv.add_global_callback('+', |s| {
+    s.with_user_data(|count: &mut u32| *count += 1);
+    update_display(s);
+});
+
+siv.add_global_callback('-', |s| {
+    s.with_user_data(|count: &mut u32| *count -= 1);
+    update_display(s);
+});
+```
+
+**Pattern 2: `Rc<RefCell<T>>` (for state shared between specific callbacks)**
+
+```rust
+use std::cell::RefCell;
+use std::rc::Rc;
+
+let shared_state = Rc::new(RefCell::new(Vec::<String>::new()));
+
+let state_clone = shared_state.clone();
+siv.add_layer(
+    Dialog::around(
+        EditView::new().on_submit(move |s, text| {
+            state_clone.borrow_mut().push(text.to_string());
+            s.pop_layer();
+        })
+    )
+);
+```
+
+This pattern is necessary when closures captured at different points in the code need
+access to the same data. It incurs a runtime borrow-check cost (`RefCell` panics on
+concurrent borrows).
+
+**Pattern 3: Named views as state containers**
+
+Use the views themselves as the source of truth:
+
+```rust
+// Read state from the view when you need it
+siv.call_on_name("items", |view: &mut SelectView<String>| {
+    let selected = view.selection().unwrap();
+    // ... use selected item ...
+});
+```
+
+---
+
+## Extensibility and Ecosystem
+
+### Third-Party View Crates
+
+| Crate                      | Description                                          |
+| -------------------------- | ---------------------------------------------------- |
+| `cursive_table_view`       | Sortable, scrollable data table with columns.        |
+| `cursive_tree_view`        | Hierarchical tree with expand/collapse.              |
+| `cursive-aligned-view`     | Aligns a child view within available space.          |
+| `cursive-tabs`             | Tabbed container switching between child views.      |
+| `cursive_buffered_backend` | Backend wrapper that buffers output for performance. |
+| `cursive-hjkl`             | Vim-style hjkl navigation wrapper.                   |
+| `cursive-syntect`          | Syntax highlighting via the syntect library.         |
+
+### Community
+
+- **Gitter chat** for discussion and support.
+- Active maintenance with regular releases (50+ releases).
+- Used in real-world applications: Git clients, password managers, Spotify TUI clients.
+
+### Ecosystem Size
+
+The Cursive ecosystem is **smaller than Ratatui's**. Ratatui has 12,700+ dependent crates
+and a much larger selection of community widgets. Cursive's third-party view library is
+modest but covers common needs (tables, trees, tabs). The difference is partly due to
+architectural philosophy: Cursive's retained-mode view tree with trait objects makes
+third-party views somewhat heavier to implement than Ratatui's stateless `Widget` trait.
+
+---
+
+## Strengths
+
+- **High-level, batteries-included API.** Dialog-heavy apps require very little code.
+  A functional form with validation can be built in under 50 lines.
+- **Familiar OOP-like architecture.** Developers coming from GTK, Qt, or Swing will
+  recognize the view tree, event bubbling, and layout negotiation patterns.
+- **Built-in event loop and focus management.** The framework handles event routing, focus
+  traversal (Tab/Shift-Tab), and layer management. The application does not need to
+  implement any of this.
+- **Excellent for dialog-heavy and form-driven apps.** The `Dialog`, `EditView`,
+  `SelectView`, `RadioGroup`, and `Checkbox` views cover form scenarios comprehensively.
+- **Backend flexibility.** Five backends covering pure-Rust, ncurses-based, and
+  graphical (BearLibTerminal) options. Backend swapping is a Cargo feature flag.
+- **Named view access.** The `call_on_name` pattern provides a clean way to reach into
+  the view tree without passing references through layers of callbacks.
+- **Theme support with TOML loading.** Theme switching at runtime, palette-based color
+  roles, and external theme files.
+- **Method chaining for view composition.** The `Resizable`, `Scrollable`, and `Nameable`
+  traits enable fluent, left-to-right view wrapping that reads naturally.
+- **Canvas for quick custom views.** The closure-based `Canvas` view allows prototyping
+  custom rendering without implementing the full `View` trait.
+- **Async callback injection.** The `cb_sink()` channel enables safe communication from
+  background threads to the UI thread.
+
+---
+
+## Weaknesses and Limitations
+
+- **Trait object overhead.** Views are stored as `Box<dyn View>`, incurring virtual
+  dispatch on every `draw`, `layout`, `on_event`, and `required_size` call. This is
+  negligible for most apps but prevents whole-program monomorphization optimizations.
+- **`Rc<RefCell<T>>` for shared state.** Sharing mutable state across callbacks requires
+  reference-counted interior mutability, which trades compile-time safety for runtime
+  panics on borrow violations. This is a common pain point for Cursive users.
+- **Harder to do fully custom rendering.** The `Printer` abstraction is convenient for
+  text-based views but limiting for pixel-level or cell-level custom drawing (e.g.,
+  sparklines, charts, custom graphs). Ratatui's raw `Buffer` access is more flexible here.
+- **Less suitable for dashboard-style UIs.** Cursive's layout system is designed for
+  dialogs and forms, not for splitting a screen into many independently-updating panels.
+  Ratatui's constraint solver handles this more naturally.
+- **Smaller community and ecosystem than Ratatui.** Fewer third-party widgets, fewer
+  examples, less Stack Overflow coverage. Ratatui has roughly 4x the GitHub stars and
+  a much larger dependent crate count.
+- **Callback spaghetti in complex apps.** As applications grow, the callback-based event
+  model can lead to deeply nested closures and difficult-to-follow control flow. There is
+  no built-in architectural pattern (like Elm/MVU) to impose structure.
+- **Single-threaded UI assumption.** The `Cursive` struct is not `Send` or `Sync`. All
+  view mutations must happen on the main thread, with `cb_sink()` as the only bridge to
+  async work.
+- **No incremental layout.** The entire view tree is re-laid-out and re-drawn on every
+  event, even if only a small part changed. There is no dirty-tracking or partial
+  invalidation at the framework level (individual views can optimize via
+  `needs_relayout`).
+- **Weight system limitations.** The `LinearLayout` weight system is documented but noted
+  as "currently unused by layout process" in the docs, suggesting it may not work as
+  expected in all versions.
+
+---
+
+## Lessons for D / Sparkles
+
+This section maps Cursive's patterns to D idioms, evaluating what would translate well
+and where D's unique capabilities could improve upon the design.
+
+### View Trait -> D Interface or Template Constraint
+
+Cursive's `View` trait uses dynamic dispatch (`dyn View`). In D, there are two paths:
+
+**Runtime polymorphism via D interface** (closest analog, necessary for a heterogeneous
+view tree):
+
+```d
+interface View {
+    void draw(ref const Printer printer) const;
+    Vec2 requiredSize(Vec2 constraint);
+    void layout(Vec2 size);
+    EventResult onEvent(Event event);
+    Result!(EventResult, CannotFocus) takeFocus(Direction dir);
+    bool needsRelayout() const;
+}
+```
+
+**Compile-time polymorphism via template constraint** (for static view trees,
+zero-overhead):
+
+```d
+enum isView(T) = is(typeof((ref T v, ref const Printer p) {
+    v.draw(p);
+    Vec2 s = v.requiredSize(Vec2.init);
+    v.layout(Vec2.init);
+    EventResult r = v.onEvent(Event.init);
+}));
+```
+
+D could offer **both**: a template-based fast path for compile-time-known trees, and an
+interface-based path for dynamic trees. This dual approach is not easily achievable in
+Rust due to its stricter trait object rules.
+
+### Method Chaining -> UFCS in D (Natural Fit)
+
+Cursive's wrapping traits:
+
+```rust
+EditView::new().with_name("input").fixed_width(30).scrollable()
+```
+
+This maps directly to D's UFCS:
+
+```d
+auto view = editView()
+    .withName("input")
+    .fixedWidth(30)
+    .scrollable;
+```
+
+D's UFCS is even more flexible than Rust's trait-based extension methods because it works
+on any type without needing a trait definition. Free functions in scope automatically
+participate:
+
+```d
+/// Any view -> ResizedView wrapping it at fixed width.
+auto fixedWidth(V)(V view, uint width) if (isView!V) {
+    return ResizedView!V(view, SizeConstraint.fixed(width));
+}
+```
+
+### Named View Access -> D AA Lookup or Compile-Time Indexing
+
+Cursive's `call_on_name` pattern (runtime string lookup):
+
+```d
+// Runtime approach: associative array of views by name
+View[string] namedViews;
+if (auto v = "input" in namedViews) {
+    if (auto edit = cast(EditView)*v) {
+        edit.setContent("hello");
+    }
+}
+```
+
+D could also offer a **compile-time** variant using string template parameters:
+
+```d
+// Compile-time approach: view tree with string-indexed children
+auto tree = viewTree(
+    named!("input", editView()),
+    named!("output", textView()),
+);
+
+// Zero-cost access at compile time
+tree.get!"input".setContent("hello");
+```
+
+This would be a significant improvement over Cursive's runtime lookup, catching name
+mismatches at compile time.
+
+### Weight-Based Layout -> D Struct with DbI
+
+Cursive's weight system:
+
+```rust
+LinearLayout::vertical()
+    .child(header).weight(1)
+    .child(body).weight(3)
+    .child(footer).weight(1)
+```
+
+In D, using Design by Introspection, the layout container can detect whether a child
+provides a weight capability:
+
+```d
+enum hasWeight(T) = is(typeof(T.init.layoutWeight) : uint);
+
+struct LinearLayout(Children...) {
+    void layout(Vec2 available) {
+        // For each child, check if it has a weight
+        static foreach (i, C; Children) {
+            static if (hasWeight!C)
+                uint w = children[i].layoutWeight;
+            else
+                uint w = 1;  // default weight
+        }
+        // ... distribute space proportionally ...
+    }
+}
+```
+
+This avoids runtime checks entirely -- the layout logic is specialized per-child at
+compile time.
+
+### Theme / Palette -> D Enum-Based Palette with CTFE Theme Parsing
+
+Cursive's `PaletteColor` enum maps directly to D:
+
+```d
+enum PaletteColor {
+    background, shadow, view,
+    primary, secondary, tertiary,
+    titlePrimary, titleSecondary,
+    highlight, highlightInactive, highlightText,
+}
+
+struct Theme {
+    bool shadow;
+    BorderStyle borders;
+    Color[PaletteColor] palette;
+}
+```
+
+D's CTFE could **parse TOML themes at compile time**:
+
+```d
+// Compile-time theme parsing -- zero runtime cost
+enum myTheme = parseThemeToml(import("theme.toml"));
+
+// The theme struct is fully resolved at compile time
+static assert(myTheme.palette[PaletteColor.primary] == Color.rgb(255, 255, 255));
+```
+
+This is impossible in Rust (TOML parsing at compile time is not feasible without `const`
+evaluation of the parser). D's CTFE can execute arbitrary code at compile time, including
+string parsing.
+
+### Callback Pattern -> D Delegates, or MVU Alternative
+
+Cursive's callback model:
+
+```rust
+siv.add_global_callback('q', |s| s.quit());
+```
+
+D delegates are the direct translation:
+
+```d
+siv.addGlobalCallback('q', (ref Cursive s) { s.quit(); });
+```
+
+However, D could also offer an **MVU (Model-View-Update) alternative** that avoids
+callback spaghetti entirely:
+
+```d
+struct AppState { int count; bool running; }
+
+enum Msg { increment, decrement, quit }
+
+AppState update(AppState state, Msg msg) pure {
+    final switch (msg) {
+        case Msg.increment: return AppState(state.count + 1, true);
+        case Msg.decrement: return AppState(state.count - 1, true);
+        case Msg.quit:      return AppState(state.count, false);
+    }
+}
+```
+
+The MVU approach with pure update functions is a better fit for D's `pure` and `@nogc`
+capabilities than the `Rc<RefCell<T>>` pattern that Cursive users resort to for shared
+state.
+
+### Retained View Tree -> Tradeoffs vs. Immediate-Mode for D's `@nogc` Goals
+
+Cursive's retained-mode architecture has inherent tension with `@nogc`:
+
+- **View tree allocation:** `Box<dyn View>` requires heap allocation. In D with `@nogc`,
+  this would need `pureMalloc`-based allocators or arena allocation.
+- **State persistence:** Views hold mutable state across frames, which is natural in
+  retained mode but means allocation lifetimes are unbounded.
+- **Trait objects / interfaces:** Dynamic dispatch through `dyn View` (or D's `interface`)
+  requires indirection and prevents inlining.
+
+By contrast, **immediate-mode** (Ratatui's approach) is more naturally `@nogc`-friendly:
+
+- Widgets are stack-allocated value types, constructed and consumed per frame.
+- No persistent tree means no long-lived heap allocations.
+- Template-based widgets enable full monomorphization.
+
+A D TUI framework could pursue a **hybrid approach**:
+
+- **Immediate-mode rendering** for the draw path (`@nogc`, stack-allocated widgets).
+- **Retained state** for input focus, scroll positions, and text buffers, stored in a
+  flat `App` struct rather than distributed across a view tree.
+- **Compile-time view composition** using D's template system to build static view trees
+  where the structure is known, avoiding dynamic dispatch entirely.
+
+This would combine Cursive's ergonomic view composition with Ratatui's rendering
+efficiency, enabled by D's unique ability to straddle compile-time and runtime patterns.
+
+---
+
+## References
+
+- **GitHub Repository:** <https://github.com/gyscos/cursive>
+- **API Reference (docs.rs):** <https://docs.rs/cursive/latest/cursive/>
+  - View trait: <https://docs.rs/cursive/latest/cursive/view/trait.View.html>
+  - Cursive struct: <https://docs.rs/cursive/latest/cursive/struct.Cursive.html>
+  - Views module: <https://docs.rs/cursive/latest/cursive/views/index.html>
+  - Theme module: <https://docs.rs/cursive/latest/cursive/theme/index.html>
+  - Event module: <https://docs.rs/cursive/latest/cursive/event/enum.Event.html>
+  - EventResult: <https://docs.rs/cursive/latest/cursive/event/enum.EventResult.html>
+  - PaletteColor: <https://docs.rs/cursive/latest/cursive/theme/enum.PaletteColor.html>
+  - ColorStyle: <https://docs.rs/cursive/latest/cursive/theme/struct.ColorStyle.html>
+  - LinearLayout: <https://docs.rs/cursive/latest/cursive/views/struct.LinearLayout.html>
+  - Dialog: <https://docs.rs/cursive/latest/cursive/views/struct.Dialog.html>
+  - SelectView: <https://docs.rs/cursive/latest/cursive/views/struct.SelectView.html>
+  - ResizedView: <https://docs.rs/cursive/latest/cursive/views/struct.ResizedView.html>
+  - OnEventView: <https://docs.rs/cursive/latest/cursive/views/struct.OnEventView.html>
+  - Canvas: <https://docs.rs/cursive/latest/cursive/views/struct.Canvas.html>
+  - ViewWrapper: <https://docs.rs/cursive/latest/cursive/view/trait.ViewWrapper.html>
+  - NamedView: <https://docs.rs/cursive/latest/cursive/views/struct.NamedView.html>
+- **Backends Wiki:** <https://github.com/gyscos/cursive/wiki/Backends>
+- **Ecosystem:**
+  - cursive_table_view: <https://github.com/BonsaiDen/cursive_table_view>
+  - cursive_tree_view: <https://github.com/BonsaiDen/cursive_tree_view>
+  - cursive-tabs: <https://github.com/deinstapel/cursive-tabs>
+  - cursive-aligned-view: <https://github.com/deinstapel/cursive-aligned-view>

--- a/docs/research/tui-libraries/ftxui.md
+++ b/docs/research/tui-libraries/ftxui.md
@@ -1,0 +1,1280 @@
+# FTXUI (C++)
+
+A C++ library for building functional terminal user interfaces through declarative Element trees, a flexbox-inspired layout engine, and a dual-layer architecture separating pure rendering from interactive stateful components.
+
+| Field          | Value                                     |
+| -------------- | ----------------------------------------- |
+| Language       | C++17                                     |
+| License        | MIT                                       |
+| Repository     | <https://github.com/ArthurSonzogni/FTXUI> |
+| Documentation  | <https://arthursonzogni.github.io/FTXUI/> |
+| Latest Version | ~6.1.9 (May 2025)                         |
+| GitHub Stars   | ~9.6k                                     |
+
+---
+
+## Overview
+
+FTXUI is a C++ library for building terminal user interfaces using a functional,
+declarative approach inspired by React and the browser DOM. It targets a problem space
+that most C++ TUI libraries (ncurses, notcurses) address with imperative, stateful APIs:
+FTXUI instead models the UI as a tree of immutable value-like **Element** nodes
+constructed by composing pure functions, then rendered to a **Screen** each frame.
+
+**What it solves.** Building terminal UIs in C++ traditionally means managing raw ANSI
+sequences, stateful cursor positioning, and complex widget hierarchies with manual
+invalidation. FTXUI replaces all of this with a functional composition model: you
+construct an Element tree from functions like `text`, `hbox`, `vbox`, `border`, and
+`gauge`, hand it to a `Screen`, and the library handles layout computation, diffing,
+and terminal output. The programmer never manages cursor state or escape codes directly.
+
+**Design philosophy.** FTXUI has two distinct layers by design:
+
+1. **Dom layer** -- Pure functional. Elements are values created by calling functions.
+   An Element tree is built each frame, laid out by a constraint solver, and rendered to
+   a Screen. There is no mutation, no retained state, no callbacks. This is the
+   immediate-mode rendering layer.
+
+2. **Component layer** -- Retained-mode. Components wrap Elements with event handling
+   and mutable state. A Component produces an Element tree via its `Render()` method,
+   handles keyboard/mouse events via `OnEvent()`, and participates in a focus tree.
+   The `ScreenInteractive` class drives the event loop.
+
+This separation means you can use the dom layer alone for static output (dashboards,
+progress displays, formatted reports) without ever touching the component layer. When
+interactivity is needed, the component layer adds the minimum necessary statefulness.
+
+**History.** FTXUI was created by Arthur Sonzogni and has been under active development
+since 2019. It has grown to 9,600+ GitHub stars with 800+ commits. The library is
+notable for having no external dependencies beyond the C++ standard library, supporting
+C++20 modules, and compiling to WebAssembly via Emscripten -- enabling live interactive
+demos in the browser. It works on Linux, macOS, Windows, and WebAssembly.
+
+---
+
+## Architecture
+
+### Two-Tier Architecture
+
+FTXUI's architecture separates concerns into two composable layers:
+
+```
+                    Component Layer (retained, stateful)
+                    +-----------------------------------------+
+                    | ScreenInteractive event loop            |
+                    |   Component tree (shared_ptr)           |
+                    |     Render() -> Element                 |
+                    |     OnEvent(Event) -> bool              |
+                    |     Focus management                    |
+                    +-----------------------------------------+
+                              |  calls Render() each frame
+                              v
+                    Dom Layer (pure, functional)
+                    +-----------------------------------------+
+                    | Element tree (shared_ptr<Node>)          |
+                    |   text, hbox, vbox, border, gauge, ...  |
+                    |   ComputeRequirement() -> up            |
+                    |   SetBox() -> down                      |
+                    |   Render(Screen) -> pixels               |
+                    +-----------------------------------------+
+                              |
+                              v
+                    Screen (pixel grid)
+                    +-----------------------------------------+
+                    | Pixel[dimx][dimy]                        |
+                    | ToString() -> ANSI escape sequences      |
+                    | Print() -> stdout                        |
+                    +-----------------------------------------+
+```
+
+### Dom Layer: Pure Functional Elements
+
+The dom layer is the foundation. An `Element` is a `std::shared_ptr<Node>`, where `Node`
+is a base class with three key virtual methods:
+
+- **`ComputeRequirement()`** -- Bottom-up pass. Each node computes its minimum/preferred
+  size based on its children. Propagated from leaves to root.
+- **`SetBox(Box)`** -- Top-down pass. The parent assigns each child its final bounding
+  box based on available space and the child's requirements. Propagated from root to
+  leaves.
+- **`Render(Screen&)`** -- Each node writes its content into the Screen's pixel grid.
+
+Element trees are constructed by calling functions that return `Element`:
+
+```cpp
+Element document = vbox({
+    hbox({
+        text("Name:") | bold,
+        text(" Arthur") | color(Color::Cyan),
+    }),
+    separator(),
+    hbox({
+        gauge(0.7) | flex | color(Color::Green),
+    }),
+}) | border;
+```
+
+Every call creates a new node. There is no mutation: you build a new tree each frame.
+The functions are pure in the sense that they take values and return values -- the
+returned Element is a self-contained description of what to render. This is analogous
+to React's virtual DOM or Elm's view function.
+
+### Component Layer: Retained-Mode Interactivity
+
+The component layer adds state and event handling on top of the dom layer. A `Component`
+is a `std::shared_ptr<ComponentBase>`, where `ComponentBase` provides:
+
+- **`Element Render()`** / **`Element OnRender()`** -- Returns an Element tree describing
+  the component's current visual state.
+- **`bool OnEvent(Event)`** -- Handles a keyboard or mouse event. Returns `true` if the
+  event was consumed.
+- **`void OnAnimation(animation::Params&)`** -- Handles animation ticks.
+- **`Component ActiveChild()`** -- Focus tree management.
+- **`void Add(Component)`** / **`Component& ChildAt(size_t)`** -- Child component hierarchy.
+
+The `ScreenInteractive` class manages the event loop:
+
+```cpp
+auto screen = ScreenInteractive::Fullscreen();
+screen.Loop(component);  // blocks, runs event loop
+```
+
+Each iteration of the loop: (1) polls for events, (2) dispatches events to the component
+tree via `OnEvent()`, (3) calls `Render()` on the root component to get an Element tree,
+(4) lays out and renders the Element tree to the screen buffer, (5) diffs against the
+previous frame and flushes changes to the terminal.
+
+### How the Layers Compose
+
+Components produce Elements. The framework calls `Render()` on the root Component each
+frame, receives an Element tree, and passes it through the dom layer's layout and
+rendering pipeline. This means:
+
+- A Component's `Render()` method is a pure function from state to Element tree.
+- The dom layer knows nothing about Components, events, or state.
+- Components can freely mix hand-built Element trees with factory-created child Components.
+
+This is a clean separation: the dom layer is a pure functional rendering engine, and the
+component layer is a thin stateful shell around it.
+
+---
+
+## Terminal Backend
+
+### Screen
+
+The `Screen` class (inheriting from `Image`) is a 2D grid of `Pixel` cells. Each Pixel
+holds a character (UTF-8), foreground/background colors, and style attributes (bold, dim,
+underlined, etc.).
+
+Factory methods:
+
+- `Screen::Create(Dimension::Full())` -- Full terminal size.
+- `Screen::Create(Dimension::Fixed(width), Dimension::Fixed(height))` -- Explicit size.
+
+Key methods:
+
+- `ToString()` -- Converts the pixel grid to a string of ANSI escape sequences.
+- `Print()` -- Writes to stdout.
+- `Clear()` -- Resets all pixels.
+- `ResetPosition()` -- Returns a string that moves the cursor back to the origin, enabling
+  in-place animation without clearing the screen.
+- `RegisterHyperlink(link)` -- Registers an OSC 8 hyperlink, returns an ID for pixels.
+
+### ScreenInteractive
+
+`ScreenInteractive` extends `Screen` with an event loop for interactive applications:
+
+- **`Fullscreen()`** -- Uses the alternate screen buffer, full terminal.
+- **`FullscreenAlternateScreen()`** / **`FullscreenPrimaryScreen()`** -- Explicit screen
+  buffer selection.
+- **`FitComponent()`** -- Sizes the screen to fit the rendered component.
+- **`TerminalOutput()`** -- Output-only mode, no alternate screen.
+- **`FixedSize(dimx, dimy)`** -- Fixed dimensions.
+
+Loop control:
+
+- `Loop(component)` -- Blocks, runs the event loop.
+- `Exit()` / `ExitLoopClosure()` -- Signals loop termination.
+- `Post(task)` -- Queues a task for execution on the event loop thread.
+- `PostEvent(event)` -- Injects a synthetic event.
+- `RequestAnimationFrame()` -- Triggers a redraw on the next frame.
+- `TrackMouse(bool)` -- Enables/disables mouse tracking.
+- `ForceHandleCtrlC(bool)` / `ForceHandleCtrlZ(bool)` -- Signal handling control.
+
+### Color Support
+
+The `Color` class supports four tiers:
+
+- **Palette1** -- Default/transparent.
+- **Palette16** -- Standard 16 ANSI colors: `Color::Red`, `Color::Blue`, `Color::GrayDark`,
+  `Color::CyanLight`, etc.
+- **Palette256** -- Extended 256-color palette via `Color(Color::Palette256(index))`.
+- **TrueColor** -- 24-bit RGB via `Color(r, g, b)` or `Color::RGB(r, g, b)`.
+- **HSV** -- `Color::HSV(hue, saturation, value)` for hue-based color specification.
+- **Alpha blending** -- `Color::RGBA(r, g, b, a)`, `Color::Blend(a, b)`,
+  `Color::Interpolate(t, a, b)`.
+
+The library detects terminal color capabilities at runtime and degrades gracefully.
+
+### Platform Support
+
+- **Linux/macOS** -- Primary targets. Full feature set.
+- **Windows** -- Community-supported. Uses the Windows Console API.
+- **WebAssembly** -- Via Emscripten. Renders to an HTML `<pre>` element, enabling live
+  interactive demos in the browser. Mouse and keyboard events are translated from DOM
+  events.
+
+---
+
+## Layout System
+
+The layout system is one of FTXUI's most distinctive features. It implements a
+**flexbox-inspired** model directly in the terminal, bringing CSS-like layout semantics
+to character-grid rendering.
+
+### Box Composition
+
+The three fundamental layout primitives compose child Elements along an axis:
+
+```cpp
+// Horizontal: children laid out left to right
+hbox({child1, child2, child3})
+
+// Vertical: children laid out top to bottom
+vbox({child1, child2, child3})
+
+// Depth: children stacked on top of each other (last painted on top)
+dbox({background, foreground})
+```
+
+### Grid Layout
+
+`gridbox` arranges children in a 2D grid:
+
+```cpp
+gridbox({
+    {text("R1C1"), text("R1C2"), text("R1C3")},
+    {text("R2C1"), text("R2C2"), text("R2C3")},
+})
+```
+
+### Flexbox Layout
+
+`flexbox` provides full CSS Flexbox semantics with `FlexboxConfig`:
+
+```cpp
+FlexboxConfig config;
+config.direction = FlexboxConfig::Direction::Row;
+config.wrap = FlexboxConfig::Wrap::Wrap;
+config.justify_content = FlexboxConfig::JustifyContent::SpaceEvenly;
+config.align_items = FlexboxConfig::AlignItems::Center;
+config.align_content = FlexboxConfig::AlignContent::SpaceBetween;
+config.gap_x = 1;
+config.gap_y = 0;
+
+flexbox(children, config);
+```
+
+FlexboxConfig options:
+
+| Property          | Values                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| `direction`       | `Row`, `RowInversed`, `Column`, `ColumnInversed`                                          |
+| `wrap`            | `NoWrap`, `Wrap`, `WrapInversed`                                                          |
+| `justify_content` | `FlexStart`, `FlexEnd`, `Center`, `Stretch`, `SpaceBetween`, `SpaceAround`, `SpaceEvenly` |
+| `align_items`     | `FlexStart`, `FlexEnd`, `Center`, `Stretch`                                               |
+| `align_content`   | `FlexStart`, `FlexEnd`, `Center`, `Stretch`, `SpaceBetween`, `SpaceAround`, `SpaceEvenly` |
+| `gap_x`, `gap_y`  | Integer gap between items                                                                 |
+
+### Flex Decorators
+
+Flex decorators control how children grow and shrink within `hbox`/`vbox`:
+
+```cpp
+hbox({
+    text("fixed"),
+    text("grows") | flex,           // Takes remaining space
+    text("fixed"),
+})
+
+hbox({
+    text("a") | flex_grow,          // Grows to fill
+    text("b") | flex_shrink,        // Shrinks if needed
+})
+```
+
+Directional variants:
+
+- `xflex`, `yflex` -- Flex in X or Y direction only.
+- `xflex_grow`, `yflex_grow` -- Grow in X or Y only.
+- `xflex_shrink`, `yflex_shrink` -- Shrink in X or Y only.
+
+### Size Constraints
+
+Explicit size constraints use the `size()` decorator:
+
+```cpp
+text("constrained") | size(WIDTH, EQUAL, 30)
+text("minimum")     | size(HEIGHT, GREATER_THAN, 5)
+text("maximum")     | size(WIDTH, LESS_THAN, 50)
+```
+
+The `WidthOrHeight` enum selects the axis (`WIDTH`, `HEIGHT`), and the `Constraint` enum
+selects the relation (`EQUAL`, `GREATER_THAN`, `LESS_THAN`).
+
+### Centering and Alignment
+
+```cpp
+text("centered") | center     // Both axes
+text("h-center") | hcenter    // Horizontal only
+text("v-center") | vcenter    // Vertical only
+```
+
+The `filler()` element expands to fill available space, useful for manual alignment:
+
+```cpp
+hbox({text("left"), filler(), text("right")})
+```
+
+### Non-Trivial Layout Example: Multi-Panel Dashboard
+
+```cpp
+#include <ftxui/dom/elements.hpp>
+#include <ftxui/screen/screen.hpp>
+#include <ftxui/dom/node.hpp>
+
+using namespace ftxui;
+
+int main() {
+    // Left sidebar: vertical stack of labeled sections
+    auto sidebar = vbox({
+        text("Navigation") | bold | hcenter,
+        separator(),
+        text(" > Dashboard"),
+        text("   Settings"),
+        text("   Logs"),
+        filler(),
+        text("v2.1.0") | dim | hcenter,
+    }) | size(WIDTH, EQUAL, 20) | border;
+
+    // Top-right: metrics row
+    auto metric = [](std::string label, float value, Color c) {
+        return vbox({
+            text(label) | bold | hcenter,
+            gauge(value) | color(c),
+        }) | flex | border;
+    };
+
+    auto metrics = hbox({
+        metric("CPU", 0.73, Color::Green),
+        metric("RAM", 0.58, Color::Yellow),
+        metric("Disk", 0.91, Color::Red),
+    });
+
+    // Bottom-right: log area
+    auto logs = vbox({
+        text("Recent Logs") | bold,
+        separator(),
+        text("[12:01] Service started"),
+        text("[12:03] Connection established"),
+        text("[12:05] Processing 1,247 records"),
+        text("[12:06] Checkpoint saved"),
+        filler(),
+    }) | flex | border;
+
+    // Compose: sidebar | (metrics / logs)
+    auto document = hbox({
+        sidebar,
+        vbox({
+            metrics,
+            logs,
+        }) | flex,
+    });
+
+    auto screen = Screen::Create(Dimension::Full());
+    Render(screen, document);
+    screen.Print();
+}
+```
+
+This produces a layout like:
+
+```
++--------------------+-------------------+------------------+------------------+
+|    Navigation      |       CPU         |       RAM        |       Disk       |
+|--------------------| ########===       | ######===        | ################ |
+| > Dashboard        +-------------------+------------------+------------------+
+|   Settings         | Recent Logs                                             |
+|   Logs             |--------------------------------------------------------|
+|                    | [12:01] Service started                                |
+|                    | [12:03] Connection established                         |
+|                    | [12:05] Processing 1,247 records                       |
+|                    | [12:06] Checkpoint saved                               |
+|       v2.1.0       |                                                        |
++--------------------+--------------------------------------------------------+
+```
+
+The key points: `flex` makes the right panel grow to fill remaining space. `size(WIDTH,
+EQUAL, 20)` fixes the sidebar width. `hbox` and `vbox` nest freely. `border` wraps any
+Element. The entire layout is a single expression -- a tree of function calls.
+
+---
+
+## Widget / Component System
+
+### Elements (Dom Layer)
+
+Elements are the pure, functional building blocks. Every element is created by a function
+call that returns `Element` (`std::shared_ptr<Node>`).
+
+**Text and Content:**
+
+| Function                                  | Description                            |
+| ----------------------------------------- | -------------------------------------- |
+| `text(str)`                               | Single-line text                       |
+| `vtext(str)`                              | Vertical text (one character per line) |
+| `paragraph(str)`                          | Word-wrapping paragraph                |
+| `paragraphAlignLeft/Center/Right/Justify` | Aligned paragraphs                     |
+
+**Layout:**
+
+| Function                                | Description                  |
+| --------------------------------------- | ---------------------------- |
+| `hbox({...})`                           | Horizontal composition       |
+| `vbox({...})`                           | Vertical composition         |
+| `dbox({...})`                           | Depth composition (stacking) |
+| <code v-pre>gridbox({{...},...})</code> | 2D grid layout               |
+| `flexbox({...}, config)`                | CSS Flexbox layout           |
+
+**Decorators (visual):**
+
+| Function                 | Description                    |
+| ------------------------ | ------------------------------ |
+| `bold(elem)`             | Bold text                      |
+| `dim(elem)`              | Dimmed/faint text              |
+| `italic(elem)`           | Italic text                    |
+| `underlined(elem)`       | Underlined text                |
+| `underlinedDouble(elem)` | Double underline               |
+| `strikethrough(elem)`    | Strikethrough text             |
+| `blink(elem)`            | Blinking text                  |
+| `inverted(elem)`         | Inverted foreground/background |
+| `hyperlink(url, elem)`   | OSC 8 hyperlink                |
+
+**Color:**
+
+| Function                        | Description         |
+| ------------------------------- | ------------------- |
+| `color(Color, elem)`            | Foreground color    |
+| `bgcolor(Color, elem)`          | Background color    |
+| `color(LinearGradient, elem)`   | Gradient foreground |
+| `bgcolor(LinearGradient, elem)` | Gradient background |
+
+**Borders and Separators:**
+
+| Function                                                      | Description                               |
+| ------------------------------------------------------------- | ----------------------------------------- |
+| `border(elem)`                                                | Default border (light)                    |
+| `borderLight(elem)`                                           | Light border style                        |
+| `borderDashed(elem)`                                          | Dashed border style                       |
+| `borderHeavy(elem)`                                           | Heavy/thick border style                  |
+| `borderDouble(elem)`                                          | Double-line border style                  |
+| `borderRounded(elem)`                                         | Rounded corner border style               |
+| `borderEmpty(elem)`                                           | Empty border (padding only)               |
+| `separator()`                                                 | Horizontal/vertical line between siblings |
+| `separatorLight()` / `separatorHeavy()` / `separatorDouble()` | Styled separators                         |
+| `window(title, elem)`                                         | Bordered element with a title             |
+
+**Progress and Data Visualization:**
+
+| Function               | Description                              |
+| ---------------------- | ---------------------------------------- |
+| `gauge(float)`         | Horizontal progress bar (0.0 - 1.0)      |
+| `gaugeUp(float)`       | Vertical gauge (bottom to top)           |
+| `gaugeDown(float)`     | Vertical gauge (top to bottom)           |
+| `gaugeRight(float)`    | Horizontal gauge (left to right)         |
+| `gaugeLeft(float)`     | Horizontal gauge (right to left)         |
+| `spinner(int, size_t)` | Animated spinner (22 built-in styles)    |
+| `graph(GraphFunction)` | Line graph from a function               |
+| `canvas(lambda)`       | Freeform canvas with braille/block chars |
+
+**Scroll and Frame:**
+
+| Function                        | Description                        |
+| ------------------------------- | ---------------------------------- |
+| `frame(elem)`                   | Scrollable frame                   |
+| `xframe(elem)` / `yframe(elem)` | Directional scrollable frame       |
+| `focus(elem)`                   | Frame that focuses on this element |
+| `select(elem)`                  | Frame that selects this element    |
+| `vscroll_indicator`             | Vertical scroll indicator          |
+| `hscroll_indicator`             | Horizontal scroll indicator        |
+
+**Sizing and Flex:**
+
+| Function                        | Description                    |
+| ------------------------------- | ------------------------------ |
+| `flex(elem)`                    | Grow and shrink to fill        |
+| `flex_grow(elem)`               | Grow to fill, do not shrink    |
+| `flex_shrink(elem)`             | Shrink if needed, do not grow  |
+| `xflex(elem)` / `yflex(elem)`   | Directional flex               |
+| `size(axis, constraint, value)` | Explicit size constraint       |
+| `filler()`                      | Empty element that fills space |
+
+### Composability: Elements as Function Calls
+
+The critical design pattern is that **every element is a function call**, and elements
+compose by nesting function calls:
+
+```cpp
+// Nesting: the return value of one function is an argument to another
+auto ui = border(
+    vbox({
+        hbox({
+            text("Name:") | bold,
+            separator(),
+            text("Arthur") | color(Color::Cyan),
+        }),
+        separator(),
+        hbox({
+            text("Status:") | bold,
+            separator(),
+            gauge(0.85) | flex | color(Color::Green),
+        }),
+    })
+);
+```
+
+Or equivalently, using the **pipe operator** `|` for decorators:
+
+```cpp
+auto ui = vbox({
+    hbox({
+        text("Name:") | bold,
+        separator(),
+        text("Arthur") | color(Color::Cyan),
+    }),
+    separator(),
+    hbox({
+        text("Status:") | bold,
+        separator(),
+        gauge(0.85) | flex | color(Color::Green),
+    }),
+}) | border;
+```
+
+The pipe operator is defined as:
+
+```cpp
+Element operator|(Element element, Decorator decorator) {
+    return decorator(std::move(element));
+}
+```
+
+This means `elem | bold` is exactly `bold(elem)`, and decorators chain left-to-right:
+`text("hi") | bold | color(Color::Red)` reads as "text, then bold, then red".
+
+### Components (Interactive Layer)
+
+Components are created via factory functions that return `Component`
+(`std::shared_ptr<ComponentBase>`):
+
+| Factory Function                        | Description                        |
+| --------------------------------------- | ---------------------------------- |
+| `Button(label, callback)`               | Clickable button with callback     |
+| `Checkbox(label, &bool)`                | Toggle with label, bound to a bool |
+| `Radiobox(entries, &selected)`          | Single selection from a list       |
+| `Input(&str, placeholder)`              | Text input field                   |
+| `Menu(entries, &selected)`              | Navigable menu                     |
+| `Dropdown(config)`                      | Collapsible dropdown selector      |
+| `Toggle(entries, &selected)`            | Horizontal toggle switch           |
+| `Slider(label, &value, min, max, step)` | Numeric slider                     |
+
+**Container components** group children and manage focus:
+
+```cpp
+auto container = Container::Vertical({
+    input_name,
+    input_email,
+    button_submit,
+});
+
+auto container = Container::Horizontal({
+    menu,
+    content_panel,
+});
+
+auto container = Container::Tab({
+    tab1_content,
+    tab2_content,
+    tab3_content,
+}, &selected_tab);
+```
+
+**Decorator components** add behavior to existing components:
+
+| Decorator                                | Description                                       |
+| ---------------------------------------- | ------------------------------------------------- |
+| `Renderer(component, fn)`                | Overrides the Render() of a component             |
+| `Renderer(fn)`                           | Creates a non-interactive component from a lambda |
+| `CatchEvent(component, fn)`              | Intercepts events before the component sees them  |
+| `Maybe(component, &bool)`                | Conditionally shows/hides a component             |
+| `Modal(main, modal, &show)`              | Overlay modal dialog                              |
+| `Hoverable(component, &hovered)`         | Tracks mouse hover state                          |
+| `Collapsible(label, content)`            | Expandable/collapsible section                    |
+| `ResizableSplitLeft(left, right, &size)` | Draggable split pane                              |
+
+### Custom Components
+
+For complex interactive elements, subclass `ComponentBase`:
+
+```cpp
+class MyComponent : public ComponentBase {
+public:
+    MyComponent(std::string& name, int& counter)
+        : name_(name), counter_(counter) {}
+
+    Element OnRender() override {
+        return vbox({
+            text("Name: " + name_) | bold,
+            text("Count: " + std::to_string(counter_)),
+            gauge(counter_ / 100.0f) | color(Color::Cyan),
+        }) | border;
+    }
+
+    bool OnEvent(Event event) override {
+        if (event == Event::Character('+')) {
+            counter_++;
+            return true;
+        }
+        if (event == Event::Character('-')) {
+            counter_--;
+            return true;
+        }
+        return false;
+    }
+
+private:
+    std::string& name_;
+    int& counter_;
+};
+
+// Usage:
+auto component = Make<MyComponent>(name, counter);
+```
+
+For simpler cases, `Renderer` avoids the need for a subclass:
+
+```cpp
+auto component = Renderer([&] {
+    return vbox({
+        text("Hello " + name) | bold,
+        separator(),
+        gauge(progress) | color(Color::Green),
+    }) | border;
+});
+```
+
+---
+
+## Styling
+
+### Decorator-Based Styling
+
+Styling in FTXUI is applied through decorators -- functions that wrap an Element with
+visual attributes. Decorators can be applied in two equivalent ways:
+
+```cpp
+// Function call syntax
+bold(color(Color::Blue, text("hello")))
+
+// Pipe operator syntax (preferred -- reads left to right)
+text("hello") | color(Color::Blue) | bold
+```
+
+Both produce the same Element tree. The pipe operator version is idiomatic FTXUI.
+
+### Color Application
+
+```cpp
+// Foreground color
+text("error") | color(Color::Red)
+
+// Background color
+text("highlight") | bgcolor(Color::Yellow)
+
+// TrueColor RGB
+text("custom") | color(Color(135, 206, 235))  // sky blue
+text("custom") | color(Color::RGB(135, 206, 235))
+
+// HSV color
+text("hue") | color(Color::HSV(180, 255, 255))  // cyan via HSV
+
+// Palette256
+text("extended") | color(Color(Color::Palette256(208)))  // orange
+```
+
+### Linear Gradients
+
+Gradients can be applied to both foreground and background:
+
+```cpp
+// Simple two-color gradient
+text("gradient") | color(LinearGradient(Color::Red, Color::Blue))
+
+// Angled gradient with multiple stops
+auto gradient = LinearGradient()
+    .Angle(45)
+    .Stop(Color::Red, 0.0)
+    .Stop(Color::Yellow, 0.5)
+    .Stop(Color::Green, 1.0);
+
+text("rainbow") | color(gradient)
+text("bg-grad") | bgcolor(LinearGradient(Color::Blue, Color::Cyan))
+```
+
+### Combining Decorators
+
+Decorators compose freely via the pipe operator:
+
+```cpp
+auto styled = text("Important!")
+    | bold
+    | underlined
+    | color(Color::Red)
+    | bgcolor(Color::GrayDark)
+    | border;
+```
+
+The order matters for nesting: `border` wraps the colored text, not the other way around.
+Colors and attributes are applied to the innermost element and propagate to its content.
+
+### Border Styles
+
+```cpp
+auto content = text("content");
+
+content | border            // Light (default)
+content | borderLight       // Thin lines
+content | borderDashed      // Dashed lines
+content | borderHeavy       // Thick lines
+content | borderDouble      // Double lines
+content | borderRounded     // Rounded corners
+content | borderEmpty       // Padding only, no visible border
+```
+
+---
+
+## Event Handling
+
+### Event Types
+
+The `Event` struct represents terminal input. Events are created via static factory
+methods:
+
+```cpp
+// Character events
+Event::Character('a')
+Event::Character("a")
+
+// Special keys
+Event::ArrowUp, Event::ArrowDown, Event::ArrowLeft, Event::ArrowRight
+Event::Return, Event::Escape, Event::Tab, Event::TabReverse
+Event::Backspace, Event::Delete, Event::Insert
+Event::Home, Event::End, Event::PageUp, Event::PageDown
+Event::F1 ... Event::F12
+
+// Modifiers: Ctrl, Alt, CtrlAlt variants for each letter
+Event::CtrlA, Event::AltA, Event::CtrlAltA
+Event::CtrlC, Event::CtrlZ  // (can be intercepted)
+
+// Mouse events
+Event::Mouse(...)  // with button, motion type, coordinates
+```
+
+Event introspection:
+
+```cpp
+event.is_character()    // printable character input
+event.is_mouse()        // mouse event
+event.character()       // returns the UTF-8 character string
+event.mouse()           // returns mouse data (button, motion, x, y)
+```
+
+### Handling Events in Components
+
+The `OnEvent(Event)` method returns `true` if the event was consumed:
+
+```cpp
+class MyWidget : public ComponentBase {
+    bool OnEvent(Event event) override {
+        if (event == Event::Character('q')) {
+            // Handle 'q' key
+            return true;  // consumed
+        }
+        if (event.is_mouse()) {
+            auto& mouse = event.mouse();
+            if (mouse.button == Mouse::Left &&
+                mouse.motion == Mouse::Pressed) {
+                // Handle click at (mouse.x, mouse.y)
+                return true;
+            }
+        }
+        // Pass to children
+        return ComponentBase::OnEvent(event);
+    }
+};
+```
+
+### CatchEvent Decorator
+
+`CatchEvent` intercepts events before they reach a component:
+
+```cpp
+auto input = Input(&text, "placeholder");
+
+// Filter: only allow digits
+input |= CatchEvent([](Event event) {
+    return event.is_character() && !std::isdigit(event.character()[0]);
+});
+
+// Intercept Enter key
+auto component = CatchEvent(inner_component, [&](Event event) {
+    if (event == Event::Return) {
+        submit();
+        return true;
+    }
+    return false;
+});
+```
+
+### Event Propagation
+
+Events propagate through the component tree:
+
+1. The root component receives the event.
+2. If the root has an active child (focus), the event is forwarded to it.
+3. The active child may forward to its own active child (recursive).
+4. The deepest focused component handles the event first.
+5. If it returns `false` (not consumed), the event bubbles back up.
+
+This is similar to DOM event bubbling in web browsers.
+
+---
+
+## State Management
+
+FTXUI does not impose a state management framework. State is managed by the application
+through three common patterns:
+
+### Pattern 1: Lambda Capture (Most Common)
+
+State lives in `main()` (or any enclosing scope) and is captured by reference in
+component factory calls and lambdas:
+
+```cpp
+int main() {
+    // State
+    std::string name;
+    std::string password;
+    int counter = 0;
+    bool show_modal = false;
+
+    // Components capture state by reference
+    auto input_name = Input(&name, "Enter name");
+    auto input_pass = Input(&password, "password");
+    auto btn = Button("Increment", [&] { counter++; });
+
+    auto renderer = Renderer(
+        Container::Vertical({input_name, input_pass, btn}),
+        [&] {
+            return vbox({
+                text("Name: " + name),
+                text("Count: " + std::to_string(counter)),
+                separator(),
+                input_name->Render(),
+                input_pass->Render(),
+                btn->Render(),
+            }) | border;
+        }
+    );
+
+    auto screen = ScreenInteractive::FitComponent();
+    screen.Loop(renderer);
+}
+```
+
+This pattern works because `ScreenInteractive::Loop()` blocks, so the captured references
+remain valid for the lifetime of the event loop.
+
+### Pattern 2: ComponentBase Subclass
+
+State lives as member variables of a custom `ComponentBase` subclass:
+
+```cpp
+class FormComponent : public ComponentBase {
+    std::string name_;
+    std::string email_;
+    bool submitted_ = false;
+
+    Component input_name_ = Input(&name_, "name");
+    Component input_email_ = Input(&email_, "email");
+    Component submit_ = Button("Submit", [this] { submitted_ = true; });
+
+public:
+    FormComponent() {
+        Add(Container::Vertical({input_name_, input_email_, submit_}));
+    }
+
+    Element OnRender() override {
+        if (submitted_) {
+            return text("Submitted: " + name_ + " <" + email_ + ">") | border;
+        }
+        return vbox({
+            text("Registration") | bold | hcenter,
+            separator(),
+            input_name_->Render(),
+            input_email_->Render(),
+            submit_->Render(),
+        }) | border;
+    }
+};
+```
+
+### Pattern 3: External State Struct
+
+For larger applications, a state struct is defined separately and references are threaded
+through:
+
+```cpp
+struct AppState {
+    std::string search_query;
+    std::vector<std::string> results;
+    int selected_result = 0;
+    bool loading = false;
+};
+
+Component BuildUI(AppState& state) {
+    auto search = Input(&state.search_query, "Search...");
+    auto results = Menu(&state.results, &state.selected_result);
+    // ... compose components referencing state ...
+}
+```
+
+In all patterns, the key insight is that FTXUI Components are essentially closures over
+mutable state. The `Render()` method reads the current state each frame, producing a new
+Element tree. Event handlers mutate the state, triggering a visual update on the next
+frame.
+
+---
+
+## Extensibility and Ecosystem
+
+### Self-Contained
+
+FTXUI has **no external dependencies** beyond the C++ standard library. This is a
+deliberate design choice: the library compiles with any C++17-compliant compiler without
+pulling in ncurses, terminfo, or any other system library.
+
+### Integration
+
+- **CMake FetchContent** -- The recommended integration method. Add FTXUI as a dependency
+  in three lines of CMake.
+- **vcpkg** -- `vcpkg install ftxui`.
+- **Conan** -- Available in Conan Center.
+- **Bazel** -- Supported via MODULE.bazel.
+- **System packages** -- Available in Debian, Ubuntu, Arch Linux (AUR), openSUSE, Nix.
+- **Header-only friendly** -- While not strictly header-only, the library is small enough
+  to compile quickly as part of a project.
+- **C++20 modules** -- Supported for compilers that implement C++ modules.
+
+### WebAssembly
+
+FTXUI compiles to WebAssembly via Emscripten, rendering to an HTML `<pre>` element in the
+browser. This enables interactive online demos where users can try components without
+installing anything. The FTXUI documentation site features live WebAssembly examples for
+most components.
+
+### Community
+
+FTXUI powers 50+ known projects including games (2048, Minesweeper), system monitors
+(htop-style dashboards), git TUIs, and various interactive CLI tools. The library itself
+is comprehensive enough that third-party extension libraries are rare -- most needs are
+met by composing the built-in elements and components.
+
+---
+
+## Strengths
+
+- **DOM-like composability via function composition.** UI is built by nesting function
+  calls: `border(vbox({text("a"), separator(), text("b")}))`. This is declarative,
+  readable, and maps directly to the visual hierarchy.
+
+- **Pipe operator for decorator chaining.** `text("hi") | bold | color(Color::Red) | border`
+  reads naturally left-to-right, avoiding deep nesting for styled elements.
+
+- **Flexbox-inspired layout.** The `FlexboxConfig` brings CSS Flexbox semantics to the
+  terminal: direction, wrap, justify-content, align-items, gap. This is rare in TUI
+  libraries and enables responsive layouts.
+
+- **Clean dual dom/component architecture.** The pure functional dom layer can be used
+  independently for static rendering. The component layer adds only the necessary
+  statefulness for interactivity. Neither layer is aware of the other's internals.
+
+- **Zero dependencies.** No ncurses, no terminfo, no system libraries. Compiles with any
+  C++17 compiler on any platform.
+
+- **WebAssembly target.** Compiles to WASM via Emscripten for in-browser demos. This is
+  unique among TUI libraries and excellent for documentation.
+
+- **Good documentation with live demos.** The documentation site features interactive
+  WebAssembly examples for most components, allowing users to try before installing.
+
+- **Small binary size.** No heavy dependencies means compact output binaries.
+
+- **Rich built-in elements.** 22 spinner styles, braille canvas, gauges in all directions,
+  linear gradients, hyperlinks -- the standard library of elements is comprehensive.
+
+- **Mouse support.** Click, scroll, motion tracking, drag-to-resize split panes. Full
+  mouse integration without external event libraries.
+
+- **Unicode and fullwidth character support.** Correct handling of CJK characters, emoji,
+  and other multi-cell Unicode.
+
+---
+
+## Weaknesses and Limitations
+
+- **C++ complexity.** `shared_ptr` ownership, template error messages, and manual memory
+  management patterns (captured references must outlive the event loop) add cognitive
+  overhead compared to Rust (ownership) or Go (GC) alternatives.
+
+- **No built-in async/concurrency model.** `ScreenInteractive::Loop()` blocks the calling
+  thread. Background work requires manual threading with `Post()` to marshal updates back.
+  No built-in task/future/channel system.
+
+- **Limited text input features.** The `Input` component is basic compared to web-style
+  text fields. No built-in multi-line editor, syntax highlighting, or rich text editing.
+
+- **No built-in scrollable list virtualization.** Large lists are fully rendered in the
+  Element tree. There is no built-in row recycling or lazy rendering for thousand-item
+  lists.
+
+- **Documentation depth varies.** While the API reference exists, narrative documentation
+  (guides, tutorials, architecture explanations) is thinner than libraries like Ratatui
+  or Textual.
+
+- **No accessibility layer.** No screen reader support or semantic markup. Terminal
+  inherent limitation, but no effort toward bridging it.
+
+- **No built-in theming system.** Colors and styles are applied per-element. There is no
+  theme object or style-sheet abstraction for consistent application-wide styling.
+
+- **Windows support is secondary.** While functional, Windows is community-maintained
+  and may lag behind Linux/macOS in feature coverage.
+
+- **Single-threaded event loop.** The `ScreenInteractive` event loop is single-threaded.
+  CPU-intensive rendering blocks event processing.
+
+---
+
+## Lessons for D / Sparkles
+
+FTXUI's functional DOM architecture maps remarkably well to D's language features. Several
+of its core patterns can be adopted or improved upon in a D implementation.
+
+### Element Composition via Functions maps to D's UFCS + Templates
+
+FTXUI builds UIs by nesting function calls:
+
+```cpp
+// C++ FTXUI
+border(hbox({text("Name"), separator(), text("Arthur")}))
+```
+
+In D, UFCS (Uniform Function Call Syntax) makes this even more natural:
+
+```d
+// D with UFCS
+hbox(text("Name"), separator(), text("Arthur")).border
+```
+
+No special pipe operator is needed. UFCS gives D the same left-to-right readability that
+FTXUI achieves with `operator|`, but as a built-in language feature. A D TUI library
+could define `text`, `hbox`, `vbox`, `border` as free functions, and UFCS would provide
+the composition syntax for free.
+
+### Pipe Operator maps to UFCS Chaining
+
+FTXUI's most idiomatic pattern:
+
+```cpp
+// C++ FTXUI
+text("hello") | bold | color(Color::Blue) | border
+```
+
+In D, this is simply:
+
+```d
+// D with UFCS
+text("hello").bold.color(Color.blue).border
+```
+
+D's UFCS is strictly more powerful: it works with any free function, not just those that
+define `operator|`. And it works at compile time with no runtime overhead. A D TUI library
+gets FTXUI's compositional elegance without any operator overloading machinery.
+
+### Flexbox Layout maps to @nogc Structs with CTFE Validation
+
+FTXUI's `FlexboxConfig` is a plain struct with enums:
+
+```cpp
+FlexboxConfig config;
+config.direction = FlexboxConfig::Direction::Row;
+config.justify_content = FlexboxConfig::JustifyContent::Center;
+```
+
+D can do this with `@nogc` structs and use CTFE for compile-time validation:
+
+```d
+// D equivalent
+auto config = FlexboxConfig(
+    direction: Direction.row,
+    justifyContent: JustifyContent.center,
+    gap: Gap(x: 1, y: 0),
+);
+
+// Or with a builder using UFCS:
+auto config = flexboxConfig
+    .direction(Direction.row)
+    .justifyContent(JustifyContent.center)
+    .gap(1, 0);
+```
+
+The layout constraint solver (ComputeRequirement + SetBox) can be implemented as `@nogc
+pure nothrow` functions operating on stack-allocated node arrays, avoiding all heap
+allocation for the layout pass.
+
+### Dual Dom/Component Layers maps to @nogc Elements + DbI Components
+
+FTXUI's two-tier architecture translates directly:
+
+1. **Dom layer** -- Pure `@nogc nothrow` Element types. Elements are value types (D
+   structs) stored in a `SmallBuffer`-backed tree. Layout computation is a pure function
+   from Element tree to positioned boxes. No GC allocation, no exceptions, no state.
+
+2. **Component layer** -- Stateful components using Design by Introspection. A component
+   is any type that provides a `render()` method (returning an Element) and optionally
+   an `onEvent()` method. DbI detects available capabilities:
+
+   ```d
+   // D with DbI
+   auto component = struct {
+       string name;
+       int counter;
+
+       Element render() {
+           return vbox(
+               text("Name: " ~ name).bold,
+               separator(),
+               gauge(counter / 100.0).color(Color.green),
+           ).border;
+       }
+
+       bool onEvent(Event e) {
+           if (e == Event.character('+')) { counter++; return true; }
+           return false;
+       }
+   };
+   ```
+
+   The framework uses `__traits(hasMember, T, "onEvent")` to detect whether a component
+   handles events, falling back to a no-op if not. This is the Design by Introspection
+   pattern from the Sparkles guidelines.
+
+### Lambda-Captured State maps to D Delegates and Struct Components
+
+FTXUI's most common state pattern -- lambda capture in `main()` -- maps to D delegates:
+
+```d
+void main() {
+    string name;
+    int counter;
+
+    auto renderer = makeRenderer(() {
+        return vbox(
+            text("Name: " ~ name),
+            text("Count: ").bold,
+            gauge(counter / 100.0),
+        ).border;
+    });
+}
+```
+
+But D also enables struct-based components with UFCS, which FTXUI cannot express as
+cleanly due to C++'s lack of UFCS:
+
+```d
+struct Counter {
+    int value = 0;
+
+    Element render() {
+        return text(value.to!string)
+            .bold
+            .color(value > 0 ? Color.green : Color.red)
+            .border;
+    }
+}
+```
+
+### Element as Value Type maps to SmallBuffer-Backed Trees
+
+FTXUI uses `shared_ptr<Node>` for elements, which means heap allocation for every node.
+In D, elements could be value types stored in a `SmallBuffer`:
+
+```d
+// D: Element tree without GC allocation
+struct Element {
+    ElementKind kind;
+    Style style;
+    SmallBuffer!(Element*, 8) children;
+    // ... payload union for text, gauge value, etc.
+}
+```
+
+For small-to-medium UIs (the common case in CLI tools), the entire Element tree fits in
+a `SmallBuffer` with no heap allocation. This is a significant performance advantage
+over FTXUI's `shared_ptr`-per-node approach.
+
+### WebAssembly Target
+
+D compiles to WebAssembly via LDC, just as C++ compiles via Emscripten. FTXUI's
+architecture -- pure Element tree rendered to a pixel grid, then serialized to
+ANSI or HTML -- is inherently portable. A D TUI library following this architecture
+could target WASM with the same approach: render to a `Screen` abstraction, serialize
+to ANSI for terminals or HTML for browsers.
+
+### Key Takeaways
+
+| FTXUI Pattern              | D / Sparkles Equivalent                          |
+| -------------------------- | ------------------------------------------------ |
+| `Element` via `shared_ptr` | `Element` as `@nogc` struct in `SmallBuffer`     |
+| `operator\|` pipe          | UFCS (built-in, zero cost)                       |
+| `FlexboxConfig` struct     | Named-argument struct with CTFE validation       |
+| `ComponentBase` virtual    | DbI trait detection (`__traits(hasMember, ...)`) |
+| Lambda capture state       | D delegates / struct member state                |
+| `ComputeRequirement`       | `@nogc pure nothrow` layout pass                 |
+| `Screen` pixel grid        | `SmallBuffer!(Pixel, N)` grid                    |
+| WebAssembly via Emscripten | WebAssembly via LDC                              |
+
+---
+
+## References
+
+- **Repository**: <https://github.com/ArthurSonzogni/FTXUI>
+- **API Documentation**: <https://arthursonzogni.github.io/FTXUI/>
+- **DOM Elements Reference**: <https://arthursonzogni.github.io/FTXUI/group__dom.html>
+- **Component Reference**: <https://arthursonzogni.github.io/FTXUI/group__component.html>
+- **Screen Reference**: <https://arthursonzogni.github.io/FTXUI/group__screen.html>
+- **Examples Directory**: <https://github.com/ArthurSonzogni/FTXUI/tree/main/examples>
+- **FlexboxConfig Header**: <https://github.com/ArthurSonzogni/FTXUI/blob/main/include/ftxui/dom/flexbox_config.hpp>
+- **Online Interactive Demos**: <https://arthursonzogni.github.io/FTXUI/examples/>

--- a/docs/research/tui-libraries/imtui.md
+++ b/docs/research/tui-libraries/imtui.md
@@ -1,0 +1,1121 @@
+# ImTui (C++)
+
+A terminal backend for Dear ImGui that brings the entire immediate-mode GUI widget library to text-based terminals, mapping pixel draw commands to character cells via ncurses.
+
+| Field        | Value                                             |
+| ------------ | ------------------------------------------------- |
+| Language     | C++                                               |
+| License      | MIT                                               |
+| Repository   | <https://github.com/ggerganov/imtui>              |
+| Dear ImGui   | v1.81 (bundled)                                   |
+| GitHub Stars | ~3.5k                                             |
+| Dependencies | libncurses (terminal), Emscripten (web, optional) |
+
+---
+
+## Overview
+
+ImTui is a terminal rendering backend for Dear ImGui, the widely-used C++ immediate-mode
+GUI library. Rather than rendering to a GPU framebuffer as Dear ImGui normally does, ImTui
+intercepts ImGui's draw lists and converts them into character cells displayed in a text
+terminal via ncurses. The result is that the **entire Dear ImGui widget library** -- windows,
+buttons, sliders, text inputs, trees, tables, menus, popups, tabs, plots -- works
+unmodified in a terminal.
+
+**What it solves.** Building interactive terminal UIs typically requires a dedicated widget
+toolkit (ncurses panels, custom rendering logic, manual state management). ImTui sidesteps
+all of this by reusing Dear ImGui's battle-tested widget set. If you already know ImGui's
+API, you can build a terminal application with zero additional learning.
+
+**Design philosophy.** ImTui inherits Dear ImGui's **pure immediate-mode** paradigm. There
+are no widget objects. There is no retained tree. There are no callbacks. The UI is a
+function of your data, called every frame. A button is a single function call that returns
+`true` when clicked. A slider is a function call that modifies a float by pointer. The
+application owns all state; ImGui holds only transient interaction metadata (which widget
+is hovered, which is active, current input state).
+
+This represents one extreme of the TUI design space: where Textual (Python) is fully
+retained-mode with a persistent widget tree, CSS styling, and message passing, ImTui is
+fully immediate-mode with no widget lifecycle, no event routing, and no state
+synchronization -- just function calls that write to a buffer.
+
+**Author.** ImTui was created by Georgi Gerganov, also the creator of llama.cpp and
+whisper.cpp. The project demonstrates his interest in efficient, minimal C++ systems that
+do more with less.
+
+---
+
+## Architecture
+
+### Pure Immediate-Mode Rendering
+
+ImTui follows Dear ImGui's architecture exactly. The rendering pipeline each frame is:
+
+```
+Application State
+    |
+    v
+ImGui function calls (Button, Text, SliderFloat, ...)
+    |
+    v
+ImGui builds internal draw lists (vertices, indices, draw commands)
+    |
+    v
+ImTui_ImplText_RenderDrawData() converts draw lists to TScreen cells
+    |
+    v
+ImTui_ImplNcurses_DrawScreen() diffs against previous frame, writes to terminal
+    |
+    v
+Terminal emulator
+```
+
+There is no retained widget tree anywhere in this pipeline. Each frame, the application
+calls ImGui functions in sequence. ImGui accumulates geometry (triangles, text glyphs) into
+draw lists. ImTui's text backend rasterizes those triangles into a flat array of character
+cells. The ncurses backend diffs the current frame against the previous frame and writes
+only the changed cells to the terminal.
+
+### No Widget Objects
+
+In Dear ImGui / ImTui, there are no widget objects to construct, configure, store, or
+destroy. A button is:
+
+```cpp
+if (ImGui::Button("Click me")) {
+    // Handle click -- this block executes on the frame the button is pressed
+}
+```
+
+This single line:
+
+1. Lays out the button at the current cursor position
+2. Renders the button text and border into the draw list
+3. Checks if the mouse is over the button (hover state)
+4. Checks if the mouse button was pressed and released on it (active/click state)
+5. Returns `true` if the button was activated this frame
+
+The widget function IS the render code IS the event handling code. There is nothing to
+construct beforehand and nothing to clean up afterward.
+
+### The Hot/Active Widget Model
+
+Instead of a focus tree or event propagation system, Dear ImGui uses a simple two-state
+model for widget interaction:
+
+- **Hot** -- the mouse cursor is currently over this widget. Determines hover highlights.
+- **Active** -- the user is currently interacting with this widget (mouse button is held
+  down on it). Only one widget can be active at a time.
+
+Widget identity is determined by an **ID stack** built from string labels, integer indices,
+and pointer values. When you call `ImGui::Button("OK")`, ImGui hashes the string `"OK"`
+combined with the current window's ID to produce a unique identifier. This ID is used to
+track hot/active state across frames without storing any widget objects.
+
+### Double-Buffered Terminal Output
+
+ImTui's ncurses backend maintains a `screenPrev` buffer that records the previous frame's
+cells. During `ImTui_ImplNcurses_DrawScreen()`, it compares current and previous frames
+row-by-row and character-by-character, emitting ncurses calls only for changed cells. This
+minimizes terminal I/O and reduces flicker.
+
+### Cell Data Format
+
+Each terminal cell is packed into a 32-bit `TCell` value:
+
+```
+Bits  0-15:  character code (ASCII/Unicode codepoint)
+Bits 16-23:  foreground color index (ANSI 256-color palette)
+Bits 24-31:  background color index (ANSI 256-color palette)
+```
+
+This compact representation enables efficient diffing and bulk memory operations.
+
+---
+
+## Terminal Backend
+
+ImTui provides multiple backend implementations that bridge Dear ImGui's rendering to
+different output targets.
+
+### ImTui_ImplNcurses (Terminal)
+
+The primary backend for native terminal applications.
+
+```cpp
+// Initialization
+ImTui::TScreen* screen = ImTui_ImplNcurses_Init(
+    true,   // mouseSupport
+    60.0f,  // fps_active  -- redraw rate when application is active
+    -1.0f   // fps_idle    -- redraw rate when idle (-1 = same as active)
+);
+
+// Per-frame
+bool hadInput = ImTui_ImplNcurses_NewFrame();  // returns true if user input occurred
+// ... ImGui calls ...
+ImTui_ImplNcurses_DrawScreen(hadInput);  // uses active or idle FPS based on input
+
+// Shutdown
+ImTui_ImplNcurses_Shutdown();
+```
+
+The ncurses backend handles:
+
+- **Terminal initialization:** `initscr()`, `cbreak()`, `noecho()`, `curs_set(0)` for raw
+  mode with hidden cursor.
+- **Color pairs:** Dynamically allocates ncurses color pairs from a 256x256 foreground/
+  background lookup table via `init_pair()`.
+- **Mouse support:** Enables terminal mouse reporting, decodes button press/release and
+  scroll events via `getmouse()`, and feeds coordinates into `ImGui::GetIO().MousePos`.
+- **Keyboard input:** Maps ncurses key codes to ImGui key indices. Handles arrow keys,
+  function keys, and synthesizes modifier states (Ctrl+A/C/V/X/Y/Z).
+- **VSync / frame pacing:** A `VSync` class manages active and idle frame rates using
+  `std::this_thread::sleep_for()`, with input-aware wake-up to maintain responsiveness.
+
+### ImTui_ImplText (Core Rasterizer)
+
+The text backend is the core of ImTui. It converts Dear ImGui's vector draw data (triangles
+from the draw list) into character cells on a `TScreen`.
+
+```cpp
+ImTui_ImplText_Init();                                        // configure ImGui style for terminal
+ImTui_ImplText_NewFrame();                                    // prepare for new frame
+// ... ImGui calls, then ImGui::Render() ...
+ImTui_ImplText_RenderDrawData(ImGui::GetDrawData(), screen);  // rasterize to cells
+```
+
+The rasterizer:
+
+- **Triangle rasterization:** Implements scanline fill for each triangle in the draw list,
+  computing horizontal spans per row and filling cells within clipped bounds.
+- **Glyph rendering:** For text characters (detected by varying UV coordinates across
+  triangle vertices), computes the centroid of the glyph's two triangles, snaps to integer
+  cell coordinates, and writes the character with its color.
+- **Color conversion:** The `rgbToAnsi256()` function maps ImGui's 32-bit RGBA colors to
+  the ANSI 256-color palette -- detecting grayscale values for the 232-255 range and
+  converting RGB to the 6x6x6 color cube (indices 16-231).
+- **Style configuration:** On init, configures ImGui for terminal constraints: disables
+  anti-aliasing, sets minimal padding/spacing, and uses a 1.0-pixel monospace-compatible
+  font size.
+
+### ImTui_ImplEmscripten (WebAssembly)
+
+An Emscripten backend that compiles ImTui to WebAssembly and renders to an HTML page. The
+browser displays a grid of styled `<span>` elements mimicking a terminal. Input is bridged
+from JavaScript to C++ via `EMSCRIPTEN_KEEPALIVE` exported functions:
+
+- `set_mouse_pos()`, `set_mouse_down()`, `set_mouse_up()`, `set_mouse_wheel()`
+- `set_key_down()`, `set_key_up()`, `set_key_press()`
+- Modifier key tracking for Shift, Ctrl, Alt
+
+This enables live web demos of ImTui applications (e.g., the hnterm Hacker News client runs
+at hnterm.ggerganov.com).
+
+### Capabilities Summary
+
+| Capability    | Support                                                   |
+| ------------- | --------------------------------------------------------- |
+| Colors        | ANSI 256-color palette (mapped from ImGui's true color)   |
+| Mouse         | Click, release, scroll (via ncurses mouse reporting)      |
+| Keyboard      | Full key input with modifier detection                    |
+| Unicode       | Basic (single-codepoint characters, no grapheme clusters) |
+| Box drawing   | Not native -- uses ASCII approximations from ImGui        |
+| True color    | No (quantized to 256-color)                               |
+| Web rendering | Yes (via Emscripten/WebAssembly)                          |
+
+---
+
+## Layout System
+
+ImTui inherits Dear ImGui's **cursor-based procedural layout**. There is no constraint
+solver, no flexbox, no grid system. Layout is purely sequential: ImGui maintains a cursor
+position within each window, and each widget advances the cursor.
+
+### Cursor Model
+
+By default, each widget occupies a full row and advances the cursor downward. The
+application controls layout with explicit commands:
+
+```cpp
+// Vertical stacking (default)
+ImGui::Text("Line 1");       // cursor moves down
+ImGui::Text("Line 2");       // cursor moves down again
+
+// Horizontal placement
+ImGui::Text("Left");
+ImGui::SameLine();            // next widget goes on the same line
+ImGui::Text("Right");
+
+// Explicit width
+ImGui::SetNextItemWidth(200); // next input/slider will be 200 pixels wide
+ImGui::SliderFloat("##val", &value, 0.0f, 1.0f);
+
+// Indentation
+ImGui::Indent(16.0f);
+ImGui::Text("Indented text");
+ImGui::Unindent(16.0f);
+```
+
+### Child Regions
+
+Scrollable sub-regions are created with `BeginChild` / `EndChild`:
+
+```cpp
+ImGui::BeginChild("scrolling_region", ImVec2(0, 200), true);
+for (int i = 0; i < 100; i++)
+    ImGui::Text("Item %d", i);
+ImGui::EndChild();
+```
+
+The child region clips its content and provides independent scrolling.
+
+### Columns and Tables
+
+Multi-column layouts use the table API:
+
+```cpp
+if (ImGui::BeginTable("my_table", 3)) {
+    ImGui::TableSetupColumn("Name");
+    ImGui::TableSetupColumn("Value");
+    ImGui::TableSetupColumn("Action");
+    ImGui::TableHeadersRow();
+
+    for (auto& item : items) {
+        ImGui::TableNextRow();
+        ImGui::TableNextColumn(); ImGui::Text("%s", item.name);
+        ImGui::TableNextColumn(); ImGui::Text("%d", item.value);
+        ImGui::TableNextColumn();
+        if (ImGui::SmallButton("Delete"))
+            deleteItem(item);
+    }
+    ImGui::EndTable();
+}
+```
+
+### Layout Example: Dashboard
+
+```cpp
+// Main window fills the terminal
+ImGui::SetNextWindowPos(ImVec2(0, 0));
+ImGui::SetNextWindowSize(ImGui::GetIO().DisplaySize);
+ImGui::Begin("Dashboard", nullptr,
+    ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+    ImGuiWindowFlags_NoCollapse);
+
+ImGui::Text("System Monitor");
+ImGui::Separator();
+
+// Left panel (using child region for fixed width)
+ImGui::BeginChild("left_panel", ImVec2(30, 0), true);
+ImGui::Text("Navigation");
+if (ImGui::Selectable("Overview", selected == 0)) selected = 0;
+if (ImGui::Selectable("Processes", selected == 1)) selected = 1;
+if (ImGui::Selectable("Network", selected == 2)) selected = 2;
+ImGui::EndChild();
+
+ImGui::SameLine();
+
+// Right panel (fills remaining space)
+ImGui::BeginChild("right_panel", ImVec2(0, 0), true);
+ImGui::Text("Detail view for: %s", panels[selected]);
+// ... render selected panel content ...
+ImGui::EndChild();
+
+ImGui::End();
+```
+
+### Limitations
+
+The cursor-based layout is procedural and sequential. There is no way to express "this
+widget should fill the remaining space" as a declarative constraint. Complex layouts require
+manual size calculations or creative use of child regions. ImGui's layout was designed for
+GPU-rendered tool windows where pixel precision is available; in a terminal, the
+character-cell grid adds further constraints that ImGui is unaware of.
+
+---
+
+## Widget / Component System
+
+ImTui provides access to the **full Dear ImGui widget set**. Every widget that works in
+ImGui's OpenGL/Vulkan/DirectX backends works in the terminal (though visual fidelity varies
+due to character-cell rendering).
+
+### Windows
+
+```cpp
+ImGui::Begin("My Window");    // creates a movable, resizable window
+// ... widgets ...
+ImGui::End();
+
+// Window with flags
+ImGui::Begin("Fixed", nullptr,
+    ImGuiWindowFlags_NoResize |
+    ImGuiWindowFlags_NoMove |
+    ImGuiWindowFlags_NoTitleBar);
+```
+
+### Text Display
+
+```cpp
+ImGui::Text("Plain text");
+ImGui::TextColored(ImVec4(1,0,0,1), "Red text");
+ImGui::TextWrapped("This text will wrap at the window edge...");
+ImGui::TextDisabled("Grayed out");
+ImGui::BulletText("Bulleted item");
+ImGui::LabelText("Label", "Value: %d", 42);
+```
+
+### Buttons and Toggles
+
+```cpp
+if (ImGui::Button("Click Me"))           doSomething();
+if (ImGui::SmallButton("x"))             closePanel();
+if (ImGui::ArrowButton("##left", ImGuiDir_Left)) goBack();
+ImGui::Checkbox("Enable feature", &enabled);
+ImGui::RadioButton("Option A", &choice, 0);
+ImGui::RadioButton("Option B", &choice, 1);
+```
+
+### Input Widgets
+
+```cpp
+static char name[128] = "";
+ImGui::InputText("Name", name, sizeof(name));
+
+static char bio[1024] = "";
+ImGui::InputTextMultiline("Bio", bio, sizeof(bio), ImVec2(0, 100));
+
+static int count = 0;
+ImGui::InputInt("Count", &count);
+
+static float temp = 98.6f;
+ImGui::InputFloat("Temp", &temp, 0.1f, 1.0f, "%.1f");
+```
+
+### Sliders and Drags
+
+```cpp
+static float volume = 0.5f;
+ImGui::SliderFloat("Volume", &volume, 0.0f, 1.0f);
+
+static int brightness = 50;
+ImGui::SliderInt("Brightness", &brightness, 0, 100);
+
+static float speed = 1.0f;
+ImGui::DragFloat("Speed", &speed, 0.01f, 0.0f, 10.0f);
+```
+
+### Selection Widgets
+
+```cpp
+// Combo box (dropdown)
+static int current = 0;
+const char* items[] = { "Apple", "Banana", "Cherry" };
+ImGui::Combo("Fruit", &current, items, IM_ARRAYSIZE(items));
+
+// List box
+static int listIdx = 0;
+ImGui::ListBox("Items", &listIdx, items, IM_ARRAYSIZE(items), 4);
+
+// Selectable items (for custom lists)
+for (int i = 0; i < itemCount; i++) {
+    if (ImGui::Selectable(items[i], selected == i))
+        selected = i;
+}
+```
+
+### Trees and Collapsing Headers
+
+```cpp
+if (ImGui::CollapsingHeader("Settings")) {
+    ImGui::Checkbox("Auto-save", &autoSave);
+    ImGui::SliderInt("Interval", &interval, 1, 60);
+}
+
+if (ImGui::TreeNode("File System")) {
+    if (ImGui::TreeNode("Documents")) {
+        ImGui::Text("report.pdf");
+        ImGui::Text("notes.txt");
+        ImGui::TreePop();
+    }
+    ImGui::TreePop();
+}
+```
+
+### Tables
+
+```cpp
+if (ImGui::BeginTable("processes", 4,
+        ImGuiTableFlags_Sortable | ImGuiTableFlags_Borders)) {
+    ImGui::TableSetupColumn("PID");
+    ImGui::TableSetupColumn("Name");
+    ImGui::TableSetupColumn("CPU %");
+    ImGui::TableSetupColumn("Memory");
+    ImGui::TableHeadersRow();
+
+    for (auto& proc : processes) {
+        ImGui::TableNextRow();
+        ImGui::TableNextColumn(); ImGui::Text("%d", proc.pid);
+        ImGui::TableNextColumn(); ImGui::Text("%s", proc.name);
+        ImGui::TableNextColumn(); ImGui::Text("%.1f%%", proc.cpu);
+        ImGui::TableNextColumn(); ImGui::Text("%s", proc.memory);
+    }
+    ImGui::EndTable();
+}
+```
+
+### Menus
+
+```cpp
+if (ImGui::BeginMainMenuBar()) {
+    if (ImGui::BeginMenu("File")) {
+        if (ImGui::MenuItem("Open", "Ctrl+O"))  openFile();
+        if (ImGui::MenuItem("Save", "Ctrl+S"))  saveFile();
+        ImGui::Separator();
+        if (ImGui::MenuItem("Quit", "Ctrl+Q"))  quit = true;
+        ImGui::EndMenu();
+    }
+    if (ImGui::BeginMenu("Edit")) {
+        if (ImGui::MenuItem("Undo", "Ctrl+Z"))  undo();
+        if (ImGui::MenuItem("Redo", "Ctrl+Y"))  redo();
+        ImGui::EndMenu();
+    }
+    ImGui::EndMainMenuBar();
+}
+```
+
+### Popups and Modals
+
+```cpp
+if (ImGui::Button("Delete"))
+    ImGui::OpenPopup("Confirm Delete");
+
+if (ImGui::BeginPopupModal("Confirm Delete", nullptr,
+        ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::Text("Are you sure you want to delete this item?");
+    ImGui::Separator();
+    if (ImGui::Button("Yes", ImVec2(120, 0))) {
+        deleteItem();
+        ImGui::CloseCurrentPopup();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel", ImVec2(120, 0)))
+        ImGui::CloseCurrentPopup();
+    ImGui::EndPopup();
+}
+```
+
+### Tabs
+
+```cpp
+if (ImGui::BeginTabBar("MyTabs")) {
+    if (ImGui::BeginTabItem("General")) {
+        ImGui::Text("General settings here");
+        ImGui::EndTabItem();
+    }
+    if (ImGui::BeginTabItem("Advanced")) {
+        ImGui::Text("Advanced settings here");
+        ImGui::EndTabItem();
+    }
+    ImGui::EndTabBar();
+}
+```
+
+### Plots
+
+```cpp
+static float values[60] = {};
+static int offset = 0;
+values[offset] = sinf(offset * 0.1f);
+offset = (offset + 1) % 60;
+
+ImGui::PlotLines("Sin wave", values, 60, offset, nullptr, -1.0f, 1.0f, ImVec2(0, 40));
+ImGui::PlotHistogram("Histogram", values, 60, 0, nullptr, -1.0f, 1.0f, ImVec2(0, 40));
+```
+
+### "Custom Widgets"
+
+In Dear ImGui, there is no widget base class to inherit from. A "custom widget" is just a
+function that calls ImGui drawing and interaction primitives:
+
+```cpp
+bool ToggleSwitch(const char* label, bool* value) {
+    ImGui::Text("%s", label);
+    ImGui::SameLine();
+    if (ImGui::Button(*value ? "[ON ]" : "[OFF]")) {
+        *value = !*value;
+        return true;  // value changed
+    }
+    return false;
+}
+```
+
+### Complete Application Example
+
+```cpp
+#include "imtui/imtui.h"
+#include "imtui/imtui-impl-ncurses.h"
+
+int main() {
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+
+    auto screen = ImTui_ImplNcurses_Init(true);
+    ImTui_ImplText_Init();
+
+    // Application state -- owned entirely by the application
+    bool running = true;
+    char searchBuf[256] = "";
+    int selected = -1;
+    float volume = 0.5f;
+    bool darkMode = true;
+
+    while (running) {
+        ImTui_ImplNcurses_NewFrame();
+        ImTui_ImplText_NewFrame();
+        ImGui::NewFrame();
+
+        ImGui::Begin("My App");
+        ImGui::InputText("Search", searchBuf, sizeof(searchBuf));
+        ImGui::SliderFloat("Volume", &volume, 0.0f, 1.0f);
+        ImGui::Checkbox("Dark mode", &darkMode);
+
+        if (ImGui::Button("Quit"))
+            running = false;
+        ImGui::End();
+
+        ImGui::Render();
+        ImTui_ImplText_RenderDrawData(ImGui::GetDrawData(), screen);
+        ImTui_ImplNcurses_DrawScreen();
+    }
+
+    ImTui_ImplText_Shutdown();
+    ImTui_ImplNcurses_Shutdown();
+    return 0;
+}
+```
+
+---
+
+## Styling
+
+ImTui inherits Dear ImGui's style system, which is based on a global `ImGuiStyle` struct
+containing colors, sizes, and spacing values.
+
+### ImGuiStyle
+
+The style struct contains ~55 color values (indexed by `ImGuiCol_` enum) and ~25 size/
+spacing values. Key fields:
+
+```cpp
+ImGuiStyle& style = ImGui::GetStyle();
+
+// Spacing and sizing
+style.WindowPadding    = ImVec2(2, 1);    // padding inside windows
+style.FramePadding     = ImVec2(1, 0);    // padding inside framed widgets
+style.ItemSpacing      = ImVec2(1, 1);    // spacing between widgets
+style.IndentSpacing    = 4.0f;            // indentation for tree nodes
+style.ScrollbarSize    = 1.0f;            // scrollbar width
+
+// Colors (set individually or via theme)
+style.Colors[ImGuiCol_WindowBg]     = ImVec4(0.0f, 0.0f, 0.0f, 1.0f);
+style.Colors[ImGuiCol_Text]         = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+style.Colors[ImGuiCol_Button]       = ImVec4(0.2f, 0.4f, 0.7f, 1.0f);
+style.Colors[ImGuiCol_ButtonHovered]= ImVec4(0.3f, 0.5f, 0.8f, 1.0f);
+style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.1f, 0.3f, 0.6f, 1.0f);
+```
+
+### Scoped Style Changes (Push/Pop)
+
+Temporary style overrides use a push/pop stack:
+
+```cpp
+// Change button color for one button
+ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.8f, 0.1f, 0.1f, 1.0f));
+ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.9f, 0.2f, 0.2f, 1.0f));
+if (ImGui::Button("Delete"))
+    deleteItem();
+ImGui::PopStyleColor(2);  // pop both colors
+
+// Change spacing temporarily
+ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+// ... tightly packed widgets ...
+ImGui::PopStyleVar();
+```
+
+### Built-in Themes
+
+```cpp
+ImGui::StyleColorsDark();      // dark theme (default)
+ImGui::StyleColorsLight();     // light theme
+ImGui::StyleColorsClassic();   // classic ImGui gray theme
+```
+
+### Terminal Color Mapping
+
+ImGui's colors are specified as `ImVec4` (RGBA float). ImTui's text backend converts these
+to the ANSI 256-color palette via `rgbToAnsi256()`:
+
+1. **Grayscale detection:** If R, G, B values are close (within a threshold), map to the
+   24-step grayscale ramp (indices 232-255).
+2. **RGB color cube:** Otherwise, quantize each channel to a 6-level scale and map to the
+   6x6x6 color cube (indices 16-231).
+
+This means ImGui's smooth color gradients and precise RGB values are approximated. Subtle
+color differences in GPU-rendered ImGui may collapse to the same terminal color. ImTui's
+`ImTui_ImplText_Init()` configures ImGui's style with terminal-appropriate defaults:
+disabled anti-aliasing, minimal padding, and compact spacing.
+
+---
+
+## Event Handling
+
+Event handling in ImTui is **fully integrated into the immediate-mode widget calls**. There
+is no separate event system, no event bus, no callback registration, and no event
+propagation/bubbling model.
+
+### Widget Return Values
+
+Interactive widgets return a boolean indicating whether they were activated or their value
+changed:
+
+```cpp
+// Button: returns true on the frame it was clicked
+if (ImGui::Button("Submit")) {
+    submitForm();
+}
+
+// Checkbox: returns true when toggled (value is modified via pointer)
+bool changed = ImGui::Checkbox("Enable logging", &loggingEnabled);
+
+// Slider: returns true while the value is being dragged
+if (ImGui::SliderFloat("Zoom", &zoom, 0.1f, 10.0f)) {
+    applyZoom(zoom);
+}
+
+// Input text: returns true when the buffer is modified
+if (ImGui::InputText("Search", buf, sizeof(buf))) {
+    updateSearchResults(buf);
+}
+
+// Combo: returns true when selection changes
+if (ImGui::Combo("Theme", &themeIdx, themes, numThemes)) {
+    applyTheme(themeIdx);
+}
+```
+
+### Item Query Functions
+
+After any widget call, you can query its interaction state:
+
+```cpp
+ImGui::Button("Hover me");
+if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("This is a tooltip");
+}
+
+ImGui::InputText("Name", buf, sizeof(buf));
+if (ImGui::IsItemActive()) {
+    // Input field is currently focused and accepting input
+}
+if (ImGui::IsItemDeactivatedAfterEdit()) {
+    // User just finished editing (pressed Enter or clicked away)
+    validateInput(buf);
+}
+```
+
+### Keyboard Input
+
+```cpp
+ImGuiIO& io = ImGui::GetIO();
+
+// Direct key state queries
+if (ImGui::IsKeyPressed(ImGuiKey_Escape))
+    closePopup();
+
+if (ImGui::IsKeyPressed(ImGuiKey_Enter))
+    submitForm();
+
+// Modifier keys
+if (io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_S))
+    saveFile();
+```
+
+### Mouse Input
+
+```cpp
+ImGuiIO& io = ImGui::GetIO();
+
+// Mouse position (in terminal cell coordinates for ImTui)
+float mouseX = io.MousePos.x;
+float mouseY = io.MousePos.y;
+
+// Mouse button states
+bool leftDown = io.MouseDown[0];
+bool rightDown = io.MouseDown[1];
+
+// Double-click detection
+if (ImGui::IsMouseDoubleClicked(0))
+    openItem();
+```
+
+### No Event Propagation
+
+There is no bubbling, no capturing, no event delegation. When `ImGui::Button("OK")` is
+called, ImGui checks the mouse position against the button's bounding rectangle right then
+and there. If the mouse is over the button and clicked, the function returns `true`. If the
+button is behind another window, ImGui knows because it tracks window Z-order internally.
+That is the entire event model.
+
+---
+
+## State Management
+
+Application state management in ImTui is trivially simple because it follows Dear ImGui's
+fundamental principle: **the application owns all state**.
+
+### Application Owns Permanent State
+
+Every piece of persistent data -- checkbox values, text buffers, slider positions, list
+selections -- lives in application variables. ImGui functions take pointers or references to
+these variables and modify them directly:
+
+```cpp
+// Application state
+struct AppState {
+    char username[128] = "";
+    char password[128] = "";
+    bool rememberMe = false;
+    int themeChoice = 0;
+    float fontSize = 14.0f;
+    std::vector<std::string> items;
+    int selectedItem = -1;
+};
+
+AppState state;
+
+// In render loop -- ImGui reads/writes state directly
+ImGui::InputText("Username", state.username, sizeof(state.username));
+ImGui::InputText("Password", state.password, sizeof(state.password),
+    ImGuiInputTextFlags_Password);
+ImGui::Checkbox("Remember me", &state.rememberMe);
+ImGui::SliderFloat("Font size", &state.fontSize, 8.0f, 24.0f);
+```
+
+There is no binding system, no observable properties, no signals/slots, no `setState()`
+calls. The ImGui function reads the current value from the pointer, renders the widget
+showing that value, and if the user interacts with the widget, writes the new value back
+through the same pointer. This happens every frame.
+
+### ImGui Holds Only Transient State
+
+The `ImGuiContext` (created by `ImGui::CreateContext()`) holds only transient interaction
+metadata:
+
+- **Hot widget ID** -- which widget the mouse is currently over
+- **Active widget ID** -- which widget is currently being interacted with
+- **Input state** -- current mouse position, button states, keyboard state, text input
+  buffer
+- **Window state** -- positions, sizes, collapsed/expanded state, scroll offsets, Z-order
+- **ID stack** -- current stack for generating unique widget identifiers
+
+None of this is "application state" in the traditional sense. It is all interaction
+bookkeeping that ImGui manages automatically.
+
+### No State Synchronization Problem
+
+Because the application state and the UI state are the same thing (the application variable
+IS the widget's value), there is no synchronization problem. There is no possibility of the
+UI showing a stale value, no need for dirty flags, no data binding bugs. The slider shows
+whatever `state.fontSize` currently is, because it reads it directly every frame.
+
+---
+
+## Extensibility and Ecosystem
+
+### Dear ImGui Ecosystem
+
+Because ImTui is a backend for Dear ImGui, it inherits access to Dear ImGui's massive
+ecosystem. Dear ImGui has over 1000 community extensions, including:
+
+- **ImPlot** -- advanced plotting (line, scatter, bar, heatmap, etc.)
+- **ImGuiFileDialog** -- file browser dialog
+- **ImGuiColorTextEdit** -- syntax-highlighted text editor
+- **ImNodes** -- node editor for visual programming interfaces
+- **ImGuizmo** -- 3D gizmos for manipulation
+
+However, extensions that rely heavily on pixel-precise rendering, anti-aliased lines, or
+GPU textures will have degraded visual quality or may not function correctly in the terminal
+context.
+
+### ImTui-Specific
+
+ImTui itself is minimal by design. Its specific additions beyond the backends are limited to
+the `TScreen` data structure and the color conversion utilities. The value proposition is
+that Dear ImGui itself provides everything needed.
+
+### hnterm: A Complete Application
+
+The hnterm example (Hacker News terminal client) demonstrates a production-quality
+application built with ImTui:
+
+- Queries the official Hacker News API via libcurl
+- Displays stories, comments, and user profiles in navigable windows
+- Supports split-view for browsing multiple stories simultaneously
+- Fetches only currently visible content for efficiency
+- Compiles to both native (ncurses) and web (Emscripten) targets
+- Development has since moved to its own repository at
+  <https://github.com/ggerganov/hnterm>
+
+---
+
+## Strengths
+
+- **Zero widget boilerplate.** No classes to define, no constructors, no destructors, no
+  inheritance hierarchies. A widget is a function call. A custom widget is a function you
+  write.
+- **UI code is extremely concise.** A complete interactive form with input fields, sliders,
+  checkboxes, and buttons can be written in 10-20 lines of code.
+- **Full Dear ImGui ecosystem.** Access to the entire ImGui widget library and 1000+
+  community extensions, battle-tested across thousands of applications.
+- **No callback hell.** Event handling is inline with rendering. There is no registration,
+  no subscription, no handler maps. The code reads top to bottom.
+- **Easy to prototype.** Building a terminal UI is as fast as writing a sequence of ImGui
+  calls. Iteration is instant -- change a call, recompile, see the result.
+- **State management is trivial.** The application owns all state as plain variables. No
+  binding system, no state containers, no synchronization logic.
+- **Live demos via WebAssembly.** The Emscripten backend allows ImTui applications to run
+  in a web browser, making it easy to share and demonstrate applications.
+- **Minimal dependencies.** Only ncurses for the terminal backend. No framework, no runtime,
+  no build system complexity.
+- **Active/idle frame rate optimization.** The ncurses backend supports different redraw
+  rates for active and idle states, reducing CPU usage when there is no user input.
+
+---
+
+## Weaknesses and Limitations
+
+- **Pixel-to-character mapping loses precision.** ImGui was designed for pixel-addressed
+  displays. Mapping to a character grid means widgets are coarser, alignment is approximate,
+  and the visual polish of GPU-rendered ImGui is lost.
+- **Limited terminal color support.** ImGui's full RGBA color space is quantized to 256
+  ANSI colors. Subtle color variations collapse; gradients become bands.
+- **ncurses dependency.** The primary backend requires libncurses, which adds a system
+  dependency and does not support all terminal features (e.g., true color, Kitty keyboard
+  protocol, sixel graphics).
+- **Cursor-based layout is limited for complex terminal UIs.** There is no constraint
+  solver, no flexbox, no proportional sizing. Complex layouts require manual size
+  calculations and careful use of child regions.
+- **No styled text support.** ImGui's `Text()` renders plain monochrome text. There is no
+  concept of inline styled spans (bold word within a sentence, colored substrings). The
+  `TextColored()` function applies a single color to an entire text block.
+- **No proper box-drawing characters.** ImGui renders borders using its own vector graphics
+  (lines, rectangles). ImTui approximates these with ASCII characters rather than using
+  Unicode box-drawing characters (e.g., `+--+` instead of `+---+`), which
+  looks less polished than native terminal UIs.
+- **ImGui's horizontal bias does not match terminal's vertical bias.** ImGui was designed
+  for wide tool windows on a GPU display. Terminal UIs tend to be vertically oriented with
+  narrow columns. ImGui's default spacing, padding, and widget sizing assumes more
+  horizontal room than a typical terminal provides.
+- **No accessibility.** Being a graphical rendering approach adapted for terminal, there is
+  no semantic widget information exposed to screen readers or other assistive technology.
+- **Stale Dear ImGui version.** ImTui bundles ImGui v1.81, which is several versions behind
+  the latest Dear ImGui releases. Newer ImGui features (docking, multi-viewport, improved
+  tables) are not available.
+
+---
+
+## Lessons for D / Sparkles
+
+This section maps ImTui/Dear ImGui patterns to D idioms, exploring how the pure
+immediate-mode paradigm could inform Sparkles' design.
+
+### Pure Immediate-Mode as a Rapid Prototyping Layer
+
+D could support an ImGui-like API layer for rapid terminal UI prototyping. The core idea:
+UI is a function of your data, called every frame, with zero retained state.
+
+```d
+// Hypothetical Sparkles immediate-mode API
+void renderUI(ref AppState state, ref TerminalBuffer buf) @nogc {
+    if (button(buf, "Submit"))
+        state.submit();
+
+    sliderInt(buf, "Volume", &state.volume, 0, 100);
+    checkbox(buf, "Mute", &state.muted);
+
+    if (inputText(buf, "Search", state.searchBuf[]))
+        state.updateResults();
+}
+```
+
+This would complement (not replace) a more structured widget system. The immediate-mode
+layer is ideal for quick tools, debug UIs, and configuration panels where visual polish
+matters less than development speed.
+
+### Widget-as-Function-Call
+
+In the ImGui model, there are no traits, no interfaces, no objects. A widget is just a
+function that writes to a buffer and returns interaction state. In D:
+
+```d
+/// A button that returns true when clicked.
+/// Zero allocations, zero retained state.
+bool button(ref TerminalBuffer buf, string label) @safe pure nothrow @nogc {
+    auto rect = layoutNext(buf, label.length + 2, 1);
+    bool hovered = isMouseOver(rect);
+    bool clicked = hovered && mouseClicked();
+
+    auto style = hovered ? Style.highlighted : Style.normal;
+    buf.putString(rect.x, rect.y, label, style);
+
+    return clicked;
+}
+```
+
+No widget type to implement. No render method to override. Just a `@nogc` function
+returning `bool` for activation. This is the most minimal possible widget API.
+
+### Hot/Active Model with Compile-Time Widget IDs
+
+ImGui identifies widgets by hashing their string labels. D could use compile-time string
+hashing for zero-cost widget IDs:
+
+```d
+/// Widget ID generated at compile time from source location.
+WidgetId widgetId(string label = "", string file = __FILE__, size_t line = __LINE__)() {
+    enum id = hashOf(label ~ file ~ line.stringof);
+    return WidgetId(id);
+}
+
+bool button(string label = "", string file = __FILE__, size_t line = __LINE__)(
+    ref TerminalBuffer buf
+) @safe pure nothrow @nogc {
+    enum id = hashOf(label ~ file ~ line.stringof);
+    auto rect = layoutNext(buf, label.length + 2, 1);
+
+    bool hovered = isMouseOver(rect);
+    if (hovered) setHot(id);
+    if (hovered && mouseClicked()) setActive(id);
+    bool activated = isActive(id) && mouseReleased();
+
+    // ...render...
+    return activated;
+}
+```
+
+Using `__FILE__` and `__LINE__` as template parameters gives each call site a unique ID at
+compile time with zero runtime overhead -- no string hashing per frame.
+
+### Direct State Mutation via `ref` Parameters
+
+ImGui's `InputText("Name", &myString)` pattern maps directly to D:
+
+```d
+bool inputText(ref TerminalBuffer buf, string label, char[] buffer) @nogc {
+    // Render input field, handle keyboard input
+    // Directly modify buffer contents
+    return changed;
+}
+
+// Usage: state is mutated in place
+inputText(buf, "Name", state.name[]);
+sliderFloat(buf, "Volume", &state.volume, 0.0f, 1.0f);
+checkbox(buf, "Mute", &state.muted);
+```
+
+Passing `ref` or pointer parameters is natural in D and avoids any need for a binding or
+synchronization system. The function directly reads and writes the application's state.
+
+### Push/Pop Style Stacks with `scope(exit)`
+
+ImGui's `PushStyleColor` / `PopStyleColor` maps elegantly to D's `scope` guards:
+
+```d
+/// RAII-style color push that auto-pops.
+auto pushColor(ref StyleStack stack, StyleColor idx, Color color) @nogc {
+    stack.push(idx, color);
+    struct Guard {
+        StyleStack* s;
+        ~this() @nogc { s.pop(); }
+    }
+    return Guard(&stack);
+}
+
+// Usage with scope(exit) -- cannot forget to pop
+{
+    auto _ = pushColor(styleStack, StyleColor.button, Color.red);
+    // Everything in this scope renders with red buttons
+    if (button(buf, "Delete"))
+        deleteItem();
+}  // auto-pops here
+```
+
+Alternatively, using D's `scope(exit)` directly:
+
+```d
+styleStack.pushColor(StyleColor.button, Color.red);
+scope(exit) styleStack.popColor();
+```
+
+Both approaches prevent the "forgot to pop" bugs that plague C++ ImGui code.
+
+### No Retained State Means @nogc Friendly
+
+The entire immediate-mode render pass can be `@nogc` because there is no widget tree to
+allocate. Each frame:
+
+1. Read application state (plain variables, `@nogc`)
+2. Call widget functions that write to a fixed-size terminal buffer (`@nogc`)
+3. Diff the buffer against the previous frame (`@nogc`)
+4. Write changed cells to the terminal (`@nogc` or `@trusted` for syscalls)
+
+There is no `new`, no GC array append, no class instantiation anywhere in the hot path.
+This makes immediate-mode a natural fit for Sparkles' `@nogc` philosophy and `SmallBuffer`
+infrastructure.
+
+### ImGui ID System via D's `__LINE__` and `__FILE__`
+
+ImGui requires unique widget IDs to track interaction state across frames. In C++, this is
+done by hashing string labels at runtime. In D, the same can be achieved at compile time
+with zero runtime cost:
+
+```d
+/// Each call site gets a unique ID at compile time.
+bool button(string file = __FILE__, size_t line = __LINE__)(
+    ref TerminalBuffer buf, string label
+) @safe pure nothrow @nogc {
+    // ID is computed at compile time -- zero runtime cost
+    enum id = hashCombine(fnv1aHash(file), line);
+    // ... use id for hot/active tracking ...
+}
+```
+
+For dynamic widget lists (e.g., buttons generated in a loop), the application can push
+additional ID components:
+
+```d
+foreach (i, item; items) {
+    idStack.push(i);
+    scope(exit) idStack.pop();
+    if (button(buf, item.name))
+        selectItem(i);
+}
+```
+
+---
+
+## References
+
+- **ImTui Repository:** <https://github.com/ggerganov/imtui>
+- **Dear ImGui:** <https://github.com/ocornut/imgui>
+- **Dear ImGui Documentation:** <https://github.com/ocornut/imgui/wiki>
+- **Dear ImGui Demo:** <https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp>
+  (comprehensive widget reference)
+- **hnterm (Hacker News terminal client):** <https://github.com/ggerganov/hnterm>
+- **hnterm Live Web Demo:** <https://hnterm.ggerganov.com>
+- **Dear ImGui ID System:** <https://github.com/ocornut/imgui/wiki/FAQ#q-why-is-my-widget-not-reacting-when-i-click-on-it>
+- **Dear ImGui Style Reference:** <https://github.com/ocornut/imgui/issues/707>
+  (community style gallery)
+- **ImGui Immediate-Mode GUI Introduction:**
+  Casey Muratori's original talk: <https://caseymuratori.com/blog_0001>

--- a/docs/research/tui-libraries/index.md
+++ b/docs/research/tui-libraries/index.md
@@ -1,0 +1,178 @@
+# TUI Libraries Catalog
+
+A breadth-first survey of terminal user interface (TUI) libraries across programming languages. This catalog covers rendering models, architecture patterns, and abstraction levels to inform the design of TUI capabilities for Sparkles.
+
+## Rust
+
+| Library                   | Rendering Model | Architecture    | Abstraction | Status       | Links                                                                                 |
+| ------------------------- | --------------- | --------------- | ----------- | ------------ | ------------------------------------------------------------------------------------- |
+| **[Ratatui](ratatui.md)** | Immediate       | App-driven loop | Mid-level   | Active       | [repo](https://github.com/ratatui/ratatui) · [docs](https://ratatui.rs)               |
+| **[Cursive](cursive.md)** | Retained        | Callback-based  | High-level  | Maintained   | [repo](https://github.com/gyscos/cursive) · [docs](https://docs.rs/cursive)           |
+| **Crossterm**             | N/A (backend)   | Imperative      | Low-level   | Active       | [repo](https://github.com/crossterm-rs/crossterm) · [docs](https://docs.rs/crossterm) |
+| **Termion**               | N/A (backend)   | Imperative      | Low-level   | Maintained   | [repo](https://github.com/redox-os/termion)                                           |
+| **Termwiz**               | Immediate       | Imperative      | Mid-level   | Active       | [repo](https://github.com/wez/wezterm/tree/main/termwiz)                              |
+| **Dioxus TUI**            | Retained        | React-like      | High-level  | Experimental | [repo](https://github.com/DioxusLabs/dioxus)                                          |
+
+## Python
+
+| Library                   | Rendering Model | Architecture      | Abstraction | Status       | Links                                                                                                                  |
+| ------------------------- | --------------- | ----------------- | ----------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| **[Textual](textual.md)** | Retained        | CSS + widgets     | High-level  | Active       | [repo](https://github.com/Textualize/textual) · [docs](https://textual.textualize.io)                                  |
+| **Rich**                  | Immediate       | Render-to-console | Mid-level   | Active       | [repo](https://github.com/Textualize/rich) · [docs](https://rich.readthedocs.io)                                       |
+| **Urwid**                 | Retained        | Widget tree       | Mid-level   | Maintained   | [repo](https://github.com/urwid/urwid) · [docs](https://urwid.org)                                                     |
+| **npyscreen**             | Retained        | Form-based        | High-level  | Unmaintained | [repo](https://github.com/npcole/npyscreen)                                                                            |
+| **prompt_toolkit**        | Retained        | Component-based   | Mid-level   | Active       | [repo](https://github.com/prompt-toolkit/python-prompt-toolkit) · [docs](https://python-prompt-toolkit.readthedocs.io) |
+| **curses** (stdlib)       | Immediate       | Imperative        | Low-level   | Stable       | [docs](https://docs.python.org/3/library/curses.html)                                                                  |
+
+## JavaScript / TypeScript
+
+| Library           | Rendering Model     | Architecture         | Abstraction | Status       | Links                                             |
+| ----------------- | ------------------- | -------------------- | ----------- | ------------ | ------------------------------------------------- |
+| **[Ink](ink.md)** | Retained            | React components     | High-level  | Active       | [repo](https://github.com/vadimdemedes/ink)       |
+| **Blessed**       | Retained            | Widget tree          | High-level  | Unmaintained | [repo](https://github.com/chjj/blessed)           |
+| **Neo-blessed**   | Retained            | Widget tree          | High-level  | Low activity | [repo](https://github.com/embarklabs/neo-blessed) |
+| **Terminal Kit**  | Hybrid              | Imperative + widgets | Mid-level   | Maintained   | [repo](https://github.com/cronvel/terminal-kit)   |
+| **Yoga (layout)** | N/A (layout engine) | Flexbox              | Low-level   | Active       | [repo](https://github.com/nicolo-ribaudo/yoga)    |
+
+## Go
+
+| Library                        | Rendering Model | Architecture    | Abstraction | Status     | Links                                              |
+| ------------------------------ | --------------- | --------------- | ----------- | ---------- | -------------------------------------------------- |
+| **[Bubble Tea](bubbletea.md)** | Immediate       | Elm / MVU       | Mid-level   | Active     | [repo](https://github.com/charmbracelet/bubbletea) |
+| **Lip Gloss**                  | N/A (styling)   | Builder pattern | Mid-level   | Active     | [repo](https://github.com/charmbracelet/lipgloss)  |
+| **Bubbles**                    | Immediate       | MVU components  | Mid-level   | Active     | [repo](https://github.com/charmbracelet/bubbles)   |
+| **[tview](tview.md)**          | Retained        | Widget tree     | High-level  | Active     | [repo](https://github.com/rivo/tview)              |
+| **gocui**                      | Retained        | View-based      | Mid-level   | Maintained | [repo](https://github.com/jroimartin/gocui)        |
+| **tcell**                      | N/A (backend)   | Imperative      | Low-level   | Active     | [repo](https://github.com/gdamore/tcell)           |
+| **Termbox-go**                 | N/A (backend)   | Imperative      | Low-level   | Archived   | [repo](https://github.com/nsf/termbox-go)          |
+
+## Haskell
+
+| Library               | Rendering Model | Architecture                  | Abstraction | Status | Links                                                                                            |
+| --------------------- | --------------- | ----------------------------- | ----------- | ------ | ------------------------------------------------------------------------------------------------ |
+| **[Brick](brick.md)** | Retained        | Pure functional / declarative | High-level  | Active | [repo](https://github.com/jtdaugherty/brick) · [docs](https://hackage.haskell.org/package/brick) |
+| **Vty**               | Immediate       | Imperative                    | Low-level   | Active | [repo](https://github.com/jtdaugherty/vty)                                                       |
+
+## C / C++
+
+| Library                       | Rendering Model   | Architecture            | Abstraction | Status     | Links                                                                             |
+| ----------------------------- | ----------------- | ----------------------- | ----------- | ---------- | --------------------------------------------------------------------------------- |
+| **[Notcurses](notcurses.md)** | Retained (planes) | Imperative + planes     | Mid-level   | Active     | [repo](https://github.com/dankamongmen/notcurses) · [docs](https://notcurses.com) |
+| **ncurses**                   | Immediate         | Imperative              | Low-level   | Stable     | [docs](https://invisible-island.net/ncurses/)                                     |
+| **[FTXUI](ftxui.md)**         | Immediate         | Functional components   | Mid-level   | Active     | [repo](https://github.com/ArthurSonzogni/FTXUI)                                   |
+| **[ImTui](imtui.md)**         | Immediate         | Dear ImGui for terminal | Mid-level   | Maintained | [repo](https://github.com/ggerganov/imtui)                                        |
+| **CDK**                       | Retained          | Widget-based            | High-level  | Maintained | [docs](https://invisible-island.net/cdk/)                                         |
+| **Termbox2**                  | N/A (backend)     | Imperative              | Low-level   | Active     | [repo](https://github.com/termbox/termbox2)                                       |
+
+## D
+
+| Library           | Rendering Model | Architecture         | Abstraction | Status       | Links                                      |
+| ----------------- | --------------- | -------------------- | ----------- | ------------ | ------------------------------------------ |
+| **Scone**         | Immediate       | Imperative           | Low-level   | Low activity | [repo](https://github.com/Elronnd/scone)   |
+| **Arsd terminal** | Hybrid          | Imperative + widgets | Mid-level   | Active       | [repo](https://github.com/adamdruppe/arsd) |
+| **Nice**          | N/A (backend)   | Imperative           | Low-level   | Unmaintained | [repo](https://github.com/zhfkt/nice)      |
+
+## Java / Kotlin
+
+| Library                 | Rendering Model    | Architecture | Abstraction | Status     | Links                                         |
+| ----------------------- | ------------------ | ------------ | ----------- | ---------- | --------------------------------------------- |
+| **Lanterna**            | Retained           | Widget tree  | High-level  | Maintained | [repo](https://github.com/mabe02/lanterna)    |
+| **JLine**               | N/A (line editing) | Imperative   | Low-level   | Active     | [repo](https://github.com/jline/jline3)       |
+| **[Mosaic](mosaic.md)** | Retained           | Compose-like | High-level  | Active     | [repo](https://github.com/JakeWharton/mosaic) |
+
+## Ruby
+
+| Library          | Rendering Model | Architecture      | Abstraction | Status     | Links                                      |
+| ---------------- | --------------- | ----------------- | ----------- | ---------- | ------------------------------------------ |
+| **TTY**          | Hybrid          | Component toolkit | Mid-level   | Maintained | [repo](https://github.com/piotrmurach/tty) |
+| **Curses** (gem) | Immediate       | Imperative        | Low-level   | Maintained | [repo](https://github.com/ruby/curses)     |
+
+## Zig
+
+| Library                     | Rendering Model | Architecture     | Abstraction | Status | Links                                          |
+| --------------------------- | --------------- | ---------------- | ----------- | ------ | ---------------------------------------------- |
+| **Tuile**                   | Immediate       | Functional       | Mid-level   | Early  | [repo](https://github.com/unvariant/tuile)     |
+| **zbox**                    | Immediate       | Ratatui-inspired | Mid-level   | Active | [repo](https://github.com/sackosoft/zbox)      |
+| **[libvaxis](libvaxis.md)** | Immediate       | Imperative       | Low-level   | Active | [repo](https://github.com/rockorager/libvaxis) |
+
+## Nim
+
+| Library     | Rendering Model | Architecture    | Abstraction | Status       | Links                                        |
+| ----------- | --------------- | --------------- | ----------- | ------------ | -------------------------------------------- |
+| **Illwill** | Immediate       | Imperative      | Low-level   | Maintained   | [repo](https://github.com/johnnovak/illwill) |
+| **nimbox**  | Immediate       | Termbox binding | Low-level   | Unmaintained | [repo](https://github.com/dom96/nimbox)      |
+
+## OCaml
+
+| Library                 | Rendering Model | Architecture        | Abstraction | Status     | Links                                                  |
+| ----------------------- | --------------- | ------------------- | ----------- | ---------- | ------------------------------------------------------ |
+| **[Nottui](nottui.md)** | Retained        | Functional reactive | Mid-level   | Maintained | [repo](https://github.com/let-def/lwd)                 |
+| **Lambda-term**         | Retained        | Widget tree         | Mid-level   | Maintained | [repo](https://github.com/ocaml-community/lambda-term) |
+
+## Clojure
+
+| Library              | Rendering Model | Architecture | Abstraction | Status       | Links                                                |
+| -------------------- | --------------- | ------------ | ----------- | ------------ | ---------------------------------------------------- |
+| **Clansi**           | N/A (styling)   | Functional   | Low-level   | Maintained   | [repo](https://github.com/ams-clj/clansi)            |
+| **clojure-lanterna** | Retained        | Wrapper      | Mid-level   | Unmaintained | [repo](https://github.com/MultiMUD/clojure-lanterna) |
+
+## Scala
+
+| Library   | Rendering Model | Architecture | Abstraction | Status     | Links                                        |
+| --------- | --------------- | ------------ | ----------- | ---------- | -------------------------------------------- |
+| **Fansi** | N/A (styling)   | Functional   | Low-level   | Maintained | [repo](https://github.com/com-lihaoyi/fansi) |
+
+---
+
+## Architectural Taxonomy
+
+### By Rendering Model
+
+| Model         | Description                                                          | Libraries                                                                  |
+| ------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Immediate** | Application redraws entire UI each frame; framework diffs or flushes | Ratatui, FTXUI, ImTui, Bubble Tea, ncurses                                 |
+| **Retained**  | Framework maintains widget tree; updates propagate automatically     | Textual, Brick, Blessed, Ink, Cursive, tview, Lanterna, Notcurses (planes) |
+| **Hybrid**    | Mix of retained state with explicit render calls                     | Terminal Kit, arsd terminal, TTY                                           |
+
+### By Architecture Pattern
+
+| Pattern                   | Description                                       | Libraries                                         |
+| ------------------------- | ------------------------------------------------- | ------------------------------------------------- |
+| **Elm / MVU**             | Model-View-Update loop with messages              | Bubble Tea, Brick (partially)                     |
+| **React / Component**     | Declarative components with props, reconciliation | Ink, Dioxus TUI, Mosaic                           |
+| **Pure Functional**       | Immutable state, declarative combinators          | Brick, Nottui                                     |
+| **Widget Tree**           | Mutable tree of widget objects                    | Textual, Cursive, tview, Urwid, Lanterna, Blessed |
+| **Imperative**            | Direct terminal manipulation                      | ncurses, Crossterm, tcell, Termbox                |
+| **Functional Components** | Stateless functions returning UI trees            | FTXUI                                             |
+
+### By Layout Approach
+
+| Approach               | Description                                     | Libraries                                        |
+| ---------------------- | ----------------------------------------------- | ------------------------------------------------ |
+| **CSS / Flexbox**      | Web-inspired box model and flex layout          | Textual (CSS subset), Ink (Yoga/flexbox)         |
+| **Constraint-based**   | Size constraints flow through widget tree       | Ratatui, Brick, tview                            |
+| **Combinators**        | Compositional layout via functional combinators | Brick (`hBox`, `vBox`, `padded`)                 |
+| **Manual / Absolute**  | Explicit coordinates and sizes                  | ncurses, Notcurses (planes), Termbox             |
+| **Declarative Splits** | Layout DSL with percentage/fixed splits         | Ratatui (`Layout::default().constraints([...])`) |
+
+---
+
+## Detailed Studies
+
+The following libraries are analyzed in depth:
+
+- **[Ratatui](ratatui.md)** — Rust immediate-mode TUI with constraint-based layout
+- **[Ink](ink.md)** — React for the terminal (JavaScript)
+- **[Textual](textual.md)** — CSS-styled retained-mode framework (Python)
+- **[Bubble Tea](bubbletea.md)** — Elm Architecture for terminals (Go)
+- **[Brick](brick.md)** — Pure functional declarative TUI (Haskell)
+- **[Notcurses](notcurses.md)** — Modern ncurses successor (C)
+- **[FTXUI](ftxui.md)** — Functional DOM-like components with flexbox layout (C++)
+- **[Cursive](cursive.md)** — Retained-mode callback-based view hierarchy (Rust)
+- **[Mosaic](mosaic.md)** — Jetpack Compose runtime for terminals (Kotlin)
+- **[Nottui](nottui.md)** — Incremental computation / functional reactive TUI (OCaml)
+- **[libvaxis](libvaxis.md)** — comptime-powered, allocator-aware terminal library (Zig)
+- **[tview](tview.md)** — Retained widget tree with flex layout (Go)
+- **[ImTui](imtui.md)** — Dear ImGui paradigm adapted for terminals (C++)
+
+See the **[Comparison](comparison.md)** for cross-library synthesis and design recommendations for Sparkles.

--- a/docs/research/tui-libraries/ink.md
+++ b/docs/research/tui-libraries/ink.md
@@ -1,0 +1,792 @@
+# Ink (JavaScript)
+
+React-based declarative component framework for building and testing command-line interfaces using Flexbox layout.
+
+| Field          | Value                                        |
+| -------------- | -------------------------------------------- |
+| Language       | JavaScript / TypeScript (Node.js)            |
+| License        | MIT                                          |
+| Repository     | <https://github.com/vadimdemedes/ink>        |
+| Documentation  | <https://github.com/vadimdemedes/ink#readme> |
+| Latest Version | ~6.7.0                                       |
+| GitHub Stars   | ~35k                                         |
+
+## Overview
+
+Ink is a React renderer for command-line applications. It provides the same component-based UI building experience that React offers in the browser, but targeting terminal output instead of the DOM. The core idea is captured by its tagline: "React for CLIs. Build and test your CLI output using components."
+
+### What It Solves
+
+Traditional CLI tools are built with imperative string concatenation and manual cursor management. Ink replaces this with a declarative component model where developers describe _what_ the UI should look like, and the framework handles rendering, diffing, and incremental updates to the terminal. This makes it straightforward to build rich, interactive terminal UIs with progress bars, tables, spinners, selection lists, and multi-panel layouts.
+
+### Design Philosophy
+
+Ink is built on a declarative, component-driven philosophy inherited directly from React. Every piece of terminal output is a component. Layout is handled by Flexbox (via Yoga), not manual column counting. State changes trigger re-renders, and the framework diffs the output to minimize terminal writes. All text must be explicitly wrapped in `<Text>` components, enforcing a clean separation between layout containers and content.
+
+### History
+
+Ink was created by **Vadim Demedes** and first released in 2017. It was inspired by React Native's approach of using React's component model and reconciler outside the browser. The project evolved through several major versions: Ink 2 introduced hooks support, Ink 3 brought major API improvements, Ink 4 upgraded to modern React patterns, and Ink 5/6 added features like concurrent rendering, the Kitty keyboard protocol, ARIA accessibility attributes, and screen reader support.
+
+Ink is used by a wide range of popular tools, including **Jest** (Facebook's testing framework), **Gatsby CLI**, **Terraform CDK CLI**, **Prisma**, **Cloudflare Wrangler**, **Shopify CLI**, **GitHub Copilot CLI**, and many others.
+
+## Architecture
+
+### Rendering Model: Retained-Mode with React Reconciler
+
+Ink uses a **retained-mode** rendering architecture built on top of `react-reconciler` (the same package that powers React DOM and React Native). This means Ink maintains an internal representation of the component tree and manages its lifecycle through React's standard reconciliation process.
+
+The rendering pipeline works as follows:
+
+1. **Component tree** -- The developer writes JSX components using `<Box>`, `<Text>`, and custom components. React manages the component tree, handling state, effects, and context.
+
+2. **Reconciliation** -- When state changes (via `useState`, `useReducer`, etc.), React's reconciler diffs the virtual tree against the previous version, determining the minimal set of changes.
+
+3. **Layout computation** -- Changed nodes are passed to Yoga (Facebook's Flexbox layout engine) which computes the absolute position and dimensions of every element in terminal-cell coordinates.
+
+4. **Output generation** -- The laid-out tree is rendered to a string buffer with ANSI escape codes for styling (colors, bold, underline, etc.).
+
+5. **Terminal flush** -- The rendered string is written to stdout, replacing the previous output. Ink uses a patching mechanism: it moves the cursor up to the start of its output region and overwrites only what changed, reducing flicker.
+
+This architecture means Ink components behave exactly like React components. Developers can use `useState`, `useEffect`, `useContext`, `useReducer`, `useMemo`, `useCallback`, `useRef`, Suspense, and even React DevTools.
+
+```
+JSX Components
+    |
+    v
+React Reconciler (react-reconciler ^0.33.0)
+    |
+    v
+Ink Host Config (custom renderer)
+    |
+    v
+Yoga Layout Engine (yoga-layout ~3.2.1)
+    |
+    v
+ANSI String Buffer
+    |
+    v
+stdout (with incremental patching)
+```
+
+The default maximum frame rate is **30 FPS**, configurable via the `maxFps` option in the `render()` call. Ink also supports **concurrent rendering** mode (React 19 features like Suspense, deferred values) via the `concurrent: true` option.
+
+## Terminal Backend
+
+### Layout Engine: Yoga
+
+Ink uses **Yoga** (`yoga-layout ~3.2.1`), Facebook's cross-platform Flexbox layout engine. Yoga computes the position and size of every element in the component tree according to the Flexbox specification. In the terminal context, one "pixel" equals one character cell -- widths are measured in columns and heights in rows.
+
+Every `<Box>` component is a Yoga node with `display: flex` by default. This means all layout is Flexbox-based, with no alternative layout modes (block, grid, absolute positioning outside of Flexbox).
+
+### Terminal Output
+
+Ink writes to stdout using ANSI escape codes for:
+
+- **Cursor movement** -- moving up to overwrite previous output
+- **Text styling** -- SGR (Select Graphic Rendition) codes for colors, bold, italic, underline, strikethrough, dim, and inverse
+- **Color support** -- Named colors, hex (`#ff0000`), RGB (`rgb(255, 0, 0)`), and ANSI-256 palette, powered by chalk's color detection and downsampling
+
+### Patching Mechanism
+
+Rather than clearing and redrawing the entire screen on each render, Ink uses an incremental patching approach:
+
+1. After Yoga computes layout, Ink renders the tree to a string buffer.
+2. The framework tracks how many lines its output occupies.
+3. On re-render, it moves the cursor up to the beginning of its output region.
+4. It overwrites the previous output with the new content, clearing any trailing characters.
+
+This approach avoids full-screen flicker and works well for CLI tools that show a bounded region of output (progress bars, status displays, interactive prompts).
+
+### CI and Non-Interactive Mode
+
+Ink detects non-interactive environments (CI, piped output) and can adjust behavior accordingly. The `isRawModeSupported` property from `useStdin()` indicates whether the terminal supports raw mode input. When raw mode is not available, interactive features like keyboard input are gracefully disabled.
+
+### Console Patching
+
+By default (`patchConsole: true`), Ink intercepts `console.log`, `console.error`, and similar calls. When a console method is called, Ink clears its output, writes the console message, and re-renders its component tree below it. This prevents console output from corrupting the Ink UI.
+
+## Layout System
+
+Ink implements a comprehensive Flexbox layout system via Yoga. Every `<Box>` component is a flex container by default (`display: flex`). The layout system supports the following properties:
+
+### Flex Container Properties
+
+| Property         | Values                                                                                          | Default        |
+| ---------------- | ----------------------------------------------------------------------------------------------- | -------------- |
+| `flexDirection`  | `'row'`, `'row-reverse'`, `'column'`, `'column-reverse'`                                        | `'row'`        |
+| `justifyContent` | `'flex-start'`, `'center'`, `'flex-end'`, `'space-between'`, `'space-around'`, `'space-evenly'` | `'flex-start'` |
+| `alignItems`     | `'flex-start'`, `'center'`, `'flex-end'`                                                        | `'flex-start'` |
+| `flexWrap`       | `'nowrap'`, `'wrap'`, `'wrap-reverse'`                                                          | `'nowrap'`     |
+
+### Flex Item Properties
+
+| Property     | Type                                         | Default  |
+| ------------ | -------------------------------------------- | -------- |
+| `flexGrow`   | `number`                                     | `0`      |
+| `flexShrink` | `number`                                     | `1`      |
+| `flexBasis`  | `number\|string`                             | --       |
+| `alignSelf`  | `'auto'\|'flex-start'\|'center'\|'flex-end'` | `'auto'` |
+
+### Dimensions
+
+| Property    | Type             | Description              |
+| ----------- | ---------------- | ------------------------ |
+| `width`     | `number\|string` | Columns or percentage    |
+| `height`    | `number\|string` | Rows or percentage       |
+| `minWidth`  | `number`         | Minimum width in columns |
+| `minHeight` | `number`         | Minimum height in rows   |
+
+### Spacing
+
+Padding and margin are specified in character cells:
+
+- `padding`, `paddingX`, `paddingY`, `paddingTop`, `paddingBottom`, `paddingLeft`, `paddingRight`
+- `margin`, `marginX`, `marginY`, `marginTop`, `marginBottom`, `marginLeft`, `marginRight`
+- `gap`, `columnGap`, `rowGap`
+
+### Overflow and Display
+
+| Property    | Values                  | Default     |
+| ----------- | ----------------------- | ----------- |
+| `display`   | `'flex'`, `'none'`      | `'flex'`    |
+| `overflowX` | `'visible'`, `'hidden'` | `'visible'` |
+| `overflowY` | `'visible'`, `'hidden'` | `'visible'` |
+| `overflow`  | shorthand for X and Y   | `'visible'` |
+
+### Multi-Panel Layout Example
+
+```jsx
+import React from "react";
+import { render, Box, Text } from "ink";
+
+function Dashboard() {
+  return (
+    <Box flexDirection="column" width={80} height={24}>
+      {/* Header bar */}
+      <Box
+        borderStyle="single"
+        borderColor="cyan"
+        justifyContent="center"
+        paddingX={1}
+      >
+        <Text bold color="cyan">
+          Dashboard v1.0
+        </Text>
+      </Box>
+
+      {/* Main content area: sidebar + content */}
+      <Box flexGrow={1} flexDirection="row">
+        {/* Sidebar */}
+        <Box
+          flexDirection="column"
+          width={20}
+          borderStyle="single"
+          borderColor="gray"
+          paddingX={1}
+        >
+          <Text bold underline>
+            Navigation
+          </Text>
+          <Text color="green"> > Overview</Text>
+          <Text> Processes</Text>
+          <Text> Network</Text>
+          <Text> Settings</Text>
+        </Box>
+
+        {/* Main content */}
+        <Box
+          flexDirection="column"
+          flexGrow={1}
+          borderStyle="single"
+          borderColor="gray"
+          paddingX={1}
+        >
+          <Text bold underline>
+            System Overview
+          </Text>
+          <Box marginTop={1} gap={2}>
+            <Box flexDirection="column">
+              <Text dimColor>CPU Usage</Text>
+              <Text color="green" bold>
+                23%
+              </Text>
+            </Box>
+            <Box flexDirection="column">
+              <Text dimColor>Memory</Text>
+              <Text color="yellow" bold>
+                4.2 GB / 16 GB
+              </Text>
+            </Box>
+            <Box flexDirection="column">
+              <Text dimColor>Disk</Text>
+              <Text color="red" bold>
+                87% full
+              </Text>
+            </Box>
+          </Box>
+          <Box marginTop={1} flexDirection="column">
+            <Text dimColor>Uptime</Text>
+            <Text>14 days, 3 hours, 22 minutes</Text>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Status bar */}
+      <Box
+        justifyContent="space-between"
+        paddingX={1}
+        borderStyle="single"
+        borderColor="gray"
+      >
+        <Text dimColor>Connected to localhost</Text>
+        <Text dimColor>Last refresh: 2s ago</Text>
+      </Box>
+    </Box>
+  );
+}
+
+render(<Dashboard />);
+```
+
+This produces a terminal layout with a centered header, a two-column body (sidebar with navigation, main area with metrics), and a footer status bar -- all computed by Yoga's Flexbox engine.
+
+## Widget / Component System
+
+### Built-in Components
+
+**`<Box>`** -- The primary layout container. Acts as a Flexbox div. All layout props described above apply to Box. It also supports borders and background colors, making it suitable for panels, cards, and frames.
+
+**`<Text>`** -- The only component that can contain text content. Supports styling props (see Styling section below). Text wrapping behavior is controlled via the `wrap` prop. Nested `<Text>` components inherit styling from their parent.
+
+**`<Newline>`** -- Inserts line breaks. Accepts a `count` prop (default `1`) to insert multiple blank lines.
+
+**`<Spacer>`** -- A flexible space filler that expands along the main axis of the parent flex container. Equivalent to a `<Box>` with `flexGrow={1}`. Commonly used to push elements to opposite ends of a row.
+
+**`<Static>`** -- Renders items that should appear once and never re-render. Useful for log-style output where previous lines should remain unchanged while new content appends below. Accepts an `items` array and a `children` render function:
+
+```jsx
+<Static items={logs}>
+  {(log, index) => (
+    <Text key={index} color="gray">
+      {log.timestamp} {log.message}
+    </Text>
+  )}
+</Static>
+```
+
+**`<Transform>`** -- Applies a transformation function to its children's rendered output, line by line. Useful for adding prefixes, indentation, or post-processing:
+
+```jsx
+<Transform transform={(output) => `>> ${output}`}>
+  <Text>This line will be prefixed</Text>
+</Transform>
+```
+
+### Hooks
+
+**`useInput(handler, options?)`** -- Subscribes to keyboard input. The handler receives `(input: string, key: Key)` where `key` contains boolean flags for special keys. Can be deactivated with `isActive: false`.
+
+**`useApp()`** -- Returns `{ exit }` to programmatically unmount the application. Optionally accepts an `Error` to exit with a failure.
+
+**`useFocus(options?)`** -- Returns `{ isFocused }`. Components using this hook become focusable via Tab/Shift+Tab navigation. Options include `autoFocus`, `isActive`, and `id`.
+
+**`useFocusManager()`** -- Returns methods to control focus programmatically: `enableFocus()`, `disableFocus()`, `focusNext()`, `focusPrevious()`, `focus(id)`.
+
+**`useStdin()`** -- Returns `{ stdin, isRawModeSupported, setRawMode }` for low-level stdin access.
+
+**`useStdout()`** -- Returns `{ stdout, write }` for writing to stdout without disrupting Ink's output.
+
+**`useStderr()`** -- Returns `{ stderr, write }` for writing to stderr without disrupting Ink's output.
+
+**`useCursor()`** -- Returns `{ setCursorPosition }` to place or hide the terminal cursor.
+
+**`useIsScreenReaderEnabled()`** -- Returns a boolean indicating whether a screen reader is active.
+
+### Custom Components
+
+Custom components are standard React function components. There is no special registration or base class required. Any function that returns JSX using Ink's built-in components is a valid Ink component:
+
+```jsx
+import React, { useState, useEffect } from "react";
+import { Box, Text, useInput, useApp } from "ink";
+
+function Timer() {
+  const [seconds, setSeconds] = useState(0);
+  const [running, setRunning] = useState(true);
+  const { exit } = useApp();
+
+  useEffect(() => {
+    if (!running) return;
+
+    const timer = setInterval(() => {
+      setSeconds((prev) => prev + 1);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [running]);
+
+  useInput((input, key) => {
+    if (input === " ") {
+      setRunning((prev) => !prev);
+    }
+    if (input === "q") {
+      exit();
+    }
+  });
+
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  const display = `${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+
+  return (
+    <Box flexDirection="column" alignItems="center" padding={1}>
+      <Text bold>Stopwatch</Text>
+      <Box marginY={1}>
+        <Text color={running ? "green" : "yellow"} bold>
+          {display}
+        </Text>
+      </Box>
+      <Text dimColor>
+        {running ? "Press SPACE to pause" : "Press SPACE to resume"}
+        {" | Press Q to quit"}
+      </Text>
+    </Box>
+  );
+}
+```
+
+This example demonstrates `useState` for local state, `useEffect` for a timer side-effect with cleanup, `useInput` for keyboard handling, and `useApp` for programmatic exit.
+
+## Styling
+
+Ink's styling is applied through props rather than CSS stylesheets or class names. There are two main surfaces for styling: `<Box>` for layout and border decoration, and `<Text>` for text appearance.
+
+### Box Styling
+
+`<Box>` supports border and background styling:
+
+| Prop                | Type      | Description                                                                                                    |
+| ------------------- | --------- | -------------------------------------------------------------------------------------------------------------- |
+| `borderStyle`       | `string`  | `'single'`, `'double'`, `'round'`, `'bold'`, `'singleDouble'`, `'doubleSingle'`, `'classic'`, or custom object |
+| `borderColor`       | `string`  | Color for all borders                                                                                          |
+| `borderTopColor`    | `string`  | Color for top border                                                                                           |
+| `borderRightColor`  | `string`  | Color for right border                                                                                         |
+| `borderBottomColor` | `string`  | Color for bottom border                                                                                        |
+| `borderLeftColor`   | `string`  | Color for left border                                                                                          |
+| `borderDimColor`    | `boolean` | Dim all borders                                                                                                |
+| `borderTop`         | `boolean` | Show/hide top border (default `true`)                                                                          |
+| `borderRight`       | `boolean` | Show/hide right border                                                                                         |
+| `borderBottom`      | `boolean` | Show/hide bottom border                                                                                        |
+| `borderLeft`        | `boolean` | Show/hide left border                                                                                          |
+| `backgroundColor`   | `string`  | Fill the entire box area                                                                                       |
+
+Custom border styles can be provided as an object with `topLeft`, `top`, `topRight`, `right`, `bottomRight`, `bottom`, `bottomLeft`, `left` keys.
+
+### Text Styling
+
+`<Text>` supports the following style props:
+
+| Prop              | Type      | Default  | Description                                                                       |
+| ----------------- | --------- | -------- | --------------------------------------------------------------------------------- |
+| `color`           | `string`  | --       | Text foreground color                                                             |
+| `backgroundColor` | `string`  | --       | Text background color                                                             |
+| `bold`            | `boolean` | `false`  | Bold weight                                                                       |
+| `italic`          | `boolean` | `false`  | Italic style                                                                      |
+| `underline`       | `boolean` | `false`  | Underline decoration                                                              |
+| `strikethrough`   | `boolean` | `false`  | Strikethrough decoration                                                          |
+| `dimColor`        | `boolean` | `false`  | Reduced brightness                                                                |
+| `inverse`         | `boolean` | `false`  | Swap foreground and background                                                    |
+| `wrap`            | `string`  | `'wrap'` | `'wrap'`, `'truncate'`, `'truncate-start'`, `'truncate-middle'`, `'truncate-end'` |
+
+### Color Formats
+
+Colors support multiple formats (powered by chalk's terminal color detection):
+
+- **Named colors**: `'red'`, `'green'`, `'blue'`, `'cyan'`, `'magenta'`, `'yellow'`, `'white'`, `'gray'`, etc.
+- **Hex**: `'#ff6347'`, `'#00ff00'`
+- **RGB**: `'rgb(255, 99, 71)'`
+- **ANSI-256**: Chalk automatically downsamples to the best available color depth for the terminal.
+
+### Styling Code Example
+
+```jsx
+import React from "react";
+import { render, Box, Text } from "ink";
+
+function StyledCard({ title, status, description }) {
+  const statusColor =
+    status === "passing" ? "green" : status === "failing" ? "red" : "yellow";
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={2}
+      paddingY={1}
+      width={50}
+    >
+      <Box justifyContent="space-between">
+        <Text bold color="white">
+          {title}
+        </Text>
+        <Text color={statusColor} bold inverse>
+          {" "}
+          {status.toUpperCase()}{" "}
+        </Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor italic>
+          {description}
+        </Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text>
+          Priority:{" "}
+          <Text color="#ff6347" bold>
+            HIGH
+          </Text>
+          {" | "}
+          Updated: <Text underline>2 hours ago</Text>
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+render(
+  <StyledCard
+    title="Build Pipeline"
+    status="passing"
+    description="All 247 tests passing across 12 suites"
+  />,
+);
+```
+
+## Event Handling
+
+### Keyboard Input
+
+The primary mechanism for handling keyboard input is the `useInput` hook. It receives two arguments: the raw input string, and a `key` object with boolean flags for special keys.
+
+```jsx
+import React, { useState } from "react";
+import { Box, Text, useInput, useApp } from "ink";
+
+function SelectableList({ items }) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [confirmed, setConfirmed] = useState(null);
+  const { exit } = useApp();
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setSelectedIndex((prev) => Math.max(0, prev - 1));
+    }
+
+    if (key.downArrow) {
+      setSelectedIndex((prev) => Math.min(items.length - 1, prev + 1));
+    }
+
+    if (key.return) {
+      setConfirmed(items[selectedIndex]);
+    }
+
+    if (input === "q" || key.escape) {
+      exit();
+    }
+  });
+
+  if (confirmed) {
+    return <Text color="green">Selected: {confirmed}</Text>;
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Choose an option (arrows to move, enter to select):</Text>
+      {items.map((item, i) => (
+        <Text key={item} color={i === selectedIndex ? "cyan" : undefined}>
+          {i === selectedIndex ? "> " : "  "}
+          {item}
+        </Text>
+      ))}
+      <Text dimColor>Press Q or Escape to quit</Text>
+    </Box>
+  );
+}
+```
+
+The `key` object provides boolean flags for:
+
+- Arrow keys: `leftArrow`, `rightArrow`, `upArrow`, `downArrow`
+- Action keys: `return`, `escape`, `tab`, `backspace`, `delete`
+- Modifiers: `ctrl`, `shift`, `meta`
+- Navigation: `pageDown`, `pageUp`, `home`, `end`
+- Kitty protocol extras: `super`, `hyper`, `capsLock`, `numLock`, and `eventType` (`'press'`, `'repeat'`, `'release'`)
+
+The `useInput` hook accepts an `isActive` option to conditionally disable input handling, which is useful for modal UIs or focus-dependent input.
+
+### Focus Management
+
+Ink provides a focus system via `useFocus` and `useFocusManager`. Components declare themselves as focusable, and users navigate with Tab/Shift+Tab:
+
+```jsx
+function FocusableItem({ label }) {
+  const { isFocused } = useFocus();
+
+  return (
+    <Box>
+      <Text color={isFocused ? "green" : "gray"}>
+        {isFocused ? "> " : "  "}
+        {label}
+      </Text>
+    </Box>
+  );
+}
+```
+
+Programmatic focus control is available through `useFocusManager()`:
+
+```jsx
+const { focusNext, focusPrevious, focus } = useFocusManager();
+focusNext(); // Move focus to next component
+focusPrevious(); // Move focus to previous component
+focus("submit-btn"); // Focus a specific component by ID
+```
+
+### Mouse Support
+
+Ink does **not** support mouse events. All interaction is keyboard-based.
+
+### stdin Handling
+
+For low-level input needs beyond `useInput`, the `useStdin` hook provides direct access:
+
+```jsx
+const { stdin, setRawMode, isRawModeSupported } = useStdin();
+```
+
+Raw mode must be enabled for character-by-character input. When raw mode is not supported (e.g., in CI environments), `isRawModeSupported` returns `false`.
+
+## State Management
+
+Ink uses React's standard state management primitives. There is no Ink-specific state system.
+
+### React Built-in State
+
+- **`useState`** -- Component-local state, the most common pattern. State changes trigger re-renders, which flow through the reconciler and Yoga layout engine to produce updated terminal output.
+
+- **`useReducer`** -- For complex state logic with multiple sub-values or when the next state depends on the previous state.
+
+- **`useEffect`** -- For side effects: timers, subscriptions, API calls. Cleanup functions run on unmount, making it safe for interval-based animations or polling.
+
+- **`useContext`** -- For sharing state across the component tree without prop drilling. Commonly used for theme configuration or application-wide settings.
+
+- **`useRef`** -- For mutable values that persist across renders without triggering re-renders. Also used with `measureElement` to get element dimensions.
+
+- **`useMemo` / `useCallback`** -- For memoization and preventing unnecessary re-renders in complex component trees.
+
+### External State Libraries
+
+Because Ink components are standard React components, external state management libraries work without modification:
+
+- **zustand** -- Lightweight stores with hooks
+- **jotai** -- Atomic state management
+- **Redux** (via `react-redux`) -- Centralized state with reducers
+- **React Query / TanStack Query** -- Server state and async data fetching
+
+### Component-Local State as Default
+
+The idiomatic Ink pattern favors component-local state. CLI tools typically have simpler state requirements than web applications, and most Ink applications can be built entirely with `useState` and `useEffect`. Context is used when multiple components need to share state (e.g., a global configuration or theme).
+
+## Extensibility and Ecosystem
+
+Ink has a rich ecosystem of community components and tools:
+
+### Testing
+
+**[ink-testing-library](https://github.com/vadimdemedes/ink-testing-library)** -- The official testing utility. It provides a `render()` function that mounts components in a virtual terminal and exposes:
+
+- `lastFrame()` -- Returns the most recent rendered output as a string
+- `frames` -- Array of all rendered frames for asserting on rendering sequences
+- `rerender(tree)` -- Update the component with new props
+- `unmount()` -- Unmount the component
+- `stdin.write(input)` -- Simulate keyboard input
+
+```jsx
+import { render } from "ink-testing-library";
+import Counter from "./Counter.js";
+
+const { lastFrame, stdin } = render(<Counter />);
+assert.equal(lastFrame(), "Count: 0");
+
+stdin.write("i"); // simulate pressing 'i' to increment
+assert.equal(lastFrame(), "Count: 1");
+```
+
+### Popular Community Components
+
+| Package            | Description                           |
+| ------------------ | ------------------------------------- |
+| `ink-select-input` | Interactive select/list input         |
+| `ink-text-input`   | Text input field with cursor          |
+| `ink-spinner`      | Animated loading spinners             |
+| `ink-table`        | Formatted data tables                 |
+| `ink-gradient`     | Gradient-colored text                 |
+| `ink-link`         | Clickable terminal hyperlinks (OSC 8) |
+| `ink-big-text`     | Large ASCII art text (figlet-style)   |
+
+### Frameworks Built on Ink
+
+**[Pastel](https://github.com/vadimdemedes/pastel)** -- A Next.js-inspired framework for building CLI apps on top of Ink. Provides file-system-based routing for commands, automatic argument parsing, and a structured project layout.
+
+### Scaffolding
+
+**`create-ink-app`** -- Official CLI scaffolding tool. Generates a starter Ink project with TypeScript support:
+
+```bash
+npx create-ink-app my-cli-tool --typescript
+```
+
+### React DevTools
+
+Ink supports React DevTools for debugging component trees. Enable with the `DEV=true` environment variable and connect via `react-devtools-core`.
+
+## Strengths
+
+- **Familiar React mental model** -- Any developer with React experience can immediately build CLI applications. No new paradigm to learn, just a different render target.
+- **Huge JavaScript/npm ecosystem** -- Access to hundreds of thousands of npm packages for data fetching, parsing, file system operations, and more.
+- **Easy to test with ink-testing-library** -- Components can be rendered to strings and asserted against, making CLI UI testing as straightforward as testing React web components.
+- **Flexbox layout is powerful and intuitive** -- Yoga provides a well-understood, battle-tested layout model. Developers do not need to manually compute column positions or row offsets.
+- **Good for CLI tool UIs** -- Progress indicators, interactive prompts, multi-step wizards, and status dashboards are all natural fits for Ink's component model.
+- **Declarative and composable** -- UI is described as a function of state, making it easy to reason about what the terminal shows at any given moment.
+- **Rich component ecosystem** -- Pre-built components for common CLI patterns (selection lists, text inputs, spinners, tables) reduce boilerplate.
+- **Full React feature support** -- Hooks, context, Suspense, concurrent mode, and React DevTools all work.
+- **Accessibility support** -- ARIA roles, states, and labels with screen reader detection.
+- **Incremental rendering** -- Patching mechanism avoids full redraws, reducing terminal flicker.
+
+## Weaknesses and Limitations
+
+- **Node.js runtime overhead** -- Requires a full Node.js process with React, react-reconciler, and Yoga loaded. Startup time and memory footprint are significant compared to native CLI tools.
+- **No mouse support** -- All interaction is keyboard-based. Applications requiring mouse clicks, hover effects, or scroll wheels cannot use Ink.
+- **Limited to what React's reconciler can express** -- The terminal is fundamentally different from a browser DOM. Some patterns (absolute positioning, z-index layering, overlapping elements) are difficult or impossible.
+- **Yoga dependency adds complexity** -- Yoga is a native/WASM binary that must be compiled or bundled. This can cause issues in some deployment environments and adds to the dependency footprint.
+- **Performance ceiling for complex UIs** -- React's reconciliation, Yoga's layout computation, and ANSI string generation all add overhead. High-frequency updates (e.g., smooth animations at 60 FPS) push against this ceiling.
+- **Not suitable for full-screen high-refresh-rate applications** -- Games, terminal multiplexers, or text editors with complex scrolling are better served by lower-level libraries (blessed, ncurses, notcurses).
+- **All text must be wrapped in `<Text>` components** -- A common source of runtime errors for new users who place bare strings inside `<Box>`.
+- **JavaScript/TypeScript only** -- Cannot be used from other languages without Node.js interop.
+- **Bundled output size** -- Distributing an Ink CLI means shipping Node.js dependencies, which can result in large `node_modules` trees compared to single-binary CLIs.
+- **30 FPS default cap** -- While configurable, the rendering pipeline is not designed for frame-rate-sensitive applications.
+
+## Lessons for D / Sparkles
+
+Ink demonstrates several patterns that can be adapted to D's strengths, often with better performance characteristics due to compile-time computation and zero-overhead abstractions.
+
+### Component Model via Compile-Time Introspection
+
+Ink's component model relies on React's runtime reconciler to manage component lifecycle. In D, **compile-time introspection** (`__traits`, `is` expressions, template constraints) could define component interfaces as static contracts rather than runtime abstractions. A component could be any struct satisfying a trait (e.g., having a `render` method returning a layout node), with validation happening entirely at compile time:
+
+```d
+// D analogue: components as introspected structs
+enum isComponent(T) = is(typeof((T t) {
+    auto node = t.render();  // must have render()
+    static assert(isLayoutNode!(typeof(node)));
+}));
+```
+
+This eliminates the virtual dispatch, garbage collection, and runtime type checking overhead that React's reconciler requires.
+
+### Flexbox Layout via CTFE
+
+Ink uses Yoga (a WASM/native runtime dependency) to compute Flexbox layout. For **static layouts** where dimensions are known at compile time, D's CTFE could pre-compute the entire layout at compile time, producing a flat array of positioned rectangles with zero runtime cost. For dynamic layouts, a `@nogc` Yoga-equivalent could compute layout into a `SmallBuffer` without heap allocation:
+
+```d
+// Static layout computed at compile time
+enum layout = flexLayout(
+    box(direction: row, width: 80, children: [
+        box(width: 20),    // sidebar
+        box(flexGrow: 1),  // content
+    ]),
+);
+// layout is a compile-time constant array of positioned rects
+```
+
+### Hooks Pattern via UFCS and Scope
+
+Ink's hooks (`useState`, `useEffect`, `useInput`) are runtime constructs that rely on React's fiber architecture and call-order tracking. In D, similar patterns could use **UFCS chains** for composable state transformations and **scope-based resource management** for effect cleanup:
+
+```d
+// UFCS chain for state transformation
+auto newState = currentState
+    .handleInput(key)
+    .applyLayout(termSize)
+    .renderToBuffer(buf);
+
+// Scope-based cleanup (analogous to useEffect cleanup)
+auto subscription = onInput(&handleKey);
+scope(exit) subscription.cancel();
+```
+
+### Virtual DOM Diffing via `@nogc` Buffers
+
+Ink's rendering pipeline diffs a virtual tree and flushes changes to the terminal. D's `SmallBuffer` (already in Sparkles) could implement efficient terminal diffing without GC allocation. A double-buffering approach -- writing the new frame to one buffer while comparing against the previous frame in another -- maps naturally to `@nogc` D:
+
+```d
+@nogc nothrow
+void renderFrame(ref SmallBuffer!(char, 4096) front, ref SmallBuffer!(char, 4096) back) {
+    // Render new frame into `back`
+    renderTree(root, back);
+    // Diff against `front`, emit only changed ANSI sequences
+    emitDiff(front[], back[], stdout);
+    // Swap buffers
+    swap(front, back);
+}
+```
+
+### Declarative DSL via Mixins or IES
+
+Ink's JSX provides a declarative syntax for describing UI trees. D could achieve a similar developer experience through **mixin templates** or **interpolated expression sequences** (IES, already documented in Sparkles' guidelines). An IES-based DSL could describe layout trees that compile down to direct struct construction:
+
+```d
+// Hypothetical D DSL using IES or string mixins
+auto ui = box(
+    direction: column,
+    border: Border.single,
+    children: [
+        text("Dashboard", style: bold | color(Color.cyan)),
+        box(direction: row, children: [
+            text("CPU: 23%"),
+            spacer(),
+            text("MEM: 4.2GB"),
+        ]),
+    ],
+);
+```
+
+### Testing via Output Ranges
+
+Ink's `ink-testing-library` renders components to strings for assertion. In D, since Sparkles already uses output ranges extensively (`prettyPrint` writes to any output range), **testing terminal UI is natural**: render to a `SmallBuffer` or `appender!string` and compare the output. No special testing library is needed -- the output range pattern makes UI components inherently testable:
+
+```d
+@safe pure nothrow @nogc
+unittest {
+    SmallBuffer!(char, 4096) buf;
+    renderComponent(myWidget, buf);
+    assert(buf[] == expectedOutput);
+}
+```
+
+## References
+
+- **Repository**: <https://github.com/vadimdemedes/ink>
+- **README / API Documentation**: <https://github.com/vadimdemedes/ink#readme>
+- **npm Package**: <https://www.npmjs.com/package/ink>
+- **ink-testing-library**: <https://github.com/vadimdemedes/ink-testing-library>
+- **create-ink-app scaffolding**: <https://github.com/vadimdemedes/create-ink-app>
+- **Pastel framework**: <https://github.com/vadimdemedes/pastel>
+- **Yoga Layout Engine**: <https://github.com/nicolo-ribaudo/yoga>
+- **react-reconciler**: <https://www.npmjs.com/package/react-reconciler>
+- **Vadim Demedes (author)**: <https://github.com/vadimdemedes>
+- **"Building a React Renderer" (Sophie Alpert talk)**: <https://www.youtube.com/watch?v=CGpMlWVcHok> -- foundational talk on custom React renderers that influenced Ink's architecture
+- **Awesome Ink (community components)**: <https://github.com/vadimdemedes/ink#useful-components> -- curated list of Ink ecosystem packages

--- a/docs/research/tui-libraries/libvaxis.md
+++ b/docs/research/tui-libraries/libvaxis.md
@@ -1,0 +1,1197 @@
+# libvaxis (Zig)
+
+A modern terminal UI library for Zig that eschews terminfo in favor of runtime capability detection, providing both a low-level cell-based API and a Flutter-inspired widget framework with explicit allocator passing and comptime-powered generics.
+
+| Field          | Value                                    |
+| -------------- | ---------------------------------------- |
+| Language       | Zig                                      |
+| License        | MIT                                      |
+| Repository     | <https://github.com/rockorager/libvaxis> |
+| Documentation  | <https://rockorager.github.io/libvaxis/> |
+| Latest Version | 0.5.1 (targeting Zig 0.15.1)             |
+| GitHub Stars   | ~1.4k                                    |
+
+---
+
+## Overview
+
+**What it solves.** libvaxis provides a complete terminal UI toolkit for Zig that handles
+screen rendering, keyboard/mouse input, color management, image display, and Unicode
+grapheme clustering. It eliminates the need for terminfo databases by detecting terminal
+capabilities at runtime through escape-sequence queries, enabling direct use of modern
+terminal features without static capability files.
+
+**Design philosophy.** libvaxis is built on four core principles:
+
+1. **Modern terminals first.** Rather than targeting the lowest common denominator of VT100
+   compatibility, libvaxis is designed around the Kitty keyboard protocol, Kitty graphics
+   protocol, SGR pixel mouse mode, and other features available in modern terminals (Kitty,
+   WezTerm, Ghostty, foot, Alacritty). Legacy terminals are supported through fallback
+   paths, but the API is designed around the capabilities of modern emulators.
+
+2. **Explicit allocator passing.** Every allocation site accepts a `std.mem.Allocator`
+   parameter. There are no global allocators, no hidden heap usage. The caller controls
+   exactly where memory comes from -- general-purpose, arena, fixed-buffer, or a custom
+   allocator.
+
+3. **comptime-powered generics.** Zig's `comptime` is used pervasively: generic event types,
+   duck-typed widget interfaces, compile-time field iteration for table rendering, and
+   compile-time format string evaluation. No runtime reflection, no vtable overhead for
+   generic code paths.
+
+4. **Minimal dependencies.** The library depends only on `zigimg` (for image decoding) and
+   `uucode` (for Unicode tables). There is no libc dependency, no terminfo, no curses.
+
+**History and motivation.** libvaxis was created by rockorager as a ground-up Zig
+implementation that rejects the terminfo model used by ncurses, notcurses, and most existing
+TUI libraries. The author observed that modern terminal emulators have converged on a set of
+de facto standard protocols (Kitty keyboard, synchronized output, true color) and that
+querying the terminal directly is more reliable than relying on potentially outdated terminfo
+entries. The library has gained significant traction in the Zig ecosystem: it is used by
+Ghostty (the terminal emulator by Mitchell Hashimoto) and Superhtml, among other projects.
+
+---
+
+## Architecture
+
+### Three Primitives
+
+libvaxis is structured around three fundamental objects:
+
+1. **`Tty`** -- A platform-specific TTY handle (POSIX or Windows) that manages raw mode,
+   signal handling, and byte-level I/O with the terminal.
+2. **`Vaxis`** -- The core library context. Holds screen buffers, capability state, image
+   IDs, and rendering logic. Initialized with an allocator.
+3. **`Loop`** -- A multi-threaded event loop that reads from the TTY on a background thread,
+   parses escape sequences, and enqueues typed events into a thread-safe queue.
+
+```zig
+var tty = try vaxis.Tty.init();
+defer tty.deinit();
+
+var vx = try vaxis.init(alloc, .{});
+defer vx.deinit(alloc, &tty);
+
+var loop = try vaxis.Loop(Event).init(&vx, &tty);
+defer loop.deinit();
+loop.start();
+```
+
+### Double-Buffered Rendering
+
+Vaxis maintains two screen representations:
+
+- **`screen: Screen`** -- The current (back) buffer. Widgets write into this buffer during
+  the draw phase.
+- **`screen_last: InternalScreen`** -- The previous (front) buffer, representing what is
+  currently displayed on the terminal.
+
+On each `render()` call, Vaxis diffs the current screen against `screen_last`, emitting only
+the escape sequences needed to update changed cells. Unchanged cells are skipped via a fast
+equality check (`InternalCell.eql()`), with a fast path when both cells are in their default
+state.
+
+### Render Loop
+
+The render loop follows an immediate-mode pattern:
+
+```
+App State
+   |
+   v
+win = vx.window()      // get the full-screen Window
+win.clear()             // clear the back buffer
+   |
+   v
+Draw widgets into win   // write cells via win.writeCell(), win.print(), widget.draw()
+   |
+   v
+vx.render(&tty)         // diff back buffer vs front buffer, flush escape sequences
+   |
+   v
+Terminal emulator        // only changed cells are updated
+```
+
+Each frame, the application clears the back buffer, draws the entire UI from scratch, and
+calls `render()`. Despite rebuilding every frame, performance is bounded by the number of
+_changed_ cells, not the total cell count.
+
+### Event Loop
+
+The `Loop` is parameterized on a user-defined `Event` type. The library uses Zig's
+`@hasField` comptime introspection to determine which event categories the application
+cares about:
+
+```zig
+const Event = union(enum) {
+    key_press: vaxis.Key,
+    winsize: vaxis.Winsize,
+    // Only declare the events you handle.
+    // The loop uses @hasField to check at comptime.
+};
+
+// Blocking wait for next event
+const event = loop.nextEvent();
+
+// Non-blocking poll
+if (loop.tryEvent()) |event| { ... }
+```
+
+This is a powerful pattern: the event loop adapter inspects the application's `Event` union
+at compile time and only generates dispatch code for the variants the application declares.
+If the application does not declare `mouse`, mouse events are never enqueued. This is
+zero-cost event filtering via comptime.
+
+---
+
+## Terminal Backend
+
+### No Terminfo
+
+libvaxis generates escape sequences directly from hardcoded control strings defined in
+`ctlseqs.zig`. Instead of querying a terminfo database for "does this terminal support bold",
+it sends a query escape sequence to the terminal and reads the response. This approach has
+several advantages:
+
+- No dependency on system-installed terminfo files (which may be incomplete or outdated).
+- Correct capability detection for terminals running over SSH or in containers.
+- Support for features that terminfo does not describe (Kitty keyboard protocol, graphics
+  protocol, synchronized output).
+
+### Feature Detection
+
+During initialization, `vx.queryTerminal(&tty, timeout)` sends a batch of capability
+queries and waits for responses. The detected capabilities are stored in `vx.caps`:
+
+```zig
+pub const Capabilities = struct {
+    kitty_keyboard: bool,
+    kitty_graphics: bool,
+    rgb: bool,
+    sgr_pixels: bool,
+    unicode: bool,
+    color_scheme_updates: bool,
+    // ...
+};
+```
+
+### Supported Capabilities
+
+| Feature                 | Protocol / Mode  | Notes                                        |
+| ----------------------- | ---------------- | -------------------------------------------- |
+| Kitty keyboard protocol | CSI >1u          | Press/release/repeat, full modifier tracking |
+| Kitty graphics protocol | APC Gq           | Inline images, image placement and lifecycle |
+| True color (24-bit RGB) | SGR 38;2 / 48;2  | Detected via DA1 response                    |
+| Mouse (SGR pixel mode)  | Mode 1003 + 1016 | Sub-cell precision via pixel coordinates     |
+| Synchronized output     | Mode 2026        | Prevents tearing on fast updates             |
+| Unicode core            | Mode 2027        | Proper grapheme clustering in terminal       |
+| Styled underlines       | SGR 4:x          | Curly, dotted, dashed, double                |
+| Hyperlinks              | OSC 8            | Clickable URIs in terminal text              |
+| System clipboard        | OSC 52           | Read/write system clipboard                  |
+| Bracketed paste         | Mode 2004        | Distinguishes typed input from paste         |
+| In-band resize reports  | Mode 2048        | Resize events via escape sequences           |
+| Color scheme updates    | Mode 2031        | Dark/light mode change notifications         |
+| Desktop notifications   | OSC 9 / OSC 777  | Toast notifications from TUI apps            |
+| Mouse cursor shape      | OSC 22           | Change cursor appearance on hover            |
+| Alt screen              | Mode 1049        | Separate buffer for full-screen UI           |
+
+### Fallback Path
+
+For legacy terminals that do not respond to capability queries, libvaxis falls back to
+standard SGR rendering mode (256-color palette, basic modifiers, no Kitty keyboard). The
+`sgr` field on `Vaxis` tracks whether to use standard or legacy escape sequence formatting.
+
+---
+
+## Layout System
+
+### Manual Window-Based Layout
+
+libvaxis does not include a constraint solver. Layout is performed manually by creating
+**child windows** from a parent window, specifying offsets and dimensions:
+
+```zig
+const win = vx.window();
+win.clear();
+
+// Create a child window: left panel, 30 columns wide, full height
+const left_panel = win.child(.{
+    .x_off = 0,
+    .y_off = 0,
+    .width = .{ .limit = 30 },
+    .height = .{ .limit = win.height },
+});
+
+// Right panel fills remaining space
+const right_panel = win.child(.{
+    .x_off = 30,
+    .y_off = 0,
+    .width = .{ .limit = win.width -| 30 },
+    .height = .{ .limit = win.height },
+});
+```
+
+A `Window` is a view into the underlying `Screen` buffer with an offset and dimensions. It
+provides bounds-checked `writeCell()` and `readCell()` methods -- writes outside the window
+bounds are silently discarded. This is memory-safe without any runtime overhead beyond a
+bounds check.
+
+### Window.child()
+
+The `child()` method creates a sub-window with relative positioning. Key properties:
+
+- **`x_off`, `y_off`** -- Offset relative to the parent.
+- **`width`, `height`** -- Size specification (limit or unbounded, clamped to parent).
+- **`border`** -- Optional border using customizable Unicode glyphs.
+
+Child windows accumulate offsets. A child of a child has its absolute position computed from
+the chain of offsets, enabling nested composition.
+
+### Alignment Helpers
+
+The `widgets/alignment.zig` module provides positioning helpers:
+
+```zig
+// Center a 20x5 region within the parent window
+const centered = vaxis.widgets.alignment.center(win, 20, 5);
+
+// Other alignment options
+const top_right = vaxis.widgets.alignment.topRight(win, 20, 5);
+const bottom_left = vaxis.widgets.alignment.bottomLeft(win, 20, 5);
+```
+
+Each helper returns a `Window` (child) positioned at the appropriate offset within the
+parent.
+
+### vxfw FlexBox Layout
+
+The higher-level `vxfw` framework adds flex-based layout through `FlexRow` and `FlexColumn`
+widgets. These implement a two-pass algorithm:
+
+1. **Measure pass:** Children with `flex = 0` are drawn with unconstrained size to determine
+   their inherent dimensions.
+2. **Distribute pass:** Remaining space is allocated proportionally among flex children. The
+   last child receives any remainder to prevent rounding gaps.
+
+```zig
+// Three columns: fixed 10 + flex 1 + flex 2
+const row = FlexRow{
+    .children = &.{
+        .{ .widget = sidebar.widget(), .flex = 0 },  // inherent width
+        .{ .widget = content.widget(), .flex = 1 },   // 1/3 remaining
+        .{ .widget = preview.widget(), .flex = 2 },   // 2/3 remaining
+    },
+};
+```
+
+---
+
+## Widget / Component System
+
+### Low-Level API: Duck-Typed via Convention
+
+In the low-level API, a "widget" is any type that knows how to draw itself into a `Window`.
+There is no formal interface or trait. By convention, widgets implement:
+
+- `draw(win: Window) void` -- Render into the given window.
+- `update(event: Event) void` -- Process an input event (optional).
+
+The `TextInput` widget exemplifies this pattern:
+
+```zig
+const TextInput = @import("vaxis").widgets.TextInput;
+
+var text_input = TextInput.init(alloc);
+defer text_input.deinit();
+
+// In event handling:
+try text_input.update(.{ .key_press = key });
+
+// In rendering:
+const child = win.child(.{ .x_off = 1, .y_off = 1, .width = .{ .limit = 40 }, .height = .{ .limit = 1 } });
+text_input.draw(child);
+```
+
+The `Table` widget goes further, using comptime field iteration to render arbitrary struct
+types:
+
+```zig
+// Table renders any Slice, ArrayList, or MultiArrayList
+// using inline for over struct fields at comptime
+const table = Table(MyData){
+    .ctx = &table_ctx,
+};
+table.drawTable(win, data_slice);
+```
+
+This uses `@typeInfo`, `std.meta.fields()`, and `inline for` to iterate struct fields at
+compile time, generating specialized rendering code for each column with zero runtime
+overhead.
+
+### vxfw Framework: Type-Erased Widget Protocol
+
+The `vxfw` (Vaxis Framework) provides a more structured widget system with type erasure.
+Widgets implement their behavior through a standardized protocol:
+
+```zig
+pub const Widget = struct {
+    userdata: *anyopaque,
+    eventHandler: ?*const fn (*anyopaque, *EventContext) anyerror!void = null,
+    drawFn: *const fn (*anyopaque, DrawContext) Allocator.Error!Surface,
+
+    /// Draw the widget, returning a Surface
+    pub fn draw(self: Widget, ctx: DrawContext) Allocator.Error!Surface {
+        return self.drawFn(self.userdata, ctx);
+    }
+};
+```
+
+Any concrete widget provides a `widget()` method that returns a type-erased `Widget`:
+
+```zig
+const Center = struct {
+    child: vxfw.Widget,
+
+    pub fn widget(self: *const Center) vxfw.Widget {
+        return .{
+            .userdata = @ptrCast(@constCast(self)),
+            .drawFn = typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedDrawFn(userdata: *anyopaque, ctx: DrawContext) !Surface {
+        const self: *const Center = @ptrCast(@alignCast(userdata));
+        return self.draw(ctx);
+    }
+
+    fn draw(self: *const Center, ctx: DrawContext) !Surface {
+        const child_surface = try self.child.draw(ctx.withConstraints(.{}, ctx.max));
+        // Center the child within available space
+        const x = (ctx.max.width -| child_surface.size.width) / 2;
+        const y = (ctx.max.height -| child_surface.size.height) / 2;
+        return Surface{
+            .size = ctx.max,
+            .children = &.{.{ .origin = .{ .x = x, .y = y }, .surface = child_surface }},
+        };
+    }
+};
+```
+
+**Key point:** Zig's comptime duck typing here (any type with the right method signatures
+becomes a widget) is structurally identical to D's Design by Introspection. The `Widget`
+struct is a manually constructed vtable -- Zig does not have interfaces, so type erasure is
+built by hand using `*anyopaque` and function pointers. D can achieve the same pattern more
+ergonomically with template constraints.
+
+### Built-In Widgets
+
+**Low-level API widgets** (`src/widgets/`):
+
+| Widget        | Purpose                                        |
+| ------------- | ---------------------------------------------- |
+| `TextInput`   | Single-line text input with cursor and editing |
+| `Table`       | Generic table rendering from struct data       |
+| `ScrollView`  | Scrollable content container                   |
+| `Scrollbar`   | Visual scroll position indicator               |
+| `TextView`    | Multi-line text display                        |
+| `CodeView`    | Syntax-aware code display with line numbers    |
+| `LineNumbers` | Line number column                             |
+| `View`        | Base container widget                          |
+| `alignment`   | Positioning helpers (center, topLeft, etc.)    |
+| `Terminal`    | Embedded terminal emulator widget              |
+
+**vxfw framework widgets** (`src/vxfw/`):
+
+| Widget       | Purpose                                      |
+| ------------ | -------------------------------------------- |
+| `FlexRow`    | Horizontal flex layout (proportional widths) |
+| `FlexColumn` | Vertical flex layout (proportional heights)  |
+| `Border`     | Decorative border wrapper                    |
+| `Center`     | Center a child within available space        |
+| `Padding`    | Add spacing around a child                   |
+| `SizedBox`   | Fix a child to specific dimensions           |
+| `SplitView`  | Two-pane split with adjustable divider       |
+| `ScrollView` | Scrollable container with scroll bars        |
+| `ListView`   | Virtualized list for large datasets          |
+| `Text`       | Basic text rendering                         |
+| `RichText`   | Styled text with inline formatting           |
+| `TextField`  | Text input field                             |
+| `Button`     | Clickable button with event handler          |
+| `Spinner`    | Animated loading indicator                   |
+
+---
+
+## Styling
+
+### Cell Struct
+
+Each terminal cell is represented by a `Cell` struct:
+
+```zig
+pub const Cell = struct {
+    char: Character = .{},
+    style: Style = .{},
+    link: Hyperlink = .{},
+    image: ?Image.Placement = null,
+    default: bool = false,
+    wrapped: bool = false,
+};
+
+pub const Character = struct {
+    grapheme: []const u8 = " ",  // UTF-8 bytes, may be multi-codepoint
+    width: u8 = 1,               // display width in columns
+};
+```
+
+The `grapheme` field stores a byte slice, not a single codepoint. This correctly handles
+multi-codepoint grapheme clusters (emoji with ZWJ sequences, combining characters, etc.).
+The `width` field stores the pre-computed East Asian width for the grapheme.
+
+### Style
+
+```zig
+pub const Style = struct {
+    fg: Color = .default,
+    bg: Color = .default,
+    ul: Color = .default,          // underline color (separate from text color)
+    ul_style: Underline = .off,    // off, single, double, curly, dotted, dashed
+    bold: bool = false,
+    dim: bool = false,
+    italic: bool = false,
+    blink: bool = false,
+    reverse: bool = false,
+    invisible: bool = false,
+    strikethrough: bool = false,
+};
+```
+
+### Color
+
+```zig
+pub const Color = union(enum) {
+    default,             // terminal default foreground/background
+    index: u8,           // 256-color palette index
+    rgb: [3]u8,          // 24-bit true color [r, g, b]
+};
+```
+
+No palette abstraction or named colors. Direct values. This avoids the overhead of color
+resolution at render time.
+
+### Hyperlink
+
+```zig
+pub const Hyperlink = struct {
+    uri: []const u8 = "",
+    params: []const u8 = "",  // OSC 8 parameters (e.g., id=...)
+};
+```
+
+### Usage Example
+
+```zig
+const style: vaxis.Style = .{
+    .fg = .{ .rgb = .{ 0, 255, 128 } },
+    .bg = .{ .index = 236 },
+    .bold = true,
+    .ul = .{ .rgb = .{ 255, 0, 0 } },
+    .ul_style = .curly,
+};
+
+win.writeCell(.{
+    .char = .{ .grapheme = "A", .width = 1 },
+    .style = style,
+    .link = .{ .uri = "https://example.com" },
+});
+```
+
+---
+
+## Event Handling
+
+### Tagged Union Events
+
+libvaxis represents events as a Zig tagged union. The internal `Event` type covers all
+possible terminal events:
+
+```zig
+pub const Event = union(enum) {
+    key_press: Key,
+    key_release: Key,
+    mouse: Mouse,
+    mouse_leave,
+    focus_in,
+    focus_out,
+    paste_start,
+    paste_end,
+    paste: []const u8,
+    color_report: Color.Report,
+    color_scheme: Color.Scheme,
+    winsize: Winsize,
+    // Capability detection results
+    cap_kitty_keyboard,
+    cap_kitty_graphics,
+    cap_rgb,
+    cap_sgr_pixels,
+    cap_unicode,
+    cap_da1,
+    cap_color_scheme_updates,
+};
+```
+
+### Key Events
+
+```zig
+pub const Key = struct {
+    codepoint: u21,                    // Unicode codepoint
+    shifted_codepoint: ?u21 = null,    // codepoint with shift applied
+    base_layout_codepoint: ?u21 = null, // layout-independent codepoint
+    mods: Modifiers = .{},
+    text: ?[]const u8 = null,          // generated text (if any)
+};
+
+pub const Modifiers = packed struct {
+    shift: bool = false,
+    alt: bool = false,
+    ctrl: bool = false,
+    super: bool = false,
+    hyper: bool = false,
+    meta: bool = false,
+    caps_lock: bool = false,
+    num_lock: bool = false,
+};
+```
+
+The Kitty keyboard protocol provides press, release, and repeat events as separate union
+variants (`key_press` vs `key_release`), full modifier tracking including Super/Hyper/Meta,
+and the `shifted_codepoint` field for disambiguating shifted keys. The `text` field contains
+the actual text generated by the key event, which may differ from the codepoint (e.g., for
+dead keys or input methods).
+
+### Mouse Events
+
+```zig
+pub const Mouse = struct {
+    col: i16,
+    row: i16,
+    xoffset: u16 = 0,  // sub-cell pixel offset (SGR pixel mode)
+    yoffset: u16 = 0,
+    button: Button,
+    mods: Modifiers,
+    type: Type,
+
+    pub const Button = enum { left, middle, right, wheel_up, wheel_down, ... };
+    pub const Type = enum { press, release, motion, drag };
+    pub const Modifiers = packed struct { shift: bool, alt: bool, ctrl: bool };
+};
+```
+
+When SGR pixel mode is available, `xoffset` and `yoffset` provide sub-cell precision for
+mouse events, enabling precise hit testing within grapheme clusters or images.
+
+### Event Loop Example
+
+```zig
+while (true) {
+    const event = loop.nextEvent();  // blocking wait
+
+    switch (event) {
+        .key_press => |key| {
+            if (key.matches('c', .{ .ctrl = true })) {
+                break;  // Ctrl+C to exit
+            }
+            if (key.matches('l', .{ .ctrl = true })) {
+                vx.queueRefresh();  // Ctrl+L to refresh
+            }
+            try text_input.update(.{ .key_press = key });
+        },
+        .winsize => |ws| {
+            try vx.resize(alloc, &tty, ws);
+        },
+        .mouse => |mouse| {
+            if (win.hasMouse(mouse)) {
+                // Mouse is within this window's bounds
+            }
+        },
+        else => {},
+    }
+
+    // Render after handling all available events
+    const win = vx.window();
+    win.clear();
+    text_input.draw(win);
+    try vx.render(&tty);
+}
+```
+
+Zig's `switch` on tagged unions is exhaustive: if you do not handle a variant and do not
+include an `else` branch, the code will not compile. This is a compile-time guarantee that
+all event types are considered.
+
+---
+
+## State Management
+
+libvaxis is purely imperative. The application owns all state. There is no framework-imposed
+architecture, no model-view separation, no signals, no reactive bindings.
+
+### Low-Level API
+
+State management is entirely ad-hoc. The application struct holds whatever fields it needs,
+mutates them in response to events, and renders from them:
+
+```zig
+const App = struct {
+    counter: u32 = 0,
+    text_input: TextInput,
+    running: bool = true,
+
+    fn handleEvent(self: *App, event: Event) void {
+        switch (event) {
+            .key_press => |key| {
+                if (key.matches('q', .{})) self.running = false;
+                if (key.matches(vaxis.Key.up, .{})) self.counter += 1;
+            },
+            else => {},
+        }
+    }
+
+    fn render(self: *App, win: Window) void {
+        win.clear();
+        // Draw UI based on current state
+    }
+};
+```
+
+### vxfw Framework
+
+The `vxfw` framework provides an `App` runtime that manages the event loop, focus tracking,
+and frame timing (default 60 FPS). State is still application-managed, but the framework
+provides structure:
+
+- **`eventHandler`**: Called for each event, receives an `EventContext` for issuing commands
+  (redraw, focus change, set cursor, etc.).
+- **`drawFn`**: Called to produce a `Surface` with layout constraints.
+- **Arena allocation**: Per-frame arena for temporary allocations (formatted text, layout
+  scratch space). Freed automatically at frame end.
+
+```zig
+const Model = struct {
+    counter: u32 = 0,
+    button: vxfw.Button,
+
+    fn eventHandler(self: *Model, ctx: *EventContext) !void {
+        switch (ctx.event) {
+            .key_press => |key| {
+                if (key.matches('c', .{ .ctrl = true })) {
+                    ctx.quit = true;
+                }
+            },
+            else => {},
+        }
+    }
+
+    fn drawFn(self: *Model, ctx: DrawContext) !Surface {
+        const label = try std.fmt.allocPrint(ctx.arena, "Count: {}", .{self.counter});
+        // Return Surface with children
+    }
+};
+```
+
+Zig's explicit memory management means every allocation is visible. There are no hidden
+heap allocations, no GC pauses, no reference counting. The developer sees exactly where
+memory is allocated and when it is freed.
+
+---
+
+## Extensibility and Ecosystem
+
+### Ecosystem
+
+libvaxis's ecosystem is small but growing, anchored by high-profile users:
+
+- **Ghostty** -- Mitchell Hashimoto's GPU-accelerated terminal emulator uses libvaxis as a
+  dependency for its TUI rendering layer.
+- **Superhtml** -- An HTML tool built with libvaxis.
+- The Zig community is active on **#vaxis on libera.chat IRC** and GitHub Discussions.
+
+### Package Integration
+
+libvaxis is distributed via the Zig package manager:
+
+```bash
+zig fetch --save git+https://github.com/rockorager/libvaxis.git
+```
+
+Then in `build.zig`:
+
+```zig
+const vaxis_dep = b.dependency("vaxis", .{});
+exe.root_module.addImport("vaxis", vaxis_dep.module("vaxis"));
+```
+
+### C API
+
+A C API wrapper is available for non-Zig consumers, enabling use from C, C++, or any
+language with C FFI. This broadens the library's reach beyond the Zig ecosystem.
+
+### Unicode Tables
+
+libvaxis bundles its own Unicode data tables (via the `uucode` dependency) for grapheme
+cluster breaking, East Asian width calculation, and emoji detection. This avoids depending
+on the system's ICU or locale configuration.
+
+---
+
+## Strengths
+
+- **comptime type safety without runtime overhead.** Generic event types, duck-typed widgets,
+  compile-time table column generation, and `@hasField`-based event filtering all resolve at
+  compile time. The emitted machine code is fully monomorphized.
+
+- **Explicit allocator control.** Every allocation site accepts an `Allocator` parameter.
+  Applications can use arena allocators for per-frame temporaries, fixed-buffer allocators
+  for `@nogc`-style operation, or custom allocators for profiling and debugging.
+
+- **Modern terminal features are first-class.** Kitty keyboard protocol, Kitty graphics,
+  SGR pixel mouse, styled underlines, hyperlinks, and synchronized output are not
+  afterthoughts bolted onto a legacy abstraction -- they are the primary API surface.
+
+- **Small and focused.** The library has a clear scope (terminal UI) and does not attempt to
+  be a framework, an async runtime, or a widget toolkit. The low-level API gives full
+  control; the vxfw framework is opt-in.
+
+- **No terminfo dependency.** Runtime capability detection means correct behavior on any
+  terminal, including over SSH, in containers, and on systems without terminfo databases.
+
+- **Fast compilation.** Zig compiles quickly, and libvaxis has minimal dependencies. Build
+  times are measured in seconds, not minutes.
+
+- **Cross-platform.** macOS, Linux, BSD, and Windows are supported from a single codebase.
+
+- **Panic-safe terminal restoration.** A custom panic handler resets the terminal (exits alt
+  screen, restores cursor, disables raw mode) before crashing, preventing corrupted terminal
+  state.
+
+- **Double-buffered differential rendering.** Only changed cells are written to the terminal,
+  minimizing I/O and preventing flicker (especially with synchronized output mode).
+
+---
+
+## Weaknesses and Limitations
+
+- **Manual layout.** The low-level API has no layout engine at all. Even the vxfw flex
+  widgets are basic compared to CSS flexbox or Ratatui's constraint solver. Complex layouts
+  require manual coordinate arithmetic.
+
+- **Zig language instability.** Zig has not reached 1.0. The language and standard library
+  change between versions. libvaxis targets Zig 0.15.1 specifically and may require updates
+  for future Zig releases. This is a risk for long-lived projects.
+
+- **Small ecosystem.** Compared to Ratatui (12,700+ dependents) or ncurses, the libvaxis
+  ecosystem is tiny. There are few third-party widgets, no template generators, and limited
+  learning resources beyond the source code and examples.
+
+- **Targets modern terminals.** Terminals that do not support the Kitty keyboard protocol or
+  SGR mouse fall back to degraded functionality. This is a deliberate design choice but
+  limits compatibility with older or minimal terminals (e.g., the Linux console, very old
+  xterm builds).
+
+- **Limited built-in widgets.** The low-level widget set covers basics (text input, table,
+  scroll view) but lacks a tree view, tabs, progress bar, chart, or other common components.
+  The vxfw set is more complete but still growing.
+
+- **Documentation is code-focused.** There is no prose tutorial or conceptual guide. The
+  documentation is auto-generated API docs plus example programs. Learning the library
+  requires reading source code.
+
+- **Type erasure is manual.** Zig lacks interfaces and traits, so the vxfw widget protocol
+  requires manual vtable construction with `*anyopaque` and function pointers. This is
+  verbose and error-prone compared to Rust traits or D template constraints.
+
+- **No retained mode option.** Every frame redraws from scratch. For UIs with expensive
+  widget construction, there is no built-in mechanism to cache subtrees.
+
+---
+
+## Lessons for D / Sparkles
+
+Zig and D share fundamental design goals: compile-time execution of arbitrary code, explicit
+control over memory allocation, zero-cost generic programming, and systems-level performance.
+libvaxis is the most directly relevant TUI library for Sparkles' design because the patterns
+translate almost one-to-one.
+
+### comptime -> CTFE
+
+Zig's `comptime` and D's CTFE (Compile-Time Function Evaluation) serve the same purpose:
+execute arbitrary code at compile time to generate specialized runtime code.
+
+**Zig pattern -- comptime event filtering:**
+
+```zig
+fn handleEventGeneric(comptime Event: type, raw: RawEvent) ?Event {
+    if (@hasField(Event, "key_press")) {
+        if (raw.isKeyPress()) return Event{ .key_press = raw.toKey() };
+    }
+    // Only generates code for declared event variants
+}
+```
+
+**D equivalent -- CTFE + `static if`:**
+
+```d
+Event handleEvent(Event)(RawEvent raw)
+{
+    static if (__traits(hasMember, Event, "keyPress"))
+    {
+        if (raw.isKeyPress)
+            return Event(Event.Kind.keyPress, raw.toKey);
+    }
+    // Only generates code for declared event variants
+}
+```
+
+D can go further than Zig's comptime with **string mixins** and **CTFE evaluation of
+arbitrary expressions**. For example, D can generate an entire event dispatch table at
+compile time from a list of handler function names:
+
+```d
+/// Generate a dispatch switch at compile time from handler method names.
+enum generateDispatch(Handlers...) = {
+    string code = "switch (event.kind) {\n";
+    static foreach (H; Handlers)
+        code ~= "    case Event.Kind." ~ H.name ~ ": "
+              ~ H.name ~ "Handler(event); break;\n";
+    code ~= "    default: break;\n}\n";
+    return code;
+}();
+
+// Usage:
+mixin(generateDispatch!(onKeyPress, onMouse, onResize));
+```
+
+### Explicit Allocators -> D's @nogc + SmallBuffer
+
+Zig passes allocators explicitly to every function that allocates:
+
+```zig
+var vx = try vaxis.init(alloc, .{});
+var text_input = TextInput.init(alloc);
+const label = try std.fmt.allocPrint(ctx.arena, "Count: {}", .{count});
+```
+
+D achieves similar control through a combination of mechanisms:
+
+1. **`@nogc` attribute** -- Enforces at the type level that a function cannot use the GC.
+   This is arguably more ergonomic than explicit allocator passing because it is checked by
+   the compiler rather than by convention.
+
+2. **`SmallBuffer`** -- Sparkles' existing `SmallBuffer` provides inline allocation with
+   heap fallback, similar to Zig's `std.ArrayList` but with a small-buffer optimization
+   that avoids allocation entirely for typical sizes.
+
+3. **Scoped allocators via D's `scope`** -- D's `scope` and `-preview=dip1000` enable
+   stack-like allocation disciplines similar to Zig's arena pattern.
+
+```d
+@safe pure nothrow @nogc:
+
+/// Arena-style per-frame allocation using SmallBuffer.
+struct FrameArena
+{
+    SmallBuffer!(ubyte, 4096) storage;
+
+    T[] alloc(T)(size_t count) return
+    {
+        auto bytes = storage.extendUnsafe(count * T.sizeof);
+        return (cast(T*) bytes.ptr)[0 .. count];
+    }
+
+    void reset() { storage.clear(); }
+}
+
+void renderFrame(ref FrameArena arena, ref Screen screen)
+{
+    // All allocations come from the arena, freed at frame end
+    auto cells = arena.alloc!Cell(screen.width * screen.height);
+    // ...
+    arena.reset();  // zero-cost "free all"
+}
+```
+
+The key difference: D's approach is **attribute-based** (`@nogc` is enforced by the compiler
+globally) while Zig's is **parameter-based** (allocator must be threaded through every call
+site). D's approach catches violations at compile time even in code you did not write;
+Zig's approach gives more flexibility in choosing different allocators per call site.
+
+### Duck-Typed Widgets -> Design by Introspection (DbI)
+
+Zig's widget pattern relies on "any type with the right methods":
+
+```zig
+// Any type with a draw method can be used as a widget
+text_input.draw(window);
+table.drawTable(window, data);
+```
+
+In the vxfw framework, type erasure is manual:
+
+```zig
+pub fn widget(self: *const Center) vxfw.Widget {
+    return .{
+        .userdata = @ptrCast(@constCast(self)),
+        .drawFn = typeErasedDrawFn,
+    };
+}
+```
+
+D's Design by Introspection achieves this more directly:
+
+```d
+/// Compile-time widget concept -- no interface, no vtable.
+enum isWidget(T) = __traits(hasMember, T, "draw")
+    && is(typeof((T w, Window win) { w.draw(win); }));
+
+/// Optional capabilities detected at compile time.
+enum isInteractiveWidget(T) = isWidget!T
+    && __traits(hasMember, T, "handleEvent");
+
+/// Render any widget -- monomorphized, zero overhead.
+void renderWidget(W)(ref W widget, Window win)
+if (isWidget!W)
+{
+    widget.draw(win);
+}
+
+/// Dispatch events with optional handler.
+void dispatchEvent(W)(ref W widget, Event event)
+if (isWidget!W)
+{
+    static if (isInteractiveWidget!W)
+        widget.handleEvent(event);
+    // else: silently skip -- widget does not handle events
+}
+```
+
+This is structurally identical to Zig's pattern but with two advantages:
+
+1. **No manual vtable construction.** D's templates monomorphize automatically; there is no
+   need to cast through `*anyopaque` and build function pointer tables by hand.
+2. **`static if` for optional capabilities.** D can check for optional methods at compile
+   time and generate different code paths, exactly like Zig's `@hasField` but integrated
+   into the template system.
+
+### Tagged Union Events -> D's SumType
+
+Zig's tagged unions:
+
+```zig
+const Event = union(enum) {
+    key_press: Key,
+    key_release: Key,
+    mouse: Mouse,
+    focus_in,
+    focus_out,
+    winsize: Winsize,
+};
+
+switch (event) {
+    .key_press => |key| { ... },
+    .winsize => |ws| { ... },
+    else => {},
+}
+```
+
+D equivalent with `std.sumtype.SumType`:
+
+```d
+import std.sumtype : SumType;
+
+alias Event = SumType!(
+    KeyPress,
+    KeyRelease,
+    Mouse,
+    FocusIn,
+    FocusOut,
+    Winsize,
+);
+
+event.match!(
+    (KeyPress key)  => handleKeyPress(key),
+    (Winsize ws)    => handleResize(ws),
+    (_)             => {},  // default case
+);
+```
+
+Both provide exhaustive matching (the compiler errors if a variant is unhandled without a
+default branch). D's `match!` uses lambdas, which is slightly more verbose but composes
+well with UFCS chains. D also allows pattern matching with `static if` and `is()` checks
+for more complex dispatch logic.
+
+### Cell Struct -> D Struct with SmallBuffer
+
+Zig's `Cell` with its `Character` containing a `[]const u8` grapheme maps directly to D:
+
+```d
+@safe pure nothrow @nogc:
+
+struct Character
+{
+    SmallBuffer!(char, 16) grapheme;  // inline storage for typical graphemes
+    ubyte width = 1;                  // East Asian display width
+
+    this(string s, ubyte w = 1)
+    {
+        grapheme ~= s;
+        width = w;
+    }
+}
+
+struct Style
+{
+    Color fg = Color.init;
+    Color bg = Color.init;
+    Color ul = Color.init;
+    UnderlineStyle ulStyle = UnderlineStyle.off;
+    bool bold, dim, italic, blink, reverse, invisible, strikethrough;
+}
+
+struct Cell
+{
+    Character ch;
+    Style style;
+    string hyperlink;     // OSC 8 URI
+}
+```
+
+The `SmallBuffer!(char, 16)` stores most grapheme clusters (even complex emoji sequences
+like family emoji are under 16 bytes of UTF-8) inline without heap allocation. This mirrors
+Zig's approach where the grapheme is a byte slice, but with D's small-buffer optimization
+to avoid the need for an external allocator for typical cases.
+
+### Window as Buffer Slice -> Typed Slice with Bounds Checking
+
+Zig's `Window` is a view into a `Screen`'s cell buffer with offset and dimensions:
+
+```zig
+const Window = struct {
+    x_off: u16,
+    y_off: u16,
+    width: u16,
+    height: u16,
+    screen: *Screen,
+};
+```
+
+D equivalent with `@safe` bounds checking:
+
+```d
+@safe pure nothrow @nogc:
+
+struct Window
+{
+    ushort xOff, yOff;
+    ushort width, height;
+    Screen* screen;
+
+    /// Write a cell with automatic bounds checking.
+    void writeCell(ushort x, ushort y, Cell cell)
+    in (x < width, "x out of bounds")
+    in (y < height, "y out of bounds")
+    {
+        screen.buf[(yOff + y) * screen.width + (xOff + x)] = cell;
+    }
+
+    /// Create a child window with relative positioning.
+    Window child(ChildOpts opts) const
+    {
+        import std.algorithm : min;
+        return Window(
+            xOff: cast(ushort)(xOff + opts.xOff),
+            yOff: cast(ushort)(yOff + opts.yOff),
+            width: cast(ushort) min(opts.width, width - opts.xOff),
+            height: cast(ushort) min(opts.height, height - opts.yOff),
+            screen: screen,
+        );
+    }
+}
+```
+
+D's expression-based contracts (`in (x < width, "x out of bounds")`) provide the same
+bounds safety as Zig's runtime checks but with more descriptive error messages and the
+ability to be disabled in release builds.
+
+### No Terminfo -> Direct Escape Sequences with C Interop Fallback
+
+libvaxis generates escape sequences directly and queries the terminal for capabilities.
+D could follow the same approach:
+
+```d
+/// Direct escape sequence generation -- no terminfo dependency.
+@safe pure nothrow @nogc:
+
+enum CtlSeqs : string
+{
+    enterAltScreen = "\x1b[?1049h",
+    exitAltScreen  = "\x1b[?1049l",
+    syncStart      = "\x1b[?2026h",
+    syncEnd        = "\x1b[?2026l",
+    curlyUnderline = "\x1b[4:3m",
+}
+
+/// Query terminal capabilities via escape sequence round-trip.
+Capabilities queryTerminal(ref Tty tty, Duration timeout)
+{
+    tty.write("\x1b[?u");  // Query Kitty keyboard support
+    tty.write("\x1b[c");   // DA1 query
+    // Parse responses within timeout...
+}
+```
+
+For legacy terminals, D's seamless C interop enables fallback to terminfo without a
+separate binding layer:
+
+```d
+/// Fallback to terminfo via D's C interop.
+extern(C) int setupterm(const(char)* term, int fildes, int* errret);
+extern(C) const(char)* tigetstr(const(char)* capname);
+
+string getTerminfoCapability(string cap)
+{
+    auto result = tigetstr(cap.toStringz);
+    if (result is null || result == cast(const(char)*) -1)
+        return null;
+    return result.fromStringz.idup;
+}
+```
+
+This hybrid approach gives the best of both worlds: modern terminals get direct protocol
+support (fast, no dependency), while legacy terminals fall back to terminfo through D's
+zero-cost C FFI.
+
+---
+
+## References
+
+- **GitHub Repository:** <https://github.com/rockorager/libvaxis>
+- **API Documentation:** <https://rockorager.github.io/libvaxis/>
+- **Zig Package Registry (Zigistry):** <https://zigistry.dev/programs/github/rockorager/libvaxis/>
+- **Ziggit Community Discussion:** <https://ziggit.dev/t/libvaxis-a-modern-tui-library/4380>
+- **IRC Channel:** `#vaxis` on libera.chat
+- **Key Source Files:**
+  - Vaxis core: `src/Vaxis.zig`
+  - Cell/Style: `src/Cell.zig`
+  - Window: `src/Window.zig`
+  - Event types: `src/event.zig`
+  - Key input: `src/Key.zig`
+  - Mouse input: `src/Mouse.zig`
+  - Control sequences: `src/ctlseqs.zig`
+  - Event loop: `src/Loop.zig`
+  - Screen buffer: `src/Screen.zig`, `src/InternalScreen.zig`
+  - vxfw framework: `src/vxfw/vxfw.zig`, `src/vxfw/App.zig`
+- **Notable Users:**
+  - Ghostty terminal emulator: <https://github.com/ghostty-org/ghostty>
+- **Related Protocols:**
+  - Kitty keyboard protocol: <https://sw.kovidgoyal.net/kitty/keyboard-protocol/>
+  - Kitty graphics protocol: <https://sw.kovidgoyal.net/kitty/graphics-protocol/>
+  - OSC 8 hyperlinks: <https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda>

--- a/docs/research/tui-libraries/mosaic.md
+++ b/docs/research/tui-libraries/mosaic.md
@@ -1,0 +1,1028 @@
+# Mosaic (Kotlin)
+
+Jetpack Compose's compiler plugin and reactive runtime, retargeted from Android views to terminal ANSI output.
+
+| Attribute     | Value                                                              |
+| ------------- | ------------------------------------------------------------------ |
+| Language      | Kotlin (Multiplatform)                                             |
+| Repository    | <https://github.com/JakeWharton/mosaic>                            |
+| License       | Apache 2.0                                                         |
+| Author        | Jake Wharton                                                       |
+| First release | June 2021                                                          |
+| Latest        | 0.18.0 (2025)                                                      |
+| Platforms     | JVM, Linux x64, macOS ARM/x64, Windows x64, JS (experimental)      |
+| Paradigm      | Declarative reactive UI with compiler-plugin-powered recomposition |
+
+---
+
+## Overview
+
+Mosaic is a Kotlin library that brings the Jetpack Compose programming model to terminal user interfaces. Rather than reimplementing Compose's reactive semantics from scratch, Mosaic uses the **actual Compose compiler plugin and runtime** -- the same compiler infrastructure that powers Android's Jetpack Compose and JetBrains' Compose Multiplatform -- and retargets it to produce ANSI-encoded terminal output instead of Android views or desktop windows.
+
+The core insight is that Compose is not fundamentally an Android UI framework. It is a general-purpose compiler and runtime for **state tracking and tree manipulation**. The compiler plugin transforms `@Composable` functions into incremental tree-building code. The runtime maintains a slot table of composition state, observes snapshot state for changes, and triggers minimal recomposition when state mutates. Mosaic supplies a custom `Applier` that maps the abstract composition tree to a grid of styled text pixels, which are then rendered as ANSI escape sequences to stdout.
+
+Mosaic was created by Jake Wharton, a well-known figure in the Android development community and a member of Google's Android team. The project draws direct inspiration from [Ink](https://github.com/vadimdemedes/ink), the React-based terminal UI library for JavaScript. Where Ink proves that React's reconciliation model works for terminals, Mosaic proves the same for Compose's compiler-driven recomposition model -- with the added benefit that recomposition decisions happen at compile time rather than at runtime through virtual DOM diffing.
+
+The library has evolved significantly since its 2021 debut as a JVM-only experiment. Version 0.4.0 (2023) introduced Kotlin Multiplatform support across Linux, macOS, Windows, and experimental JS. Version 0.15.0 added a `mosaic-animation` module. Version 0.17.0 overhauled terminal integration with a custom terminal parsing library, enabling theme detection and focus awareness.
+
+---
+
+## Architecture
+
+Mosaic's architecture is best understood as four layers: the **compiler plugin** that transforms source code, the **runtime** that manages composition state, the **applier** that builds a terminal node tree, and the **renderer** that converts that tree to ANSI output.
+
+### Compose Compiler Plugin
+
+The Compose compiler plugin is a Kotlin compiler plugin (originally from Google, now maintained by JetBrains) that transforms `@Composable` functions at compile time. This is genuine **metaprogramming** -- the plugin rewrites function signatures and bodies to thread composition context, insert change-detection guards, and generate slot-table management code.
+
+When you write:
+
+```kotlin
+@Composable
+fun Greeting(name: String) {
+    Text("Hello, $name!")
+}
+```
+
+The compiler plugin transforms this into code that roughly:
+
+1. Receives a hidden `Composer` parameter and a change-tracking bitmask (`$changed`).
+2. Checks whether `name` has actually changed since the last composition by comparing against the value stored in the slot table.
+3. If `name` is unchanged, **skips** the function body entirely (the function is "skippable").
+4. If `name` has changed, re-executes the body, updating the slot table and emitting tree operations.
+
+This is fundamentally different from React's virtual DOM diffing. There is no diff at runtime. The compiler has already inserted the exact comparison checks needed, so the runtime only re-executes functions whose inputs have demonstrably changed. This is what makes Compose's recomposition model so efficient.
+
+### Slot Table
+
+The slot table is the runtime data structure that stores the composition's state. It is a flat, gap-buffer-style array that records:
+
+- Which `@Composable` functions were called and in what order (the **group** structure).
+- The parameter values passed to each function (for skip-checking).
+- State objects created via `remember { ... }` and `mutableStateOf(...)`.
+- The structural identity of each node (positional memoization).
+
+The slot table enables Compose to "remember" the previous composition and make surgical updates rather than rebuilding the entire tree.
+
+### Recomposition
+
+Recomposition is the process of re-executing `@Composable` functions when their inputs change. Key properties:
+
+- **Incremental**: Only functions whose read state has changed are re-executed.
+- **Positional memoization**: The identity of a composable call is determined by its position in the call tree (augmented by optional `key` calls), not by an explicit ID.
+- **Idempotent**: Composable functions must be side-effect-free with respect to the composition. Side effects are channeled through `LaunchedEffect`, `DisposableEffect`, and similar APIs.
+- **Concurrent-safe**: The snapshot system ensures that recomposition reads a consistent view of state.
+
+### Snapshot System
+
+Compose's snapshot system provides **observable state** that automatically triggers recomposition. When you write:
+
+```kotlin
+var count by remember { mutableIntStateOf(0) }
+```
+
+The `mutableIntStateOf` creates a state object backed by the snapshot system. During composition, the runtime records which state objects each `@Composable` function reads. When a state object is written to, the runtime knows exactly which functions need to recompose -- no manual subscriptions, no explicit invalidation.
+
+The snapshot system also provides **isolation**: state changes are committed atomically, preventing torn reads during recomposition.
+
+### Applier: MosaicNodeApplier
+
+The `Applier` is the bridge between Compose's abstract composition and the concrete output format. In Android Compose, the applier inserts `LayoutNode` objects into the Android view hierarchy. In Mosaic, the `MosaicNodeApplier` inserts `MosaicNode` objects into a terminal node tree.
+
+```
+Compose Runtime  --[Applier]-->  MosaicNode tree  --[Layout]-->  TextSurface  --[Render]-->  ANSI string
+```
+
+The `MosaicNodeApplier` extends `AbstractApplier<MosaicNode>` and manages bottom-up insertion and structural changes (insertions, removals, moves) on the node tree.
+
+### Frame-Based Rendering
+
+Mosaic renders the composition to the terminal in a frame-based loop:
+
+1. A frame clock provides timing signals.
+2. Keyboard events are drained and routed to the node tree.
+3. The runtime applies any pending recompositions.
+4. **Layout phase**: `performLayout()` measures and positions all nodes.
+5. **Draw phase**: `performDraw()` renders nodes onto a `TextSurface` (a grid of `TextPixel` objects).
+6. **Output phase**: The `TextSurface` is converted to an ANSI string and written to stdout.
+
+The rendering uses **snapshot observers** to track which state objects are read during layout and draw, so these phases are also incrementally re-executed only when relevant state changes.
+
+---
+
+## Terminal Backend
+
+Mosaic renders to stdout using ANSI escape sequences. The ANSI subsystem supports multiple color levels detected at runtime:
+
+| Level       | Description                             |
+| ----------- | --------------------------------------- |
+| `NONE`      | No color support                        |
+| `ANSI16`    | 16 standard colors (codes 30-37, 90-97) |
+| `ANSI256`   | 256-color palette (code 5;N)            |
+| `TRUECOLOR` | 24-bit RGB (code 2;R;G;B)               |
+
+### Control Sequences
+
+The rendering system uses several ANSI/CSI control sequences:
+
+- **Synchronized output** (mode 2026): Wraps each frame in begin/end markers to prevent flicker on terminals that support it.
+- **Clear line** (`CSI K`): Erases previously drawn rows.
+- **Clear display** (`CSI J`): Used when static content is emitted, to avoid positioning ambiguity.
+- **Cursor positioning**: Moves the cursor to overwrite previous frame output in place.
+
+### Rendering Modes
+
+Mosaic provides two entry points with different output strategies:
+
+**`runMosaic` (interactive mode)**: A suspend function that sets up the terminal, enables raw mode for keyboard input, and renders frames interactively. Each frame overwrites the previous frame's output using cursor movement and line clearing. This is the mode for interactive applications like games or dashboards.
+
+```kotlin
+fun main() = runMosaicMain {
+    // Interactive composable content
+}
+```
+
+**`runMosaicBlocking` (static/batch mode)**: Used when output should be appended rather than redrawn. Suited for command-line tools that produce progressive output (like test runners). Supports a `NonInteractivePolicy` parameter for environments without a TTY:
+
+```kotlin
+fun main() {
+    runMosaicBlocking(onNonInteractive = Ignore) {
+        // Content that appends to terminal
+    }
+}
+```
+
+### Non-Interactive Policies
+
+When no TTY is available, Mosaic offers several fallback strategies:
+
+- `Exit` -- terminate with an error message.
+- `Throw` -- raise an exception.
+- `Return` -- return false immediately.
+- `Ignore` -- use a stub terminal with no capabilities.
+- `AssumeAndIgnore` -- skip TTY detection entirely.
+
+### Rendering Optimization
+
+The `AnsiRendering` implementation reuses a `StringBuilder` buffer across frames, tracks the previous render height to clear stale lines, and emits ANSI style codes only when pixel attributes change from one cell to the next. This differential encoding minimizes the bytes written per frame.
+
+---
+
+## Layout System
+
+Mosaic's layout system mirrors Jetpack Compose's layout model, adapted for a character grid. Dimensions are measured in **character cells** rather than pixels.
+
+### Core Layout Composables
+
+**`Row`** -- arranges children horizontally:
+
+```kotlin
+@Composable
+public fun Row(
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+    verticalAlignment: Alignment.Vertical = Alignment.Top,
+    content: @Composable RowScope.() -> Unit,
+)
+```
+
+**`Column`** -- arranges children vertically:
+
+```kotlin
+@Composable
+public fun Column(
+    modifier: Modifier = Modifier,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    content: @Composable ColumnScope.() -> Unit,
+)
+```
+
+**`Box`** -- stacks children on top of each other (z-axis layering):
+
+```kotlin
+@Composable
+public fun Box(
+    modifier: Modifier = Modifier,
+    contentAlignment: Alignment = Alignment.TopStart,
+    propagateMinConstraints: Boolean = false,
+    content: @Composable BoxScope.() -> Unit,
+)
+```
+
+### Arrangement and Alignment
+
+Arrangements control how children are distributed within the available space:
+
+| Arrangement      | Pattern     | Description                     |
+| ---------------- | ----------- | ------------------------------- |
+| `Start` / `Top`  | `123####`   | Pack toward the start           |
+| `End` / `Bottom` | `####123`   | Pack toward the end             |
+| `Center`         | `##123##`   | Cluster in the middle           |
+| `SpaceBetween`   | `1##2##3`   | Even spacing, no outer edges    |
+| `SpaceEvenly`    | `#1#2#3#`   | Equal gaps including boundaries |
+| `SpaceAround`    | `#1##2##3#` | Half-spacing at edges           |
+| `spacedBy(n)`    | Fixed `n`   | Fixed spacing between children  |
+
+Alignments position content within available space using a bias system where -1 is start/top, 0 is center, and 1 is end/bottom. Nine 2D alignments (`TopStart`, `TopCenter`, ..., `BottomEnd`) and six 1D alignments are provided.
+
+### Layout Modifiers
+
+Modifiers form a chain that wraps around a composable, transforming its layout, drawing, or input behavior:
+
+```kotlin
+Modifier
+    .width(20)
+    .height(10)
+    .padding(left = 1, top = 1, right = 1, bottom = 1)
+    .background(Color.Blue)
+```
+
+Key size modifiers:
+
+| Modifier                  | Effect                                             |
+| ------------------------- | -------------------------------------------------- |
+| `width(n)` / `height(n)`  | Set preferred dimension (constraints may override) |
+| `size(w, h)`              | Set both dimensions                                |
+| `requiredWidth(n)`        | Enforce exact width regardless of constraints      |
+| `fillMaxWidth(fraction)`  | Fill available width (0.0 to 1.0)                  |
+| `fillMaxHeight(fraction)` | Fill available height                              |
+| `fillMaxSize(fraction)`   | Fill both dimensions                               |
+| `wrapContentWidth()`      | Measure at desired size with alignment             |
+| `defaultMinSize(w, h)`    | Minimum only when otherwise unconstrained          |
+
+Other modifiers:
+
+| Modifier               | Effect                                        |
+| ---------------------- | --------------------------------------------- |
+| `padding(...)`         | Add padding (per-side, axis-wise, or uniform) |
+| `offset(x, y)`         | Displace without changing layout size         |
+| `offset { IntOffset }` | Dynamic offset evaluated during placement     |
+| `background(color)`    | Fill background with color behind content     |
+| `drawBehind { ... }`   | Custom drawing behind content                 |
+
+### Custom Layout
+
+The `Layout` composable allows fully custom measurement and placement:
+
+```kotlin
+@Composable
+public fun Layout(
+    content: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    measurePolicy: MeasurePolicy,
+)
+```
+
+A `MeasurePolicy` receives a list of `Measurable` children and `Constraints`, and returns a `MeasureResult` specifying the layout's width, height, and child placements:
+
+```kotlin
+@Composable
+fun CenteredOverlay(content: @Composable () -> Unit) {
+    Layout(content) { measurables, constraints ->
+        val placeables = measurables.map { it.measure(constraints) }
+        val width = placeables.maxOf { it.width }
+        val height = placeables.sumOf { it.height }
+        layout(width, height) {
+            var y = 0
+            placeables.forEach { placeable ->
+                placeable.place((width - placeable.width) / 2, y)
+                y += placeable.height
+            }
+        }
+    }
+}
+```
+
+### Non-Trivial Layout Example
+
+A dashboard with a bordered world containing a movable entity:
+
+```kotlin
+@Composable
+fun Dashboard(x: Int, y: Int) {
+    Column {
+        Text("Position: $x, $y")
+        Spacer(Modifier.height(1))
+        Row(horizontalArrangement = Arrangement.spacedBy(2)) {
+            // Stats panel
+            Column(Modifier.width(15)) {
+                Text("HP:  100/100", color = Color.Green)
+                Text("MP:   45/80", color = Color.Blue)
+                Text("Gold: 1234", color = Color.Yellow)
+            }
+            // Game world with border
+            Box(
+                modifier = Modifier
+                    .drawBehind {
+                        drawRect('*', drawStyle = DrawStyle.Stroke(1))
+                    }
+                    .padding(1)
+                    .size(20, 10),
+            ) {
+                Text("@", modifier = Modifier.offset { IntOffset(x, y) })
+            }
+        }
+    }
+}
+```
+
+---
+
+## Widget / Component System
+
+In Mosaic, **`@Composable` functions are the components**. There is no separate widget class hierarchy. Any function annotated with `@Composable` participates in the composition, can hold state, and composes with other composables.
+
+### Built-in Composables
+
+**`Text`** -- the primary content primitive:
+
+```kotlin
+@Composable
+public fun Text(
+    value: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    background: Color = Color.Unspecified,
+    textStyle: TextStyle = TextStyle.Unspecified,
+    underlineStyle: UnderlineStyle = UnderlineStyle.Unspecified,
+    underlineColor: Color = Color.Unspecified,
+)
+```
+
+An `AnnotatedString` overload supports inline styled spans for mixed formatting within a single text block.
+
+**`Spacer`** -- empty space whose size is controlled by modifiers:
+
+```kotlin
+Spacer(Modifier.height(1))  // Blank line
+Spacer(Modifier.size(5, 2)) // 5x2 empty block
+```
+
+**`Filler`** -- fills its area with a repeated character:
+
+```kotlin
+Filler('=', modifier = Modifier.fillMaxWidth().height(1), foreground = Color.Cyan)
+```
+
+**`Row`**, **`Column`**, **`Box`** -- layout composables (see Layout System above).
+
+### Custom Composables
+
+Any `@Composable` function is a reusable component:
+
+```kotlin
+@Composable
+fun StatusBadge(label: String, isActive: Boolean) {
+    val bg = if (isActive) Color.Green else Color.Red
+    val symbol = if (isActive) "ON " else "OFF"
+    Row {
+        Text(
+            symbol,
+            modifier = Modifier.background(bg).padding(horizontal = 1),
+            color = Color.Black,
+        )
+        Text(" $label")
+    }
+}
+```
+
+### State: `remember` and `mutableStateOf`
+
+Local state survives recomposition via `remember`:
+
+```kotlin
+@Composable
+fun Counter() {
+    var count by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1000)
+            count++
+        }
+    }
+
+    Text("Count: $count")
+}
+```
+
+When `count` is incremented, only the `Text("Count: $count")` call recomposes -- not the entire function if the compiler determines other parts are unaffected.
+
+### Side Effects: `LaunchedEffect`
+
+`LaunchedEffect` launches a coroutine scoped to the composition. It restarts when its key changes and cancels when the composable leaves the composition:
+
+```kotlin
+@Composable
+fun Timer(running: Boolean) {
+    var elapsed by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(running) {
+        while (running) {
+            delay(1000)
+            elapsed++
+        }
+    }
+
+    Text("Elapsed: ${elapsed}s")
+}
+```
+
+### StaticEffect
+
+`StaticEffect` renders content once and emits it as permanent output above the dynamic section. It composes its content, measures, draws, and logs the result, then never recomposes:
+
+```kotlin
+@Composable
+fun Log(entries: List<String>) {
+    entries.forEach { entry ->
+        StaticEffect {
+            Text(entry)
+        }
+    }
+}
+```
+
+This is how Mosaic's jest sample implements scrolling log output above a live progress bar.
+
+---
+
+## Styling
+
+### TextStyle
+
+`TextStyle` is a value class backed by a bitmask, supporting combinable styles:
+
+| Style           | Description                |
+| --------------- | -------------------------- |
+| `Bold`          | Bold weight                |
+| `Dim`           | Dimmed/faint               |
+| `Italic`        | Italic                     |
+| `Strikethrough` | Strikethrough line         |
+| `Invert`        | Swap foreground/background |
+
+Styles compose via the `+` operator:
+
+```kotlin
+Text("Important", textStyle = TextStyle.Bold + TextStyle.Italic)
+```
+
+### Colors
+
+The `Color` value class stores RGB as a packed 32-bit integer:
+
+```kotlin
+// Named constants
+Color.Red
+Color.Green
+Color.Blue
+Color.Black
+Color.White
+Color.Yellow
+Color.Magenta
+Color.Cyan
+
+// Custom RGB (integer 0-255)
+Color(128, 0, 255)
+
+// Custom RGB (float 0.0-1.0)
+Color(0.5f, 0.0f, 1.0f)
+```
+
+Colors are automatically downconverted based on detected terminal capabilities: true color terminals get full RGB, 256-color terminals get the nearest palette entry, and 16-color terminals get the nearest ANSI code based on brightness analysis.
+
+### UnderlineStyle
+
+Mosaic supports rich underline styles (terminals permitting):
+
+| Style      | Description          |
+| ---------- | -------------------- |
+| `None`     | No underline         |
+| `Straight` | Single solid line    |
+| `Double`   | Two parallel lines   |
+| `Curly`    | Wavy/undulating line |
+| `Dotted`   | Dot pattern          |
+| `Dashed`   | Dash pattern         |
+
+Underline color can be set independently from text color.
+
+### Styled Text Example
+
+```kotlin
+@Composable
+fun StyledOutput() {
+    Column {
+        Text("Error: file not found",
+            color = Color.Red,
+            textStyle = TextStyle.Bold)
+
+        Text("Warning: deprecated API",
+            color = Color.Yellow,
+            textStyle = TextStyle.Italic)
+
+        Text(
+            buildAnnotatedString {
+                append("Status: ")
+                withStyle(SpanStyle(color = Color.Green, textStyle = TextStyle.Bold)) {
+                    append("ONLINE")
+                }
+            },
+        )
+
+        Text("secret",
+            color = Color.Black,
+            background = Color.Black,
+            textStyle = TextStyle.Invert)
+    }
+}
+```
+
+### Background Modifier
+
+The `background` modifier draws a colored rectangle behind the content:
+
+```kotlin
+Text(
+    "PASS",
+    modifier = Modifier.background(Color.Green).padding(horizontal = 1),
+    color = Color.Black,
+)
+```
+
+The implementation uses a `DrawModifier` that calls `drawRect(background = color)` before `drawContent()`, layering the background beneath the text.
+
+---
+
+## Event Handling
+
+Mosaic is primarily an output-focused framework, but it provides keyboard input handling through a modifier-based event system integrated with Kotlin coroutines.
+
+### Key Event Modifiers
+
+The `onKeyEvent` and `onPreviewKeyEvent` modifiers attach keyboard handlers to any composable:
+
+```kotlin
+@Composable
+fun InteractiveApp() {
+    var message by remember { mutableStateOf("Press a key...") }
+
+    Column(
+        modifier = Modifier.onKeyEvent { event ->
+            when (event) {
+                KeyEvent("q") -> { /* handle quit */ true }
+                KeyEvent("ArrowUp") -> { message = "Up!"; true }
+                KeyEvent("ArrowDown") -> { message = "Down!"; true }
+                else -> false  // Not consumed
+            }
+        },
+    ) {
+        Text(message)
+    }
+}
+```
+
+The `KeyEvent` data class captures the pressed key along with modifier flags:
+
+```kotlin
+data class KeyEvent(
+    val key: String,
+    val alt: Boolean = false,
+    val ctrl: Boolean = false,
+    val shift: Boolean = false,
+)
+```
+
+### Two-Phase Event Propagation
+
+Key events follow a two-phase dispatch model similar to Android's touch events:
+
+1. **Preview phase (downward)**: `onPreviewKeyEvent` handlers fire from ancestor to descendant. Returning `true` intercepts the event before it reaches children.
+2. **Bubble phase (upward)**: `onKeyEvent` handlers fire from the focused component back up to ancestors. Returning `true` stops propagation.
+
+### Robot Example: Full Interactive Application
+
+```kotlin
+fun main() = runMosaicMain {
+    var x by remember { mutableIntStateOf(0) }
+    var y by remember { mutableIntStateOf(0) }
+    var exit by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.onKeyEvent {
+            when (it) {
+                KeyEvent("ArrowUp") -> y = (y - 1).coerceAtLeast(0)
+                KeyEvent("ArrowDown") -> y = (y + 1).coerceAtMost(9)
+                KeyEvent("ArrowLeft") -> x = (x - 1).coerceAtLeast(0)
+                KeyEvent("ArrowRight") -> x = (x + 1).coerceAtMost(17)
+                KeyEvent("q") -> exit = true
+                else -> return@onKeyEvent false
+            }
+            true
+        },
+    ) {
+        Text("Use arrow keys to move. Press 'q' to exit.")
+        Text("Position: $x, $y")
+        Spacer(Modifier.height(1))
+        Box(
+            modifier = Modifier
+                .drawBehind { drawRect('*', drawStyle = DrawStyle.Stroke(1)) }
+                .padding(1)
+                .size(20, 10),
+        ) {
+            Text("^_^", modifier = Modifier.offset { IntOffset(x, y) })
+        }
+    }
+
+    if (!exit) {
+        LaunchedEffect(Unit) { awaitCancellation() }
+    }
+}
+```
+
+### Terminal State
+
+Mosaic exposes terminal state through Compose's `CompositionLocal` mechanism:
+
+```kotlin
+val state = LocalTerminalState.current
+// state.focused  -- whether the terminal has focus
+// state.theme    -- light/dark theme
+// state.size     -- terminal dimensions (width, height)
+```
+
+This state is reactive: composables that read `LocalTerminalState` automatically recompose when the terminal is resized or focus changes.
+
+---
+
+## State Management
+
+Mosaic inherits Compose's full snapshot state system, which is one of the most sophisticated reactive state implementations in any UI framework.
+
+### `mutableStateOf` -- Observable State
+
+```kotlin
+var name by remember { mutableStateOf("World") }
+// Reading `name` during composition registers a dependency.
+// Writing `name` triggers recomposition of readers.
+```
+
+Specialized variants avoid boxing overhead:
+
+```kotlin
+var count by remember { mutableIntStateOf(0) }
+var ratio by remember { mutableFloatStateOf(1.0f) }
+```
+
+### `remember` -- State Survival
+
+`remember` stores a value in the slot table so it persists across recompositions. Without `remember`, values would be re-initialized every time the function re-executes:
+
+```kotlin
+@Composable
+fun ExpensiveComputation(input: List<Int>) {
+    // Recomputed only when `input` changes
+    val sorted = remember(input) { input.sorted() }
+    Text("First: ${sorted.first()}, Last: ${sorted.last()}")
+}
+```
+
+### `derivedStateOf` -- Computed State
+
+Creates state that is automatically recomputed when its dependencies change, but only triggers recomposition when the derived value itself changes:
+
+```kotlin
+@Composable
+fun FilteredList(items: List<String>, query: String) {
+    val filtered by remember(items, query) {
+        derivedStateOf { items.filter { it.contains(query) } }
+    }
+    Column {
+        filtered.forEach { Text(it) }
+    }
+}
+```
+
+### `snapshotFlow` -- State to Flow Bridge
+
+Converts snapshot state reads into a Kotlin `Flow`, bridging the reactive state system with coroutine-based streaming:
+
+```kotlin
+LaunchedEffect(Unit) {
+    snapshotFlow { count }
+        .filter { it > 0 && it % 10 == 0 }
+        .collect { milestone ->
+            // Log every 10th count
+        }
+}
+```
+
+### Observable Collections
+
+Compose provides snapshot-aware collection types:
+
+```kotlin
+val items = remember { mutableStateListOf<String>() }
+val settings = remember { mutableStateMapOf<String, Int>() }
+// Mutations to these collections trigger recomposition of readers.
+```
+
+### State Hoisting Pattern
+
+Mosaic follows Compose's state hoisting convention: state flows down, events flow up.
+
+```kotlin
+@Composable
+fun App() {
+    var selected by remember { mutableIntStateOf(0) }
+    val items = listOf("Alpha", "Beta", "Gamma")
+
+    Menu(
+        items = items,
+        selectedIndex = selected,
+        onSelect = { selected = it },
+    )
+}
+
+@Composable
+fun Menu(items: List<String>, selectedIndex: Int, onSelect: (Int) -> Unit) {
+    Column(
+        modifier = Modifier.onKeyEvent { event ->
+            when (event) {
+                KeyEvent("ArrowUp") -> { onSelect((selectedIndex - 1).coerceAtLeast(0)); true }
+                KeyEvent("ArrowDown") -> { onSelect((selectedIndex + 1).coerceAtMost(items.lastIndex)); true }
+                else -> false
+            }
+        },
+    ) {
+        items.forEachIndexed { index, item ->
+            val prefix = if (index == selectedIndex) "> " else "  "
+            val color = if (index == selectedIndex) Color.Cyan else Color.Unspecified
+            Text("$prefix$item", color = color)
+        }
+    }
+}
+```
+
+### Reactive State Driving UI Updates
+
+A complete example showing how state mutations automatically drive recomposition:
+
+```kotlin
+fun main() {
+    runMosaicBlocking(onNonInteractive = Ignore) {
+        val tests = remember { mutableStateListOf<Test>() }
+        var elapsed by remember { mutableIntStateOf(0) }
+        var done by remember { mutableStateOf(false) }
+
+        LaunchedEffect(Unit) {
+            launch {
+                // Simulate test execution
+                listOf("auth", "api", "db").forEach { name ->
+                    tests += Test(name, Running)
+                    delay(1500)
+                    tests[tests.lastIndex] = tests.last().copy(state = Pass)
+                }
+                done = true
+            }
+        }
+
+        LaunchedEffect(done) {
+            while (!done) { delay(1000); elapsed++ }
+        }
+
+        // This entire block recomposes only where state is read:
+        Column {
+            tests.forEach { test -> TestRow(test) }  // Recomposes when `tests` mutates
+            Text("Time: ${elapsed}s")                 // Recomposes when `elapsed` changes
+            if (!done) Text("Running...")             // Recomposes when `done` changes
+        }
+    }
+}
+```
+
+---
+
+## Extensibility and Ecosystem
+
+Mosaic is a relatively standalone library. It does not maintain a large ecosystem of third-party widgets or plugins. Its extensibility comes from the inherent composability of the Compose model and integration with the broader Kotlin ecosystem.
+
+### Kotlin Coroutines Integration
+
+Mosaic is deeply integrated with Kotlin coroutines. `runMosaic` is a suspend function. `LaunchedEffect` launches coroutines. `snapshotFlow` bridges reactive state with `Flow`. Any coroutine-based library (networking, file I/O, timers) integrates naturally.
+
+### Kotlin Flows
+
+Since state can be observed via `snapshotFlow`, and coroutines can collect external flows within `LaunchedEffect`, Mosaic composes naturally with reactive streams:
+
+```kotlin
+@Composable
+fun LogViewer(logFlow: Flow<String>) {
+    val lines = remember { mutableStateListOf<String>() }
+    LaunchedEffect(logFlow) {
+        logFlow.collect { lines += it }
+    }
+    Column {
+        lines.takeLast(20).forEach { Text(it) }
+    }
+}
+```
+
+### Testing via `runMosaicTest`
+
+The `mosaic-testing` module provides a test harness:
+
+```kotlin
+suspend fun runMosaicTest(
+    capabilities: Terminal.Capabilities = TestTerminal.Capabilities(),
+    block: suspend TestMosaic<String>.() -> Unit,
+)
+```
+
+The `TestMosaic<String>` interface provides:
+
+- `setContentAndSnapshot()` -- set content and immediately capture output.
+- `awaitSnapshot(duration)` -- wait for state changes and capture output.
+- `sendKeyEvent()` -- inject keyboard events.
+
+Snapshots are plain text (ANSI stripped), enabling string-based assertions for visual regression testing.
+
+### Sample Applications
+
+The repository includes six samples demonstrating different patterns:
+
+| Sample  | Demonstrates                                                        |
+| ------- | ------------------------------------------------------------------- |
+| counter | Basic state and timed updates                                       |
+| demo    | Feature showcase                                                    |
+| jest    | Test runner UI with `StaticEffect`, progress bar, `AnnotatedString` |
+| robot   | Keyboard input, interactive movement                                |
+| rrtop   | System monitoring dashboard                                         |
+| snake   | Full game with ViewModel pattern                                    |
+
+---
+
+## Strengths
+
+- **Compiler-powered recomposition**: The Compose compiler plugin inserts precise change-detection checks at compile time. Unlike virtual DOM diffing, there is no runtime tree comparison -- only changed functions re-execute.
+- **Minimal re-execution on state change**: The snapshot system tracks exactly which composables read which state, enabling surgical recomposition with zero wasted work.
+- **Familiar to Android/Compose developers**: Anyone who has written Jetpack Compose or Compose Multiplatform code can immediately write Mosaic code. The API surface is intentionally parallel.
+- **Reactive state is automatic**: No manual subscriptions, no `observe()` calls, no explicit dependency declarations. Read a state value during composition and you are subscribed.
+- **Deep coroutine integration**: `LaunchedEffect`, `snapshotFlow`, structured concurrency, and cancellation all work seamlessly for managing async operations in terminal UIs.
+- **Kotlin's expressive syntax**: Property delegates (`by`), trailing lambdas, extension functions, and inline classes make the API ergonomic and type-safe.
+- **Real Compose runtime guarantees**: Positional memoization, consistent snapshot reads, atomic state commits, and idempotent recomposition are all inherited from the battle-tested Compose runtime.
+- **Multiplatform**: Runs on JVM, native Linux/macOS/Windows, and experimentally on JS.
+- **Rich layout model**: The constraint-based layout system with `Row`, `Column`, `Box`, custom `Layout`, and modifiers is far more sophisticated than most TUI frameworks offer.
+
+---
+
+## Weaknesses and Limitations
+
+- **Requires Kotlin and the Compose compiler plugin**: The entire approach depends on a Kotlin compiler plugin that rewrites function signatures. This is not portable to other languages and adds build complexity.
+- **JVM startup overhead**: On the JVM target, there is noticeable startup latency from class loading and JIT compilation. Native targets mitigate this but have their own limitations.
+- **Limited built-in widget set**: Mosaic provides `Text`, `Row`, `Column`, `Box`, `Spacer`, and `Filler`. There are no built-in tables, scrollable lists, input fields, borders, or dialog components.
+- **Primarily output-focused**: While key event handling exists, there is no built-in focus management, tab navigation, mouse support, or input field abstraction. Interactive applications must build these from primitives.
+- **Small community**: Compared to alternatives like Textual (Python), Bubbletea (Go), or Ratatui (Rust), Mosaic has a much smaller user base and fewer third-party components.
+- **Less mature than alternatives**: Despite years of development, Mosaic is still labeled experimental. APIs change between releases, and some features are incomplete.
+- **Debugging difficulty**: Compose's slot table and recomposition behavior can be opaque. Understanding why something recomposes (or fails to) requires deep knowledge of Compose internals.
+- **No scrolling or viewport abstraction**: Long content simply overflows. There is no built-in scrollable container.
+
+---
+
+## Lessons for D / Sparkles
+
+Mosaic demonstrates that a compiler-plugin-powered reactive model produces remarkably clean terminal UI code. While D lacks Kotlin's compiler plugin infrastructure, many of the patterns can be approximated using D's compile-time capabilities.
+
+### Compiler Plugin Recomposition --> CTFE + Templates
+
+Compose's compiler plugin transforms `@Composable` functions to thread composition context and insert skip-checks. D cannot rewrite function bodies at compile time, but it can generate boilerplate:
+
+- **`mixin` templates** could generate recomposition tracking for struct fields. A `mixin Reactive!(MyState)` could introspect the fields of `MyState` and generate change-detection logic.
+- **CTFE** can compute layout properties, style constants, and widget trees at compile time, eliminating the need for runtime tree construction in static cases.
+- **Template metaprogramming** can validate composable function signatures at compile time, catching errors like incorrect return types or invalid modifier chains.
+
+### Snapshot State --> Wrapper Structs with `opDispatch`
+
+Compose's `mutableStateOf` creates observable state that triggers recomposition on write. D can approximate this:
+
+```d
+struct Reactive(T) {
+    private T _value;
+    private bool _dirty;
+
+    T opCall() const { return _value; }  // read
+    void opAssign(T v) {                 // write
+        if (_value != v) {
+            _value = v;
+            _dirty = true;
+        }
+    }
+    bool isDirty() const { return _dirty; }
+    void clearDirty() { _dirty = false; }
+}
+```
+
+Using `opDispatch` or `alias this`, a `Reactive!int` could be used almost transparently as an `int` while tracking mutations. Combined with Design by Introspection, a render loop could check `isDirty` on all reactive fields to decide what to re-render.
+
+### `@Composable` Functions --> Template Functions Producing Element Trees
+
+In Compose, `@Composable` functions build a tree implicitly through the `Composer`. In D, composable functions could return explicit element trees:
+
+```d
+auto statusBadge(string label, bool active) {
+    return row(
+        text(active ? "ON " : "OFF")
+            .bg(active ? Color.green : Color.red)
+            .pad(0, 1),
+        text(" " ~ label),
+    );
+}
+```
+
+Compile-time validation via template constraints can ensure these functions return valid `Element` types, catching composition errors at build time.
+
+### Modifier Chains --> UFCS
+
+Compose's `Modifier.width(10).padding(2).background(Color.Red)` maps directly to D's UFCS:
+
+```d
+auto element = text("hello")
+    .bold
+    .pad(1)
+    .fillMaxWidth
+    .bg(Color.blue);
+```
+
+Each UFCS call returns a modified copy of the element or wraps it in a modifier node. D's `@property` attribute enables modifier-like accessors without parentheses for flags like `.bold` and `.italic`.
+
+### Layout Protocol --> Template Constraints
+
+Mosaic's `MeasurePolicy` interface (with `measure` receiving `Measurable` children and `Constraints`) can be modeled in D using template constraints and Design by Introspection:
+
+```d
+enum isLayout(T) = __traits(hasMember, T, "measure")
+    && __traits(hasMember, T, "place");
+
+auto customLayout(L)(L layout, Element[] children)
+if (isLayout!L)
+{
+    // Use layout.measure(children, constraints)
+    // Then layout.place(children, positions)
+}
+```
+
+This provides compile-time validation that custom layouts implement the required protocol, similar to how Compose validates `MeasurePolicy` implementations at the type level.
+
+### Reactive State --> Introspection-Based Dirty Tracking
+
+Compose's snapshot system tracks reads during composition to build a dependency graph. D can approximate this with a render context that records field accesses:
+
+```d
+struct RenderContext {
+    bool[string] readFields;
+
+    auto track(T)(ref Reactive!T field, string name) {
+        readFields[name] = true;
+        return field();
+    }
+}
+```
+
+When state changes, the framework checks which render functions read the changed field and marks only those for re-execution. This is coarser than Compose's per-expression tracking but achieves the same goal of avoiding unnecessary re-renders.
+
+### Coroutine Effects --> Fibers or `std.concurrency`
+
+Compose's `LaunchedEffect` launches a coroutine scoped to the composition lifetime. D offers several analogous mechanisms:
+
+- **Fibers** (`core.thread.fiber`): Cooperative multitasking that can yield during I/O waits, similar to how coroutines suspend.
+- **`std.concurrency`**: Message-passing concurrency for spawning background tasks that communicate results back to the render thread.
+- **Event loop integration**: A render loop that polls fibers, processes messages, and redraws on state changes mirrors Mosaic's frame-based rendering.
+
+### TextSurface / TextPixel --> Character Grid with Differential Rendering
+
+Mosaic's `TextSurface` is a grid of `TextPixel` objects, each storing a code point and style attributes. The renderer emits ANSI codes only when attributes change between adjacent pixels. This differential encoding pattern is directly applicable to a D implementation:
+
+```d
+struct TextPixel {
+    dchar codePoint = ' ';
+    Color fg = Color.unspecified;
+    Color bg = Color.unspecified;
+    Style style;
+}
+```
+
+A D renderer can maintain a front buffer and back buffer, comparing them to emit only the changes -- a classic double-buffering approach that Mosaic's `AnsiRendering` essentially implements with its reused `StringBuilder`.
+
+---
+
+## References
+
+- **GitHub Repository**: <https://github.com/JakeWharton/mosaic>
+- **Compose Runtime (upstream)**: <https://developer.android.com/jetpack/compose/mental-model>
+- **Compose Compiler Plugin**: <https://developer.android.com/jetpack/compose/compiler>
+- **Compose Snapshot System**: <https://dev.to/zachklipp/introduction-to-the-compose-snapshot-system-19cn>
+- **Jake Wharton's "Compose Runtime" Talk**: <https://jakewharton.com/a-jetpack-compose-by-any-other-name/>
+- **Ink (JavaScript inspiration)**: <https://github.com/vadimdemedes/ink>
+- **Mosaic Changelog**: <https://github.com/JakeWharton/mosaic/blob/trunk/CHANGELOG.md>
+- **Kotlin Compose Multiplatform**: <https://www.jetbrains.com/compose-multiplatform/>
+- **Mosaic Maven Central**: `com.jakewharton.mosaic:mosaic-runtime:0.18.0`

--- a/docs/research/tui-libraries/notcurses.md
+++ b/docs/research/tui-libraries/notcurses.md
@@ -1,0 +1,720 @@
+# Notcurses (C)
+
+A modern, high-performance terminal UI library that reimagines TUI programming from scratch, exploiting the full capabilities of contemporary terminal emulators rather than constraining itself to the lowest common denominator.
+
+| Field              | Value                                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Language**       | C (C17), with C++17 optional components                                                                                                   |
+| **License**        | Apache 2.0                                                                                                                                |
+| **Repository**     | [github.com/dankamongmen/notcurses](https://github.com/dankamongmen/notcurses)                                                            |
+| **Documentation**  | [notcurses.com](https://notcurses.com) (man pages), [nick-black.com/dankwiki](https://nick-black.com/dankwiki/index.php/Notcurses) (wiki) |
+| **Latest Version** | ~3.0.17 (October 2024)                                                                                                                    |
+| **GitHub Stars**   | ~4.3k                                                                                                                                     |
+
+---
+
+## Overview
+
+### What It Solves
+
+Notcurses provides a modern foundation for building complex terminal user interfaces that go far beyond what ncurses (or any X/Open Curses implementation) can offer. Where ncurses assumes the terminal is a VT100-era device and requires developers to opt into each advanced feature individually, Notcurses assumes the terminal is a modern emulator capable of 24-bit color, Unicode, bitmap graphics, and advanced keyboard protocols -- then gracefully degrades when it encounters limitations.
+
+The library addresses several long-standing deficiencies in the terminal UI ecosystem:
+
+- **True color**: 24-bit RGB as the default, with automatic quantization for limited terminals.
+- **Bitmap graphics**: Sixel, Kitty graphics protocol, and Linux framebuffer for actual pixel-level rendering within the terminal.
+- **Unicode completeness**: Full Extended Grapheme Cluster (EGC) support, wide characters, and emoji.
+- **Thread safety**: Designed from inception for concurrent access, unlike ncurses which requires external synchronization.
+- **Multimedia**: Video playback and image rendering directly in the terminal via FFmpeg integration.
+
+### Design Philosophy
+
+Notcurses deliberately abandons the X/Open Curses API. It is **not** an ncurses wrapper, not a source-compatible replacement, and not constrained by decades of backward-compatibility baggage. The core philosophy is stated directly in the project documentation:
+
+> Notcurses assumes the maximum and steps down (by itself) when necessary.
+
+This is the inverse of ncurses, which assumes the minimum and steps up only when explicitly asked. The result is a library that can exploit every capability a modern terminal offers while still functioning (with reduced fidelity) on older terminals.
+
+### History
+
+Notcurses was created by **Nick Black**, a systems programmer, author, and former Googler. Development began around 2019 as a clean-room reimagining of what a terminal UI library should look like in the era of GPU-accelerated terminal emulators like Kitty, Alacritty, and WezTerm. The library reached its 1.0 release and has since evolved through major versions, with the 3.x series representing the current stable API. Nick Black also authored _Hacking the Planet with Notcurses_, a comprehensive guidebook available as both a free PDF and paperback.
+
+---
+
+## Architecture
+
+### Rendering Model
+
+Notcurses uses a **retained-mode rendering model** built around the concept of **planes** (`ncplane`). The architecture is a compositor: the library maintains a stack of overlapping rectangular drawing surfaces, and on each render call, composites them together (including alpha blending) to produce the final frame. It then diffs against the previous frame and emits only the minimal set of terminal escape sequences needed to update the display.
+
+### Core Structures
+
+- **`struct notcurses`** -- The top-level context. Represents the connection to a terminal and owns all associated state. Created with `notcurses_init()`, destroyed with `notcurses_stop()`. A program typically has exactly one.
+
+- **`struct ncplane`** -- The fundamental drawing surface. A rectangular region of cells that can be positioned, resized, and layered. Planes are organized into **piles** (independent z-ordered stacks). Each pile has its own render/rasterize cycle.
+
+- **`struct nccell`** -- A single cell on a plane. Contains a grapheme cluster (UTF-8 encoded, 32-bit packed or spilled to storage), a 16-bit style mask, and 64-bit channels (32-bit foreground + 32-bit background, each with RGB + alpha).
+
+- **`struct ncinput`** -- An input event. Carries a Unicode codepoint (or synthesized key constant), mouse coordinates, modifier flags, and event type (press/repeat/release).
+
+### The Standard Plane
+
+When a `notcurses` context is created, a **standard plane** is automatically allocated. It spans the entire terminal and sits at the bottom of the default pile. It cannot be destroyed and is always available via `notcurses_stdplane()`.
+
+### Render Pipeline
+
+```
+Application draws to planes
+        |
+        v
+ncpile_render()  -- composites all planes in the pile,
+                    producing a flattened cell grid
+        |
+        v
+ncpile_rasterize() -- diffs against previous frame,
+                      emits escape sequences to terminal
+```
+
+The convenience function `notcurses_render()` performs both steps for the standard pile. Separating render from rasterize allows the application to inspect the composed frame before committing it to the terminal.
+
+```c
+#include <notcurses/notcurses.h>
+
+int main(void) {
+    // Initialize with default options
+    struct notcurses* nc = notcurses_init(NULL, stdout);
+    if (nc == NULL) return 1;
+
+    // Get the standard plane
+    struct ncplane* std = notcurses_stdplane(nc);
+
+    // Draw on the standard plane
+    ncplane_set_fg_rgb8(std, 0x00, 0xff, 0x00);  // green foreground
+    ncplane_putstr_yx(std, 0, 0, "Hello, Notcurses!");
+
+    // Render to terminal
+    notcurses_render(nc);
+
+    // Wait for input
+    notcurses_get_blocking(nc, NULL);
+
+    // Cleanup
+    notcurses_stop(nc);
+    return 0;
+}
+```
+
+---
+
+## Terminal Backend
+
+### Direct Terminal Manipulation
+
+Notcurses communicates directly with the terminal via escape sequences. It does not use ncurses for rendering; however, it does leverage ncurses' **terminfo** database (6.1+) for baseline capability detection. On top of terminfo, Notcurses performs **runtime terminal interrogation**: it sends query sequences to the terminal and parses responses to discover capabilities dynamically.
+
+### Capability Detection
+
+The library combines multiple strategies:
+
+1. **Terminfo database** -- baseline capabilities (colors, cursor movement, etc.)
+2. **`COLORTERM` environment variable** -- `truecolor` or `24bit` signals 24-bit color support
+3. **Terminal query responses** -- DA1/DA2/DA3 device attribute queries, XTVERSION, Kitty keyboard protocol probes
+4. **`TERM` and `TERM_PROGRAM`** -- terminal identification for known-good feature sets
+
+The included `notcurses-info` tool reports detected capabilities for any terminal.
+
+### Supported Capabilities
+
+| Capability                  | Details                                                                                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **True color**              | 24-bit RGB (16.7M colors), auto-quantized to 256 or 8 when needed                                                                                                        |
+| **Sixel graphics**          | Pixel-level bitmap rendering on Sixel-capable terminals                                                                                                                  |
+| **Kitty graphics protocol** | High-performance pixel graphics with animation support                                                                                                                   |
+| **Unicode**                 | Full EGC support, wide characters, combining characters, emoji                                                                                                           |
+| **Video/multimedia**        | MPEG4 and other video codecs via FFmpeg, rendered as frames in the terminal                                                                                              |
+| **Mouse**                   | Button press/release, motion tracking, scroll events                                                                                                                     |
+| **Kitty keyboard protocol** | Disambiguated key events with press/repeat/release distinction                                                                                                           |
+| **Blitting modes**          | Multiple character-based bitmap approximations: half-blocks (`2x1`), quadrants (`2x2`), sextants (`3x2`), octants (`4x2`), Braille (`BRAILLE`), and true pixel (`PIXEL`) |
+| **Alpha blending**          | Per-cell alpha: opaque, transparent, blend, high-contrast                                                                                                                |
+
+### Performance
+
+Notcurses is designed for high throughput. The frame-diffing approach means only changed cells produce escape sequences. Header-only static inline functions minimize call overhead. The library is thread-safe, allowing concurrent plane manipulation with rendering on a dedicated thread. Benchmark-oriented design choices pervade the codebase -- for example, glyph clusters are packed inline in the 32-bit `gcluster` field of `nccell` when they fit, avoiding heap allocation for the common case of ASCII and BMP characters.
+
+---
+
+## Layout System
+
+### Manual / Absolute Positioning
+
+Notcurses does **not** provide an automatic layout engine. All positioning is explicit. Planes have:
+
+- **y/x position** -- relative to parent plane (for child planes) or absolute within the pile (for root planes)
+- **rows/columns dimensions** -- the size of the plane's cell grid
+
+This is fundamentally different from CSS-based or constraint-based layout systems. The application is responsible for computing positions and sizes, typically in response to terminal resize events.
+
+### Key Layout Functions
+
+```c
+// Query plane dimensions
+unsigned rows, cols;
+ncplane_dim_yx(plane, &rows, &cols);
+
+// Move plane to new position (relative to parent)
+ncplane_move_yx(plane, new_y, new_x);
+
+// Resize a plane, preserving a region of existing content
+// Parameters: keep_y, keep_x, keep_len_y, keep_len_x,
+//             y_off, x_off, new_rows, new_cols
+ncplane_resize(plane, 0, 0, 0, 0, 0, 0, new_rows, new_cols);
+
+// Get absolute position on screen
+int abs_y, abs_x;
+ncplane_abs_yx(plane, &abs_y, &abs_x);
+```
+
+### Plane Hierarchy
+
+Child planes are positioned relative to their parent. When a parent moves, all children move with it. This provides a basic form of relative layout:
+
+```c
+#include <notcurses/notcurses.h>
+
+int main(void) {
+    struct notcurses* nc = notcurses_init(NULL, stdout);
+    struct ncplane* std = notcurses_stdplane(nc);
+
+    unsigned term_rows, term_cols;
+    ncplane_dim_yx(std, &term_rows, &term_cols);
+
+    // Create a "panel" plane centered on screen
+    struct ncplane_options panel_opts = {
+        .y = (int)(term_rows / 4),
+        .x = (int)(term_cols / 4),
+        .rows = term_rows / 2,
+        .cols = term_cols / 2,
+        .name = "panel",
+    };
+    struct ncplane* panel = ncplane_create(std, &panel_opts);
+    ncplane_set_bg_rgb8(panel, 0x20, 0x20, 0x40);
+
+    // Fill panel background
+    for (unsigned y = 0; y < panel_opts.rows; y++) {
+        for (unsigned x = 0; x < panel_opts.cols; x++) {
+            ncplane_putchar_yx(panel, y, x, ' ');
+        }
+    }
+
+    // Create a title bar as a child plane (position relative to panel)
+    struct ncplane_options title_opts = {
+        .y = 0,
+        .x = 0,
+        .rows = 1,
+        .cols = panel_opts.cols,
+        .name = "title",
+    };
+    struct ncplane* title = ncplane_create(panel, &title_opts);
+    ncplane_set_fg_rgb8(title, 0xff, 0xff, 0xff);
+    ncplane_set_bg_rgb8(title, 0x40, 0x40, 0x80);
+    ncplane_putstr_aligned(title, 0, NCALIGN_CENTER, " My Panel ");
+
+    // Create a status bar at the bottom of the panel
+    struct ncplane_options status_opts = {
+        .y = (int)(panel_opts.rows - 1),
+        .x = 0,
+        .rows = 1,
+        .cols = panel_opts.cols,
+        .name = "status",
+    };
+    struct ncplane* status = ncplane_create(panel, &status_opts);
+    ncplane_set_fg_rgb8(status, 0xaa, 0xaa, 0xaa);
+    ncplane_set_bg_rgb8(status, 0x30, 0x30, 0x50);
+    ncplane_putstr_yx(status, 0, 1, "Press 'q' to quit");
+
+    notcurses_render(nc);
+
+    // Event loop
+    struct ncinput ni;
+    while (notcurses_get_blocking(nc, &ni) != (uint32_t)-1) {
+        if (ni.id == 'q') break;
+    }
+
+    notcurses_stop(nc);
+    return 0;
+}
+```
+
+### Resize Callbacks
+
+Planes can have resize callbacks that fire when the terminal is resized. This is the primary mechanism for responsive layout:
+
+```c
+// Callback signature
+int resize_cb(struct ncplane* plane);
+
+// Common built-in callbacks:
+// ncplane_resize_maximize   -- resize to fill parent
+// ncplane_resize_marginalized -- resize with fixed margins
+```
+
+---
+
+## Widget / Component System
+
+Notcurses provides a set of high-level **widget** types, each backed by one or more planes. Widgets are opaque structs created via `*_create()` functions and destroyed with `*_destroy()`. They receive input via `*_offer_input()` functions.
+
+### Built-in Widgets
+
+| Widget                               | Description                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------------------ |
+| **`ncselector`**                     | Single-selection scrollable menu with title, footer, and descriptions          |
+| **`ncmultiselector`**                | Multi-selection variant of `ncselector` with checkbox-style toggling           |
+| **`ncmenu`**                         | Top-of-screen menu bar with dropdown sub-menus and keyboard shortcuts          |
+| **`nctree`**                         | Hierarchical tree view with expandable/collapsible nodes                       |
+| **`ncplot` / `ncuplot` / `ncdplot`** | Line/scatter plots for `uint64_t` or `double` data streams                     |
+| **`ncprogbar`**                      | Progress bar with configurable direction and EGC fill characters               |
+| **`nctabbed`**                       | Tabbed interface with a tab bar and per-tab content planes                     |
+| **`ncreader`**                       | Text input widget with cursor movement and editing                             |
+| **`ncreel`**                         | Scrollable "card stack" (reel of tablets) for browsing variable-height content |
+
+### Widget Example: Selector
+
+```c
+#include <notcurses/notcurses.h>
+
+int main(void) {
+    struct notcurses* nc = notcurses_init(NULL, stdout);
+    struct ncplane* std = notcurses_stdplane(nc);
+
+    // Define selector items
+    struct ncselector_item items[] = {
+        { .option = "Option A", .desc = "First option" },
+        { .option = "Option B", .desc = "Second option" },
+        { .option = "Option C", .desc = "Third option" },
+    };
+
+    // Configure the selector
+    struct ncselector_options sopts = {
+        .title = "Select an item",
+        .items = items,
+        .itemcount = 3,
+        .maxdisplay = 5,
+        .opchannels = NCCHANNELS_INITIALIZER(0xff, 0xff, 0xff,
+                                              0x20, 0x20, 0x20),
+        .descchannels = NCCHANNELS_INITIALIZER(0xaa, 0xaa, 0xaa,
+                                                0x20, 0x20, 0x20),
+        .titlechannels = NCCHANNELS_INITIALIZER(0x00, 0xff, 0x00,
+                                                 0x20, 0x20, 0x20),
+        .boxchannels = NCCHANNELS_INITIALIZER(0x80, 0x80, 0x80,
+                                               0x20, 0x20, 0x20),
+    };
+
+    struct ncselector* sel = ncselector_create(std, &sopts);
+    notcurses_render(nc);
+
+    // Feed input to the selector
+    struct ncinput ni;
+    while (notcurses_get_blocking(nc, &ni) != (uint32_t)-1) {
+        if (ni.id == 'q') break;
+        if (ni.id == NCKEY_ENTER) {
+            const char* selected = ncselector_selected(sel);
+            // Use selected item...
+            break;
+        }
+        ncselector_offer_input(sel, &ni);
+        notcurses_render(nc);
+    }
+
+    ncselector_destroy(sel, NULL);
+    notcurses_stop(nc);
+    return 0;
+}
+```
+
+### Custom Widgets
+
+There is no formal widget protocol or base class. Custom widgets are built by drawing directly on `ncplane` surfaces. The pattern is:
+
+1. Create one or more planes for the widget.
+2. Draw the widget's visual representation on those planes.
+3. Accept input and update the planes accordingly.
+4. Attach user data via `ncplane_set_userptr()` for associating application state with planes.
+
+---
+
+## Styling
+
+### Cell-Based Model
+
+Every cell on a plane has three styling components:
+
+1. **Foreground channel** (32 bits) -- 8-bit R, G, B + 2-bit alpha + flags
+2. **Background channel** (32 bits) -- 8-bit R, G, B + 2-bit alpha + flags
+3. **Style mask** (16 bits) -- bold, italic, underline, undercurl, struck, blink
+
+Together, the two channels form a 64-bit `channels` value. The `nccell` struct packs all of this alongside the glyph:
+
+```c
+typedef struct nccell {
+    uint32_t gcluster;     // EGC, packed or spilled
+    uint8_t  width;        // occupied columns (0 for continuation)
+    uint16_t stylemask;    // style attributes
+    uint64_t channels;     // fg (high 32) + bg (low 32)
+} nccell;
+```
+
+### Color and Alpha
+
+```c
+// Set plane-level default colors (affect subsequent output)
+ncplane_set_fg_rgb8(plane, 0xff, 0x80, 0x00);  // orange foreground
+ncplane_set_bg_rgb8(plane, 0x00, 0x00, 0x00);  // black background
+
+// Set colors on a channel pair directly
+uint64_t channels = 0;
+ncchannels_set_fg_rgb8(&channels, 0xff, 0x80, 0x00);
+ncchannels_set_bg_rgb8(&channels, 0x00, 0x00, 0x00);
+
+// Alpha modes per channel
+ncchannels_set_fg_alpha(&channels, NCALPHA_OPAQUE);       // fully opaque
+ncchannels_set_bg_alpha(&channels, NCALPHA_TRANSPARENT);   // see-through
+ncchannels_set_fg_alpha(&channels, NCALPHA_BLEND);         // alpha blend
+ncchannels_set_fg_alpha(&channels, NCALPHA_HIGHCONTRAST);  // auto fg color
+```
+
+### Alpha Blending Between Planes
+
+When planes overlap, Notcurses composites them using per-cell alpha values:
+
+- **`NCALPHA_OPAQUE`** -- cell fully covers planes below
+- **`NCALPHA_TRANSPARENT`** -- cell is invisible, plane below shows through
+- **`NCALPHA_BLEND`** -- cell blends with plane below using alpha channel
+- **`NCALPHA_HIGHCONTRAST`** -- foreground automatically chosen for maximum contrast against the composited background
+
+### Style Attributes
+
+```c
+// Set styles on a plane (affect subsequent output)
+ncplane_set_styles(plane, NCSTYLE_BOLD | NCSTYLE_ITALIC);
+
+// Turn on additional styles
+ncplane_on_styles(plane, NCSTYLE_UNDERLINE);
+
+// Turn off specific styles
+ncplane_off_styles(plane, NCSTYLE_BOLD);
+
+// Available style flags:
+// NCSTYLE_BOLD       NCSTYLE_ITALIC      NCSTYLE_UNDERLINE
+// NCSTYLE_UNDERCURL  NCSTYLE_STRUCK      NCSTYLE_BLINK
+```
+
+### Palette Mode
+
+For terminals limited to 256 colors, palette-indexed colors are supported:
+
+```c
+ncplane_set_fg_palindex(plane, 196);  // palette index 196 (red)
+ncplane_set_bg_palindex(plane, 17);   // palette index 17 (dark blue)
+```
+
+---
+
+## Event Handling
+
+### Input API
+
+Notcurses provides three input functions, all returning a 32-bit value (Unicode codepoint or synthesized key):
+
+```c
+// Blocking: waits up to ts nanoseconds (NULL = wait forever)
+uint32_t notcurses_get(struct notcurses* nc, const struct timespec* ts,
+                       struct ncinput* ni);
+
+// Non-blocking: returns immediately
+uint32_t notcurses_get_nblock(struct notcurses* nc, struct ncinput* ni);
+
+// Blocking: waits indefinitely
+uint32_t notcurses_get_blocking(struct notcurses* nc, struct ncinput* ni);
+```
+
+### The `ncinput` Structure
+
+```c
+typedef struct ncinput {
+    uint32_t id;        // Unicode codepoint or NCKEY_* constant
+    int y, x;           // cell coordinates for mouse events (-1 if N/A)
+    unsigned modifiers;  // bitmask: NCKEY_MOD_SHIFT, NCKEY_MOD_ALT,
+                        //          NCKEY_MOD_CTRL, NCKEY_MOD_SUPER,
+                        //          NCKEY_MOD_HYPER, NCKEY_MOD_META,
+                        //          NCKEY_MOD_CAPSLOCK, NCKEY_MOD_NUMLOCK
+    ncintype_e evtype;  // NCTYPE_PRESS, NCTYPE_REPEAT, NCTYPE_RELEASE
+    uint32_t eff_text[4]; // effective UTF-32 text accounting for modifiers
+} ncinput;
+```
+
+### Kitty Keyboard Protocol
+
+When the terminal supports the Kitty keyboard protocol, Notcurses can distinguish between key press, repeat, and release events. This enables:
+
+- Detecting modifier-only key presses (e.g., pressing Shift alone)
+- Distinguishing `Enter` from `Ctrl+M`
+- Reporting key release events for game-style input
+
+### Mouse Events
+
+```c
+// Enable mouse tracking
+notcurses_mice_enable(nc, NCMICE_ALL_EVENTS);
+
+// In event loop, check for mouse events
+struct ncinput ni;
+notcurses_get_blocking(nc, &ni);
+if (ni.id == NCKEY_BUTTON1) {
+    // Left mouse button at (ni.y, ni.x)
+    if (ni.evtype == NCTYPE_PRESS) {
+        // button pressed
+    } else if (ni.evtype == NCTYPE_RELEASE) {
+        // button released
+    }
+} else if (ni.id == NCKEY_SCROLL_UP) {
+    // scroll wheel up
+}
+
+// Disable mouse tracking
+notcurses_mice_disable(nc);
+```
+
+### Signal Handling
+
+Notcurses installs signal handlers for `SIGWINCH` (terminal resize), `SIGCONT` (resume from suspend), and optionally for `SIGINT`/`SIGQUIT`/`SIGTERM` (to restore the terminal before exit). The `NCOPTION_NO_QUIT_SIGHANDLERS` flag disables the quit signal handlers if the application wants to manage them itself.
+
+### Event Loop Example
+
+```c
+struct ncinput ni;
+uint32_t id;
+while ((id = notcurses_get_blocking(nc, &ni)) != (uint32_t)-1) {
+    if (id == 'q' || id == 'Q') {
+        break;  // quit on 'q'
+    }
+
+    if (id == NCKEY_RESIZE) {
+        // Terminal was resized -- re-layout
+        unsigned new_rows, new_cols;
+        notcurses_stddim_yx(nc, &new_rows, &new_cols);
+        // Recompute layout for new dimensions...
+    }
+
+    if (ni.modifiers & NCKEY_MOD_CTRL) {
+        // Ctrl was held
+    }
+
+    // Offer input to widgets
+    ncselector_offer_input(my_selector, &ni);
+
+    // Re-render
+    notcurses_render(nc);
+}
+```
+
+---
+
+## State Management
+
+### Imperative Model
+
+Notcurses is fundamentally imperative. There is no framework-imposed state management pattern -- no model-view-update loop, no reactive data binding, no virtual DOM. The application is fully responsible for:
+
+1. Maintaining its own data model.
+2. Drawing the appropriate visual representation onto planes.
+3. Handling input and updating both the model and the planes.
+
+### Plane as Visual State
+
+Each `ncplane` holds its own visual state: a grid of `nccell` values representing the current appearance. The application mutates this state directly via `ncplane_putstr()`, `ncplane_putchar()`, `ncplane_set_fg_rgb8()`, etc. The plane retains its contents until explicitly overwritten or erased.
+
+```c
+// Erase a plane (reset all cells to defaults)
+ncplane_erase(plane);
+
+// Erase a specific region
+ncplane_erase_region(plane, y, x, rows, cols);
+```
+
+### User Data Pointers
+
+Every plane can carry an opaque user pointer, providing a way to associate application-level state with a drawing surface:
+
+```c
+struct my_widget_state {
+    int counter;
+    char label[64];
+};
+
+struct my_widget_state* state = malloc(sizeof(*state));
+state->counter = 0;
+snprintf(state->label, sizeof(state->label), "Widget A");
+
+ncplane_set_userptr(plane, state);
+
+// Later, retrieve it:
+struct my_widget_state* s = ncplane_userptr(plane);
+s->counter++;
+```
+
+### No Automatic Dirty Tracking
+
+Notcurses does not track which cells have been modified since the last render. Instead, `notcurses_render()` composites all visible planes and diffs the result against the previously rendered frame. This means modifying a plane's contents is cheap (just memory writes), and the cost of rendering depends on the number of cells that actually changed on screen, not the number of API calls made.
+
+---
+
+## Extensibility & Ecosystem
+
+### Language Bindings
+
+| Language   | Binding                                                         | Maintainer                    |
+| ---------- | --------------------------------------------------------------- | ----------------------------- |
+| **C++**    | Built-in (`notcurses/ncpp.hh`)                                  | Official                      |
+| **Python** | Built-in (`cffi` based)                                         | Official                      |
+| **Rust**   | [`libnotcurses-sys`](https://crates.io/crates/libnotcurses-sys) | Community (official-adjacent) |
+| **Ada**    | Community                                                       | Community                     |
+| **Dart**   | Community                                                       | Community                     |
+| **Julia**  | Community                                                       | Community                     |
+| **Nim**    | Community                                                       | Community                     |
+| **Zig**    | Community                                                       | Community                     |
+
+### Multimedia Integration
+
+With FFmpeg linked, Notcurses can decode and render images and video directly in the terminal. The `ncvisual` API handles:
+
+- Loading images from files or memory
+- Decoding video frame-by-frame
+- Blitting frames to planes using the best available pixel protocol (Kitty > Sixel > character-based)
+- Scaling and interpolation
+
+The included `ncplayer` tool demonstrates video playback, and `ncls` renders file thumbnails in directory listings.
+
+### Direct Pixel Rendering
+
+Via `NCBLIT_PIXEL`, Notcurses can render true pixel graphics using whichever protocol the terminal supports:
+
+```c
+struct ncvisual* ncv = ncvisual_from_file("image.png");
+struct ncvisual_options vopts = {
+    .blitter = NCBLIT_PIXEL,
+    .n = target_plane,
+    .scaling = NCSCALE_STRETCH,
+};
+ncvisual_blit(nc, ncv, &vopts);
+notcurses_render(nc);
+ncvisual_destroy(ncv);
+```
+
+### Demo Suite
+
+The `notcurses-demo` binary showcases the library's full capabilities across multiple demonstrations: scrolling, transparency, video, Unicode, Braille plots, fading, and more. It serves as both a feature showcase and a stress test.
+
+---
+
+## Strengths
+
+- **Unmatched performance** -- Frame-diffing, minimal escape sequence output, header-inline functions, and packed cell representation minimize overhead.
+- **Richest terminal capability support** -- No other TUI library matches its breadth: true color, Sixel, Kitty graphics, Kitty keyboard protocol, Unicode EGC, video playback, octant/sextant/Braille blitting.
+- **True alpha compositing between planes** -- Four alpha modes (opaque, transparent, blend, high-contrast) enable sophisticated layered UIs without manual z-order management.
+- **Multimedia support** -- Built-in FFmpeg integration for image and video rendering directly in the terminal.
+- **Modern terminal features as defaults** -- 24-bit color and Unicode are assumed, not opted into. Graceful degradation handles older terminals automatically.
+- **Zero-dependency core** -- `libnotcurses-core` can be built without the multimedia stack, C++ compiler, or any optional dependencies.
+- **Thorough documentation** -- Comprehensive man pages, a published book, wiki, and an extensive demo suite.
+- **Thread-safe design** -- Concurrent plane manipulation with rendering on a dedicated thread is supported out of the box.
+
+---
+
+## Weaknesses & Limitations
+
+- **C API complexity** -- The API surface is very large (hundreds of functions) with C-style naming conventions. Managing `nccell` channels, style masks, and plane lifecycles requires careful attention.
+- **Manual memory management** -- Planes, widgets, visuals, and cells with spilled glyph clusters all require explicit destruction. Missing a `*_destroy()` call leaks resources.
+- **No automatic layout** -- All positioning is manual. Building responsive layouts requires implementing your own layout engine on top of planes and resize callbacks. This is a significant burden for complex UIs.
+- **Steep learning curve** -- The combination of a large API, manual layout, manual memory management, and the compositor mental model makes Notcurses harder to learn than higher-level alternatives like Textual, Ink, or Bubble Tea.
+- **Platform limitations** -- Primary development targets Linux and macOS. Windows support exists (10 v1093+) but is less mature. FreeBSD and DragonFly BSD are supported but less tested.
+- **Complex build requirements** -- Full builds need CMake, a C17 compiler, terminfo, libunistring, and optionally FFmpeg, OpenImageIO, and a C++17 compiler. The dependency chain is non-trivial compared to single-file or header-only alternatives.
+- **Lower-level than most alternatives** -- Notcurses sits closer to a "terminal compositor" than to an application framework. Features like routing, state management, and layout that higher-level frameworks provide must be built by the application.
+
+---
+
+## Lessons for D / Sparkles
+
+Notcurses offers several architectural patterns that translate well to D's strengths:
+
+### Plane Abstraction with RAII
+
+Notcurses planes require manual `ncplane_destroy()` calls. In D, planes could be wrapped in `@nogc`-compatible structs with deterministic cleanup via `~this()` (the destructor). D's `scope` and DIP1000 lifetime tracking would prevent dangling plane references at compile time:
+
+```d
+struct Plane {
+    private ncplane* handle;
+
+    @disable this(this);  // no copy
+
+    ~this() @nogc nothrow {
+        if (handle) ncplane_destroy(handle);
+    }
+}
+```
+
+### Channel-Based Coloring
+
+Notcurses packs RGBA into 32-bit channels and pairs them into 64-bit values. D's bitwise operations on `uint` and `ulong` are natural for this, and `@nogc` helper functions could provide a type-safe API:
+
+```d
+struct Channel {
+    uint raw;
+
+    @nogc nothrow pure @safe:
+    void setRgb8(ubyte r, ubyte g, ubyte b) { /* bit manipulation */ }
+    ubyte r() const { return cast(ubyte)(raw >> 16 & 0xff); }
+}
+```
+
+### Compositor Model with Output Ranges
+
+Notcurses' plane compositing (iterate planes in z-order, blend cells) maps naturally to D output ranges. A `composit()` function could accept any output range of cells, enabling both direct terminal writing and testing with in-memory buffers.
+
+### Capability Detection via Design by Introspection
+
+Notcurses detects terminal capabilities at runtime (Sixel, Kitty, true color). D's compile-time introspection (Design by Introspection / DbI) could complement this with static feature detection, building different code paths based on backend capabilities -- e.g., a `SixelBlitter` that only compiles when the Sixel trait is satisfied.
+
+### Cell Struct with SmallBuffer
+
+The `nccell` approach of packing short glyph clusters inline (32-bit `gcluster`) and spilling to heap for longer EGCs maps directly to `SmallBuffer`. A D cell could use `SmallBuffer!(char, 4)` for the glyph cluster, keeping the common case allocation-free while supporting arbitrary Unicode:
+
+```d
+struct Cell {
+    SmallBuffer!(char, 4) gcluster;  // inline for ASCII/BMP, spills for long EGCs
+    ushort stylemask;
+    ulong channels;
+}
+```
+
+### Direct C Interop
+
+D has excellent C interop via `extern(C)` and `importC`. A D binding to Notcurses could be nearly zero-cost, directly calling into `libnotcurses-core` without a wrapper layer. This would give Sparkles access to Notcurses' full capability set (including multimedia) while providing a D-idiomatic API on top.
+
+### Performance Patterns
+
+Notcurses' zero-allocation rendering philosophy (packed cells, frame diffing, minimal escape output) aligns with D's `@nogc` + output range patterns. A D TUI renderer could write escape sequences to a `SmallBuffer` or directly to an output range, avoiding GC allocation entirely in the render path.
+
+---
+
+## References
+
+- **Repository**: [github.com/dankamongmen/notcurses](https://github.com/dankamongmen/notcurses)
+- **Man pages**: [notcurses.com](https://notcurses.com)
+- **Wiki**: [nick-black.com/dankwiki/Notcurses](https://nick-black.com/dankwiki/index.php/Notcurses)
+- **Book**: _Hacking the Planet with Notcurses: A Guide to TUIs and Character Graphics_ by Nick Black ([free PDF](https://nick-black.com/htp-notcurses.pdf))
+- **Nick Black's blog**: [nick-black.com](https://nick-black.com)
+- **API header**: [`include/notcurses/notcurses.h`](https://github.com/dankamongmen/notcurses/blob/master/include/notcurses/notcurses.h)
+- **Rust binding**: [libnotcurses-sys on crates.io](https://crates.io/crates/libnotcurses-sys)
+- **Demo video / showcase**: Run `notcurses-demo` after installation
+- **NEWS / changelog**: [NEWS.md](https://github.com/dankamongmen/notcurses/blob/master/NEWS.md)
+- **FOSDEM 2021 talk**: Nick Black on Notcurses and modern terminal capabilities

--- a/docs/research/tui-libraries/nottui.md
+++ b/docs/research/tui-libraries/nottui.md
@@ -1,0 +1,899 @@
+# Nottui (OCaml)
+
+A reactive terminal UI library built on incremental computation primitives, where the UI is defined as a dependency-tracked reactive document that automatically recomputes only the affected subtrees when state changes.
+
+| Field         | Value                                                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Language      | OCaml                                                                                                                       |
+| License       | MIT                                                                                                                         |
+| Repository    | [github.com/let-def/lwd](https://github.com/let-def/lwd) (monorepo: Lwd + Nottui)                                           |
+| Documentation | [README](https://github.com/let-def/lwd/blob/master/lib/nottui/README.md) / [opam](https://opam.ocaml.org/packages/nottui/) |
+| Install       | `opam install nottui`                                                                                                       |
+| Author        | Frederic Bour (also known for Merlin, the OCaml IDE service)                                                                |
+
+---
+
+## Overview
+
+### What It Solves
+
+Nottui provides a fundamentally different approach to terminal UI: instead of immediate-mode full redraws or retained-mode virtual DOM diffing, it uses **incremental computation** to build UIs as reactive documents. When a piece of state changes, only the computations that depend on that state are re-evaluated -- not the entire UI tree. This is the same paradigm as a spreadsheet: change one cell, and only the formulas that reference it recalculate.
+
+### Design Philosophy
+
+The UI is a **value that changes over time**. Rather than imperatively mutating a DOM or redrawing every frame, the developer declares how UI fragments depend on reactive variables. The runtime maintains a dependency graph and propagates changes minimally. This is functional reactive programming applied to terminal interfaces, with automatic dependency tracking replacing manual subscriptions or dirty flags.
+
+### Lineage
+
+Nottui is not a standalone library. It is a composition of three layers:
+
+1. **Lwd (Lightweight Documents)** -- the incremental computation engine. Provides the core `'a Lwd.t` type (a reactive value that tracks its dependencies), `Lwd.var` (mutable reactive cells), and combinators (`map`, `map2`, `bind`, `join`) for composing reactive computations into a DAG. This layer knows nothing about terminals -- it is a general-purpose incremental computation library.
+
+2. **Nottui** -- the TUI widget layer built on Lwd. Defines `Ui.t` (a terminal UI element with layout, events, and rendering), composition combinators (`join_x`, `join_y`, `hcat`, `vcat`), event dispatch, and focus management. A Nottui UI is an `Ui.t Lwd.t` -- a reactive value producing UI trees.
+
+3. **Notty** -- the terminal rendering backend. Provides the `Notty.image` type (a 2D grid of styled characters), styled text construction, image composition operators, and terminal I/O. Nottui renders its `Ui.t` trees into Notty images for display.
+
+Frederic Bour created Lwd and Nottui. He is also the author of **Merlin**, the widely-used OCaml IDE service providing autocompletion, type information, and error reporting. This background in language tooling and incremental analysis directly informs Lwd's design -- Merlin itself must incrementally reprocess source code as the user edits, a problem structurally similar to incrementally updating a UI.
+
+---
+
+## Architecture
+
+### Incremental Computation Model
+
+The core insight of Lwd is that UI updates are typically **sparse** -- a single user action changes one or two state variables, affecting a small fraction of the UI tree. Lwd exploits this by maintaining a **directed acyclic graph (DAG)** of computations with automatic dependency tracking.
+
+#### `'a Lwd.t` -- Reactive Values
+
+The central type is `'a Lwd.t`, representing a value of type `'a` that may change over time. It is analogous to a spreadsheet cell: it may be a constant, or it may be computed from other reactive values. When any input changes, dependent outputs are automatically invalidated.
+
+```ocaml
+(* A reactive value is a node in the computation DAG *)
+type +'a t
+
+(* A constant reactive value -- never changes *)
+val pure : 'a -> 'a t
+val return : 'a -> 'a t
+```
+
+#### `Lwd.var` -- Mutable Reactive Variables
+
+Source nodes in the DAG are created with `Lwd.var`. These are the only mutable entry points into the reactive graph:
+
+```ocaml
+(* Create a mutable reactive variable *)
+val var : 'a -> 'a var
+
+(* Read the variable's value within the reactive graph (creates a dependency) *)
+val get : 'a var -> 'a t
+
+(* Read the variable's value immediately (no dependency tracking) *)
+val peek : 'a var -> 'a
+
+(* Update the variable, invalidating all dependents *)
+val set : 'a var -> 'a -> unit
+```
+
+The distinction between `get` and `peek` is critical. `get` returns an `'a Lwd.t`, registering the caller as a dependent. `peek` returns a plain `'a` with no dependency -- useful inside event handlers where you want the current value without creating a reactive dependency.
+
+#### Combinators -- Building the DAG
+
+Lwd implements the standard functional programming abstractions (Functor, Applicative, Monad) for composing reactive values:
+
+```ocaml
+(* Functor: transform a reactive value *)
+val map : 'a t -> f:('a -> 'b) -> 'b t
+
+(* Applicative: combine two independent reactive values *)
+val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
+
+(* Monad: nest reactive computations (use sparingly) *)
+val bind : 'a t -> f:('a -> 'b t) -> 'b t
+val join : 'a t t -> 'a t
+```
+
+`map` and `map2` create static edges in the DAG -- the dependency structure is fixed at construction time. `bind` and `join` create **dynamic** edges: the shape of the DAG itself depends on a reactive value. This is powerful but more expensive, as the runtime must rewire dependencies when the structure changes.
+
+#### Observation and Sampling
+
+To consume the reactive graph, you create a **root** -- an observation point:
+
+```ocaml
+type 'a root
+
+(* Create a root observation point *)
+val observe : ?on_invalidate:('a -> unit) -> 'a t -> 'a root
+
+(* Compute the current value (triggers recomputation if damaged) *)
+val sample : release_queue -> 'a root -> 'a
+
+(* Check if any input has changed since last sample *)
+val is_damaged : 'a root -> bool
+
+(* Stop observing -- releases the graph for GC *)
+val release : 'a root -> unit
+```
+
+A root has three states:
+
+1. **Released** -- not observing, graph can be GC'd
+2. **Sampled** -- graph is live, value is current
+3. **Damaged** -- an input changed, value is stale, next `sample` will recompute
+
+#### Reactive Collections with `Lwd_table`
+
+For collections where items are inserted, removed, or reordered, `Lwd_table` provides a reactive doubly-linked list:
+
+```ocaml
+type 'a t    (* A reactive table *)
+type 'a row  (* A handle to a row in the table *)
+
+val make    : unit -> 'a t
+val append  : ?set:'a -> 'a t -> 'a row
+val prepend : ?set:'a -> 'a t -> 'a row
+val before  : ?set:'a -> 'a row -> 'a row
+val after   : ?set:'a -> 'a row -> 'a row
+val remove  : 'a row -> unit
+val set     : 'a row -> 'a -> unit
+val get     : 'a row -> 'a option
+
+(* Reactively reduce the table using a monoid *)
+val reduce     : 'a Lwd_utils.monoid -> 'a t -> 'a Lwd.t
+val map_reduce : ('a row -> 'a -> 'b) -> 'b Lwd_utils.monoid -> 'a t -> 'b Lwd.t
+```
+
+When a row is inserted, removed, or modified, only the affected portion of the reduction is recomputed. This makes `Lwd_table` efficient for dynamic lists, log views, or any collection that changes incrementally.
+
+### How It Differs from Other Approaches
+
+| Approach                             | Update Strategy                     | Cost of Sparse Update               | Example            |
+| ------------------------------------ | ----------------------------------- | ----------------------------------- | ------------------ |
+| **Immediate mode** (full redraw)     | Redraw entire UI every frame        | O(n) where n = total UI size        | Ratatui, Notcurses |
+| **Retained mode** (virtual DOM diff) | Diff old tree vs new tree           | O(n) for the diff pass              | React/Ink, Textual |
+| **Incremental computation** (Lwd)    | Recompute only invalidated subgraph | O(k) where k = changed dependencies | Nottui             |
+
+The key advantage: when a single `Lwd.var` changes, only the `map`/`map2`/`bind` nodes that transitively depend on it are re-evaluated. In a large UI with hundreds of widgets, changing one counter value might recompute 3-4 nodes instead of the entire tree. There is no O(n) diff pass and no full redraw.
+
+---
+
+## Terminal Backend
+
+### Notty
+
+Nottui renders to the terminal via **Notty**, a declarative terminal graphics library for OCaml. Notty's philosophy is "describe what should be seen" rather than issuing terminal control sequences imperatively.
+
+#### Image Model
+
+Notty's central type is `Notty.image` -- a 2D grid of Unicode characters with per-cell styling. Images are immutable values that compose with pure functions:
+
+```ocaml
+(* Primitive image constructors *)
+val I.string  : attr -> string -> image    (* styled text *)
+val I.uchar   : attr -> Uchar.t -> int -> int -> image  (* repeated character *)
+val I.char    : attr -> char -> int -> int -> image
+val I.void    : int -> int -> image        (* empty space *)
+
+(* Image composition *)
+val I.(<|>) : image -> image -> image      (* horizontal composition *)
+val I.(<->) : image -> image -> image      (* vertical composition *)
+val I.(</>) : image -> image -> image      (* overlay/superposition *)
+```
+
+#### Capabilities
+
+| Capability | Details                                       |
+| ---------- | --------------------------------------------- |
+| Unicode    | Full Unicode support, multi-column characters |
+| Color      | 24-bit true color, 256-color, 16-color        |
+| Styling    | Bold, underline, reverse, blink               |
+| Input      | Keyboard events, mouse events                 |
+| Platform   | Pure OCaml core; Unix module for terminal I/O |
+
+Notty was inspired by Haskell's Vty library and shares its declarative, compositional approach to terminal rendering.
+
+---
+
+## Layout System
+
+### Combinator-Based Reactive Layout
+
+Nottui's layout system uses combinators for spatial composition, similar to Brick's approach but with reactivity built in at the foundation. Every layout combinator works with both plain `Ui.t` values and reactive `Ui.t Lwd.t` values.
+
+### Layout Specification
+
+Each UI element carries a `layout_spec` describing its space requirements:
+
+```ocaml
+type layout_spec = {
+  w  : int;   (* minimum/fixed width *)
+  h  : int;   (* minimum/fixed height *)
+  sw : int;   (* stretch factor, horizontal (0 = fixed) *)
+  sh : int;   (* stretch factor, vertical   (0 = fixed) *)
+}
+```
+
+The stretch factors (`sw`, `sh`) control how extra space is distributed. A widget with `sw = 0` has a fixed width; one with `sw = 1` will expand to fill available horizontal space. When multiple stretchable widgets share a container, space is divided proportionally by their stretch factors.
+
+### Core Layout Combinators
+
+| Combinator      | Purpose                                                       |
+| --------------- | ------------------------------------------------------------- |
+| `Ui.atom img`   | Leaf widget from a Notty image                                |
+| `Ui.space w h`  | Empty space with given dimensions                             |
+| `Ui.empty`      | Zero-size empty widget                                        |
+| `Ui.join_x a b` | Horizontal composition (a left of b)                          |
+| `Ui.join_y a b` | Vertical composition (a above b)                              |
+| `Ui.join_z a b` | Overlay/superposition (a on top of b)                         |
+| `Ui.hcat list`  | Horizontal concatenation of a list                            |
+| `Ui.vcat list`  | Vertical concatenation of a list                              |
+| `Ui.zcat list`  | Overlay concatenation of a list                               |
+| `Ui.resize`     | Override layout spec (set fixed dimensions, stretch, gravity) |
+| `Ui.shift_area` | Scroll/pan the content (positive = crop, negative = pad)      |
+
+### Gravity
+
+The `Gravity` module controls alignment within allocated space:
+
+```ocaml
+type direction = [ `Negative | `Neutral | `Positive ]
+type t  (* pairs horizontal and vertical gravity *)
+
+val make : h:direction -> v:direction -> t
+
+(* Examples:
+   `Negative, `Negative  = top-left
+   `Neutral,  `Neutral   = center
+   `Positive, `Positive  = bottom-right *)
+```
+
+When a widget receives more space than its minimum, gravity determines where the widget sits within that space.
+
+### Layout Example
+
+```ocaml
+open Nottui
+open Notty
+
+(* A simple two-panel layout with a status bar *)
+let sidebar items =
+  items
+  |> List.map (fun name ->
+    Ui.atom (I.string A.(fg green) name))
+  |> Ui.vcat
+
+let main_content text =
+  Ui.atom (I.string A.empty text)
+  |> Ui.resize ~w:0 ~sw:1  (* stretch horizontally *)
+
+let status_bar msg =
+  Ui.atom (I.string A.(fg white ++ bg blue) msg)
+  |> Ui.resize ~w:0 ~sw:1 ~h:1 ~sh:0  (* full width, fixed height *)
+
+let layout =
+  Ui.join_y
+    (Ui.join_x
+      (sidebar ["main.ml"; "lib.ml"; "test.ml"])
+      (main_content "Welcome to Nottui"))
+    (status_bar " Ready")
+```
+
+### Reactive Layout with Lwd
+
+The same combinators work with reactive values using `Lwd.map` and `Lwd.map2`:
+
+```ocaml
+let selected = Lwd.var 0
+
+let reactive_sidebar items =
+  Lwd.map (Lwd.get selected) ~f:(fun sel ->
+    items
+    |> List.mapi (fun i name ->
+      let attr = if i = sel then A.(fg black ++ bg white) else A.(fg green) in
+      Ui.atom (I.string attr name))
+    |> Ui.vcat)
+```
+
+When `selected` changes, only the sidebar subtree is recomputed -- the main content and status bar are untouched.
+
+---
+
+## Widget / Component System
+
+### Widgets Are Values
+
+In Nottui, a widget is a value of type `Ui.t`. There are no widget classes, no inheritance hierarchies, and no widget IDs. Widgets are constructed from primitives and composed with combinators -- pure functional construction.
+
+```ocaml
+type Ui.t  (* a terminal UI element *)
+```
+
+A `Ui.t` carries:
+
+- A `layout_spec` (size requirements and stretch factors)
+- A description variant (atom, composition, event handler, sensor, etc.)
+- Focus status
+- Cached rendering state
+
+### Leaf Widgets
+
+Leaf widgets are created from Notty images:
+
+```ocaml
+(* A leaf widget displaying a Notty image *)
+let label text =
+  Ui.atom (I.string A.empty text)
+
+(* A styled label *)
+let bold_label text =
+  Ui.atom (I.string A.(st bold) text)
+
+(* A colored block *)
+let colored_block w h color =
+  Ui.atom (I.char A.(bg color) ' ' w h)
+```
+
+### Container Widgets
+
+Containers compose child widgets spatially:
+
+```ocaml
+(* Vertical list *)
+let menu items =
+  List.map (fun (label, _action) ->
+    Ui.atom (I.string A.empty label))
+    items
+  |> Ui.vcat
+
+(* Horizontal bar *)
+let toolbar buttons =
+  buttons
+  |> List.map (fun label ->
+    Ui.atom (I.string A.(fg white ++ bg blue) (Printf.sprintf " %s " label)))
+  |> Ui.hcat
+```
+
+### Interactive Widgets
+
+Interactivity is added by wrapping widgets with event handlers:
+
+```ocaml
+(* A clickable button *)
+let button label on_click =
+  let ui = Ui.atom (I.string A.(fg white ++ bg blue) (Printf.sprintf " %s " label)) in
+  Ui.mouse_area (fun ~x:_ ~y:_ _button ->
+    on_click ();
+    `Handled
+  ) ui
+
+(* A keyboard-interactive widget *)
+let key_handler inner on_key =
+  Ui.keyboard_area (fun key ->
+    match key with
+    | `ASCII 'q', [] -> on_key `Quit; `Handled
+    | `Enter, []     -> on_key `Enter; `Handled
+    | _              -> `Unhandled
+  ) inner
+```
+
+### Custom Reactive Widgets
+
+Custom widgets combine Lwd reactivity with Ui primitives:
+
+```ocaml
+(* A reactive counter widget *)
+let counter () =
+  let count = Lwd.var 0 in
+  Lwd.map (Lwd.get count) ~f:(fun n ->
+    let label = Printf.sprintf " Count: %d " n in
+    let ui = Ui.atom (I.string A.(fg yellow) label) in
+    Ui.mouse_area (fun ~x:_ ~y:_ _btn ->
+      Lwd.set count (Lwd.peek count + 1);
+      `Handled
+    ) ui)
+
+(* A reactive toggle *)
+let toggle label =
+  let state = Lwd.var false in
+  Lwd.map (Lwd.get state) ~f:(fun on ->
+    let indicator = if on then "[x]" else "[ ]" in
+    let text = Printf.sprintf "%s %s" indicator label in
+    let attr = if on then A.(fg green) else A.(fg white) in
+    Ui.mouse_area (fun ~x:_ ~y:_ _btn ->
+      Lwd.set state (not (Lwd.peek state));
+      `Handled
+    ) (Ui.atom (I.string attr text)))
+```
+
+### Built-In Widgets (Nottui_widgets)
+
+The `Nottui_widgets` module provides higher-level widgets:
+
+| Widget              | Signature (simplified)                                     | Purpose                        |
+| ------------------- | ---------------------------------------------------------- | ------------------------------ |
+| `string`            | `?attr -> string -> ui`                                    | Text display                   |
+| `printf`            | `?attr -> format -> ui`                                    | Formatted text                 |
+| `button`            | `?attr -> string -> (unit -> unit) -> ui`                  | Clickable button               |
+| `toggle`            | `?init:bool -> string Lwd.t -> (bool -> unit) -> ui Lwd.t` | Checkbox toggle                |
+| `edit_field`        | `(string * int) Lwd.t -> ... -> ui Lwd.t`                  | Text input with cursor         |
+| `scrollbox`         | `ui Lwd.t -> ui Lwd.t`                                     | Scrollable container with bars |
+| `vlist`             | `?bullet -> ui Lwd.t list -> ui Lwd.t`                     | Vertical bullet list           |
+| `grid`              | `?headers -> ui Lwd.t list list -> ui Lwd.t`               | Table/grid layout              |
+| `tabs`              | `(string * (unit -> ui Lwd.t)) list -> ui Lwd.t`           | Tabbed view                    |
+| `unfoldable`        | `ui Lwd.t -> (unit -> ui Lwd.t) -> ui Lwd.t`               | Collapsible tree node          |
+| `file_select`       | `?filter -> on_select -> unit -> ui Lwd.t`                 | File browser                   |
+| `v_pane` / `h_pane` | `ui Lwd.t -> ui Lwd.t -> ui Lwd.t`                         | Resizable split panes          |
+
+---
+
+## Styling
+
+### Notty Attributes
+
+All styling in Nottui flows through Notty's `Notty.A` (attribute) module. Attributes are attached per-cell in Notty images -- there is no separate styling layer or CSS-like system.
+
+```ocaml
+(* Foreground and background colors *)
+A.fg red
+A.bg blue
+A.(fg green ++ bg black)
+
+(* Text styles *)
+A.st bold
+A.st underline
+A.st reverse
+A.st blink
+
+(* Combining attributes with ++ *)
+A.(fg cyan ++ st bold ++ st underline)
+
+(* 24-bit color *)
+A.fg (A.rgb_888 ~r:255 ~g:128 ~b:0)
+
+(* Grayscale *)
+A.fg (A.gray 12)  (* 0-23 grayscale levels *)
+
+(* Apply attributes to text *)
+I.string A.(fg red ++ st bold) "Error!"
+I.string A.(fg white ++ bg blue) " Status Bar "
+```
+
+### Attribute Composition
+
+Attributes compose with `++` (the `Notty.A.(++)` operator). Later attributes override earlier ones for conflicting properties:
+
+```ocaml
+let base_attr = A.(fg white ++ bg black)
+let highlight  = A.(base_attr ++ fg yellow ++ st bold)
+let error_attr = A.(base_attr ++ fg red ++ st bold ++ st underline)
+```
+
+### Color Support
+
+| Color Type   | API                                | Range             |
+| ------------ | ---------------------------------- | ----------------- |
+| Named colors | `A.red`, `A.blue`, `A.green`, etc. | 8 standard colors |
+| Light colors | `A.lightred`, `A.lightblue`, etc.  | 8 light variants  |
+| 256-color    | `A.rgb ~r ~g ~b` (0-5 each)        | 216 colors        |
+| Grayscale    | `A.gray level` (0-23)              | 24 gray levels    |
+| 24-bit       | `A.rgb_888 ~r ~g ~b` (0-255 each)  | 16.7M colors      |
+
+---
+
+## Event Handling
+
+### Event Flow
+
+Events flow through the widget tree from the root toward leaves. Event handlers at each level can intercept events or let them propagate.
+
+### Event Types
+
+```ocaml
+type event = [
+  | `Key of key                          (* keyboard input *)
+  | `Mouse of [ `Press of button         (* mouse press *)
+              | `Release                  (* mouse release *)
+              | `Drag ]                   (* mouse drag *)
+              * (int * int)              (* coordinates *)
+              * Unescape.mods            (* modifier keys *)
+  | `Paste of string                     (* bracketed paste *)
+]
+
+type key = [
+  | `ASCII of char                       (* printable ASCII *)
+  | `Uchar of Uchar.t                   (* Unicode character *)
+  | `Enter | `Escape | `Tab | `Backspace
+  | `Arrow of [ `Up | `Down | `Left | `Right ]
+  | `Page of [ `Up | `Down ]
+  | `Home | `End | `Insert | `Delete
+  | `Function of int                     (* F1-F12 *)
+] * Unescape.mods                        (* modifier keys *)
+```
+
+### Attaching Event Handlers
+
+```ocaml
+(* Mouse events: handler receives coordinates and button *)
+val Ui.mouse_area :
+  (x:int -> y:int -> [ `Press of button | `Release | `Drag ] ->
+   [ `Handled | `Unhandled | `Grab of ... ]) ->
+  t -> t
+
+(* Keyboard events *)
+val Ui.keyboard_area :
+  (key -> [ `Handled | `Unhandled ]) ->
+  t -> t
+
+(* General event filter: intercepts all events for a subtree *)
+val Ui.event_filter :
+  ([ `Key of key | `Mouse of ... ] -> [ `Handled | `Unhandled ]) ->
+  t -> t
+```
+
+### Propagation Control
+
+Handlers return a variant controlling propagation:
+
+- **`` `Handled ``** -- the event is consumed; it does not propagate further up the tree
+- **`` `Unhandled ``** -- the event is ignored by this handler and continues propagating
+- **`` `Grab ``** (mouse only) -- captures subsequent mouse events (drag, release) regardless of cursor position
+
+### Event Handler Example
+
+```ocaml
+(* A navigable list with keyboard and mouse support *)
+let navigable_list items selected =
+  let handle_key = function
+    | `Arrow `Up, []   ->
+      Lwd.set selected (max 0 (Lwd.peek selected - 1));
+      `Handled
+    | `Arrow `Down, [] ->
+      Lwd.set selected (min (List.length items - 1) (Lwd.peek selected + 1));
+      `Handled
+    | `Enter, []       ->
+      (* activate selected item *)
+      `Handled
+    | _ -> `Unhandled
+  in
+  Lwd.map (Lwd.get selected) ~f:(fun sel ->
+    items
+    |> List.mapi (fun i item ->
+      let attr = if i = sel then A.(fg black ++ bg white) else A.empty in
+      Ui.mouse_area (fun ~x:_ ~y:_ _ ->
+        Lwd.set selected i;
+        `Handled
+      ) (Ui.atom (I.string attr item)))
+    |> Ui.vcat
+    |> Ui.keyboard_area handle_key)
+```
+
+### Renderer and Event Dispatch
+
+The `Renderer` module bridges the reactive UI and the terminal:
+
+```ocaml
+module Renderer : sig
+  type t
+  val make : unit -> t
+  val update : t -> size:(int * int) -> Ui.t -> unit
+  val image : t -> Notty.image
+  val dispatch_mouse : t -> int -> int -> ... -> [ `Handled | `Unhandled ]
+  val dispatch_key : t -> key -> [ `Handled | `Unhandled ]
+  val dispatch_event : t -> event -> [ `Handled | `Unhandled ]
+end
+```
+
+The renderer maintains the current UI tree, produces Notty images for display, and routes input events to the appropriate handlers in the tree.
+
+---
+
+## State Management
+
+### `Lwd.var` -- The Primary State Primitive
+
+All mutable state in a Nottui application is held in `Lwd.var` values. A `Lwd.var` is a mutable cell that participates in the incremental computation graph:
+
+```ocaml
+(* Create a reactive variable with an initial value *)
+let counter = Lwd.var 0
+
+(* Read within the reactive graph -- creates a dependency *)
+let counter_doc : int Lwd.t = Lwd.get counter
+
+(* Read immediately -- no dependency, for use in event handlers *)
+let current : int = Lwd.peek counter
+
+(* Update the variable -- invalidates all dependents *)
+let () = Lwd.set counter 42
+```
+
+### Automatic Dependency Tracking
+
+When you build a computation with `Lwd.map`, `Lwd.map2`, or `Lwd.bind`, the runtime tracks which `Lwd.var` values are read (via `Lwd.get`). This builds the dependency graph **automatically** -- there is no need to:
+
+- Manually subscribe to state changes
+- Implement an observer pattern
+- Mark widgets as dirty
+- Declare dependencies explicitly
+
+The graph is built by the act of computation. If a `map` function reads variable A, then the result depends on A. Period.
+
+```ocaml
+let name = Lwd.var "World"
+let greeting = Lwd.map (Lwd.get name) ~f:(fun n ->
+  Printf.sprintf "Hello, %s!" n)
+
+(* greeting automatically depends on name.
+   When name changes, greeting is invalidated. *)
+let () = Lwd.set name "OCaml"
+(* greeting is now "damaged" -- next sample will recompute it *)
+```
+
+### Invalidation and Recomputation
+
+The lifecycle of a reactive value follows this pattern:
+
+1. **Construction** -- `Lwd.map`/`Lwd.map2`/`Lwd.bind` builds the DAG
+2. **Sampling** -- `Lwd.sample root` evaluates the graph, caching results
+3. **Mutation** -- `Lwd.set var value` marks the variable and all transitive dependents as **damaged**
+4. **Re-sampling** -- the next `Lwd.sample` recomputes only damaged nodes, caching new results
+5. **Quiescence** -- if no variables change, sampling returns cached values at zero cost
+
+The framework (specifically `Ui_loop` or `Nottui_lwt`) calls `sample` on each frame. If nothing changed, the frame is essentially free.
+
+### State Patterns
+
+```ocaml
+(* Pattern: local state encapsulated in a widget *)
+let expandable_section title content =
+  let open_ = Lwd.var false in
+  Lwd.map (Lwd.get open_) ~f:(fun is_open ->
+    let header =
+      let arrow = if is_open then "v " else "> " in
+      Ui.mouse_area (fun ~x:_ ~y:_ _ ->
+        Lwd.set open_ (not (Lwd.peek open_));
+        `Handled
+      ) (Ui.atom (I.string A.(st bold) (arrow ^ title)))
+    in
+    if is_open then
+      Ui.join_y header content
+    else
+      header)
+
+(* Pattern: shared state across widgets *)
+let app () =
+  let selected_tab = Lwd.var 0 in
+  let tab_bar = Lwd.map (Lwd.get selected_tab) ~f:(fun sel ->
+    (* renders tab headers, clicking sets selected_tab *) ...)
+  in
+  let tab_content = Lwd.map (Lwd.get selected_tab) ~f:(fun sel ->
+    (* renders content for the selected tab *) ...)
+  in
+  Lwd.map2 tab_bar tab_content ~f:(fun bar content ->
+    Ui.join_y bar content)
+```
+
+---
+
+## Extensibility & Ecosystem
+
+### Ecosystem
+
+Nottui exists within the broader Lwd ecosystem:
+
+| Package           | Purpose                                             |
+| ----------------- | --------------------------------------------------- |
+| **lwd**           | Core incremental computation library                |
+| **nottui**        | Terminal UI widgets and layout on Lwd               |
+| **nottui-lwt**    | Async/concurrent support via Lwt                    |
+| **nottui-pretty** | Interactive pretty-printer based on Pprint          |
+| **tyxml-lwd**     | Web DOM rendering via Js_of_ocaml (Lwd for the web) |
+| **brr-lwd**       | Browser integration layer                           |
+
+The Lwd core is backend-agnostic. The same incremental computation model that drives Nottui's terminal UI also drives `tyxml-lwd` for web UIs. This demonstrates the generality of the reactive document approach.
+
+### Usage in Practice
+
+Nottui is used in some OCaml developer tools and academic projects. The ecosystem is small but the library demonstrates ideas that are relevant far beyond its direct usage. The incremental computation approach has roots in academic work on self-adjusting computation (Acar et al.) and is related to Jane Street's `Incremental` library for OCaml.
+
+### Extension Points
+
+- **Custom widgets**: compose `Ui.atom`, `Ui.join_x/y/z`, `Ui.mouse_area`, `Ui.keyboard_area` with `Lwd.map` for reactivity
+- **Custom backends**: Lwd itself is backend-agnostic; one could build a non-Notty renderer
+- **Custom reactive primitives**: `Lwd.prim` allows defining lifecycle-managed reactive leaves with acquire/release semantics
+
+---
+
+## Strengths
+
+- **Automatic fine-grained reactivity** -- dependencies are tracked by the runtime, not declared by the programmer. No manual subscriptions, no observer boilerplate, no forgotten unsubscribes.
+- **Efficient sparse updates** -- changing one variable recomputes only its dependents. In a large UI, this can be O(1) instead of O(n) for a full redraw or O(n) for a virtual DOM diff.
+- **No virtual DOM overhead** -- there is no diffing pass. The dependency graph directly encodes what needs to update, avoiding the O(n) tree comparison that retained-mode frameworks require.
+- **Mathematically principled** -- the Functor/Applicative/Monad structure of `Lwd.t` provides well-understood composition laws. The incremental computation model has formal foundations in self-adjusting computation theory.
+- **Elegant functional API** -- widgets are values, composition is function application, state is explicit `Lwd.var` cells. The entire API surface is small and orthogonal.
+- **Compositional state management** -- each widget can own its local `Lwd.var` state. State is encapsulated naturally by lexical scope, not by framework-imposed patterns.
+- **Backend-agnostic core** -- Lwd works for terminal UIs (Nottui), web UIs (tyxml-lwd), and any other output. The incremental computation layer is fully separated from rendering.
+- **Lazy evaluation of collapsed subtrees** -- `Lwd.bind` enables conditional computation: collapsed sections do not evaluate their children until expanded.
+
+---
+
+## Weaknesses & Limitations
+
+- **Small OCaml ecosystem** -- OCaml's community is much smaller than Rust, Python, Go, or JavaScript. Fewer users means fewer bug reports, fewer tutorials, and fewer ready-made components.
+- **Limited documentation** -- the README covers basics but the Layout DSL section is literally marked "TODO". Understanding the full API requires reading `.mli` files and source code.
+- **Few built-in widgets** -- `Nottui_widgets` provides essentials (buttons, text input, scroll, tabs, grid) but lacks the breadth of Brick's widget ecosystem or Textual's 30+ built-in widgets.
+- **Steep learning curve** -- the incremental computation model, monadic composition, and OCaml's type system present a significant barrier for developers not already comfortable with functional programming.
+- **Small community** -- finding help, examples, or third-party extensions is harder than with mainstream TUI libraries.
+- **Less battle-tested** -- compared to ncurses-based systems with decades of deployment or Brick with hundreds of downstream projects, Nottui has seen limited production use.
+- **Memory management discipline** -- `Lwd.root` values must be explicitly released to avoid memory leaks. Forgetting `release` keeps the entire dependency graph alive.
+- **Dynamic dependency cost** -- `Lwd.bind` / `Lwd.join` (dynamic graph rewiring) is more expensive than `Lwd.map` / `Lwd.map2` (static edges). Overuse of `bind` can degrade the incremental performance advantage.
+
+---
+
+## Lessons for D / Sparkles
+
+### `Lwd.t` Reactive Values --> D `Reactive!T` Struct
+
+The core `'a Lwd.t` pattern could be implemented in D as a `Reactive!T` struct that tracks access during rendering. When a reactive value is read during a render pass, it registers itself as a dependency of the current computation context. On mutation, dependent subtrees are marked dirty.
+
+```d
+/// A reactive value that tracks dependencies automatically.
+struct Reactive(T)
+{
+    private T _value;
+    private DependencyNode _node;
+
+    /// Read the value, registering a dependency on the current computation.
+    T get() @safe
+    {
+        if (auto ctx = RenderContext.current)
+            ctx.registerDependency(&_node);
+        return _value;
+    }
+
+    /// Read without dependency tracking (for event handlers).
+    T peek() @safe pure nothrow @nogc
+    {
+        return _value;
+    }
+
+    /// Set the value, invalidating all dependents.
+    void set(T newVal) @safe
+    {
+        _value = newVal;
+        _node.invalidateDependents();
+    }
+}
+```
+
+The render context could use thread-local storage or a scope parameter to track which reactive values are read during each computation, building the dependency graph implicitly -- just as Lwd does.
+
+### Incremental Computation --> D Template Metaprogramming + Runtime Tracking
+
+D's template metaprogramming could create a **compile-time dependency graph** for static reactive relationships (where the structure is known at compile time), with runtime `Lwd.var`-style tracking for dynamic state:
+
+```d
+/// A computed reactive value (like Lwd.map).
+/// The dependency on `source` is known at compile time.
+auto computed(alias fn, Sources...)(Sources sources)
+{
+    // The dependency edges are encoded in the type at compile time.
+    // At runtime, only invalidation propagation occurs.
+    return ComputedReactive!(fn, Sources)(sources);
+}
+
+// Usage:
+auto name = reactive("World");
+auto greeting = computed!(n => "Hello, " ~ n ~ "!")(name);
+// greeting is invalidated when name changes -- zero-cost dependency tracking
+```
+
+For the dynamic case (where the dependency graph changes at runtime, analogous to `Lwd.bind`), a runtime dependency tracker with generation counters could be used, similar to Lwd's internal invalidation mechanism.
+
+### `Lwd.map` / `Lwd.bind` --> D Range Composition or UFCS Monadic Style
+
+Lwd's combinators map to D idioms:
+
+```d
+// Lwd-style: Lwd.map (Lwd.get counter) ~f:(fun n -> ...)
+// D-style with UFCS:
+auto counterView = counter
+    .asReactive
+    .map!(n => text(format!"Count: %d"(n)));
+
+// Lwd-style: Lwd.map2 a b ~f:(fun x y -> ...)
+// D-style:
+auto combined = map2!(
+    (header, body) => vBox(header, body)
+)(headerWidget, bodyWidget);
+```
+
+D's `alias` parameters and template lambdas provide the same composition power as OCaml's first-class functions, with the added benefit of compile-time specialization.
+
+### `Lwd_table` (Reactive Collections) --> D `ReactiveList!T`
+
+A reactive list in D could track insertions and deletions, invalidating only affected reductions:
+
+```d
+/// A reactive ordered collection with incremental reduction.
+struct ReactiveList(T)
+{
+    void append(T item) @safe;
+    void remove(size_t index) @safe;
+    void set(size_t index, T item) @safe;
+
+    /// Incrementally reduce the collection.
+    /// Only recomputes the portion affected by changes.
+    auto reduce(alias monoidOp, B)(B identity)
+    {
+        return IncrementalReduction!(typeof(this), monoidOp, B)(this, identity);
+    }
+}
+```
+
+This is particularly valuable for log views, list widgets, and table displays where items change one at a time but the rendered list may contain thousands of entries.
+
+### No Virtual DOM Diffing --> Incremental `@nogc` Reactivity
+
+The key insight from Lwd is that **dependency-tracked incremental computation avoids the O(n) diff cost** entirely. For a D TUI library targeting `@nogc` operation, this is especially relevant:
+
+- Virtual DOM diffing allocates a new tree each frame and walks both trees -- incompatible with `@nogc`
+- Immediate-mode redraws the entire screen -- wastes work for sparse updates
+- Incremental computation with `Reactive!T` values can propagate changes through a pre-allocated DAG with no allocation, making it naturally `@nogc`-compatible
+
+```d
+// The dependency graph is allocated once and reused.
+// Updates only touch changed nodes -- no allocation, no diffing.
+@safe @nogc nothrow
+void propagateChanges(DependencyGraph* graph)
+{
+    foreach (node; graph.damagedNodes)
+    {
+        node.recompute();
+        node.markClean();
+    }
+}
+```
+
+### Automatic Dependency Tracking --> D `opDispatch` or Scope Guards
+
+D's metaprogramming facilities could intercept property reads to build dependency graphs automatically:
+
+```d
+/// A reactive wrapper that tracks reads via opDispatch.
+struct Tracked(T)
+{
+    private T _inner;
+
+    auto opDispatch(string member)()
+    {
+        // Register that `member` was read during this render pass
+        RenderContext.current.trackRead(&this, member);
+        return __traits(getMember, _inner, member);
+    }
+}
+
+// Alternatively, scope-based tracking:
+auto renderScope = RenderContext.beginScope();
+scope(exit) renderScope.commit();
+// Any Reactive!T.get() calls within this scope automatically
+// register dependencies on renderScope.
+```
+
+This mirrors Lwd's approach where `Lwd.get` implicitly registers dependencies during evaluation, but uses D's compile-time introspection capabilities instead of OCaml's runtime tracking.
+
+---
+
+## References
+
+- **Lwd repository (includes Nottui)**: <https://github.com/let-def/lwd>
+- **Nottui source**: <https://github.com/let-def/lwd/tree/master/lib/nottui>
+- **Nottui README with examples**: <https://github.com/let-def/lwd/blob/master/lib/nottui/README.md>
+- **Lwd README (incremental computation model)**: <https://github.com/let-def/lwd/blob/master/README.md>
+- **Lwd API (`.mli`)**: <https://github.com/let-def/lwd/blob/master/lib/lwd/lwd.mli>
+- **Nottui API (`.mli`)**: <https://github.com/let-def/lwd/blob/master/lib/nottui/nottui.mli>
+- **Nottui widgets API (`.mli`)**: <https://github.com/let-def/lwd/blob/master/lib/nottui/nottui_widgets.mli>
+- **Lwd_table API (`.mli`)**: <https://github.com/let-def/lwd/blob/master/lib/lwd/lwd_table.mli>
+- **Notty (terminal backend)**: <https://github.com/pqwy/notty>
+- **opam package**: <https://opam.ocaml.org/packages/nottui/>
+- **Frederic Bour (author)**: <https://github.com/let-def>
+- **Merlin (OCaml IDE service, also by Bour)**: <https://github.com/ocaml/merlin>

--- a/docs/research/tui-libraries/ratatui.md
+++ b/docs/research/tui-libraries/ratatui.md
@@ -1,0 +1,982 @@
+# Ratatui (Rust)
+
+A Rust library for building rich terminal user interfaces using an immediate-mode rendering model with constraint-based layout and a composable widget system.
+
+| Field          | Value                                            |
+| -------------- | ------------------------------------------------ |
+| Language       | Rust                                             |
+| License        | MIT                                              |
+| Repository     | <https://github.com/ratatui/ratatui>             |
+| Documentation  | <https://ratatui.rs> / <https://docs.rs/ratatui> |
+| Latest Version | ~0.30.0 (December 2025)                          |
+| GitHub Stars   | ~18.3k                                           |
+
+---
+
+## Overview
+
+Ratatui is the de facto standard TUI framework for Rust. It provides a toolkit for
+building text-based user interfaces in the terminal, targeting dashboards, interactive CLI
+tools, log viewers, file managers, and similar applications.
+
+**What it solves.** Writing terminal UIs from scratch requires managing raw ANSI escape
+sequences, screen buffering, cursor positioning, resize handling, and color support across
+different terminal emulators. Ratatui provides a high-level abstraction over all of this:
+a `Buffer` you write widgets into, a `Layout` engine that subdivides screen real estate,
+and a `Terminal` that diffs frames and emits only the changed cells.
+
+**Design philosophy.** Ratatui is deliberately minimal in what it _enforces_. It does not
+own your main loop, does not impose a state management pattern, and does not bundle an
+event system. The application is in control: you poll events, mutate your state, and call
+`terminal.draw(...)` whenever you want a new frame. This makes Ratatui a _library_, not a
+_framework_ -- it composes with any async runtime, event source, or architecture (Elm,
+component-based, ad-hoc).
+
+**History and lineage.** Ratatui was forked from Florian Dehau's `tui-rs` crate in 2023
+after development on the original stalled. The community-driven fork has since far
+surpassed the original in features, documentation, and ecosystem support. With 267+
+contributors and 12,700+ dependent crates, it is the overwhelmingly dominant choice for
+Rust TUI development.
+
+---
+
+## Architecture
+
+### Rendering Model: Immediate-Mode with Double Buffering
+
+Ratatui uses an **immediate-mode rendering model**. Every frame, the application rebuilds
+the entire UI from scratch by calling `terminal.draw(|frame| { ... })`. There is no
+retained widget tree; no persistent scene graph. The `draw` closure receives a `Frame`,
+which exposes `render_widget(widget, area)` to place widgets into a back buffer.
+
+Under the hood, `Terminal` maintains **two buffers** (current and previous). After the
+draw closure returns, the terminal diffs the current buffer against the previous one and
+writes only the changed cells to the backend. This gives the _programming model_ of
+immediate mode (stateless re-render) with the _performance_ of differential updates.
+
+```
+ App State
+    |
+    v
+ terminal.draw(|frame| {
+    frame.render_widget(header, areas[0]);
+    frame.render_widget(body,   areas[1]);
+    frame.render_widget(footer, areas[2]);
+ })
+    |
+    v
+ Buffer (current frame)
+    |  diff against previous frame
+    v
+ Backend (crossterm/termion/termwiz)
+    |
+    v
+ Terminal emulator
+```
+
+### Application Pattern
+
+Ratatui does not prescribe an architecture. The most common pattern is an **app-driven
+loop**:
+
+```rust
+fn main() -> Result<()> {
+    let mut terminal = ratatui::init();
+    let mut app = App::new();
+
+    loop {
+        terminal.draw(|frame| app.render(frame))?;
+
+        if let Event::Key(key) = crossterm::event::read()? {
+            match app.handle_key(key) {
+                Action::Quit => break,
+                Action::Update => continue,
+            }
+        }
+    }
+
+    ratatui::restore();
+    Ok(())
+}
+```
+
+This pattern is compatible with Elm/MVU if you choose to structure it that way (separate
+`update` and `view` functions), but nothing in the library requires it.
+
+### Data Flow
+
+Data flows in one direction: **App state -> Widget construction -> Buffer -> Backend**.
+Widgets are typically constructed inline during the draw call using references to app
+state. They do not persist between frames.
+
+---
+
+## Terminal Backend
+
+Ratatui abstracts the underlying terminal library through a `Backend` trait. The
+`Terminal<B: Backend>` struct wraps a backend and manages buffering, diffing, and cursor
+state.
+
+### Backend Trait
+
+```rust
+pub trait Backend {
+    type Error;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>;
+
+    fn hide_cursor(&mut self) -> Result<(), Self::Error>;
+    fn show_cursor(&mut self) -> Result<(), Self::Error>;
+    fn get_cursor_position(&mut self) -> Result<Position, Self::Error>;
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P)
+        -> Result<(), Self::Error>;
+    fn clear(&mut self) -> Result<(), Self::Error>;
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error>;
+    fn size(&self) -> Result<Size, Self::Error>;
+    fn window_size(&mut self) -> Result<WindowSize, Self::Error>;
+    fn flush(&mut self) -> Result<(), Self::Error>;
+    fn scroll_region_up(&mut self, region: Rect, amount: u16)
+        -> Result<(), Self::Error>;
+    fn scroll_region_down(&mut self, region: Rect, amount: u16)
+        -> Result<(), Self::Error>;
+}
+```
+
+### Backend Implementations
+
+| Backend            | Crate                | Platforms       | Notes                                            |
+| ------------------ | -------------------- | --------------- | ------------------------------------------------ |
+| `CrosstermBackend` | `ratatui-crossterm`  | Windows + POSIX | Most popular. True color, mouse, Kitty keyboard. |
+| `TermionBackend`   | `ratatui-termion`    | POSIX only      | Lightweight, Unix-focused.                       |
+| `TermwizBackend`   | `ratatui-termwiz`    | Cross-platform  | From the wezterm project.                        |
+| `TestBackend`      | `ratatui` (built-in) | All             | In-memory backend for testing.                   |
+
+### Capabilities
+
+- **True color:** Supported via `Color::Rgb(r, g, b)` on all backends (terminal-dependent).
+- **Mouse support:** Available through crossterm and termion event systems.
+- **Unicode / grapheme handling:** The `Buffer` and `Span` types are grapheme-aware;
+  `width()` returns Unicode display width, `styled_graphemes()` iterates grapheme clusters.
+- **Kitty keyboard protocol:** Supported through crossterm's `PushKeyboardEnhancementFlags`.
+  Enables disambiguation of key press/release/repeat events and modifier combinations that
+  traditional terminals cannot distinguish.
+
+### Terminal Struct
+
+The `Terminal<B: Backend>` struct is the main entry point:
+
+```rust
+impl<B: Backend> Terminal<B> {
+    fn new(backend: B) -> Result<Self>;
+    fn with_options(backend: B, options: TerminalOptions) -> Result<Self>;
+
+    fn draw<F>(&mut self, f: F) -> Result<CompletedFrame>
+    where
+        F: FnOnce(&mut Frame);
+
+    fn backend(&self) -> &B;
+    fn backend_mut(&mut self) -> &mut B;
+
+    fn hide_cursor(&mut self) -> Result<()>;
+    fn show_cursor(&mut self) -> Result<()>;
+    fn clear(&mut self) -> Result<()>;
+    fn flush(&mut self) -> Result<()>;
+
+    // Insert content above an inline viewport
+    fn insert_before<F>(&mut self, height: u16, f: F) -> Result<()>;
+}
+```
+
+The `TerminalOptions` struct allows selecting a **viewport mode**: `Fullscreen` (default),
+`Inline(height)` for embedding a UI within scrollback, or `Fixed(rect)` for a specific
+region.
+
+---
+
+## Layout System
+
+Ratatui's layout engine subdivides rectangular areas using a **constraint solver** (the
+`kasuari` crate, a Rust port of the Cassowary algorithm). Constraints are resolved in
+priority order to produce a set of non-overlapping `Rect` values.
+
+### Constraint Variants
+
+```rust
+pub enum Constraint {
+    /// Allocate exactly `n` cells.
+    Length(u16),
+    /// Allocate a percentage of available space.
+    Percentage(u16),
+    /// Allocate space as a ratio (numerator / denominator).
+    Ratio(u32, u32),
+    /// Allocate at least `n` cells.
+    Min(u16),
+    /// Allocate at most `n` cells.
+    Max(u16),
+    /// Fill remaining space proportionally (weight-based).
+    Fill(u16),
+}
+```
+
+Constraints are resolved in this priority order: **Min > Max > Length > Percentage > Ratio > Fill**. `Fill` distributes any leftover space after all other constraints are satisfied, proportional to the fill weight.
+
+### Layout API
+
+```rust
+let layout = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints([
+        Constraint::Length(3),
+        Constraint::Fill(1),
+        Constraint::Length(1),
+    ])
+    .split(area);
+```
+
+The `areas::<N>()` method provides a compile-time checked alternative that returns a
+fixed-size array:
+
+```rust
+let [header, body, footer] = Layout::vertical([
+    Constraint::Length(3),
+    Constraint::Fill(1),
+    Constraint::Length(1),
+]).areas(area);
+```
+
+Layout results are cached in a **thread-local LRU cache** keyed on the layout
+configuration and input area, so repeated calls with the same parameters are essentially
+free.
+
+### Multi-Panel Layout Example
+
+A dashboard with a header, two side-by-side columns, and a footer:
+
+```rust
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::Frame;
+
+fn render_dashboard(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+
+    // Outer vertical split: header (3 rows) | body (fill) | footer (1 row)
+    let [header_area, body_area, footer_area] = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Fill(1),
+        Constraint::Length(1),
+    ]).areas(area);
+
+    // Body: two columns, left is 40%, right fills the rest
+    let [left_col, right_col] = Layout::horizontal([
+        Constraint::Percentage(40),
+        Constraint::Fill(1),
+    ]).areas(body_area);
+
+    // Right column: split vertically into two panels
+    let [top_right, bottom_right] = Layout::vertical([
+        Constraint::Ratio(1, 2),
+        Constraint::Ratio(1, 2),
+    ]).areas(right_col);
+
+    // Render widgets into each area
+    frame.render_widget(
+        Paragraph::new(app.title.as_str())
+            .block(Block::bordered().title("Header")),
+        header_area,
+    );
+    frame.render_widget(
+        List::new(app.items.iter().map(|i| i.as_str()))
+            .block(Block::bordered().title("Sidebar")),
+        left_col,
+    );
+    frame.render_widget(
+        Paragraph::new(app.detail.as_str())
+            .block(Block::bordered().title("Detail")),
+        top_right,
+    );
+    frame.render_widget(
+        Paragraph::new(app.logs.as_str())
+            .block(Block::bordered().title("Logs"))
+            .wrap(Wrap { trim: true }),
+        bottom_right,
+    );
+    frame.render_widget(
+        Paragraph::new(app.status_line.as_str()),
+        footer_area,
+    );
+}
+```
+
+This produces a layout like:
+
+```
++---------------------------------------------+
+|                  Header                      |
++------------------+--------------------------+
+|                  |         Detail            |
+|    Sidebar       +--------------------------+
+|                  |          Logs             |
++------------------+--------------------------+
+| status line                                  |
++---------------------------------------------+
+```
+
+---
+
+## Widget / Component System
+
+### The Widget Trait
+
+The core abstraction is the `Widget` trait:
+
+```rust
+pub trait Widget {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized;
+}
+```
+
+Key design decisions:
+
+- **`self` by value:** Widgets are consumed on render. They are lightweight, typically
+  holding references to app data, and are constructed inline during the draw call.
+- **`Rect` + `Buffer`:** The widget is told _where_ to draw (`area`) and _what_ to draw
+  into (`buf`). It has no knowledge of the terminal, other widgets, or global state.
+- **Reference implementations:** Since v0.26.0, built-in widgets implement `Widget` for
+  `&W` as well, allowing a widget to be stored and rendered multiple times.
+
+### Built-in Widgets
+
+| Widget      | Description                                                      |
+| ----------- | ---------------------------------------------------------------- |
+| `Block`     | Container with borders, title, padding. Wraps other widgets.     |
+| `Paragraph` | Multi-line styled text with wrapping and scrolling.              |
+| `List`      | Scrollable list of items with selection support.                 |
+| `Table`     | Multi-column table with headers, row selection, column widths.   |
+| `Tabs`      | Horizontal tab bar with active tab indicator.                    |
+| `Gauge`     | Progress bar (percentage-based).                                 |
+| `LineGauge` | Thin-line progress indicator.                                    |
+| `Chart`     | Line/scatter chart with axes, labels, and multiple datasets.     |
+| `Canvas`    | Free-form drawing surface with shapes (line, rectangle, circle). |
+| `Sparkline` | Inline bar chart for time-series data.                           |
+| `BarChart`  | Vertical or horizontal bar chart with labels and values.         |
+| `Calendar`  | Monthly calendar view.                                           |
+| `Scrollbar` | Scrollbar indicator (vertical or horizontal).                    |
+| `Clear`     | Clears an area (useful for overlays).                            |
+
+Additionally, `Span`, `Line`, and `Text` implement `Widget`, so styled text can be
+rendered directly without wrapping it in a `Paragraph`.
+
+### StatefulWidget Trait
+
+For widgets that need to remember state between renders (e.g., scroll position, selected
+item):
+
+```rust
+pub trait StatefulWidget {
+    type State;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State);
+}
+```
+
+Usage:
+
+```rust
+// In App struct:
+struct App {
+    items: Vec<String>,
+    list_state: ListState,  // tracks selected index and scroll offset
+}
+
+// In render:
+frame.render_stateful_widget(
+    List::new(app.items.iter().map(|i| i.as_str()))
+        .highlight_style(Style::new().bold().yellow()),
+    area,
+    &mut app.list_state,
+);
+```
+
+Built-in stateful widgets: `List`/`ListState`, `Table`/`TableState`,
+`Scrollbar`/`ScrollbarState`.
+
+### Custom Widget Example
+
+Implementing a simple horizontal separator widget:
+
+```rust
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::widgets::Widget;
+
+/// A horizontal line separator that fills its area with a repeated character.
+pub struct Separator {
+    ch: char,
+    style: Style,
+}
+
+impl Separator {
+    pub fn new() -> Self {
+        Self {
+            ch: '─',
+            style: Style::default(),
+        }
+    }
+
+    pub fn char(mut self, ch: char) -> Self {
+        self.ch = ch;
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+}
+
+impl Widget for Separator {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+        let line: String = std::iter::repeat(self.ch)
+            .take(area.width as usize)
+            .collect();
+        buf.set_string(area.x, area.y, &line, self.style);
+    }
+}
+
+// Usage:
+frame.render_widget(
+    Separator::new().char('=').style(Style::new().dark_gray()),
+    separator_area,
+);
+```
+
+---
+
+## Styling
+
+### Style Struct
+
+```rust
+pub struct Style {
+    pub fg: Option<Color>,
+    pub bg: Option<Color>,
+    pub underline_color: Option<Color>,
+    pub add_modifier: Modifier,
+    pub sub_modifier: Modifier,
+}
+```
+
+Styles are **incremental** -- applying a style patches only the fields it sets, leaving
+others untouched. This enables layered styling (e.g., a `Block` style sets the background,
+then a `Span` style sets the foreground).
+
+### Color Enum
+
+```rust
+pub enum Color {
+    Reset,
+    Black, Red, Green, Yellow, Blue, Magenta, Cyan, Gray,
+    DarkGray, LightRed, LightGreen, LightYellow,
+    LightBlue, LightMagenta, LightCyan, White,
+    Rgb(u8, u8, u8),     // 24-bit true color
+    Indexed(u8),          // 256-color palette
+}
+```
+
+### Modifier Flags
+
+`Modifier` is a bitflag set: `BOLD`, `DIM`, `ITALIC`, `UNDERLINED`, `SLOW_BLINK`,
+`RAPID_BLINK`, `REVERSED`, `HIDDEN`, `CROSSED_OUT`.
+
+### Stylize Trait (Builder Pattern)
+
+The `Stylize` trait provides a fluent builder that is implemented for `Style`, `Span`,
+`Line`, `Text`, and string types:
+
+```rust
+use ratatui::style::Stylize;
+
+// Style a string directly into a Span:
+let greeting = "Hello, world!".green().bold().on_black();
+
+// Build a Style object:
+let style = Style::new().fg(Color::Rgb(255, 165, 0)).italic();
+
+// Compose styled text:
+let line = Line::from(vec![
+    "Error: ".red().bold(),
+    "file not found".white(),
+]);
+```
+
+### Text Hierarchy
+
+Styled text is built from three composable types:
+
+```
+Text (multiple lines)
+  └── Line (single line, optional alignment)
+        └── Span (contiguous text with one Style)
+```
+
+```rust
+let text = Text::from(vec![
+    Line::from(vec![
+        Span::styled("Name: ", Style::new().bold()),
+        Span::raw("Ratatui"),
+    ]),
+    Line::from("A terminal UI library".dim().italic()),
+]);
+```
+
+Each level can have its own style. A `Line`'s style is applied first, then each `Span`'s
+style patches over it. A `Text`'s style is applied before all contained lines.
+
+---
+
+## Event Handling
+
+**Ratatui does not handle events.** This is a deliberate design decision -- it keeps the
+library focused on rendering and avoids coupling to a specific event source or async
+runtime.
+
+Event handling is the application's responsibility. The typical approach is to use the same
+backend library (usually crossterm) for both rendering and input.
+
+### Typical Event Loop Pattern
+
+```rust
+use std::time::Duration;
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+
+struct App {
+    running: bool,
+    counter: i64,
+}
+
+impl App {
+    fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Key(KeyEvent { code, modifiers, .. }) => {
+                match (code, modifiers) {
+                    (KeyCode::Char('q'), _) |
+                    (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                        self.running = false;
+                    }
+                    (KeyCode::Up, _) => self.counter += 1,
+                    (KeyCode::Down, _) => self.counter -= 1,
+                    _ => {}
+                }
+            }
+            Event::Resize(_, _) => {
+                // Terminal will auto-resize buffers on next draw
+            }
+            _ => {}
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let mut terminal = ratatui::init();
+    let mut app = App { running: true, counter: 0 };
+
+    while app.running {
+        terminal.draw(|frame| {
+            // ... render using app state ...
+        })?;
+
+        // Block for up to 250ms waiting for an event
+        if event::poll(Duration::from_millis(250))? {
+            app.handle_event(event::read()?);
+        }
+    }
+
+    ratatui::restore();
+    Ok(())
+}
+```
+
+### Async Event Handling
+
+For async applications, crossterm provides `EventStream` (a tokio `Stream`):
+
+```rust
+use crossterm::event::EventStream;
+use futures::StreamExt;
+
+let mut events = EventStream::new();
+loop {
+    tokio::select! {
+        Some(Ok(event)) = events.next() => app.handle_event(event),
+        _ = tick_interval.tick() => { /* periodic update */ }
+    }
+    terminal.draw(|frame| app.render(frame))?;
+}
+```
+
+---
+
+## State Management
+
+Ratatui imposes no state management pattern. The conventional approach is an **App struct**
+that holds all application state:
+
+```rust
+struct App {
+    // Application data
+    items: Vec<Item>,
+    input_buffer: String,
+    mode: AppMode,
+
+    // Widget state (for stateful widgets)
+    list_state: ListState,
+    table_state: TableState,
+    scroll_state: ScrollbarState,
+}
+
+enum AppMode {
+    Normal,
+    Editing,
+    Help,
+}
+```
+
+### Stateful Widget State
+
+Some widgets need to track state across frames (e.g., which item is selected, scroll
+offset). Ratatui provides companion `*State` structs:
+
+- **`ListState`** -- selected index, scroll offset
+- **`TableState`** -- selected row, scroll offset
+- **`ScrollbarState`** -- position, content length, viewport length
+
+These are stored in the application's `App` struct and passed mutably during rendering:
+
+```rust
+// Selecting an item
+app.list_state.select(Some(3));
+
+// Rendering with state
+frame.render_stateful_widget(list_widget, area, &mut app.list_state);
+```
+
+The state structs are intentionally simple data holders. The application is responsible for
+updating them (e.g., moving selection on key press).
+
+### Patterns in Practice
+
+Applications commonly evolve toward one of:
+
+1. **Flat App struct** -- all state in one struct, simple applications.
+2. **Component pattern** -- sub-structs with their own render/handle methods, composed in
+   a parent App.
+3. **Elm / MVU** -- separate `Model`, `update(msg)`, and `view(model)` functions. Ratatui
+   is fully compatible with this but does not provide the scaffolding.
+
+---
+
+## Extensibility and Ecosystem
+
+Ratatui has a thriving ecosystem of companion crates:
+
+### Official / Semi-Official
+
+| Crate            | Purpose                                                 |
+| ---------------- | ------------------------------------------------------- |
+| `ratatui-macros` | Declarative macros for layout, spans, and lines.        |
+| `ratatui-core`   | Core traits extracted for third-party widget libraries. |
+
+### Community Widgets
+
+| Crate             | Purpose                                               |
+| ----------------- | ----------------------------------------------------- |
+| `tui-textarea`    | Multi-line text editor widget with cursor, selection. |
+| `tui-input`       | Single-line text input widget.                        |
+| `tui-logger`      | Log viewer widget integrated with the `log` crate.    |
+| `tui-big-text`    | Large ASCII-art text rendering (figlet-style).        |
+| `tui-scrollview`  | Scrollable container widget.                          |
+| `tui-tree-widget` | Tree view with expand/collapse.                       |
+| `tui-popup`       | Modal popup overlay.                                  |
+
+### Tooling
+
+- **`cargo-generate` templates** -- `cargo generate ratatui/templates` scaffolds a new
+  project with best-practice structure (async, component-based, etc.).
+- **`ratatui-book`** -- The official documentation site at ratatui.rs with tutorials,
+  concepts, and API guides.
+
+### Community
+
+- Active **Discord server** with dedicated help channels.
+- **Matrix bridge** for open-protocol access.
+- **Forum** at forum.ratatui.rs for long-form discussion.
+- **Open Collective** sponsorship for sustainable development.
+- 12,700+ dependent crates on crates.io.
+
+---
+
+## Strengths
+
+- **Zero-cost abstractions.** Widgets are consumed by value; the immediate-mode model means
+  no persistent allocations for a widget tree. The double-buffer diff minimizes terminal I/O.
+- **Excellent documentation.** The ratatui.rs website provides concept guides, tutorials,
+  FAQ, and a showcase. The API docs on docs.rs are thorough with examples.
+- **Very active community.** 267+ contributors, rapid release cadence, responsive Discord.
+  Issues and PRs are addressed quickly.
+- **Flexible architecture.** No forced event system, async runtime, or state pattern. Works
+  with tokio, async-std, synchronous polling, or anything else.
+- **Comprehensive built-in widget set.** Covers the vast majority of dashboard and
+  interactive-app needs out of the box.
+- **Strong type system prevents misuse.** `Rect` ensures bounds are respected, `Constraint`
+  prevents invalid layout specs, and the borrow checker enforces buffer access safety.
+- **Layout caching.** Constraint solving results are LRU-cached per thread, avoiding
+  redundant computation on unchanged layouts.
+- **Backend-agnostic.** Swapping terminal backends requires changing one type parameter.
+  The `TestBackend` enables fully deterministic UI testing without a terminal.
+- **Modular crate architecture.** `ratatui-core` allows third-party widget crates to depend
+  on just the trait definitions without pulling in the entire widget library.
+
+---
+
+## Weaknesses and Limitations
+
+- **Immediate-mode requires manual optimization for complex UIs.** Every frame rebuilds all
+  widgets. For very large or deeply nested interfaces, this can become expensive. There is
+  no built-in mechanism to skip unchanged subtrees.
+- **No built-in event handling.** The application must manage its own event loop, polling,
+  debouncing, and dispatch. This is flexible but means more boilerplate for every project.
+- **No built-in async support.** Ratatui's `draw` is synchronous. Integrating with async
+  runtimes requires manual coordination (e.g., `tokio::select!` in the event loop).
+- **Steep learning curve for custom widgets.** Writing to a raw `Buffer` requires manual
+  coordinate arithmetic. There is no relative positioning or automatic clipping within a
+  widget's render method.
+- **No built-in layout caching invalidation.** The LRU cache is per-thread and fixed-size;
+  it does not have a mechanism for the application to signal that a layout has changed.
+- **No built-in component lifecycle.** Unlike retained-mode frameworks, there is no
+  mount/unmount, focus management, or event bubbling built in. Applications must implement
+  these patterns themselves.
+- **Limited text shaping.** Grapheme width calculation is approximate and does not account
+  for all edge cases in complex scripts or emoji sequences with variation selectors.
+- **`u16` coordinate space.** Terminal dimensions and positions use `u16`, which is
+  sufficient for real terminals but can be surprising when computing layouts
+  programmatically.
+
+---
+
+## Lessons for D / Sparkles
+
+This section maps Ratatui's patterns to D idioms, identifying what would translate
+naturally and where D's unique capabilities could improve upon the design.
+
+### Widget Trait -> D Template Interfaces or Design by Introspection
+
+Ratatui's `Widget` trait:
+
+```rust
+pub trait Widget {
+    fn render(self, area: Rect, buf: &mut Buffer);
+}
+```
+
+In D, this maps to either a **template interface** (duck-typed) or **DbI** (Design by
+Introspection, checking for capabilities at compile time):
+
+```d
+/// Duck-typed widget concept -- no interface required.
+enum isWidget(T) = is(typeof((T w, Rect area, ref Buffer buf) {
+    w.render(area, buf);
+}));
+
+/// Render any widget via template constraint.
+void renderWidget(W)(W widget, Rect area, ref Buffer buf)
+if (isWidget!W)
+{
+    widget.render(area, buf);
+}
+```
+
+For optional capabilities (like `StatefulWidget`), DbI shines:
+
+```d
+enum isStatefulWidget(T) = isWidget!T && is(typeof(T.init.State));
+
+void renderWidget(W)(W widget, Rect area, ref Buffer buf, ref W.State state)
+if (isStatefulWidget!W)
+{
+    widget.render(area, buf, state);
+}
+```
+
+This avoids virtual dispatch entirely -- all widget calls are monomorphized at compile
+time, matching Rust's approach but with D's introspection ergonomics.
+
+### Constraint-Based Layout -> CTFE for Compile-Time Validation
+
+Ratatui's `areas::<N>()` method catches array-length mismatches at compile time. D can go
+further with CTFE:
+
+```d
+/// Validate constraints at compile time.
+auto layout(size_t N)(Constraint[N] constraints, Direction dir = Direction.vertical)
+{
+    // Could validate that percentages sum to <= 100,
+    // that there is at most one Fill, etc.
+    static assert(
+        constraints.percentageSum <= 100,
+        "Constraint percentages exceed 100%"
+    );
+    return LayoutSpec!N(constraints, dir);
+}
+
+// Usage:
+enum myLayout = layout([
+    Constraint.length(3),
+    Constraint.fill(1),
+    Constraint.length(1),
+]);
+```
+
+CTFE could also pre-compute fixed layouts for known terminal sizes, useful for
+size-constrained embedded terminals.
+
+### Buffer Abstraction -> D Output Ranges and @nogc SmallBuffer
+
+Ratatui's `Buffer` is a flat `Vec<Cell>` indexed by `(x, y)`. In D, this maps naturally to
+a `@nogc`-compatible buffer:
+
+```d
+@safe pure nothrow @nogc:
+
+struct Cell {
+    dchar grapheme;  // or SmallBuffer!(char, 8) for multi-codepoint graphemes
+    Style style;
+}
+
+struct Buffer {
+    Rect area;
+    SmallBuffer!(Cell, 4096) content;  // stack-allocated for typical terminal sizes
+
+    ref Cell opIndex(ushort x, ushort y) return {
+        return content[(y - area.y) * area.width + (x - area.x)];
+    }
+
+    /// Diff against previous frame, output only changed cells.
+    void diff(ref const Buffer prev, ref OutputRange sink) { ... }
+}
+```
+
+The `SmallBuffer` from sparkles/core-cli avoids GC allocation for buffers that fit in the
+inline capacity, falling back to `pureMalloc` for larger terminals.
+
+### Style Builder -> UFCS Chains in D
+
+Ratatui's `Stylize` trait:
+
+```rust
+"hello".green().bold().on_black()
+```
+
+This translates directly to D's UFCS:
+
+```d
+auto styled = "hello".fg(Color.green).bold.bg(Color.black);
+```
+
+Or with compile-time `stylizedTextBuilder` from the existing sparkles codebase:
+
+```d
+enum greeting = "hello"
+    .stylizedTextBuilder(true)
+    .green
+    .bold
+    .onBlack;
+```
+
+### Immediate-Mode Rendering -> Natural Fit for D
+
+D's lack of a GC-dependent retained widget tree makes immediate-mode rendering a natural
+choice. Widgets can be `struct` values on the stack, constructed and consumed within a
+single `draw` call, with zero GC pressure:
+
+```d
+terminal.draw((ref Frame frame) @nogc {
+    auto areas = layout.split(frame.area);
+    frame.renderWidget(Paragraph("Hello"), areas[0]);
+    frame.renderWidget(myList, areas[1]);
+});
+```
+
+The `@nogc` attribute can be enforced on the entire render path, guaranteeing no hidden
+allocations during frame rendering.
+
+### Backend Abstraction -> D Interface or Template Parameter
+
+Two viable approaches:
+
+1. **Runtime polymorphism** via D `interface` (for dynamic backend switching):
+
+```d
+interface Backend {
+    void draw(scope CellIterator content);
+    void flush();
+    void clear();
+    TermSize size();
+    // ...
+}
+```
+
+2. **Compile-time polymorphism** via template parameter (zero-overhead, Ratatui's approach):
+
+```d
+struct Terminal(B) if (isBackend!B) {
+    B backend;
+    Buffer current;
+    Buffer previous;
+
+    void draw(scope void delegate(ref Frame) @nogc renderFn) { ... }
+}
+```
+
+The template approach is more idiomatic for D and mirrors Ratatui's `Terminal<B>`. A
+`TestBackend` can be used for deterministic testing without a real terminal.
+
+---
+
+## References
+
+- **Ratatui Documentation Site:** <https://ratatui.rs>
+  - Concepts: <https://ratatui.rs/concepts/>
+  - Widgets: <https://ratatui.rs/concepts/widgets/>
+  - Layout: <https://ratatui.rs/concepts/layout/>
+- **API Reference (docs.rs):** <https://docs.rs/ratatui/latest/ratatui/>
+  - Widget trait: <https://docs.rs/ratatui/latest/ratatui/widgets/trait.Widget.html>
+  - StatefulWidget trait: <https://docs.rs/ratatui/latest/ratatui/widgets/trait.StatefulWidget.html>
+  - Layout: <https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html>
+  - Constraint: <https://docs.rs/ratatui/latest/ratatui/layout/enum.Constraint.html>
+  - Style: <https://docs.rs/ratatui/latest/ratatui/style/struct.Style.html>
+  - Color: <https://docs.rs/ratatui/latest/ratatui/style/enum.Color.html>
+  - Backend trait: <https://docs.rs/ratatui/latest/ratatui/backend/trait.Backend.html>
+  - Terminal: <https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html>
+  - Buffer: <https://docs.rs/ratatui/latest/ratatui/buffer/struct.Buffer.html>
+- **GitHub Repository:** <https://github.com/ratatui/ratatui>
+- **Community:**
+  - Discord: <https://discord.gg/pMCEU9hNEj>
+  - Forum: <https://forum.ratatui.rs>
+- **History:**
+  - Original tui-rs by Florian Dehau: <https://github.com/fdehau/tui-rs>
+  - Fork announcement and rationale: <https://github.com/ratatui/ratatui/discussions/167>
+- **Ecosystem:**
+  - tui-textarea: <https://github.com/rhysd/tui-textarea>
+  - tui-input: <https://github.com/sayanarijit/tui-input>
+  - tui-logger: <https://github.com/gin66/tui-logger>
+  - ratatui-macros: <https://github.com/ratatui/ratatui-macros>
+  - Project templates: <https://github.com/ratatui/templates>

--- a/docs/research/tui-libraries/textual.md
+++ b/docs/research/tui-libraries/textual.md
@@ -1,0 +1,816 @@
+# Textual (Python)
+
+A modern, retained-mode TUI framework that brings web development patterns -- CSS styling, a DOM-like widget tree, and reactive state management -- to terminal applications in Python.
+
+| Field          | Value                                                       |
+| -------------- | ----------------------------------------------------------- |
+| Language       | Python (3.9+)                                               |
+| License        | MIT                                                         |
+| Repository     | [Textualize/textual](https://github.com/Textualize/textual) |
+| Documentation  | [textual.textualize.io](https://textual.textualize.io/)     |
+| Latest Version | ~7.5.0 (January 2026)                                       |
+| GitHub Stars   | ~34k                                                        |
+
+---
+
+## Overview
+
+### What It Solves
+
+Textual provides a high-level, batteries-included framework for building rich terminal user interfaces with CSS-like styling, a comprehensive widget library, and a reactive programming model. It eliminates the need to manually manage terminal state, cursor positioning, and input parsing, instead offering a declarative approach where developers describe **what** the UI should look like rather than **how** to draw it.
+
+### Design Philosophy
+
+Textual's core thesis is that web development patterns -- component hierarchies, CSS for styling and layout, event bubbling through a DOM, reactive data binding -- translate directly to terminal applications. The framework deliberately mirrors the web development experience: external `.tcss` stylesheets, a DOM tree of widgets, CSS selectors for querying and styling, and a message-passing event system that bubbles through the tree. This lowers the learning curve for developers already familiar with HTML/CSS/JS, while providing a much richer abstraction than traditional curses-based approaches.
+
+### History
+
+Textual was created by Will McGugan, a Python developer based in Edinburgh, Scotland. McGugan first built [Rich](https://github.com/Textualize/rich) in 2020 as a library for beautiful text formatting in the terminal (syntax highlighting, tables, progress bars, trees). Rich grew into a widely-used rendering engine, and in 2021 McGugan began building Textual on top of it as a full application framework. He founded [Textualize](https://www.textualize.io/) at the end of 2021 to develop both projects commercially. Between them, Rich and Textual have been downloaded over 3 billion times.
+
+### Web Deployment
+
+Textual applications can also run in a web browser via [textual-web](https://github.com/Textualize/textual-web) and `textual serve`. The Python app runs server-side, serializing render diffs over WebSockets to a browser client. This means a single codebase can target both terminal and browser environments with no code changes. URLs can be shared publicly, allowing anyone with internet access to use the application.
+
+---
+
+## Architecture
+
+### Rendering Model
+
+Textual uses a **retained-mode** rendering model with a DOM-like widget tree. The application maintains a persistent tree of widget objects; when state changes, only the affected widgets are re-rendered. This contrasts with immediate-mode frameworks (like Ratatui or Bubble Tea) where the application redraws the entire UI each frame.
+
+### Core Concepts
+
+```
+App
+ +-- Screen
+      +-- Widget (Container)
+      |    +-- Widget (Button)
+      |    +-- Widget (Input)
+      +-- Widget (Footer)
+```
+
+- **App**: The top-level object. Manages screens, themes, bindings, and the event loop.
+- **Screen**: A full-screen layer of widgets. Screens can be stacked (for modals, overlays).
+- **Widget**: A rectangular region that renders content. Widgets form a tree (the DOM).
+- **Message**: An event object that propagates through the DOM.
+
+### Message-Passing System
+
+All inter-widget communication happens through messages. Messages bubble **up** the DOM tree from child to parent (analogous to DOM event bubbling in browsers). A widget posts a message via `self.post_message(MyMessage(...))`, and any ancestor can handle it. This enforces a unidirectional data flow: **attributes flow down, messages flow up**.
+
+### Compositor
+
+The compositor combines rendered output from all visible widgets into a single terminal frame. It operates on Rich `Segment` objects (styled text fragments):
+
+1. **Cuts**: Find every x-offset where a widget region begins or ends.
+2. **Chops**: Divide all segment lists at cut offsets, producing uniform sub-segments.
+3. **Occlusion**: Discard chops that are hidden behind higher-z widgets.
+4. **Composition**: Merge the remaining top-most chops into final output lines.
+
+The compositor supports **partial updates** -- if a single button changes color, only the region occupied by that button is recomposed and flushed, enabling smooth scrolling and responsive interaction even with many widgets on screen. Clipping, scrolling offsets, and modal screen stacking are all handled at this layer.
+
+### Async-First
+
+Textual is built on Python's `asyncio`. The event loop, message dispatch, timers, and workers are all async. However, synchronous usage is supported for simple cases -- the `App.run()` method blocks and manages the event loop internally.
+
+### App Lifecycle
+
+1. **`__init__`**: App and widget constructors run. No DOM exists yet.
+2. **`compose()`**: Called to build the initial widget tree. Returns/yields child widgets.
+3. **`on_mount()`**: Fired after the widget is added to the DOM. Used for initialization that requires DOM access.
+4. **CSS loading**: Textual loads `.tcss` files (from `CSS_PATH`) and applies styles to the widget tree.
+5. **Layout**: The layout engine computes positions and sizes for all widgets.
+6. **Render**: Each widget's `render()` method produces Rich renderables.
+7. **Compose to screen**: The compositor assembles the final output.
+8. **Ready**: The app is interactive. Events (key, mouse, messages) flow through the DOM.
+
+### Dirty Widget Tracking
+
+When a reactive attribute changes or a widget calls `self.refresh()`, Textual marks that widget as **dirty**. On the next frame, only dirty widgets are re-rendered and recomposed. If multiple reactive attributes change in the same frame, Textual coalesces them into a single refresh, minimizing redundant work.
+
+---
+
+## Terminal Backend
+
+### Rich Console Foundation
+
+Textual renders through Rich's `Console` object, which handles the low-level conversion of styled content into ANSI escape sequences. Rich provides:
+
+- True color (24-bit) output with automatic downgrade to 256-color or 16-color
+- Unicode rendering with wide-character and emoji support
+- Text styling (bold, italic, underline, strikethrough, dim, reverse, etc.)
+- Complex renderables: tables, trees, syntax-highlighted code, Markdown, panels
+
+### Driver Abstraction
+
+Textual abstracts terminal I/O through a **driver** layer. The driver is responsible for:
+
+- Entering/exiting alternate screen mode
+- Enabling/disabling raw mode and mouse reporting
+- Converting raw terminal input bytes into structured `Event` objects (key presses, mouse events)
+- Flushing rendered output to the terminal
+
+Platform-specific drivers handle differences between Linux, macOS, and Windows terminals. The driver abstraction also enables the **web driver** used by `textual-web` and `textual-serve`, which serializes output as WebSocket messages to a browser client.
+
+### Capabilities
+
+| Capability          | Support                               |
+| ------------------- | ------------------------------------- |
+| True color (24-bit) | Yes, with automatic fallback          |
+| Mouse click         | Yes                                   |
+| Mouse scroll        | Yes                                   |
+| Mouse hover         | Yes (`:hover` pseudo-class in CSS)    |
+| Unicode / emoji     | Yes (via Rich)                        |
+| Bracketed paste     | Yes                                   |
+| Focus tracking      | Yes                                   |
+| Web rendering       | Yes (via textual-web / textual-serve) |
+
+---
+
+## Layout System
+
+Textual uses a **CSS-inspired layout engine**. Layout is declared in `.tcss` files (or inline), never computed manually in Python code.
+
+### Layout Modes
+
+| Property                           | Values / Description                                         |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `layout`                           | `horizontal`, `vertical`, `grid`                             |
+| `dock`                             | `top`, `bottom`, `left`, `right` (removes from flow)         |
+| `width` / `height`                 | `auto`, fixed (`40`), percentage (`50%`), fractional (`1fr`) |
+| `min-width` / `max-width`          | Constrain dimensions                                         |
+| `min-height` / `max-height`        | Constrain dimensions                                         |
+| `margin`                           | Outer spacing (1-4 values)                                   |
+| `padding`                          | Inner spacing (1-4 values)                                   |
+| `overflow`                         | `auto`, `hidden`, `scroll` (x and y independently)           |
+| `grid-size-columns`                | Number of columns in grid layout                             |
+| `grid-size-rows`                   | Number of rows in grid layout                                |
+| `grid-gutter`                      | Spacing between grid cells                                   |
+| `grid-columns`                     | Explicit column widths (e.g., `1fr 2fr 1fr`)                 |
+| `grid-rows`                        | Explicit row heights                                         |
+| `box-sizing`                       | `border-box` (default), `content-box`                        |
+| `offset` / `offset-x` / `offset-y` | Translate position (for animations)                          |
+
+### Code Example: Multi-Panel Layout
+
+**app.py**:
+
+```python
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Header, Footer, Static, Tree, TextArea, RichLog
+
+
+class EditorApp(App):
+    CSS_PATH = "editor.tcss"
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Horizontal(id="main"):
+            # Left sidebar: file tree
+            yield Tree("Project", id="file-tree")
+            with Vertical(id="editor-area"):
+                # Main editor pane
+                yield TextArea(id="editor", language="python")
+                # Bottom panel: log output
+                yield RichLog(id="output", markup=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        tree = self.query_one("#file-tree", Tree)
+        src = tree.root.add("src/")
+        src.add_leaf("main.py")
+        src.add_leaf("utils.py")
+        tree.root.add_leaf("README.md")
+        tree.root.expand_all()
+
+
+if __name__ == "__main__":
+    EditorApp().run()
+```
+
+**editor.tcss**:
+
+```css
+#main {
+  layout: horizontal;
+  height: 1fr;
+}
+
+#file-tree {
+  width: 25;
+  dock: left;
+  border-right: solid $primary;
+  padding: 1;
+}
+
+#editor-area {
+  layout: vertical;
+  width: 1fr;
+}
+
+#editor {
+  height: 2fr;
+  border-bottom: solid $primary-lighten-2;
+}
+
+#output {
+  height: 1fr;
+  min-height: 5;
+  padding: 0 1;
+}
+```
+
+This produces a three-panel layout: a fixed-width file tree docked to the left, a code editor taking two-thirds of the remaining vertical space, and a log panel at the bottom.
+
+---
+
+## Widget / Component System
+
+### Base Widget Class
+
+Every widget extends `textual.widget.Widget`. Two key methods define a widget's UI:
+
+- **`render()`**: Returns a Rich renderable (string, `Text`, `Table`, etc.) for **leaf** widgets that display content directly.
+- **`compose()`**: Yields child widgets for **container** widgets that build a sub-tree.
+
+A widget uses one or the other. `render()` is for simple, self-contained content. `compose()` is for widgets that contain other widgets.
+
+### Built-in Widget Library
+
+Textual ships with a comprehensive set of widgets:
+
+| Category       | Widgets                                                                                                        |
+| -------------- | -------------------------------------------------------------------------------------------------------------- |
+| **Text**       | `Static`, `Label`, `Digits`, `Pretty`, `Rule`, `Link`, `Tooltip`                                               |
+| **Input**      | `Input`, `MaskedInput`, `TextArea`, `Checkbox`, `RadioButton`, `RadioSet`, `Switch`, `Select`, `SelectionList` |
+| **Buttons**    | `Button`                                                                                                       |
+| **Data**       | `DataTable`, `OptionList`, `ListView`, `ListItem`                                                              |
+| **Trees**      | `Tree`, `DirectoryTree`                                                                                        |
+| **Tabs**       | `Tabs`, `Tab`, `TabbedContent`, `TabPane`, `ContentSwitcher`                                                   |
+| **Containers** | `Horizontal`, `Vertical`, `Grid`, `Center`, `Middle`, `ScrollableContainer`, `Collapsible`                     |
+| **Feedback**   | `ProgressBar`, `LoadingIndicator`, `Sparkline`, `Log`, `RichLog`                                               |
+| **Document**   | `Markdown`, `MarkdownViewer`                                                                                   |
+| **Chrome**     | `Header`, `Footer`, `HelpPanel`, `KeyPanel`                                                                    |
+| **Dev**        | `Placeholder`, `Welcome`                                                                                       |
+
+### Custom Widget Example
+
+```python
+from textual.app import ComposeResult
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Label, ProgressBar, Static
+
+
+class TaskItem(Widget):
+    """A custom widget displaying a task with name, progress, and status."""
+
+    DEFAULT_CSS = """
+    TaskItem {
+        layout: horizontal;
+        height: 3;
+        padding: 0 1;
+        border: solid $primary;
+        margin-bottom: 1;
+    }
+    TaskItem > .task-name {
+        width: 20;
+        content-align: left middle;
+    }
+    TaskItem > ProgressBar {
+        width: 1fr;
+    }
+    TaskItem > .task-status {
+        width: 12;
+        content-align: center middle;
+    }
+    """
+
+    progress = reactive(0.0)
+    status = reactive("pending")
+
+    def __init__(self, name: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.task_name = name
+
+    def compose(self) -> ComposeResult:
+        yield Label(self.task_name, classes="task-name")
+        yield ProgressBar(total=100, show_eta=False)
+        yield Static(self.status, classes="task-status")
+
+    def watch_progress(self, value: float) -> None:
+        self.query_one(ProgressBar).update(progress=value)
+
+    def watch_status(self, value: str) -> None:
+        self.query_one(".task-status", Static).update(value)
+```
+
+Key patterns:
+
+- `DEFAULT_CSS` embeds component-scoped styles directly in the widget class.
+- `compose()` declares the widget's child tree declaratively.
+- `reactive` attributes automatically trigger `watch_` methods when changed.
+- Child widgets are queried with CSS selectors via `self.query_one()`.
+
+---
+
+## Styling
+
+### CSS System
+
+Textual implements **TCSS** (Textual Cascading Style Sheets), a purpose-built CSS dialect for terminal UIs. Styles can be specified in three places, listed in increasing specificity:
+
+1. **`DEFAULT_CSS`**: A class variable on widgets. Defines the widget's base styles. Lowest specificity.
+2. **External `.tcss` files**: Referenced via `CSS_PATH` on the App class. Standard application-level styles.
+3. **Inline styles**: Set via `widget.styles.background = "red"` or `widget.styles.css = "..."` in Python code. Highest specificity.
+
+### Selectors
+
+| Selector Type | Syntax                | Example                  |
+| ------------- | --------------------- | ------------------------ |
+| Type          | `WidgetName`          | `Button { ... }`         |
+| ID            | `#id`                 | `#sidebar { ... }`       |
+| Class         | `.class`              | `.active { ... }`        |
+| Pseudo-class  | `:state`              | `Button:hover { ... }`   |
+| Child         | `Parent > Child`      | `#main > Button { ... }` |
+| Descendant    | `Ancestor Descendant` | `Screen Input { ... }`   |
+| Universal     | `*`                   | `* { ... }`              |
+
+Available pseudo-classes include `:hover`, `:focus`, `:disabled`, `:dark`, `:light`, `:blur`, and `:can-focus`.
+
+### Supported Properties
+
+| Category       | Properties                                                                                                                    |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Color**      | `color`, `background` (named, hex, RGB, HSL)                                                                                  |
+| **Text**       | `text-style` (bold, italic, underline, strike, reverse), `text-align`, `text-opacity`                                         |
+| **Border**     | `border` (ascii, solid, double, round, heavy, dashed, tall, wide, panel, etc.), `border-title-align`, `border-subtitle-align` |
+| **Outline**    | `outline` (same types as border, does not affect layout)                                                                      |
+| **Spacing**    | `margin`, `padding` (1-4 values)                                                                                              |
+| **Size**       | `width`, `height`, `min-width`, `max-width`, `min-height`, `max-height`                                                       |
+| **Layout**     | `layout`, `dock`, `overflow`, `box-sizing`                                                                                    |
+| **Grid**       | `grid-size-columns`, `grid-size-rows`, `grid-columns`, `grid-rows`, `grid-gutter`                                             |
+| **Display**    | `display`, `visibility`, `opacity`                                                                                            |
+| **Position**   | `offset`, `offset-x`, `offset-y`                                                                                              |
+| **Scroll**     | `scrollbar-color`, `scrollbar-background`, `scrollbar-size`                                                                   |
+| **Transition** | `transition` (property, duration, easing)                                                                                     |
+
+### Themes
+
+Textual ships with built-in themes: `textual-dark`, `textual-light`, `nord`, `gruvbox`, `tokyo-night`, `solarized-light`, `atom-one-dark`, `atom-one-light`, and others. Themes define CSS variables (`$primary`, `$secondary`, `$accent`, `$surface`, `$error`, `$warning`, `$success`) and auto-generate light/dark shades (`$primary-lighten-1`, `$primary-darken-2`, etc.) and auto-contrast text colors (`$text`, `$text-muted`, `$text-disabled`).
+
+Themes are switchable at runtime via the command palette or `self.theme = "nord"` in code.
+
+### TCSS Example
+
+```css
+Screen {
+  background: $surface;
+}
+
+#sidebar {
+  width: 30;
+  dock: left;
+  background: $panel;
+  border-right: tall $primary;
+  transition: offset 400ms in_out_cubic;
+}
+
+#sidebar.-hidden {
+  offset-x: -100%;
+}
+
+Button {
+  margin: 1 2;
+  min-width: 16;
+  border: solid $primary;
+  background: $primary;
+  color: $text;
+  text-style: bold;
+}
+
+Button:hover {
+  background: $primary-lighten-1;
+  border: solid $primary-lighten-2;
+}
+
+Button:focus {
+  border: double $accent;
+}
+
+DataTable > .datatable--header {
+  background: $primary-darken-1;
+  text-style: bold;
+  color: $text;
+}
+
+.error-text {
+  color: $error;
+  text-style: bold italic;
+}
+```
+
+### Live CSS Editing
+
+When running with `textual run --dev my_app.py`, changes to `.tcss` files are **hot-reloaded** instantly. The app refreshes without restarting, enabling rapid iterative design.
+
+---
+
+## Event Handling
+
+### Message System
+
+Events in Textual are **Message** objects that bubble up through the widget tree. Every widget, screen, and app can handle messages.
+
+### Handler Naming Convention
+
+Textual maps message classes to handler methods via naming convention:
+
+```
+on_<namespace>_<event_name>
+```
+
+For example:
+
+- `Button.Pressed` maps to `on_button_pressed`
+- `Input.Changed` maps to `on_input_changed`
+- `Key` (no namespace) maps to `on_key`
+- `Mount` maps to `on_mount`
+
+### The `@on` Decorator
+
+The `@on` decorator provides CSS-selector-based event dispatch, allowing fine-grained control over which widget's events a handler responds to:
+
+```python
+from textual import on
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Header, Footer, Input, Static
+
+
+class FormApp(App):
+    CSS_PATH = "form.tcss"
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Input(placeholder="Enter your name", id="name-input")
+        yield Input(placeholder="Enter your email", id="email-input")
+        yield Static("", id="status")
+        yield Button("Submit", id="submit", variant="primary")
+        yield Button("Cancel", id="cancel", variant="error")
+        yield Footer()
+
+    @on(Button.Pressed, "#submit")
+    def handle_submit(self, event: Button.Pressed) -> None:
+        name = self.query_one("#name-input", Input).value
+        email = self.query_one("#email-input", Input).value
+        self.query_one("#status", Static).update(
+            f"Submitted: {name} <{email}>"
+        )
+
+    @on(Button.Pressed, "#cancel")
+    def handle_cancel(self, event: Button.Pressed) -> None:
+        self.query_one("#name-input", Input).value = ""
+        self.query_one("#email-input", Input).value = ""
+        self.query_one("#status", Static).update("Cancelled.")
+
+    @on(Input.Changed)
+    def on_any_input_change(self, event: Input.Changed) -> None:
+        self.query_one("#status", Static).update("")
+```
+
+Without `@on`, both button presses would route to a single `on_button_pressed` handler, requiring `if`/`elif` dispatch on `event.button.id`.
+
+### Workers for Background Tasks
+
+Long-running or I/O-bound operations must not block the async event loop. Textual provides **workers**:
+
+```python
+from textual.app import App
+from textual.worker import Worker
+from textual import work
+
+
+class FetchApp(App):
+
+    @work(exclusive=True)
+    async def fetch_data(self, url: str) -> None:
+        """Run in a background worker. exclusive=True cancels previous workers."""
+        response = await some_http_client.get(url)
+        self.query_one("#results").update(response.text)
+```
+
+Workers are tied to the DOM node that created them. If the widget is removed or the screen is popped, workers are automatically cancelled. The `exclusive=True` flag cancels any previous worker on the same method, preventing race conditions with stale responses.
+
+### Timers
+
+```python
+def on_mount(self) -> None:
+    self.set_interval(1.0, self.tick)
+
+def tick(self) -> None:
+    self.query_one("#clock", Static).update(str(datetime.now()))
+```
+
+### Key Bindings
+
+```python
+from textual.app import App
+from textual.binding import Binding
+
+class MyApp(App):
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("d", "toggle_dark", "Toggle dark mode"),
+        Binding("ctrl+s", "save", "Save"),
+    ]
+
+    def action_toggle_dark(self) -> None:
+        self.dark = not self.dark
+```
+
+Bindings are searched from the focused widget upward through the DOM to the App. The `Footer` widget automatically displays active bindings.
+
+---
+
+## State Management
+
+### Reactive Attributes
+
+The `reactive` descriptor is the primary mechanism for state management. When a reactive attribute is assigned a new value, Textual automatically:
+
+1. Calls the associated `watch_<name>` method (if defined).
+2. Marks the widget as dirty for re-rendering.
+3. Calls `render()` on the next frame to produce updated content.
+
+```python
+from textual.reactive import reactive
+from textual.widget import Widget
+
+
+class CounterWidget(Widget):
+    count = reactive(0)
+
+    def render(self) -> str:
+        return f"Count: {self.count}"
+
+    def watch_count(self, old_value: int, new_value: int) -> None:
+        # Called whenever self.count changes
+        if new_value > 10:
+            self.add_class("high")
+        else:
+            self.remove_class("high")
+```
+
+Options on `reactive`:
+
+- `reactive(default)` -- basic reactive attribute.
+- `reactive(default, always_update=True)` -- fires the watcher even if the new value equals the old.
+- `reactive(default, recompose=True)` -- re-runs `compose()` on change (rebuilds the sub-tree).
+- `reactive(default, init=False)` -- skips calling the watcher on initial mount.
+
+### Compute Methods
+
+A method named `compute_<name>` lets Textual derive a reactive attribute's value from other state:
+
+```python
+class FullNameWidget(Widget):
+    first_name = reactive("")
+    last_name = reactive("")
+    full_name = reactive("")
+
+    def compute_full_name(self) -> str:
+        return f"{self.first_name} {self.last_name}".strip()
+```
+
+`full_name` is automatically recomputed whenever `first_name` or `last_name` changes.
+
+### Data Binding
+
+`data_bind` propagates reactive attributes **downward** from parent to child widgets:
+
+```python
+from textual.app import App, ComposeResult
+from textual.reactive import reactive
+from textual.widget import Widget
+
+
+class ClockApp(App):
+    current_time = reactive("")
+
+    def compose(self) -> ComposeResult:
+        # Bind ClockApp.current_time -> ClockDisplay.current_time
+        yield ClockDisplay().data_bind(ClockApp.current_time)
+
+
+class ClockDisplay(Widget):
+    current_time = reactive("")
+
+    def render(self) -> str:
+        return f"Time: {self.current_time}"
+```
+
+If the child attribute has a different name, keyword syntax is used: `data_bind(display_time=ClockApp.current_time)`.
+
+Data binding is **unidirectional**: parent changes propagate to the child, but the child cannot update the parent through the binding. For child-to-parent communication, messages are used.
+
+### Cross-Widget Communication via Messages
+
+Custom messages allow structured communication up the DOM:
+
+```python
+from textual.message import Message
+
+
+class TaskWidget(Widget):
+    class Completed(Message):
+        def __init__(self, task_id: str) -> None:
+            super().__init__()
+            self.task_id = task_id
+
+    def mark_done(self) -> None:
+        self.post_message(self.Completed(self.task_id))
+```
+
+A parent handles this with `on_task_widget_completed(self, event)`.
+
+---
+
+## Extensibility and Ecosystem
+
+### Official Tools
+
+| Package                   | Description                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `textual-dev`             | Developer tools: CSS live editing, dev console (`textual console`), widget inspector |
+| `textual-web`             | Serve Textual apps in the browser via WebSocket protocol                             |
+| `textual-serve`           | Local web server for Textual apps (`textual serve app.py`)                           |
+| `textual-plotext`         | Plotting widget (line charts, bar charts, scatter plots via plotext)                 |
+| `pytest-textual-snapshot` | SVG snapshot testing for visual regression detection                                 |
+
+### Snapshot Testing
+
+Textual provides first-class snapshot testing via `pytest-textual-snapshot`. Tests render the app to an SVG screenshot and compare against a stored baseline:
+
+```python
+def test_my_app(snap_compare):
+    assert snap_compare("my_app.py")
+```
+
+Update snapshots with `pytest --snapshot-update`. This catches visual regressions that unit tests would miss.
+
+### Developer Console
+
+Running `textual console` in a separate terminal shows all events, messages, log output, and print statements from the running app -- essential because `print()` cannot write to stdout when the TUI owns the terminal.
+
+### Command Palette
+
+Every Textual app gets a built-in fuzzy-search command palette (Ctrl+P) that exposes theme switching, focus navigation, and user-defined commands. Apps extend it by providing `CommandProvider` classes.
+
+### Community and Third-Party
+
+The Textual ecosystem includes third-party widget libraries, community themes, and integrations. The project maintains an active Discord community and has been the subject of books (e.g., "Creating TUI Applications with Textual and Python", July 2025) and conference talks.
+
+---
+
+## Strengths
+
+- **CSS familiarity lowers learning curve**: Developers with web experience can be productive immediately. The CSS-like syntax for layout, colors, borders, and spacing transfers directly.
+- **Excellent documentation**: Comprehensive guides, API reference, tutorials, a widget gallery with live examples, and a blog with deep technical posts.
+- **Hot-reloading CSS in dev mode**: `textual run --dev` watches `.tcss` files and applies changes instantly, enabling rapid visual iteration without restarting.
+- **Rich widget library**: 40+ built-in widgets covering inputs, data display, navigation, documents, and layout containers. Most applications need no custom widgets.
+- **Async-first architecture**: Built on asyncio, making it natural to handle network requests, file I/O, and concurrent tasks without blocking the UI.
+- **Web deployment option**: The same app runs in a terminal or a browser via `textual-web` / `textual serve`, expanding distribution without code changes.
+- **Snapshot testing**: SVG-based visual regression testing catches styling bugs that unit tests miss, promoting long-term maintainability.
+- **Reactive state management**: `reactive` attributes, `watch_` methods, `compute_` methods, and `data_bind` provide a coherent, declarative state model with automatic UI updates.
+- **Theme system**: Built-in themes with CSS variable propagation and runtime switching. Custom themes are simple Python objects.
+- **Compositor with partial updates**: Only dirty regions are recomposed, enabling smooth performance even with complex widget trees.
+
+---
+
+## Weaknesses and Limitations
+
+- **Python performance ceiling**: Python's interpreter overhead limits frame rates and widget counts. Complex UIs with thousands of cells (e.g., large DataTables) can feel sluggish compared to native TUI frameworks. The compositor and layout engine are written in Python, not C.
+- **CSS subset can surprise web developers**: TCSS intentionally omits many CSS features (no flexbox `flex-grow`/`flex-shrink`, no `position: absolute/relative`, no `z-index`, limited selector combinators). Developers expecting full CSS often hit unexpected limitations.
+- **Async complexity**: While powerful, the async-first design means that even simple apps must reason about the event loop. Blocking calls in handlers freeze the entire UI, and the worker/task model adds cognitive overhead.
+- **Heavy runtime overhead**: Textual loads a full Python runtime, Rich rendering pipeline, CSS parser, layout engine, and compositor. Startup time is noticeable (hundreds of milliseconds to seconds), and memory usage is substantially higher than C/Rust/Go TUI frameworks.
+- **Limited to Python ecosystem**: Cannot be embedded in applications written in other languages. No FFI-friendly C API. The framework is deeply tied to Python's object model, asyncio, and Rich.
+- **No GPU acceleration or image protocol**: Rendering is purely text-based (Rich Segments). No support for Kitty graphics protocol, Sixel, or iTerm2 inline images at the framework level.
+- **Web driver maturity**: `textual-web` is still in beta. Sessions are not persistent (closing the tab kills the app), and latency over the network can degrade interactivity.
+
+---
+
+## Lessons for D / Sparkles
+
+Textual demonstrates that web-inspired patterns can make TUI development dramatically more accessible. Several of its design choices map well to D's strengths:
+
+### CSS System -> Compile-Time CSS DSL via CTFE
+
+Textual parses `.tcss` files at runtime. D could parse a CSS-like DSL **at compile time** via CTFE, catching syntax errors, invalid property names, and type mismatches before the program runs. The parsed result would be a static data structure embedded in the binary -- zero runtime parsing cost, zero allocation.
+
+```d
+// Hypothetical: compile-time CSS parsing
+enum style = tcss!`
+    #sidebar {
+        width: 30;
+        dock: left;
+        border: solid blue;
+    }
+`;
+static assert(style.rules[0].selector == "#sidebar");
+```
+
+### Widget Compose Pattern -> Template Mixins for Declarative Trees
+
+Textual's `compose()` method yields child widgets to build a tree. D's template mixins could provide a similar declarative syntax with compile-time validation of the widget tree structure:
+
+```d
+// Hypothetical: mixin-based widget composition
+mixin App!q{
+    Header()
+    Horizontal(id: "main") {
+        Tree(id: "sidebar")
+        Vertical(id: "content") {
+            TextArea(id: "editor")
+            LogView(id: "output")
+        }
+    }
+    Footer()
+};
+```
+
+### Reactive Attributes -> `opDispatch` or Property Introspection
+
+Textual's `reactive` descriptor intercepts attribute writes to trigger watchers and refresh. D's `opDispatch`, `alias this`, or compile-time introspection via `__traits` could implement the same pattern without runtime descriptor overhead:
+
+```d
+// Hypothetical: reactive properties via introspection
+struct Counter {
+    mixin Reactive!(int, "count", 0);  // generates getter, setter, watcher hook
+
+    void watchCount(int oldVal, int newVal) {
+        if (newVal > 10) addClass("high");
+    }
+}
+```
+
+### Message Passing -> `std.concurrency` or Event Ranges
+
+Textual's message bubbling maps to D's `std.concurrency` message passing for thread-safe communication, or to lazy input ranges of event objects for `@nogc`-compatible event processing:
+
+```d
+// Event processing as a range pipeline
+events
+    .filter!(e => e.type == EventType.buttonPressed)
+    .filter!(e => e.target.id == "submit")
+    .each!(e => handleSubmit(e));
+```
+
+### TCSS Files -> Compile-Time Embedded CSS Validation
+
+Rather than loading and parsing `.tcss` files at runtime (as Textual does), D could use `import(...)` expressions to embed the file at compile time and validate it via CTFE. Invalid selectors, unknown properties, or type errors would be caught at compile time.
+
+### Widget Rendering -> Output Ranges for `@nogc` Rendering
+
+Textual widgets produce Rich `Segment` objects (text + style tuples). D widgets could render to output ranges, enabling `@nogc nothrow` rendering into `SmallBuffer` or directly to a terminal write buffer with zero heap allocation:
+
+```d
+@safe pure nothrow @nogc
+void render(Writer)(ref Writer writer, in Style style) {
+    writer.put(style.applyTo("Count: "));
+    writer.putInt(count);
+}
+```
+
+### Retained Mode with Dirty Tracking -> `@nogc` Diffing Buffers
+
+Textual's compositor diffs visible regions and only repaints changed areas. D could implement a double-buffered screen model where the current and previous frames are `SmallBuffer`-backed cell grids. A `@nogc` diff pass identifies changed cells and emits only the minimal escape sequences needed, combining retained-mode convenience with `@nogc` performance.
+
+---
+
+## References
+
+### Official Documentation
+
+- [Textual Documentation](https://textual.textualize.io/) -- comprehensive guides, API reference, widget gallery
+- [Textual GitHub Repository](https://github.com/Textualize/textual) -- source code, issues, discussions
+- [textual-web Repository](https://github.com/Textualize/textual-web) -- browser rendering for Textual apps
+- [pytest-textual-snapshot](https://github.com/Textualize/pytest-textual-snapshot) -- snapshot testing plugin
+- [Textual on PyPI](https://pypi.org/project/textual/) -- package releases and version history
+
+### Blog Posts and Articles
+
+- [Anatomy of a Textual User Interface](https://textual.textualize.io/blog/2024/09/15/anatomy-of-a-textual-user-interface/) -- deep dive into architecture and rendering pipeline
+- [Algorithms for High Performance Terminal Apps](https://textual.textualize.io/blog/2024/12/12/algorithms-for-high-performance-terminal-apps/) -- compositor algorithms, cuts, chops, and partial updates
+- [CSS in the Terminal with Python and Textual](https://www.willmcgugan.com/blog/tech/post/css-in-the-terminal-with-python-and-textual/) -- Will McGugan on the CSS design decisions
+- [Python Textual: Build Beautiful UIs in the Terminal](https://realpython.com/python-textual/) -- Real Python tutorial
+- [Textual: a framework for terminal user interfaces](https://lwn.net/Articles/929123/) -- LWN.net technical overview
+
+### Talks and Interviews
+
+- [SE Radio 669: Will McGugan on Text-Based User Interfaces](https://se-radio.net/2025/05/se-radio-669-will-mcgugan-on-text-based-user-interfaces/) -- Software Engineering Radio interview (May 2025)
+
+### Books
+
+- _Creating TUI Applications with Textual and Python_ (July 2025) -- comprehensive book on Textual application development

--- a/docs/research/tui-libraries/tview.md
+++ b/docs/research/tui-libraries/tview.md
@@ -1,0 +1,1115 @@
+# tview (Go)
+
+A batteries-included terminal UI widget toolkit for Go, built on a retained-mode widget tree with flexbox/grid layout and framework-managed event loop.
+
+| Field            | Value                                      |
+| ---------------- | ------------------------------------------ |
+| Language         | Go                                         |
+| License          | MIT                                        |
+| Repository       | <https://github.com/rivo/tview>            |
+| Documentation    | <https://pkg.go.dev/github.com/rivo/tview> |
+| Terminal Backend | [tcell](https://github.com/gdamore/tcell)  |
+| GitHub Stars     | ~13.5k                                     |
+
+---
+
+## Overview
+
+### What It Solves
+
+tview is a high-level widget toolkit for building terminal user interfaces in Go. Rather than requiring developers to manage raw terminal I/O, event loops, drawing, and focus routing, tview provides a ready-made set of interactive widgets (text views, tables, forms, trees, input fields) arranged in a retained widget tree that the framework draws and manages automatically.
+
+### Design Philosophy
+
+tview follows a **batteries-included, widget-library** approach:
+
+- **Retained-mode widget tree** -- the application constructs a tree of `Primitive` objects. The framework owns the draw cycle and redraws the tree on every event.
+- **Framework-managed event loop** -- `Application.Run()` blocks, polling terminal events and dispatching them to the focused widget. The developer registers callbacks rather than writing a loop.
+- **Flexbox/grid-inspired layout** -- `Flex` and `Grid` container primitives handle spatial arrangement, proportional sizing, and responsive breakpoints.
+- **Rich built-in widget set** -- text display, tables, forms, trees, dropdowns, modals, and tabbed panels are all provided out of the box.
+
+tview is built on [tcell](https://github.com/gdamore/tcell), which handles low-level terminal operations (cell buffer, color negotiation, mouse protocol, Unicode width).
+
+### Contrast with Bubble Tea
+
+tview and Bubble Tea are the two dominant Go TUI libraries, but they take fundamentally different architectural approaches:
+
+| Aspect           | tview                                            | Bubble Tea                                     |
+| ---------------- | ------------------------------------------------ | ---------------------------------------------- |
+| Architecture     | Retained-mode widget tree (OOP-like)             | Model-View-Update (functional)                 |
+| Event loop       | Framework-managed (`Application.Run()`)          | Framework-managed, but events are `Msg` values |
+| State ownership  | Widgets own their state (getters/setters)        | Single `Model` struct owns all state           |
+| Rendering        | Framework traverses widget tree and calls `Draw` | Developer returns a `string` from `View()`     |
+| Layout           | Built-in `Flex` and `Grid` containers            | No built-in layout; use Lip Gloss joining      |
+| Focus management | Automatic (framework tracks focus, routes input) | Manual (developer routes keys to sub-models)   |
+| Side effects     | Callbacks and `QueueUpdate` from goroutines      | `Cmd` functions that produce `Msg` values      |
+| Testability      | Harder (stateful widgets, callbacks)             | Easier (pure functions on value types)         |
+| Customization    | Inherit `Box`, implement `Primitive` interface   | Implement `tea.Model` (three functions)        |
+
+In short: tview manages the widget tree and event routing for you; Bubble Tea gives you pure functions and you manage everything yourself.
+
+---
+
+## Architecture
+
+tview uses a **retained-mode widget tree** architecture. The developer builds a tree of `Primitive` objects, hands the root to `Application`, and the framework handles the event loop, focus tracking, and full-tree redraw cycle.
+
+### Application
+
+The `Application` struct is the top-level coordinator. It owns the event loop, the tcell screen, and a reference to the root primitive.
+
+```go
+app := tview.NewApplication()
+
+// Set the root widget (fullscreen = true fills the entire terminal)
+app.SetRoot(rootPrimitive, true)
+
+// Run blocks, processing events until Stop() is called
+if err := app.Run(); err != nil {
+    panic(err)
+}
+```
+
+Internally, `Run()` spawns two goroutines:
+
+1. **Screen event poller** -- continuously calls `screen.PollEvent()` and sends events into a channel.
+2. **Main event loop** -- reads from three sources: terminal events, queued update functions (`QueueUpdate`), and screen replacement signals (after suspension). All widget mutations and draw calls happen on this single goroutine, eliminating race conditions.
+
+The draw cycle is non-incremental: on each event, `Application` calls `root.Draw(screen)` which traverses the entire widget tree. tcell's internal diff layer optimizes the actual terminal writes, only updating cells that changed.
+
+### Primitive Interface
+
+`Primitive` is the base interface for all widgets. Every visible element in a tview application implements it:
+
+```go
+type Primitive interface {
+    // Draw renders this primitive onto the screen.
+    Draw(screen tcell.Screen)
+
+    // GetRect returns the current position: x, y, width, height.
+    GetRect() (int, int, int, int)
+
+    // SetRect sets the position and size (called by parent layout).
+    SetRect(x, y, width, height int)
+
+    // InputHandler returns the key event handler.
+    // setFocus allows the handler to transfer focus to another primitive.
+    InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive))
+
+    // Focus is called when this primitive receives focus.
+    // delegate allows focus to be passed to a child.
+    Focus(delegate func(p Primitive))
+
+    // HasFocus returns true if this primitive or any child has focus.
+    HasFocus() bool
+
+    // Blur is called when focus leaves this primitive.
+    Blur()
+
+    // MouseHandler returns the mouse event handler.
+    MouseHandler() func(action MouseAction, event *tcell.EventMouse,
+        setFocus func(p Primitive)) (consumed bool, capture Primitive)
+
+    // PasteHandler returns the paste event handler.
+    PasteHandler() func(text string, setFocus func(p Primitive))
+}
+```
+
+Key design points:
+
+- **`Draw` is called by the framework** -- widgets never trigger their own drawing. The framework traverses the tree top-down.
+- **`SetRect` is called by parent containers** -- layout managers (`Flex`, `Grid`) compute child positions and call `SetRect` before `Draw`.
+- **`setFocus` callback** -- both `InputHandler` and `Focus` receive a `setFocus` function, enabling widgets to redirect focus to siblings or children.
+- **`HasFocus` is recursive** -- containers return true if any descendant has focus, enabling correct focus-chain detection.
+
+### Widget Tree
+
+The widget tree is constructed by nesting primitives inside layout containers:
+
+```
+Application
+  └─ root: Flex (FlexRow)
+       ├─ TextView (header, fixedSize=1)
+       ├─ Flex (FlexColumn, proportion=1)
+       │    ├─ List (sidebar, fixedSize=30)
+       │    └─ TextView (content, proportion=1)
+       └─ TextView (footer, fixedSize=1)
+```
+
+The tree is traversed in two phases:
+
+1. **Layout phase** -- each container calls `SetRect` on its children, computing sizes from fixed/proportional specifications.
+2. **Draw phase** -- each container calls `Draw` on its children, passing the tcell screen.
+
+### Focus Management
+
+The `Application` tracks which `Primitive` currently has focus:
+
+- `app.SetFocus(p)` explicitly moves focus to a primitive.
+- When a key event arrives, the framework calls the focused primitive's `InputHandler`.
+- The `setFocus` callback passed to `InputHandler` lets widgets transfer focus (e.g., Tab moves to the next form field).
+- `Focus(delegate)` allows composite widgets to delegate focus to a specific child. For example, `Flex.Focus()` delegates to the first child marked with `takeFocus=true`.
+- `Blur()` is called on the old focus target when focus changes.
+
+This is a significant advantage over Bubble Tea, where focus management is entirely manual.
+
+---
+
+## Terminal Backend
+
+tview is built on **tcell** (`github.com/gdamore/tcell/v2`), which provides the terminal abstraction layer.
+
+### Capabilities
+
+| Feature             | Support                                               |
+| ------------------- | ----------------------------------------------------- |
+| True color (24-bit) | Yes, via tcell's color negotiation                    |
+| 256 color           | Yes                                                   |
+| ANSI 16 color       | Yes                                                   |
+| Mouse support       | Click, drag, scroll, double-click (via `EnableMouse`) |
+| Unicode             | Full Unicode, including wide characters (CJK)         |
+| Grapheme clusters   | Yes, via `rivo/uniseg` dependency                     |
+| Bracketed paste     | Yes, via `EnablePaste`                                |
+| Platform support    | Linux, macOS, FreeBSD, Windows (native console API)   |
+
+tcell uses a cell buffer internally. When `screen.Show()` is called after a draw cycle, tcell diffs the new buffer against the previous one and writes only changed cells to the terminal. This minimizes I/O and prevents flicker.
+
+### Screen Management
+
+```go
+// Enable mouse support
+app.EnableMouse(true)
+
+// Enable paste detection
+app.EnablePaste(true)
+
+// Suspend the TUI to run a subshell
+app.Suspend(func() {
+    // Terminal restored to normal mode
+    cmd := exec.Command("vim", "file.txt")
+    cmd.Stdin = os.Stdin
+    cmd.Stdout = os.Stdout
+    cmd.Run()
+})
+// TUI resumes automatically
+```
+
+---
+
+## Layout System
+
+The layout system is one of tview's most valuable features. It provides two layout containers -- `Flex` and `Grid` -- plus `Pages` for stacked view switching. These replace the manual string-composition approach required by Bubble Tea.
+
+### Flex
+
+`Flex` implements a flexbox-inspired layout. Children are arranged in a single direction (row or column), with sizes determined by a combination of fixed sizes and proportional weights.
+
+```go
+flex := tview.NewFlex().SetDirection(tview.FlexRow) // or tview.FlexColumn
+```
+
+**Direction constants:**
+
+| Constant     | Alias           | Behavior                                      |
+| ------------ | --------------- | --------------------------------------------- |
+| `FlexRow`    | `FlexColumnCSS` | Children stacked vertically (one per row)     |
+| `FlexColumn` | `FlexRowCSS`    | Children placed side by side (one per column) |
+
+Note: tview's naming is the **opposite** of CSS flexbox. `FlexRow` means items are arranged in rows (vertical stacking), not that the flex direction is row. The `FlexRowCSS`/`FlexColumnCSS` aliases match CSS semantics.
+
+**AddItem signature:**
+
+```go
+func (f *Flex) AddItem(
+    item Primitive,   // the widget (may be nil for empty space)
+    fixedSize int,    // exact size in cells (0 = flexible)
+    proportion int,   // flex weight (only used when fixedSize == 0)
+    focus bool,       // whether this item can receive focus
+) *Flex
+```
+
+**Size calculation algorithm:**
+
+1. Sum all `fixedSize` values and subtract from available space to get `remainingSpace`.
+2. Sum all `proportion` values across flexible items to get `totalProportion`.
+3. Each flexible item gets `(remainingSpace * item.proportion) / totalProportion` cells.
+4. Items are positioned sequentially along the flex direction.
+
+An item with `proportion: 2` gets twice the space of an item with `proportion: 1`. An item with `fixedSize: 0, proportion: 0` gets no remaining space (effectively zero-sized unless it has a fixed size).
+
+**Non-trivial layout example -- IDE-like interface:**
+
+```go
+// Header bar (fixed 1 row)
+header := tview.NewTextView().SetText(" File  Edit  View  Help")
+
+// Sidebar with file tree (fixed 30 columns)
+sidebar := tview.NewTreeView()
+
+// Main editor area (takes remaining space)
+editor := tview.NewTextArea()
+
+// Bottom status bar (fixed 1 row)
+status := tview.NewTextView().SetText(" main.go | UTF-8 | Go")
+
+// Vertical split: sidebar | editor
+editorArea := tview.NewFlex().
+    SetDirection(tview.FlexColumn).
+    AddItem(sidebar, 30, 0, true).    // fixed 30 columns
+    AddItem(editor, 0, 1, false)       // takes remaining width
+
+// Full layout: header / editorArea / status
+layout := tview.NewFlex().
+    SetDirection(tview.FlexRow).
+    AddItem(header, 1, 0, false).      // fixed 1 row
+    AddItem(editorArea, 0, 1, true).   // takes remaining height
+    AddItem(status, 1, 0, false)       // fixed 1 row
+
+app.SetRoot(layout, true)
+```
+
+This produces:
+
+```
+┌─────────────────────────────────────────────────┐
+│ File  Edit  View  Help                          │  <- 1 row fixed
+├──────────────┬──────────────────────────────────┤
+│ project/     │                                  │
+│ ├─ main.go   │  package main                    │
+│ ├─ utils.go  │                                  │  <- remaining height
+│ └─ go.mod    │  func main() {                   │
+│              │      // ...                      │
+│  30 cols     │      remaining width             │
+├──────────────┴──────────────────────────────────┤
+│ main.go | UTF-8 | Go                            │  <- 1 row fixed
+└─────────────────────────────────────────────────┘
+```
+
+**Nested proportional example -- three-column layout with 1:2:1 ratio:**
+
+```go
+layout := tview.NewFlex().
+    SetDirection(tview.FlexColumn).
+    AddItem(leftPanel, 0, 1, false).   // 1/4 of width
+    AddItem(centerPanel, 0, 2, true).  // 2/4 of width (double)
+    AddItem(rightPanel, 0, 1, false)   // 1/4 of width
+```
+
+### Grid
+
+`Grid` implements a CSS Grid-inspired layout with defined rows and columns. Its key differentiator is **responsive breakpoints** -- different items can be shown at different terminal sizes.
+
+```go
+grid := tview.NewGrid()
+```
+
+**Defining rows and columns:**
+
+```go
+// SetRows/SetColumns accept a variadic list of sizes:
+//   >0  = fixed size in cells
+//   0   = proportional (weight 1)
+//  -N   = proportional (weight N), e.g., -3 gets 3x the space of 0 or -1
+grid.SetRows(3, 0, 3)        // 3 fixed, flexible, 3 fixed
+grid.SetColumns(30, 0, 30)   // 30 fixed, flexible, 30 fixed
+```
+
+Zero and `-1` are equivalent (both mean proportion weight 1). `-3` means three times the proportional space of `-1`.
+
+**AddItem with responsive breakpoints:**
+
+```go
+func (g *Grid) AddItem(
+    p Primitive,       // the widget
+    row, column int,   // grid position (0-indexed)
+    rowSpan int,       // how many rows to span
+    colSpan int,       // how many columns to span
+    minGridHeight int, // minimum grid height to show this item (0 = always)
+    minGridWidth int,  // minimum grid width to show this item (0 = always)
+    focus bool,        // whether this item can receive focus
+) *Grid
+```
+
+The `minGridHeight` and `minGridWidth` parameters are the responsive mechanism. An item is only visible when the overall grid dimensions meet or exceed both minimums. When multiple items target the same primitive, the one with the highest applicable minimum is used.
+
+**Responsive layout example -- header/footer with collapsible sidebar:**
+
+```go
+// Create widgets
+header  := tview.NewTextView().SetText("Application Header")
+footer  := tview.NewTextView().SetText("Status: Ready")
+menu    := tview.NewList().AddItem("Dashboard", "", 'd', nil)
+main    := tview.NewTextView().SetText("Main content area")
+sidebar := tview.NewTextView().SetText("Sidebar info")
+
+grid := tview.NewGrid().
+    SetRows(3, 0, 3).            // header (3), content (flex), footer (3)
+    SetColumns(30, 0, 30).       // menu (30), main (flex), sidebar (30)
+    SetBorders(true)
+
+// Header and footer always span full width
+grid.AddItem(header, 0, 0, 1, 3, 0, 0, false)
+grid.AddItem(footer, 2, 0, 1, 3, 0, 0, false)
+
+// Narrow layout (< 100 columns): main content spans all 3 columns
+grid.AddItem(main, 1, 0, 1, 3, 0, 0, false)
+
+// Wide layout (>= 100 columns): three-column layout
+grid.AddItem(menu,    1, 0, 1, 1, 0, 100, true)
+grid.AddItem(main,    1, 1, 1, 1, 0, 100, false)
+grid.AddItem(sidebar, 1, 2, 1, 1, 0, 100, false)
+```
+
+Behavior:
+
+- **Terminal width < 100**: Only the `main` item (with `minGridWidth=0`) is visible in the middle row, spanning all three columns. The menu and sidebar are hidden.
+- **Terminal width >= 100**: The three-column layout activates. `menu`, `main`, and `sidebar` each occupy their own column. The full-width `main` item is superseded because the three narrow items have a higher `minGridWidth`.
+
+This mechanism provides CSS media query-like responsive behavior without any imperative resize handling.
+
+**Grid spacing:**
+
+```go
+grid.SetGap(1, 2)           // 1 row gap, 2 column gap between cells
+grid.SetMinSize(5, 10)      // minimum row height 5, minimum column width 10
+```
+
+### Pages
+
+`Pages` manages a stack of named primitives, enabling tab-like or screen-switching behavior:
+
+```go
+pages := tview.NewPages()
+
+pages.AddPage("main", mainView, true, true)       // name, primitive, resize, visible
+pages.AddPage("settings", settingsView, true, false)
+pages.AddPage("help", helpView, true, false)
+
+// Switch between pages
+pages.SwitchToPage("settings")
+
+// Show a modal overlay (visible on top of current page)
+pages.AddPage("confirm", modal, false, true)
+
+// Query state
+name, _ := pages.GetFrontPage()
+```
+
+Pages can be overlaid (multiple visible simultaneously) or exclusive (one at a time via `SwitchToPage`).
+
+---
+
+## Widget/Component System
+
+tview provides a comprehensive set of built-in widgets. Most embed `Box`, which provides border, title, padding, background color, and focus highlight for free.
+
+### Built-in Widgets
+
+**Text display:**
+
+| Widget     | Description                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| `TextView` | Scrollable text display with color tags, regions, word wrap. Implements `io.Writer` for streaming content. |
+| `Table`    | Navigable table with selectable rows/columns/cells, fixed headers, and per-cell styling.                   |
+| `Image`    | Terminal image rendering with dithering and aspect ratio control.                                          |
+
+**Input:**
+
+| Widget       | Description                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------- |
+| `InputField` | Single-line text input with validation (`SetAcceptanceFunc`), autocomplete, and placeholder text. |
+| `TextArea`   | Multi-line text editor with cursor, selection, clipboard, word wrap, and undo.                    |
+
+**Selection:**
+
+| Widget     | Description                                                                            |
+| ---------- | -------------------------------------------------------------------------------------- |
+| `List`     | Scrollable list with main/secondary text, keyboard shortcuts, and selection callbacks. |
+| `DropDown` | Combo box with selectable options.                                                     |
+| `Checkbox` | Toggle with customizable checked/unchecked strings.                                    |
+
+**Navigation:**
+
+| Widget         | Description                                            |
+| -------------- | ------------------------------------------------------ |
+| `TreeView`     | Expandable/collapsible tree with `TreeNode` hierarchy. |
+| `Pages`        | Stacked page manager for view switching.               |
+| `TabbedPanels` | Tabbed container with labeled tab bar.                 |
+
+**Layout and decoration:**
+
+| Widget  | Description                                                      |
+| ------- | ---------------------------------------------------------------- |
+| `Flex`  | Flexbox-style layout container.                                  |
+| `Grid`  | CSS Grid-style layout with responsive breakpoints.               |
+| `Frame` | Decorative wrapper adding header/footer text around a primitive. |
+| `Modal` | Centered dialog with text and buttons.                           |
+| `Form`  | Vertical/horizontal form aggregating input widgets and buttons.  |
+
+### Box -- The Base Widget
+
+Most widgets embed `Box`, which provides:
+
+- **Border** with customizable style, color, and attributes
+- **Title** with alignment (left, center, right) and color
+- **Padding** inside the border
+- **Background color**
+- **Focus highlight** (border color changes when focused)
+- **Input/mouse capture** at the widget level
+- **Custom draw function** for overlaying content
+
+```go
+box := tview.NewBox().
+    SetBorder(true).
+    SetBorderColor(tcell.ColorCyan).
+    SetTitle(" My Widget ").
+    SetTitleAlign(tview.AlignCenter).
+    SetBorderPadding(1, 1, 2, 2).    // top, bottom, left, right
+    SetBackgroundColor(tcell.ColorDefault)
+```
+
+### Custom Widgets
+
+To create a custom widget, either embed `Box` (recommended) or implement `Primitive` from scratch.
+
+**Embedding Box for a custom gauge widget:**
+
+```go
+type Gauge struct {
+    *tview.Box
+    value   float64 // 0.0 to 1.0
+    label   string
+    barChar rune
+}
+
+func NewGauge(label string) *Gauge {
+    return &Gauge{
+        Box:     tview.NewBox(),
+        label:   label,
+        barChar: '\u2588', // full block
+    }
+}
+
+func (g *Gauge) SetValue(v float64) *Gauge {
+    g.value = v
+    return g
+}
+
+func (g *Gauge) Draw(screen tcell.Screen) {
+    // Draw the box (border, title, background)
+    g.Box.DrawForSubclass(screen, g)
+
+    // Get the inner area (inside border and padding)
+    x, y, width, height := g.GetInnerRect()
+    if width <= 0 || height <= 0 {
+        return
+    }
+
+    // Draw label
+    tview.Print(screen, g.label, x, y, width, tview.AlignLeft, tcell.ColorWhite)
+
+    // Draw bar on the next line
+    if height > 1 {
+        barWidth := int(float64(width) * g.value)
+        for i := 0; i < barWidth; i++ {
+            screen.SetContent(x+i, y+1, g.barChar, nil,
+                tcell.StyleDefault.Foreground(tcell.ColorGreen))
+        }
+    }
+}
+```
+
+Usage:
+
+```go
+gauge := NewGauge("CPU Usage").SetValue(0.73)
+gauge.SetBorder(true).SetTitle(" System Monitor ")
+
+app.SetRoot(gauge, true).Run()
+```
+
+### Form
+
+`Form` aggregates input widgets and buttons into a cohesive form layout:
+
+```go
+form := tview.NewForm().
+    AddInputField("Name", "", 30, nil, nil).
+    AddPasswordField("Password", "", 30, '*', nil).
+    AddDropDown("Role", []string{"Admin", "User", "Guest"}, 1, nil).
+    AddCheckbox("Remember me", false, nil).
+    AddTextArea("Notes", "", 40, 5, 0, nil).
+    AddButton("Submit", func() {
+        // Access form data
+        name := form.GetFormItemByLabel("Name").(*tview.InputField).GetText()
+        // Process submission...
+    }).
+    AddButton("Cancel", func() {
+        app.Stop()
+    })
+
+form.SetBorder(true).SetTitle(" Registration ").SetTitleAlign(tview.AlignCenter)
+```
+
+---
+
+## Styling
+
+tview uses two styling mechanisms: **tag-based inline styling** for text content, and **programmatic styling** via tcell's `Style` type for widget properties.
+
+### Tag-Based Text Styling
+
+Text displayed in `TextView`, `List`, `Table`, and other widgets can include inline style tags. Tags use square brackets:
+
+```
+[<foreground>:<background>:<attributes>:<url>]
+```
+
+Each field is optional. Unspecified fields remain unchanged from the current style. A dash (`-`) resets a field to the default.
+
+**Color specification:**
+
+- W3C color names: `red`, `green`, `blue`, `yellow`, `white`, `cyan`, `magenta`, etc.
+- Hex colors: `#FF6347`, `#8080ff`
+
+**Attribute flags** (lowercase to enable, uppercase to disable):
+
+| Flag | Attribute      |
+| ---- | -------------- |
+| `b`  | Bold           |
+| `d`  | Dim            |
+| `i`  | Italic         |
+| `l`  | Blink          |
+| `r`  | Reverse        |
+| `s`  | Strike-through |
+| `u`  | Underline      |
+
+**Examples:**
+
+```go
+textView := tview.NewTextView().
+    SetDynamicColors(true).  // Enable tag parsing
+    SetText(
+        "[yellow::b]Warning:[-::-] Disk usage is at [red]92%[white]\n" +
+        "[green]System[white] is [::i]operational[::I]\n" +
+        "[#8080ff:#1a1a2e]Custom colors on dark background[-:-:-]\n" +
+        "Click [:::https://example.com]here[:::-] for details",
+    )
+```
+
+Produces:
+
+- **Warning:** in bold yellow, followed by normal text with "92%" in red
+- "System" in green, "operational" in italic
+- Custom hex foreground/background colors
+- "here" as a terminal hyperlink (OSC 8)
+
+**Escaping tags:**
+
+To display literal brackets, insert `[` before the closing bracket:
+
+```go
+"Show [red[] literally"  // Displays: Show [red] literally
+```
+
+The `tview.Escape()` function automates escaping.
+
+**ANSI-to-tag conversion:**
+
+```go
+// Convert ANSI escape codes to tview tags
+tagged := tview.TranslateANSI(ansiColoredOutput)
+
+// Or use a writer that converts on the fly
+fmt.Fprintf(tview.ANSIWriter(textView), "\033[31mred text\033[0m")
+```
+
+### Programmatic Styling
+
+Widget properties are set via setter methods using tcell types:
+
+```go
+// Per-widget colors
+textView.SetTextColor(tcell.ColorGreen)
+textView.SetBackgroundColor(tcell.ColorDefault)
+
+// Table cell styling
+cell := tview.NewTableCell("Important").
+    SetTextColor(tcell.ColorRed).
+    SetAttributes(tcell.AttrBold).
+    SetAlign(tview.AlignCenter).
+    SetExpansion(1)    // flex factor for column width
+
+// tcell.Style for full control
+style := tcell.StyleDefault.
+    Foreground(tcell.NewRGBColor(255, 99, 71)).
+    Background(tcell.ColorDefault).
+    Bold(true).
+    Italic(true)
+inputField.SetFieldStyle(style)
+```
+
+### Global Theme
+
+tview provides a global `Styles` variable for theming:
+
+```go
+tview.Styles = tview.Theme{
+    PrimitiveBackgroundColor:    tcell.ColorBlack,
+    ContrastBackgroundColor:     tcell.ColorBlue,
+    MoreContrastBackgroundColor: tcell.ColorGreen,
+    BorderColor:                 tcell.ColorCyan,
+    TitleColor:                  tcell.ColorWhite,
+    GraphicsColor:               tcell.ColorCyan,
+    PrimaryTextColor:            tcell.ColorWhite,
+    SecondaryTextColor:          tcell.ColorYellow,
+    TertiaryTextColor:           tcell.ColorGreen,
+    InverseTextColor:            tcell.ColorBlack,
+    ContrastSecondaryTextColor:  tcell.ColorDarkCyan,
+}
+```
+
+All built-in widgets reference `tview.Styles` for their default colors, so changing this variable themes the entire application.
+
+---
+
+## Event Handling
+
+tview uses a **framework-managed, callback-based** event system. Events flow from the terminal through the `Application` to the focused widget, with interception points at multiple levels.
+
+### Global Input Capture
+
+`SetInputCapture` on `Application` intercepts all key events before they reach any widget:
+
+```go
+app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+    switch event.Key() {
+    case tcell.KeyEsc:
+        app.Stop()
+        return nil   // consume the event
+    case tcell.KeyCtrlS:
+        saveFile()
+        return nil
+    }
+    switch event.Rune() {
+    case 'q':
+        if !editor.HasFocus() {  // don't consume 'q' if editor is focused
+            app.Stop()
+            return nil
+        }
+    }
+    return event  // pass to focused widget
+})
+```
+
+Returning `nil` consumes the event. Returning the event (or a modified event) passes it downstream.
+
+### Widget-Level Input Capture
+
+Any widget (anything embedding `Box`) can install its own capture:
+
+```go
+sidebar.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+    if event.Key() == tcell.KeyTab {
+        app.SetFocus(editor)
+        return nil
+    }
+    return event
+})
+```
+
+The capture chain is: Application capture -> focused widget's ancestor captures (top-down) -> focused widget's `InputHandler`.
+
+### Widget-Specific Callbacks
+
+Each widget type provides semantically appropriate callbacks:
+
+```go
+// InputField -- text changes and completion
+input.SetChangedFunc(func(text string) {
+    // Called on every keystroke
+    results := search(text)
+    updateResults(results)
+})
+input.SetDoneFunc(func(key tcell.Key) {
+    // Called when Enter, Tab, or Escape is pressed
+    if key == tcell.KeyEnter {
+        submit(input.GetText())
+    }
+})
+input.SetAutocompleteFunc(func(currentText string) []string {
+    // Return suggestions based on current text
+    return filterSuggestions(currentText)
+})
+
+// List -- selection events
+list.SetSelectedFunc(func(index int, main, secondary string, shortcut rune) {
+    // Item activated (Enter pressed)
+    openItem(index)
+})
+list.SetChangedFunc(func(index int, main, secondary string, shortcut rune) {
+    // Highlight moved (arrow keys)
+    previewItem(index)
+})
+
+// Table -- cell selection
+table.SetSelectedFunc(func(row, column int) {
+    cell := table.GetCell(row, column)
+    editCell(row, column, cell.Text)
+})
+table.SetSelectionChangedFunc(func(row, column int) {
+    updateStatusBar(row, column)
+})
+
+// TreeView -- node events
+tree.SetSelectedFunc(func(node *tview.TreeNode) {
+    // Node activated
+    if node.IsExpanded() {
+        node.Collapse()
+    } else {
+        node.Expand()
+    }
+})
+
+// Form -- cancel
+form.SetCancelFunc(func() {
+    pages.SwitchToPage("main")
+})
+```
+
+### Mouse Handling
+
+```go
+// Enable mouse globally
+app.EnableMouse(true)
+
+// Global mouse capture
+app.SetMouseCapture(func(event *tcell.EventMouse, action tview.MouseAction) (tview.MouseAction, *tcell.EventMouse) {
+    if action == tview.MouseLeftClick {
+        x, y := event.Position()
+        logClick(x, y)
+    }
+    return action, event  // pass to widgets
+})
+
+// Widget-level mouse capture
+widget.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+    // Handle or pass through
+    return action, event
+})
+```
+
+### Thread-Safe Updates from Goroutines
+
+When background goroutines need to update widgets, they must use `QueueUpdate` or `QueueUpdateDraw` to serialize access on the main event loop goroutine:
+
+```go
+go func() {
+    // Background work (HTTP request, file I/O, etc.)
+    data, err := fetchData()
+
+    // WRONG: directly mutating a widget from a goroutine
+    // textView.SetText(data)  // RACE CONDITION
+
+    // CORRECT: queue the update to run on the main goroutine
+    app.QueueUpdateDraw(func() {
+        if err != nil {
+            textView.SetText("[red]Error: " + err.Error())
+        } else {
+            textView.SetText(data)
+        }
+    })
+}()
+```
+
+- `QueueUpdate(f)` executes `f` on the main goroutine but does **not** trigger a redraw.
+- `QueueUpdateDraw(f)` executes `f` and then redraws. This is the most common choice.
+- `Draw()` can also be called from any goroutine to trigger a redraw without queuing a function.
+
+---
+
+## State Management
+
+tview takes an **object-oriented, widgets-own-their-state** approach. There is no framework-imposed state pattern like Bubble Tea's MVU.
+
+### Widgets as State Containers
+
+Each widget holds its own state internally and exposes it through getters and setters:
+
+```go
+// InputField owns its text
+input.SetText("initial value")
+text := input.GetText()
+
+// List owns its items and selection
+list.AddItem("Item 1", "Description", '1', nil)
+index, text := list.GetCurrentItem()
+
+// Table owns its cells
+table.SetCell(0, 0, tview.NewTableCell("Name").SetTextColor(tcell.ColorYellow))
+cell := table.GetCell(0, 0)
+
+// TreeView owns its node hierarchy
+root := tview.NewTreeNode("Root")
+child := tview.NewTreeNode("Child")
+root.AddChild(child)
+tree.SetRoot(root)
+currentNode := tree.GetCurrentNode()
+
+// TextView owns its text content and scroll position
+textView.SetText("content")
+textView.ScrollToEnd()
+rows, cols := textView.GetScrollOffset()
+```
+
+### Application-Level State
+
+Since widgets own their state, there is no single model struct. Application state is typically spread across:
+
+1. The widget tree itself (text content, selection indices, scroll positions).
+2. Closure variables captured by callbacks.
+3. Optionally, an explicit application struct that holds references to widgets.
+
+```go
+type App struct {
+    app      *tview.Application
+    pages    *tview.Pages
+    list     *tview.List
+    detail   *tview.TextView
+    items    []Item          // domain data
+    selected int
+}
+
+func (a *App) onItemSelected(index int, _, _ string, _ rune) {
+    a.selected = index
+    item := a.items[index]
+    a.detail.SetText(item.Description)
+}
+```
+
+### Thread Safety
+
+Widget state is not inherently thread-safe. All mutations must happen on the main event loop goroutine (inside callbacks or via `QueueUpdate`). The `QueueUpdate`/`QueueUpdateDraw` mechanism is the only safe way to mutate widgets from background goroutines.
+
+---
+
+## Extensibility and Ecosystem
+
+### Built-in Completeness
+
+tview's main extensibility strategy is to provide a comprehensive built-in widget set. The library includes widgets for most common terminal UI needs: text display, forms, tables, trees, modals, tabs, and flexible layouts. This reduces the need for third-party components compared to more minimal frameworks.
+
+### Custom Widgets
+
+Custom widgets are created by implementing `Primitive` (usually by embedding `Box`):
+
+1. Embed `*tview.Box` for free border, title, padding, and focus support.
+2. Override `Draw(screen tcell.Screen)` for custom rendering.
+3. Optionally override `InputHandler()` and `MouseHandler()` for custom interaction.
+4. Call `Box.DrawForSubclass(screen, self)` in `Draw` to render the box chrome.
+
+### Community Extensions
+
+The tview ecosystem is smaller than Charm's. Some third-party projects extend tview with additional widgets (e.g., enhanced file browsers, syntax-highlighted text views), but the community relies primarily on the built-in set. Notable applications built with tview include:
+
+- **K9s** -- Kubernetes cluster management CLI
+- **lazydocker** -- Docker management TUI
+- **podman-tui** -- Podman container management
+
+### Limitations vs. Bubble Tea Ecosystem
+
+- No equivalent to Lip Gloss's standalone styling library (tview's styling is tag-based and widget-bound).
+- No SSH serving equivalent to Wish.
+- No shell-scripting tool equivalent to Gum.
+- Community contributions tend to be applications rather than reusable component libraries.
+
+---
+
+## Strengths
+
+- **Comprehensive built-in widget set** -- covers text, tables, forms, trees, tabs, modals, and more without third-party dependencies.
+- **Flex and Grid layout system** -- the most capable layout system among Go TUI libraries. Proportional sizing, fixed sizes, and nesting handle complex layouts declaratively.
+- **Responsive layout via Grid breakpoints** -- `minGridWidth`/`minGridHeight` parameters enable CSS media query-like behavior, showing different layouts at different terminal sizes.
+- **Built-in focus management** -- the framework tracks focus, routes input to the focused widget, and supports Tab/Shift-Tab navigation in forms. Developers do not need to implement focus tracking.
+- **Easy to get started** -- a functional UI can be built in under 20 lines. The widget-tree approach is intuitive for developers familiar with desktop UI toolkits (Qt, GTK, WPF).
+- **Good for form-heavy applications** -- the `Form` widget aggregates inputs, dropdowns, checkboxes, and buttons with automatic focus cycling.
+- **Thread-safe update queue** -- `QueueUpdate`/`QueueUpdateDraw` provide a clean pattern for background goroutine-to-UI communication.
+- **Chainable API** -- all setters return the receiver, enabling fluent construction.
+- **Mature and stable** -- actively maintained since 2018, used in production by major projects (K9s, lazydocker).
+
+---
+
+## Weaknesses and Limitations
+
+- **Monolithic design** -- tview is a single package with tightly coupled widgets. You cannot use the layout system without the widget system, or the styling without the event loop.
+- **Widgets are harder to customize than in Ratatui/Bubble Tea** -- widget rendering is encapsulated inside `Draw` methods. Changing how a `List` renders its items requires forking the widget rather than passing a custom render function.
+- **Less testable than MVU** -- state is distributed across mutable widgets. Testing requires constructing an `Application`, sending synthetic events, and inspecting widget state via getters. There is no equivalent to Bubble Tea's "send a message, assert on the model" pattern.
+- **Callback-heavy architecture** -- complex applications accumulate many `SetChangedFunc`, `SetSelectedFunc`, `SetDoneFunc`, and `SetInputCapture` callbacks, which can be harder to trace than a single `Update` function.
+- **Tag-based styling is limited** -- style tags in text content are powerful for inline coloring but cannot express layout, padding, or borders. The tag syntax is tview-specific and not reusable outside the framework.
+- **Less composable than functional approaches** -- widgets are concrete types with fixed behavior. Composition relies on embedding (Go struct embedding) rather than functional composition, making it harder to create mix-and-match behavior.
+- **Full-tree redraw on every event** -- while tcell diffs the cell buffer, the entire widget tree is traversed and `Draw` is called on every widget for every event. For very deep widget trees this adds overhead, though in practice terminal UIs are rarely deep enough for this to matter.
+- **No incremental or virtual rendering** -- all widgets are drawn, even those outside the viewport. No virtualization for large lists or tables (though `SetContent` provides a virtual table interface for data).
+
+---
+
+## Lessons for D / Sparkles
+
+### Flex Layout
+
+tview's `AddItem(widget, fixedSize, proportion)` API maps naturally to D named parameters:
+
+```d
+flex.add(widget, fixed: 0, proportion: 1);
+flex.add(header, fixed: 3, proportion: 0);
+```
+
+The proportional size algorithm (linear distribution of remaining space by weight) is simple enough to implement `@nogc` with a fixed-size scratch buffer for tracking item sizes. A `SmallBuffer!(FlexItem, 16)` would handle typical layout trees without allocation.
+
+### Grid with Responsive Breakpoints
+
+tview's responsive Grid is one of its most interesting features. D's CTFE could validate grid definitions at compile time:
+
+```d
+// Compile-time grid validation
+enum layout = Grid.define(
+    rows: [3, 0, 3],          // header, flex, footer
+    columns: [30, 0, 30],     // sidebar, flex, sidebar
+);
+static assert(layout.rows.length == 3);
+static assert(layout.columns.length == 3);
+
+// Runtime breakpoints via terminal size
+if (termWidth >= 100)
+    grid.show(menu, sidebar);
+else
+    grid.hide(menu, sidebar);
+```
+
+The `minGridWidth`/`minGridHeight` approach could be expressed as a list of layout rules evaluated at runtime, with the grid definition itself validated at compile time.
+
+### Box Embedding Pattern
+
+tview's `Box` provides border, title, padding, and focus highlight to all widgets. In D, this could be achieved through:
+
+- **`alias this`** -- a widget struct with `alias this` to a `BoxProperties` member, giving transparent access to border/title/padding methods.
+- **Mixin templates** -- `mixin BoxBehavior;` injecting border drawing, padding calculation, and focus tracking into any widget struct.
+
+```d
+struct MyWidget
+{
+    mixin BoxBehavior;  // provides draw border, getInnerRect, focus handling
+
+    void drawContent(ref Screen screen, Rect inner)
+    {
+        // Custom rendering within the inner rect
+    }
+}
+```
+
+### Primitive Interface as Template Constraint
+
+Go's `Primitive` interface is checked at runtime via duck typing. D can check it at compile time using template constraints or Design by Introspection:
+
+```d
+enum isPrimitive(T) = is(typeof((T t) {
+    tcell.Screen s;
+    t.draw(s);
+    auto r = t.getRect();    // returns Rect
+    t.setRect(0, 0, 80, 24);
+    bool f = t.hasFocus();
+    t.focus();
+    t.blur();
+}));
+
+void addItem(P)(P widget, int fixedSize, int proportion)
+if (isPrimitive!P)
+{
+    // Statically dispatched -- no virtual call overhead
+}
+```
+
+This gives the same polymorphism as Go's interface but with compile-time checking and monomorphized code generation. For runtime polymorphism, a type-erased wrapper (like `std.variant` or a manual vtable) could be used.
+
+### Tag-Based Text Styling at Compile Time
+
+tview parses `[red::b]text[-::-]` at runtime. D's compile-time string parsing could validate and convert tags at compile time:
+
+```d
+// Compile-time tag parsing and validation
+enum styledText = parseStyleTags!("[red::b]Warning:[-::-] Disk at [yellow]92%[-]");
+// styledText is a StyledSpan[] computed at compile time
+// Invalid tags produce a compile error with line/column info
+
+// Runtime: just iterate pre-parsed spans, no parsing overhead
+void render(ref Screen screen, typeof(styledText) spans) @nogc { ... }
+```
+
+This eliminates the runtime parsing cost and catches malformed tags at compile time rather than silently ignoring them.
+
+### QueueUpdate for Thread-Safe UI Updates
+
+tview's `QueueUpdate` pattern maps to D's `std.concurrency`:
+
+```d
+import std.concurrency : send, receive, thisTid, spawn;
+
+// Background thread sends UI updates as messages
+spawn({
+    auto data = fetchData();
+    send(ownerTid, UIUpdate(data));
+});
+
+// Main event loop receives and applies updates
+receive(
+    (UIUpdate update) {
+        widget.setText(update.text);
+        screen.redraw();
+    },
+);
+```
+
+D's `send`/`receive` provides typed message passing with compile-time safety, similar to `QueueUpdate` but without the untyped `func()` closure.
+
+### Focus Management
+
+tview's built-in focus management (tracking the focused widget, routing input, supporting Tab navigation) is worth adopting. Most minimal TUI libraries leave focus management to the developer, which is error-prone and repetitive. A D framework could provide:
+
+- A focus tracker in the application struct that maintains a `Primitive*` or type-erased reference.
+- Automatic Tab/Shift-Tab cycling through focusable children in layout containers.
+- `setFocus` delegate passed to input handlers, matching tview's pattern.
+
+```d
+struct Application
+{
+    Primitive focused;
+
+    void setFocus(Primitive p)
+    {
+        if (focused !is null)
+            focused.blur();
+        focused = p;
+        focused.focus();
+    }
+
+    void handleKey(KeyEvent event)
+    {
+        if (event.key == Key.tab)
+            setFocus(focused.nextFocusable());
+        else if (focused !is null)
+            focused.handleInput(event, &setFocus);
+    }
+}
+```
+
+---
+
+## References
+
+- **Repository**: <https://github.com/rivo/tview>
+- **API Documentation**: <https://pkg.go.dev/github.com/rivo/tview>
+- **Wiki (tutorials, custom widgets, concurrency)**: <https://github.com/rivo/tview/wiki>
+- **tcell (terminal backend)**: <https://github.com/gdamore/tcell>
+- **uniseg (Unicode segmentation)**: <https://github.com/rivo/uniseg>
+- **Grid demo (responsive layout)**: <https://github.com/rivo/tview/tree/master/demos/grid>
+- **Flex demo**: <https://github.com/rivo/tview/tree/master/demos/flex>
+- **K9s (major tview application)**: <https://github.com/derailed/k9s>


### PR DESCRIPTION
## Summary

- Research 13 TUI libraries across 9 languages to inform Sparkles TUI design
- Each library gets a detailed document (14-section template: architecture, layout, widgets, styling, events, state management, lessons for D/Sparkles)
- Cross-library comparison synthesizes findings into design recommendations
- VitePress sidebar updated with Research section linking all documents

### Libraries researched

| Library | Language | Paradigm |
|---------|----------|----------|
| Ratatui | Rust | Immediate-mode, constraint layout |
| Ink | JavaScript | React reconciler, Yoga flexbox |
| Textual | Python | Retained-mode, CSS styling |
| Bubble Tea | Go | Elm/MVU architecture |
| Brick | Haskell | Pure functional combinators |
| Notcurses | C | Plane compositor |
| FTXUI | C++ | Functional DOM + pipe operator |
| Cursive | Rust | Retained-mode, View trait + callbacks |
| Mosaic | Kotlin | Compose runtime for terminals |
| Nottui | OCaml | Incremental computation / FRP |
| libvaxis | Zig | comptime-powered, allocator-aware |
| tview | Go | Retained widget tree, Flex/Grid |
| ImTui | C++ | Dear ImGui for terminals |

### Files added

- `docs/research/tui-libraries/index.md` — Catalog of TUI libraries across 14+ languages
- 13 individual library documents (720–1,427 lines each)
- `docs/research/tui-libraries/comparison.md` — Cross-library synthesis with D/Sparkles design recommendations
- Updated `docs/.vitepress/config.mts` with Research sidebar section

### Key design recommendations (from comparison.md)

- **Core**: Ratatui-style library (not framework) with `@nogc` cell buffer rendering
- **Composition**: FTXUI-inspired functional DOM via UFCS (`text("hello").bold.border`)
- **Layout**: Brick-style combinators + optional flexbox + constraint solver
- **State**: Optional Bubble Tea-style MVU with `pure` enforcement and `SumType` events
- **Reactivity**: Nottui-inspired incremental computation as future optimization path
- **Widgets**: Template-based duck-typing with Design by Introspection for optional capabilities

## Test plan

- [ ] Verify VitePress builds: `npx vitepress build docs`
- [ ] Spot-check that all 15 documents render correctly in VitePress dev server
- [ ] Verify all internal cross-references between documents resolve