### PR TITLE
refactor(core-cli): improve styled_template, text_writers, and add logger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Nix
         uses: metacraft-labs/nixos-modules/.github/setup-nix@main
@@ -59,6 +61,9 @@ jobs:
 
       - name: Build and test with dub
         run: ./scripts/run-tests.sh
+
+      - name: Register local package
+        run: dub add-local .
 
       - name: Verify README examples
         run: ./scripts/run_md_examples.d --verify --glob='**/*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: Build and test with dub
         run: ./scripts/run-tests.sh
+
+      - name: Verify README examples
+        run: ./scripts/run_md_examples.d --verify --glob='**/*.md'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,6 +226,9 @@ sparkles/
 │   │   ├── src/sparkles/core_cli/
 │   │   │   ├── smallbuffer.d      # @nogc dynamic buffer
 │   │   │   ├── prettyprint.d      # Colorized pretty-printing
+│   │   │   ├── text_writers.d     # @nogc text writing utilities
+│   │   │   ├── styled_template.d  # IES-based styled text processing
+│   │   │   ├── logger.d           # Delta-time-prefixed logger
 │   │   │   ├── term_style.d       # Terminal styling/colors
 │   │   │   ├── term_size.d        # Terminal size detection
 │   │   │   ├── process_utils.d    # Process execution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,66 @@ For complex capability detection patterns (traits, optional primitives, fallback
 3. **Check @nogc compatibility**: Ensure tests compile with `@nogc` attribute
 4. **Use `check` helper**: In tests, use the `check` function for pretty error messages with diffs
 
+## Documenting New Features
+
+When adding a new feature to sparkles, add a runnable example to `README.md` as a dub single-file program inside a fenced `d` code block:
+
+````markdown
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_my_feature"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import sparkles.core_cli.my_module;
+
+void main()
+{
+    // Example usage
+}
+```
+````
+
+Follow the code block with a bare fenced output block (no language tag) showing the expected output:
+
+````markdown
+```
+Expected output here
+```
+````
+
+### Verifying README Examples
+
+Use `./scripts/run_md_examples.d` to verify that all README examples compile and produce correct output:
+
+```bash
+# Verify all examples match their expected output
+./scripts/run_md_examples.d --verify README.md
+
+# Update output blocks with actual output (golden snapshot update)
+./scripts/run_md_examples.d --update README.md
+
+# Just run examples and display results
+./scripts/run_md_examples.d README.md
+```
+
+### Dynamic Output with `<!-- md-example-expected -->`
+
+When an example produces dynamic output (timestamps, file paths, durations, etc.), add a `<!-- md-example-expected -->` HTML comment directive between the code block and the output block. The directive contains a wildcard pattern used by `--verify`, while the literal output block below it is preserved for readers. Use `{{_}}` as a wildcard that matches any non-empty text:
+
+````markdown
+<!-- md-example-expected
+[ {{_}} | info | {{_}} ]: Server started
+-->
+
+```
+[ 14:32:01 | info | app.d:12 ]: Server started
+```
+````
+
+The HTML comment is invisible in rendered markdown, so readers see the nice hardcoded values. The `--verify` mode uses the wildcard pattern instead of the literal block for comparison.
+
 ## Dependencies
 
 - `silly` - Test runner (dev dependency)

--- a/README.md
+++ b/README.md
@@ -350,6 +350,12 @@ void main()
 }
 ```
 
+<!-- md-example-expected
+[ {{_}} | Δt {{_}} | Δtᵢ {{_}} | INF | {{_}} ]: Listening on port 8080
+[ {{_}} | Δt {{_}} | Δtᵢ {{_}} | WRN | {{_}} ]: Disk usage above 80%
+[ {{_}} | Δt {{_}} | Δtᵢ {{_}} | ERR | {{_}} ]: Connection to database lost
+-->
+
 ```
 [ 14:32:01 | Δt 0ms   | Δtᵢ 0ms   | INF | app.d:17 ]: Listening on port 8080
 [ 14:32:01 | Δt 5ms   | Δtᵢ 5ms   | WRN | app.d:18 ]: Disk usage above 80%

--- a/libs/core-cli/examples/logger.d
+++ b/libs/core-cli/examples/logger.d
@@ -1,0 +1,26 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "logger"
+    dependency "sparkles:core-cli" version="*"
+    targetPath "build"
++/
+
+import std.logger : log, logf, LogLevel;
+
+import sparkles.core_cli.logger : initLogger;
+
+void main()
+{
+    initLogger(LogLevel.trace);
+
+    log(LogLevel.trace, "Application starting up");
+    log(LogLevel.info, "Listening on port 8080");
+    log(LogLevel.warning, "Disk usage above 80%");
+    log(LogLevel.error, "Connection to database lost");
+    log(LogLevel.critical, "Out of memory");
+
+    // Works with logf too
+    immutable host = "db-01.prod";
+    immutable port = 5432;
+    logf(LogLevel.info, "Reconnected to %s:%d", host, port);
+}

--- a/libs/core-cli/src/sparkles/core_cli/common_dirs.d
+++ b/libs/core-cli/src/sparkles/core_cli/common_dirs.d
@@ -1,0 +1,209 @@
+/// Cross-platform common directories.
+///
+/// Provides platform-aware paths for standard user directories (home, config,
+/// cache, data, state) following XDG conventions on Linux and native paths on
+/// macOS and Windows. Also provides [repoRoot] for locating the git repository
+/// root.
+///
+/// Modeled after Rust's $(LINK2 https://docs.rs/dirs/latest/dirs/, dirs) crate.
+///
+/// $(TABLE
+///     $(TR $(TH Function) $(TH Linux)                                          $(TH macOS)                                   $(TH Windows))
+///     $(TR $(TD [homeDir])   $(TD `$HOME`)                                     $(TD `$HOME`)                                 $(TD `{FOLDERID_Profile}`))
+///     $(TR $(TD [configDir]) $(TD `$XDG_CONFIG_HOME` or `$HOME/.config`)       $(TD `$HOME/Library/Application Support`)     $(TD `{FOLDERID_RoamingAppData}`))
+///     $(TR $(TD [cacheDir])  $(TD `$XDG_CACHE_HOME` or `$HOME/.cache`)         $(TD `$HOME/Library/Caches`)                  $(TD `{FOLDERID_LocalAppData}`))
+///     $(TR $(TD [dataDir])   $(TD `$XDG_DATA_HOME` or `$HOME/.local/share`)    $(TD `$HOME/Library/Application Support`)     $(TD `{FOLDERID_RoamingAppData}`))
+///     $(TR $(TD [stateDir])  $(TD `$XDG_STATE_HOME` or `$HOME/.local/state`)   $(TD —)                                       $(TD —))
+/// )
+module sparkles.core_cli.common_dirs;
+
+import std.path : absolutePath, buildNormalizedPath, buildPath;
+import std.process : environment;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// User Directories
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns the path to the user's home directory.
+///
+/// | Platform | Value                | Example           |
+/// |----------|----------------------|-------------------|
+/// | Linux    | `$HOME`              | `/home/alice`     |
+/// | macOS    | `$HOME`              | `/Users/Alice`    |
+/// | Windows  | `{FOLDERID_Profile}` | `C:\Users\Alice`  |
+///
+/// Returns `null` if the home directory cannot be determined.
+string homeDir() @safe
+{
+    version (Windows)
+        return environment.get("USERPROFILE");
+    else
+        return environment.get("HOME");
+}
+
+///
+@safe unittest
+{
+    auto home = homeDir();
+    assert(home is null || home.length > 0);
+}
+
+/// Returns the path to the user's config directory.
+///
+/// | Platform | Value                                        | Example                                   |
+/// |----------|----------------------------------------------|-------------------------------------------|
+/// | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config`        | `/home/alice/.config`                     |
+/// | macOS    | `$HOME/Library/Application Support`          | `/Users/Alice/Library/Application Support` |
+/// | Windows  | `{FOLDERID_RoamingAppData}`                  | `C:\Users\Alice\AppData\Roaming`           |
+///
+/// Returns `null` if the home directory cannot be determined.
+string configDir() @safe
+{
+    version (Windows)
+        return environment.get("APPDATA");
+    else version (OSX)
+        return xdgOrHome("XDG_CONFIG_HOME", "Library/Application Support");
+    else
+        return xdgOrHome("XDG_CONFIG_HOME", ".config");
+}
+
+///
+@safe unittest
+{
+    auto dir = configDir();
+    assert(dir is null || dir.length > 0);
+}
+
+/// Returns the path to the user's cache directory.
+///
+/// | Platform | Value                                        | Example                              |
+/// |----------|----------------------------------------------|--------------------------------------|
+/// | Linux    | `$XDG_CACHE_HOME` or `$HOME/.cache`          | `/home/alice/.cache`                 |
+/// | macOS    | `$HOME/Library/Caches`                       | `/Users/Alice/Library/Caches`         |
+/// | Windows  | `{FOLDERID_LocalAppData}`                    | `C:\Users\Alice\AppData\Local`        |
+///
+/// Returns `null` if the home directory cannot be determined.
+string cacheDir() @safe
+{
+    version (Windows)
+        return environment.get("LOCALAPPDATA");
+    else version (OSX)
+        return xdgOrHome("XDG_CACHE_HOME", "Library/Caches");
+    else
+        return xdgOrHome("XDG_CACHE_HOME", ".cache");
+}
+
+///
+@safe unittest
+{
+    auto dir = cacheDir();
+    assert(dir is null || dir.length > 0);
+}
+
+/// Returns the path to the user's data directory.
+///
+/// | Platform | Value                                            | Example                                   |
+/// |----------|--------------------------------------------------|-------------------------------------------|
+/// | Linux    | `$XDG_DATA_HOME` or `$HOME/.local/share`         | `/home/alice/.local/share`                |
+/// | macOS    | `$HOME/Library/Application Support`              | `/Users/Alice/Library/Application Support` |
+/// | Windows  | `{FOLDERID_RoamingAppData}`                      | `C:\Users\Alice\AppData\Roaming`           |
+///
+/// Returns `null` if the home directory cannot be determined.
+string dataDir() @safe
+{
+    version (Windows)
+        return environment.get("APPDATA");
+    else version (OSX)
+        return xdgOrHome("XDG_DATA_HOME", "Library/Application Support");
+    else
+        return xdgOrHome("XDG_DATA_HOME", ".local/share");
+}
+
+///
+@safe unittest
+{
+    auto dir = dataDir();
+    assert(dir is null || dir.length > 0);
+}
+
+/// Returns the path to the user's state directory.
+///
+/// | Platform | Value                                            | Example                        |
+/// |----------|--------------------------------------------------|--------------------------------|
+/// | Linux    | `$XDG_STATE_HOME` or `$HOME/.local/state`        | `/home/alice/.local/state`     |
+/// | macOS    | —                                                | —                              |
+/// | Windows  | —                                                | —                              |
+///
+/// Returns `null` on macOS and Windows (no standard equivalent), or if
+/// the home directory cannot be determined on Linux.
+string stateDir() @safe
+{
+    version (Windows)
+        return null;
+    else version (OSX)
+        return null;
+    else
+        return xdgOrHome("XDG_STATE_HOME", ".local/state");
+}
+
+///
+@safe unittest
+{
+    auto dir = stateDir();
+
+    version (Windows) { }
+    else version (OSX) { }
+    else
+        assert(dir is null || dir.length > 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository Root
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns the root directory of the current git repository.
+///
+/// Runs `git rev-parse --show-toplevel` to locate the repository root.
+/// Falls back to the current working directory (as an absolute, normalized
+/// path) if not inside a git repository.
+string repoRoot() @safe
+{
+    import std.process : execute;
+    import std.string : strip;
+
+    auto res = () @trusted { return execute(["git", "rev-parse", "--show-toplevel"]); }();
+
+    if (res.status == 0)
+        return res.output.strip;
+
+    return ".".absolutePath.buildNormalizedPath;
+}
+
+///
+@system unittest
+{
+    auto root = repoRoot();
+    assert(root.length > 0);
+
+    import std.file : exists;
+    assert(root.exists);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns `$envVar` if set and non-empty, otherwise `$HOME/fallbackSuffix`.
+/// Returns `null` when `$HOME` is also unset.
+private string xdgOrHome(string envVar, string fallbackSuffix) @safe
+{
+    auto xdg = environment.get(envVar);
+    if (xdg !is null && xdg.length > 0)
+        return xdg;
+
+    auto home = homeDir();
+    if (home is null)
+        return null;
+
+    return buildPath(home, fallbackSuffix);
+}

--- a/libs/core-cli/src/sparkles/core_cli/logger.d
+++ b/libs/core-cli/src/sparkles/core_cli/logger.d
@@ -1,0 +1,265 @@
+/**
+Delta-time-prefixed logger for CLI output.
+
+Provides [DeltaTimeLogger], a [Logger](std.logger.Logger) subclass that
+prints formatted log lines with wall-clock time, elapsed time since start,
+and elapsed time since the previous log entry. Use [initLogger] to install
+it as the global logger.
+*/
+module sparkles.core_cli.logger;
+
+import core.atomic : MemoryOrder, atomicExchange, atomicStore;
+import core.time : Duration, MonoTime, convClockFreq, dur;
+
+import std.datetime : DateTime;
+import std.logger : Logger, LogLevel;
+
+/// Thread-safe delta-time logger.
+///
+/// Writes formatted log lines to `stderr` in the format:
+/// `[ HH:MM:SS | Δt <total> | Δtᵢ <delta> | <level> | <file>:<line> ]: <message>`
+///
+/// Time deltas are tracked via `core.atomic` with relaxed memory ordering,
+/// making this class safe to use as a `shared` global logger.
+class DeltaTimeLogger : Logger
+{
+    private immutable long startTicks;
+    private shared long prevTicks;
+
+    this(LogLevel level) @safe
+    {
+        super(level);
+        startTicks = MonoTime.currTime.ticks;
+        atomicStore!(MemoryOrder.raw)(prevTicks, startTicks);
+    }
+
+    override void writeLogMsg(ref Logger.LogEntry payload) @safe
+    {
+        import sparkles.core_cli.smallbuffer : SmallBuffer;
+        import sparkles.core_cli.styled_template : writeStyled;
+        import std.range.primitives : put;
+        import std.stdio : stderr;
+
+        auto nowTicks = MonoTime.currTime.ticks;
+        auto prev = atomicExchange!(MemoryOrder.raw)(&prevTicks, nowTicks);
+
+        SmallBuffer!(char, 8) timeBuf;
+        auto dt = cast(DateTime) payload.timestamp;
+        writeTimeHms(timeBuf, dt.hour, dt.minute, dt.second);
+
+        auto w = () @trusted { return stderr.lockingTextWriter; }();
+        writeLogPrefix!true(
+            w,
+            timeBuf[],
+            durationFromTicks(nowTicks - startTicks),
+            durationFromTicks(nowTicks - prev),
+            payload.logLevel,
+            payload.file,
+            payload.line,
+        );
+        writeStyled(w, i"{bold $(payload.msg)}");
+        put(w, '\n');
+    }
+}
+
+/// Installs a [DeltaTimeLogger] as the process-wide logger.
+///
+/// Sets `std.logger.globalLogLevel` and replaces `std.logger.sharedLog` with a
+/// new `DeltaTimeLogger` instance.
+void initLogger(LogLevel level) @safe
+{
+    import std.logger : globalLogLevel, sharedLog;
+
+    globalLogLevel = level;
+    // @trusted: std.logger expects shared(Logger); DeltaTimeLogger manages its
+    // own synchronization via atomics and does not expose mutable shared state.
+    sharedLog = () @trusted { return cast(shared) new DeltaTimeLogger(level); }();
+}
+
+private:
+
+@safe
+void writeDuration(Writer)(ref Writer w, Duration d)
+{
+    import sparkles.core_cli.text_writers : writeInteger;
+    import std.range.primitives : put;
+
+    long ms = d.total!"msecs";
+    bool negative = ms < 0;
+    if (negative)
+    {
+        put(w, '-');
+        ms = -ms;
+    }
+
+    if (ms < 1_000)
+    {
+        writeInteger(w, ms);
+        put(w, 'm');
+        put(w, 's');
+        return;
+    }
+
+    if (ms < 60_000)
+        return writeTenths(w, ms, 100, 's');
+    if (ms < 3_600_000)
+        return writeTenths(w, ms, 6_000, 'm');
+    if (ms < 86_400_000)
+        return writeTenths(w, ms, 360_000, 'h');
+    return writeTenths(w, ms, 8_640_000, 'd');
+}
+
+string fmtDuration(Duration d) @safe
+{
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+    SmallBuffer!(char, 32) buf;
+    writeDuration(buf, d);
+    return buf[].idup;
+}
+
+@("fmtDuration.formatsMilliseconds")
+@safe
+unittest
+{
+    assert(dur!"msecs"(0).fmtDuration == "0ms");
+    assert(dur!"msecs"(42).fmtDuration == "42ms");
+    assert(dur!"msecs"(999).fmtDuration == "999ms");
+}
+
+@("fmtDuration.formatsSeconds")
+@safe
+unittest
+{
+    assert(dur!"msecs"(1_000).fmtDuration == "1.0s");
+    assert(dur!"msecs"(5_500).fmtDuration == "5.5s");
+    assert(dur!"msecs"(59_999).fmtDuration == "60.0s");
+}
+
+@("fmtDuration.formatsMinutes")
+@safe
+unittest
+{
+    assert(dur!"msecs"(60_000).fmtDuration == "1.0m");
+    assert(dur!"msecs"(90_000).fmtDuration == "1.5m");
+    assert(dur!"minutes"(45).fmtDuration == "45.0m");
+}
+
+@("fmtDuration.formatsHours")
+@safe
+unittest
+{
+    assert(dur!"hours"(1).fmtDuration == "1.0h");
+    assert(dur!"msecs"(5_400_000).fmtDuration == "1.5h");
+    assert(dur!"hours"(23).fmtDuration == "23.0h");
+}
+
+@("fmtDuration.formatsDays")
+@safe
+unittest
+{
+    assert(dur!"hours"(24).fmtDuration == "1.0d");
+    assert(dur!"hours"(36).fmtDuration == "1.5d");
+    assert(dur!"hours"(72).fmtDuration == "3.0d");
+}
+
+@safe
+void writeTenths(Writer)(ref Writer w, long ms, long unitTenths, char suffix)
+{
+    import sparkles.core_cli.text_writers : writeInteger;
+    import std.range.primitives : put;
+
+    auto tenths = (ms + unitTenths / 2) / unitTenths;
+    writeInteger(w, tenths / 10);
+    put(w, '.');
+    put(w, cast(char)('0' + tenths % 10));
+    put(w, suffix);
+}
+
+@safe pure nothrow @nogc
+Duration durationFromTicks(long ticks) =>
+    dur!"hnsecs"(convClockFreq(ticks, MonoTime.ticksPerSecond, 10_000_000L));
+
+@safe
+void writeTimeHms(Writer)(ref Writer w, int hour, int minute, int second)
+{
+    import sparkles.core_cli.text_writers : writeInteger;
+    import std.range.primitives : put;
+
+    writePadded2(w, hour);
+    put(w, ':');
+    writePadded2(w, minute);
+    put(w, ':');
+    writePadded2(w, second);
+}
+
+@safe
+void writePadded2(Writer)(ref Writer w, int value)
+{
+    import sparkles.core_cli.text_writers : writeInteger;
+    import std.range.primitives : put;
+
+    if (value < 10)
+        put(w, '0');
+    writeInteger(w, value);
+}
+
+@safe
+void writeDurationPadded(Writer)(ref Writer w, Duration d, size_t width)
+{
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import std.range.primitives : put;
+
+    SmallBuffer!(char, 16) buf;
+    writeDuration(buf, d);
+    auto text = buf[];
+    put(w, text);
+    if (text.length < width)
+    {
+        foreach (_; 0 .. width - text.length)
+            put(w, ' ');
+    }
+}
+
+@safe
+void writeStyledLevel(bool colored = true, Writer)(ref Writer w, LogLevel level)
+{
+    import sparkles.core_cli.styled_template : writeStyled;
+
+    switch (level)
+    {
+        case LogLevel.trace:    writeStyled!colored(w, i"{gray TRC}");     break;
+        case LogLevel.info:     writeStyled!colored(w, i"{green INF}");    break;
+        case LogLevel.warning:  writeStyled!colored(w, i"{yellow WRN}");   break;
+        case LogLevel.error:    writeStyled!colored(w, i"{red ERR}");      break;
+        case LogLevel.critical: writeStyled!colored(w, i"{bold.red CRT}"); break;
+        case LogLevel.fatal:    writeStyled!colored(w, i"{bold.red FTL}"); break;
+        default: assert(0, "unexpected log level");
+    }
+}
+
+@safe
+void writeLogPrefix(bool colored = false, Writer)(
+    ref Writer w,
+    const(char)[] timeStr,
+    Duration sinceStart,
+    Duration sincePrev,
+    LogLevel level,
+    string file,
+    int line,
+)
+{
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import sparkles.core_cli.styled_template : writeStyled;
+    import std.path : baseName;
+
+    SmallBuffer!(char, 16) startBuf;
+    writeDurationPadded(startBuf, sinceStart, 5);
+    SmallBuffer!(char, 16) prevBuf;
+    writeDurationPadded(prevBuf, sincePrev, 5);
+    auto loc = file.baseName;
+
+    writeStyled!colored(w, i"{gray [ $(timeStr)} | Δt {yellow $(startBuf[])} | Δtᵢ {yellow $(prevBuf[])} | ");
+    writeStyledLevel!colored(w, level);
+    writeStyled!colored(w, i" | {dim $(loc):$(line)} ]: ");
+}

--- a/libs/core-cli/src/sparkles/core_cli/styled_template.d
+++ b/libs/core-cli/src/sparkles/core_cli/styled_template.d
@@ -43,8 +43,7 @@ void writeStyled(Writer, Args...)(
     InterpolationFooter
 )
 {
-    import std.conv : to;
-    import std.range.primitives : put;
+    import sparkles.core_cli.text_writers : writeValue;
 
     ParserContext ctx;
 
@@ -61,8 +60,9 @@ void writeStyled(Writer, Args...)(
         }
         else
         {
-            // Output interpolated value - styles already active from block
-            put(w, arg.to!string);
+            // Output interpolated value — best-effort @nogc via writeValue,
+            // falls back to std.conv.to!string for types without @nogc conversion.
+            writeValue(w, arg);
         }
     }}
 }

--- a/libs/core-cli/src/sparkles/core_cli/styled_template.d
+++ b/libs/core-cli/src/sparkles/core_cli/styled_template.d
@@ -14,14 +14,256 @@
  * - `{bold.red text}` — Chain multiple styles
  * - `{bold outer {red nested}}` — Nested blocks (inner inherits outer)
  * - `{red text {~red normal}}` — Negation with `~` removes a style
- * - `{{` — Escaped literal `{`
- * - `}}` — Escaped literal `}`
+ * - `#{` — Escaped literal `{`
+ * - `#}` — Escaped literal `}`
  */
 module sparkles.core_cli.styled_template;
 
 import core.interpolation;
 
 import sparkles.core_cli.term_style : Style;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core Processing Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Writes styled IES output to an output range.
+///
+/// Processes IES (Interpolated Expression Sequences) containing style template
+/// syntax and writes the resulting ANSI-styled text to the given output range.
+///
+/// Style blocks use `{styleName content}` syntax, where `styleName` is one or
+/// more dot-separated style names. Blocks can be nested, and inner blocks
+/// inherit styles from outer blocks. Use `~` prefix to negate (remove) an
+/// inherited style.
+void writeStyled(Writer, Args...)(
+    ref Writer w,
+    InterpolationHeader,
+    Args args,
+    InterpolationFooter
+)
+{
+    import std.conv : to;
+    import std.range.primitives : put;
+
+    ParserContext ctx;
+
+    static foreach (arg; args)
+    {{
+        alias T = typeof(arg);
+        static if (is(T == InterpolatedLiteral!lit, string lit))
+        {
+            parseLiteral(w, lit, ctx);
+        }
+        else static if (is(T == InterpolatedExpression!code, string code))
+        {
+            // Skip expression metadata
+        }
+        else
+        {
+            // Output interpolated value - styles already active from block
+            put(w, arg.to!string);
+        }
+    }}
+}
+
+/// Single style: `{red text}` wraps text with red foreground escape codes.
+@("writeStyled.singleStyle")
+@safe unittest
+{
+    assert(styledText(i"{red error}") == "\x1b[31merror\x1b[39m");
+}
+
+/// Chained styles: `{bold.red text}` applies multiple styles separated by dots.
+@("writeStyled.chainedStyles")
+@safe unittest
+{
+    // bold.red applies both styles, closed in reverse order
+    assert(styledText(i"{bold.red text}") == "\x1b[1m\x1b[31mtext\x1b[39m\x1b[22m");
+}
+
+/// Interpolated expressions: `{green $(expr)}` styles the result of an expression.
+@("writeStyled.withInterpolation")
+@safe unittest
+{
+    int val = 42;
+    assert(styledText(i"Value: {green $(val)}") == "Value: \x1b[32m42\x1b[39m");
+}
+
+/// Nested blocks: `{bold outer {red inner}}` — inner inherits outer's styles.
+@("writeStyled.nested")
+@safe unittest
+{
+    // bold applies to all, red only to inner "B"
+    auto result = styledText(i"{bold A {red B} C}");
+    assert(result == "\x1b[1mA \x1b[31mB\x1b[39m C\x1b[22m");
+}
+
+/// Negation: `{~red text}` removes the named style from the inherited set.
+@("writeStyled.negation")
+@safe unittest
+{
+    // Start bold+red, then ~red removes red while keeping bold
+    auto result = styledText(i"{bold.red styled {~red plain}}");
+    assert(result ==
+        "\x1b[1m\x1b[31m" ~ // bold ON, red ON
+        "styled " ~
+        "\x1b[39m" ~         // red OFF (negated)
+        "plain" ~
+        "\x1b[31m" ~         // red ON (restored on exit)
+        "\x1b[39m\x1b[22m"   // red OFF, bold OFF
+    );
+}
+
+/// Escaped braces: `#{` produces literal `{`, `#}` produces literal `}`.
+@("writeStyled.escapedBraces")
+@safe unittest
+{
+    assert(styledText(i"Use #{style#} syntax") == "Use {style} syntax");
+}
+
+/// Escaped braces inside styled blocks.
+@("writeStyled.escapedBracesInStyledBlock")
+@safe unittest
+{
+    assert(styledText(i"{bold use #{braces#}}") == "\x1b[1muse {braces}\x1b[22m");
+}
+
+/// Escaped `#}` inside styled block produces literal `}`.
+@("writeStyled.escapedCloseBraceInBlock")
+@safe unittest
+{
+    assert(styledText(i"{red hey#} still red}") == "\x1b[31mhey} still red\x1b[39m");
+}
+
+/// Plain text without any style blocks passes through unchanged.
+@("writeStyled.noStyle")
+@safe unittest
+{
+    assert(styledText(i"plain text") == "plain text");
+}
+
+/// Empty block `{}` is treated as a literal `{}`.
+@("writeStyled.emptyBlock")
+@safe unittest
+{
+    assert(styledText(i"test {} here") == "test {} here");
+}
+
+/// Style block with no content (e.g. `{red}`) yields empty output.
+@("writeStyled.styleBlockWithNoContent")
+@safe unittest
+{
+    assert(styledText(i"{red}") == "");
+    assert(styledText(i"a{bold}b") == "ab");
+    assert(styledText(i"{bold.red}") == "");
+}
+
+/// Multiple adjacent blocks are independent.
+@("writeStyled.multipleBlocks")
+@safe unittest
+{
+    auto result = styledText(i"{red error} and {green success}");
+    assert(result == "\x1b[31merror\x1b[39m and \x1b[32msuccess\x1b[39m");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// String Conversion
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns styled IES as a string.
+string styledText(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.array : appender;
+
+    auto buf = appender!string;
+    writeStyled(buf, header, args, footer);
+    return buf[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lazy Wrapper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Lazy wrapper that defers styled processing until consumed.
+struct StyledText(Args...)
+{
+    Args args;
+
+    /// Convert to string (allocates)
+    string toString() const
+    {
+        import std.array : appender;
+
+        auto buf = appender!string;
+        writeStyled(buf, args);
+        return buf[];
+    }
+
+    /// Callback-based toString for writeln compatibility
+    void toString(scope void delegate(const(char)[]) sink) const
+    {
+        sink(toString());
+    }
+}
+
+/// Returns a lazy wrapper that can be converted to string or written to output range.
+auto styled(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    // Store all components including header/footer
+    return StyledText!(InterpolationHeader, Args, InterpolationFooter)(header, args, footer);
+}
+
+///
+@("styled.lazyWrapper")
+@safe unittest
+{
+    int val = 99;
+    auto lazy_ = styled(i"Test: {blue $(val)}");
+    assert(lazy_.toString == "Test: \x1b[34m99\x1b[39m");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// stdout/stderr Write Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Write styled IES to stdout.
+void styledWrite(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.stdio : stdout;
+
+    auto w = stdout.lockingTextWriter;
+    writeStyled(w, header, args, footer);
+}
+
+/// Write styled IES to stdout with newline.
+void styledWriteln(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.stdio : stdout;
+
+    auto w = stdout.lockingTextWriter;
+    writeStyled(w, header, args, footer);
+    w.put('\n');
+}
+
+/// Write styled IES to stderr.
+void styledWriteErr(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.stdio : stderr;
+
+    auto w = stderr.lockingTextWriter;
+    writeStyled(w, header, args, footer);
+}
+
+/// Write styled IES to stderr with newline.
+void styledWritelnErr(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+{
+    import std.stdio : stderr;
+
+    auto w = stderr.lockingTextWriter;
+    writeStyled(w, header, args, footer);
+    w.put('\n');
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Style Name Lookup
@@ -103,125 +345,80 @@ unittest
     assert(styleFromName("") == Style.none);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Core Processing Functions
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Writes styled IES output to an output range.
-void writeStyled(Writer, Args...)(
-    ref Writer w,
-    InterpolationHeader,
-    Args args,
-    InterpolationFooter
-)
+/// All text attributes are recognized.
+@("styleFromName.textAttributes")
+@safe pure nothrow @nogc
+unittest
 {
-    import std.conv : to;
-    import std.range.primitives : put;
-
-    ParserContext ctx;
-
-    static foreach (arg; args)
-    {{
-        alias T = typeof(arg);
-        static if (is(T == InterpolatedLiteral!lit, string lit))
-        {
-            parseLiteral(w, lit, ctx);
-        }
-        else static if (is(T == InterpolatedExpression!code, string code))
-        {
-            // Skip expression metadata
-        }
-        else
-        {
-            // Output interpolated value - styles already active from block
-            put(w, arg.to!string);
-        }
-    }}
+    assert(styleFromName("dim") == Style.dim);
+    assert(styleFromName("italic") == Style.italic);
+    assert(styleFromName("underline") == Style.underline);
+    assert(styleFromName("inverse") == Style.inverse);
+    assert(styleFromName("hidden") == Style.hidden);
+    assert(styleFromName("strikethrough") == Style.strikethrough);
 }
 
-/// Returns styled IES as a string.
-string styledText(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+/// Special style names: "none" and "reset".
+@("styleFromName.special")
+@safe pure nothrow @nogc
+unittest
 {
-    import std.array : appender;
-
-    auto buf = appender!string;
-    writeStyled(buf, header, args, footer);
-    return buf[];
+    assert(styleFromName("none") == Style.none);
+    assert(styleFromName("reset") == Style.reset);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Lazy Wrapper
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Lazy wrapper that defers styled processing until consumed.
-struct StyledText(Args...)
+/// Bright foreground colors are recognized.
+@("styleFromName.brightColors")
+@safe pure nothrow @nogc
+unittest
 {
-    Args args;
-
-    /// Convert to string (allocates)
-    string toString() const
-    {
-        import std.array : appender;
-
-        auto buf = appender!string;
-        writeStyled(buf, args);
-        return buf[];
-    }
-
-    /// Callback-based toString for writeln compatibility
-    void toString(scope void delegate(const(char)[]) sink) const
-    {
-        sink(toString());
-    }
+    assert(styleFromName("brightRed") == Style.brightRed);
+    assert(styleFromName("brightGreen") == Style.brightGreen);
+    assert(styleFromName("brightYellow") == Style.brightYellow);
+    assert(styleFromName("brightBlue") == Style.brightBlue);
+    assert(styleFromName("brightMagenta") == Style.brightMagenta);
+    assert(styleFromName("brightCyan") == Style.brightCyan);
+    assert(styleFromName("brightWhite") == Style.brightWhite);
 }
 
-/// Returns a lazy wrapper that can be converted to string or written to output range.
-auto styled(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+/// Background colors are recognized.
+@("styleFromName.bgColors")
+@safe pure nothrow @nogc
+unittest
 {
-    // Store all components including header/footer
-    return StyledText!(InterpolationHeader, Args, InterpolationFooter)(header, args, footer);
+    assert(styleFromName("bgBlack") == Style.bgBlack);
+    assert(styleFromName("bgRed") == Style.bgRed);
+    assert(styleFromName("bgGreen") == Style.bgGreen);
+    assert(styleFromName("bgYellow") == Style.bgYellow);
+    assert(styleFromName("bgBlue") == Style.bgBlue);
+    assert(styleFromName("bgMagenta") == Style.bgMagenta);
+    assert(styleFromName("bgCyan") == Style.bgCyan);
+    assert(styleFromName("bgWhite") == Style.bgWhite);
+    assert(styleFromName("bgGray") == Style.bgGray);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// stdout/stderr Write Functions
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Write styled IES to stdout.
-void styledWrite(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+/// Bright background colors are recognized.
+@("styleFromName.bgBrightColors")
+@safe pure nothrow @nogc
+unittest
 {
-    import std.stdio : stdout;
-
-    auto w = stdout.lockingTextWriter;
-    writeStyled(w, header, args, footer);
+    assert(styleFromName("bgBrightRed") == Style.bgBrightRed);
+    assert(styleFromName("bgBrightGreen") == Style.bgBrightGreen);
+    assert(styleFromName("bgBrightYellow") == Style.bgBrightYellow);
+    assert(styleFromName("bgBrightBlue") == Style.bgBrightBlue);
+    assert(styleFromName("bgBrightMagenta") == Style.bgBrightMagenta);
+    assert(styleFromName("bgBrightCyan") == Style.bgBrightCyan);
+    assert(styleFromName("bgBrightWhite") == Style.bgBrightWhite);
 }
 
-/// Write styled IES to stdout with newline.
-void styledWriteln(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
+/// Name matching is case-sensitive — wrong case returns Style.none.
+@("styleFromName.caseSensitive")
+@safe pure nothrow @nogc
+unittest
 {
-    import std.stdio : stdout;
-
-    auto w = stdout.lockingTextWriter;
-    writeStyled(w, header, args, footer);
-    w.put('\n');
-}
-
-/// Write styled IES to stderr.
-void styledWriteErr(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
-{
-    import std.stdio : stderr;
-
-    auto w = stderr.lockingTextWriter;
-    writeStyled(w, header, args, footer);
-}
-
-/// Write styled IES to stderr with newline.
-void styledWritelnErr(Args...)(InterpolationHeader header, Args args, InterpolationFooter footer)
-{
-    import std.stdio : stderr;
-
-    auto w = stderr.lockingTextWriter;
-    writeStyled(w, header, args, footer);
-    w.put('\n');
+    assert(styleFromName("Red") == Style.none);
+    assert(styleFromName("BOLD") == Style.none);
+    assert(styleFromName("BgBlue") == Style.none);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -382,28 +579,25 @@ private void parseLiteral(Writer)(
         final switch (ctx.state)
         {
             case ParseState.normal:
-                if (c == '{')
+                if (c == '#' && i + 1 < literal.length)
                 {
-                    // Check for escaped {{ -> literal {
-                    if (i + 1 < literal.length && literal[i + 1] == '{')
+                    const char next = literal[i + 1];
+                    if (next == '{' || next == '}')
                     {
-                        put(w, '{');
+                        put(w, next);
                         i += 2;
                         continue;
                     }
+                    put(w, c);
+                }
+                else if (c == '{')
+                {
                     ctx.state = ParseState.styleName;
                     ctx.styleNameStart = i + 1;
                     ctx.styleNameEnd = i + 1;
                 }
                 else if (c == '}')
                 {
-                    // Check for escaped }} -> literal }
-                    if (i + 1 < literal.length && literal[i + 1] == '}')
-                    {
-                        put(w, '}');
-                        i += 2;
-                        continue;
-                    }
                     put(w, c);
                 }
                 else
@@ -442,15 +636,19 @@ private void parseLiteral(Writer)(
                 break;
 
             case ParseState.content:
-                if (c == '{')
+                if (c == '#' && i + 1 < literal.length)
                 {
-                    // Check for escaped {{ -> literal {
-                    if (i + 1 < literal.length && literal[i + 1] == '{')
+                    const char next = literal[i + 1];
+                    if (next == '{' || next == '}')
                     {
-                        put(w, '{');
+                        put(w, next);
                         i += 2;
                         continue;
                     }
+                    put(w, c);
+                }
+                else if (c == '{')
+                {
                     // Nested block
                     ctx.state = ParseState.styleName;
                     ctx.styleNameStart = i + 1;
@@ -458,13 +656,6 @@ private void parseLiteral(Writer)(
                 }
                 else if (c == '}')
                 {
-                    // Check for escaped }} -> literal }
-                    if (i + 1 < literal.length && literal[i + 1] == '}')
-                    {
-                        put(w, '}');
-                        i += 2;
-                        continue;
-                    }
                     // End of block - close only styles that were added in this block
                     ctx.topStyle.emitCloseDiff(w, ctx.parentStyle);
                     ctx.popStyle();
@@ -525,53 +716,8 @@ private void applyStylePart(const(char)[] part, ref StyleState state)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Unit Tests
+// Non-Ddoc Unit Tests
 // ─────────────────────────────────────────────────────────────────────────────
-
-@("styled.singleStyle")
-@safe unittest
-{
-    assert(styledText(i"{red error}") == "\x1b[31merror\x1b[39m");
-}
-
-@("styled.chainedStyles")
-@safe unittest
-{
-    // bold.red applies both styles
-    auto result = styledText(i"{bold.red text}");
-    // Should have bold open, red open, text, red close, bold close
-    assert(result == "\x1b[1m\x1b[31mtext\x1b[39m\x1b[22m");
-}
-
-@("styled.withInterpolation")
-@safe unittest
-{
-    int val = 42;
-    assert(styledText(i"Value: {green $(val)}") == "Value: \x1b[32m42\x1b[39m");
-}
-
-@("styled.nested")
-@safe unittest
-{
-    // Nested: bold applies to all, red only to inner
-    auto result = styledText(i"{bold A {red B} C}");
-    // A gets bold, B gets bold+red (inherited), C gets bold (red removed)
-    // Expected: bold open, "A ", red open, "B", red close, " C", bold close
-    assert(result == "\x1b[1mA \x1b[31mB\x1b[39m C\x1b[22m");
-}
-
-@("styled.negation")
-@safe unittest
-{
-    // ~red removes red, but bold remains
-    auto result = styledText(i"{bold.red styled {~red unbold}}");
-    // "styled" = bold+red, "unbold" = bold only (red removed)
-    assert(result.length > 0); // Basic sanity check
-    // Verify structure: should have reset codes
-    import std.algorithm.searching : canFind;
-    assert(result.canFind("\x1b[1m")); // bold on
-    assert(result.canFind("\x1b[31m")); // red on
-}
 
 /// Elaborate test combining chained styles, deep nesting, and negation.
 ///
@@ -722,62 +868,399 @@ private void applyStylePart(const(char)[] part, ref StyleState state)
     );
 }
 
-@("styled.escapedOpenBrace")
+/// Text attribute styles (dim, italic, underline, etc.) each use their own
+/// open/close escape codes.
+@("styled.textAttributes")
 @safe unittest
 {
-    // {{ produces literal {
-    assert(styledText(i"Use {{style}} syntax") == "Use {style} syntax");
+    assert(styledText(i"{dim text}") == "\x1b[2mtext\x1b[22m");
+    assert(styledText(i"{italic text}") == "\x1b[3mtext\x1b[23m");
+    assert(styledText(i"{underline text}") == "\x1b[4mtext\x1b[24m");
+    assert(styledText(i"{inverse text}") == "\x1b[7mtext\x1b[27m");
+    assert(styledText(i"{hidden text}") == "\x1b[8mtext\x1b[28m");
+    assert(styledText(i"{strikethrough text}") == "\x1b[9mtext\x1b[29m");
 }
 
-@("styled.escapedCloseBrace")
+/// Background color styles use codes 40-49 (open) and 49 (close).
+@("styled.backgroundColors")
 @safe unittest
 {
-    // }} produces literal } inside styled block
-    assert(styledText(i"{red hey}} still red}") == "\x1b[31mhey} still red\x1b[39m");
+    assert(styledText(i"{bgRed text}") == "\x1b[41mtext\x1b[49m");
+    assert(styledText(i"{bgGreen text}") == "\x1b[42mtext\x1b[49m");
+    assert(styledText(i"{bgBlue text}") == "\x1b[44mtext\x1b[49m");
 }
 
-@("styled.escapedBracesInContent")
+/// Foreground and background can be combined in a single block.
+@("styled.foregroundAndBackground")
 @safe unittest
 {
-    // {{ and }} inside a styled block
-    assert(styledText(i"{bold use {{braces}}}") == "\x1b[1muse {braces}\x1b[22m");
+    auto result = styledText(i"{red.bgWhite text}");
+    assert(result == "\x1b[31m\x1b[47mtext\x1b[49m\x1b[39m");
 }
 
-@("styled.noStyle")
+/// Unknown style names in a spec are silently ignored (treated as Style.none).
+@("styled.unknownStyleIgnored")
 @safe unittest
 {
-    assert(styledText(i"plain text") == "plain text");
+    // "unknown" maps to Style.none so addStyle is a no-op
+    assert(styledText(i"{unknown text}") == "text");
 }
 
-@("styled.emptyBlock")
+/// Unknown style mixed with a known style — only the known one applies.
+@("styled.unknownMixedWithKnown")
 @safe unittest
 {
-    // Empty {} should be treated as literal
-    assert(styledText(i"test {} here") == "test {} here");
+    assert(styledText(i"{unknown.bold text}") == "\x1b[1mtext\x1b[22m");
 }
 
-@("styled.styleBlockWithNoContent")
+/// Negating a style that isn't active is a no-op.
+@("styled.negateInactiveStyle")
 @safe unittest
 {
-    // {red} with no content yields empty string
-    assert(styledText(i"{red}") == "");
-    // Mixed: {bold} between text yields just the text
-    assert(styledText(i"a{bold}b") == "ab");
-    // {bold.red} also yields empty string
-    assert(styledText(i"{bold.red}") == "");
+    // ~red on a block that doesn't have red — nothing to remove
+    assert(styledText(i"{bold {~red text}}") == "\x1b[1mtext\x1b[22m");
 }
 
-@("styled.multipleBlocks")
+/// Negating all styles in a child block — content has no styling.
+@("styled.negateAllStyles")
 @safe unittest
 {
-    auto result = styledText(i"{red error} and {green success}");
-    assert(result == "\x1b[31merror\x1b[39m and \x1b[32msuccess\x1b[39m");
+    auto result = styledText(i"{bold.red outer {~bold.~red inner} outer}");
+    assert(result ==
+        "\x1b[1m\x1b[31m" ~  // bold ON, red ON
+        "outer " ~
+        "\x1b[39m\x1b[22m" ~ // red OFF, bold OFF (negated)
+        "inner" ~
+        "\x1b[1m\x1b[31m" ~  // bold ON, red ON (restored)
+        " outer" ~
+        "\x1b[39m\x1b[22m"   // red OFF, bold OFF
+    );
 }
 
-@("styled.lazyWrapper")
+/// The same style applied redundantly at multiple nesting levels is not
+/// duplicated — the inner block is a no-op since it inherits the style.
+@("styled.duplicateStyleInherited")
 @safe unittest
 {
-    int val = 99;
-    auto lazy_ = styled(i"Test: {blue $(val)}");
-    assert(lazy_.toString == "Test: \x1b[34m99\x1b[39m");
+    // Inner {red ...} when parent is already red — should not re-emit red
+    auto result = styledText(i"{red outer {red inner} outer}");
+    // Inner block inherits red, emitOpenDiff produces nothing new,
+    // emitCloseDiff produces nothing since nothing was added
+    assert(result ==
+        "\x1b[31m" ~  // red ON
+        "outer " ~
+        "inner" ~     // no extra codes — red already active
+        " outer" ~
+        "\x1b[39m"    // red OFF
+    );
+}
+
+/// Multiple interpolated expressions in one styled block.
+@("styled.multipleInterpolations")
+@safe unittest
+{
+    int a = 1;
+    int b = 2;
+    auto result = styledText(i"{green $(a) + $(b)}");
+    assert(result == "\x1b[32m1 + 2\x1b[39m");
+}
+
+/// Interpolated expression at the boundary of a styled block — expression
+/// right after the style name space separator and right before closing brace.
+@("styled.interpolationAtBoundaries")
+@safe unittest
+{
+    int val = 7;
+    assert(styledText(i"{red $(val)}") == "\x1b[31m7\x1b[39m");
+}
+
+/// Text before and after styled blocks is unaffected.
+@("styled.textAroundBlocks")
+@safe unittest
+{
+    auto result = styledText(i"before {bold middle} after");
+    assert(result == "before \x1b[1mmiddle\x1b[22m after");
+}
+
+/// Adjacent styled blocks with no gap between them.
+@("styled.adjacentBlocks")
+@safe unittest
+{
+    auto result = styledText(i"{red A}{green B}{blue C}");
+    assert(result ==
+        "\x1b[31mA\x1b[39m" ~
+        "\x1b[32mB\x1b[39m" ~
+        "\x1b[34mC\x1b[39m"
+    );
+}
+
+/// Leading dot in style spec — the empty segment before the dot is ignored.
+@("styled.leadingDotInSpec")
+@safe unittest
+{
+    // ".bold" → empty part (skipped), then "bold"
+    assert(styledText(i"{.bold text}") == "\x1b[1mtext\x1b[22m");
+}
+
+/// Trailing dot in style spec — the empty segment after the dot is ignored.
+@("styled.trailingDotInSpec")
+@safe unittest
+{
+    // "bold." → "bold", then empty part (skipped)
+    assert(styledText(i"{bold. text}") == "\x1b[1mtext\x1b[22m");
+}
+
+/// Consecutive dots in style spec — empty segments are skipped.
+@("styled.consecutiveDotsInSpec")
+@safe unittest
+{
+    // "bold..red" → "bold", empty (skipped), "red"
+    assert(styledText(i"{bold..red text}") == "\x1b[1m\x1b[31mtext\x1b[39m\x1b[22m");
+}
+
+/// Single character content in a styled block.
+@("styled.singleCharContent")
+@safe unittest
+{
+    assert(styledText(i"{red X}") == "\x1b[31mX\x1b[39m");
+}
+
+/// Content consisting entirely of spaces.
+@("styled.spacesOnly")
+@safe unittest
+{
+    assert(styledText(i"{red   }") == "\x1b[31m  \x1b[39m");
+}
+
+/// Nesting depth of exactly maxNestingDepth (16) — should still work.
+@("styled.maxNestingDepth")
+@safe unittest
+{
+    // Build 16 levels of nesting: {bold {bold {bold ... text ...}}}...}
+    // Each level re-specifies bold, so the inherited style is the same.
+    auto result = styledText(
+        i"{bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold deep}}}}}}}}}}}}}}}}"
+    );
+
+    // "bold" inherited at every level — only emitted once at the outermost
+    assert(result ==
+        "\x1b[1m" ~
+        "deep" ~
+        "\x1b[22m"
+    );
+}
+
+/// Nesting beyond maxNestingDepth (16) is gracefully handled via overflowDepth.
+/// Overflow levels are silently ignored (content still passes through).
+@("styled.overflowNesting")
+@safe unittest
+{
+    // 17 levels — the 17th push overflows; its pop decrements overflowDepth
+    auto result = styledText(
+        i"{bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {bold {red overflow}}}}}}}}}}}}}}}}}"
+    );
+
+    // The 17th {red ...} overflows, so red is never emitted.
+    // Content "overflow" still appears, wrapped in the outermost bold.
+    assert(result ==
+        "\x1b[1m" ~
+        "overflow" ~
+        "\x1b[22m"
+    );
+}
+
+/// Maximum styles per block (8) — adding an 8th style works.
+@("styled.maxStylesPerBlock")
+@safe unittest
+{
+    // 8 distinct styles: bold, italic, underline, dim, inverse, strikethrough, red, bgBlue
+    auto result = styledText(
+        i"{bold.italic.underline.dim.inverse.strikethrough.red.bgBlue X}"
+    );
+
+    // All 8 open codes, then text, then all 8 close codes (reverse order)
+    assert(result ==
+        "\x1b[1m\x1b[3m\x1b[4m\x1b[2m\x1b[7m\x1b[9m\x1b[31m\x1b[44m" ~
+        "X" ~
+        "\x1b[49m\x1b[39m\x1b[29m\x1b[27m\x1b[22m\x1b[24m\x1b[23m\x1b[22m"
+    );
+}
+
+/// Exceeding maxStylesPerBlock (8) — the 9th style is silently dropped.
+@("styled.overflowStylesPerBlock")
+@safe unittest
+{
+    // 9 styles: hidden is the 9th
+    auto result = styledText(
+        i"{bold.italic.underline.dim.inverse.strikethrough.red.bgBlue.hidden X}"
+    );
+
+    // "hidden" is dropped (addStyle no-op because count >= length)
+    // Same output as maxStylesPerBlock test
+    assert(result ==
+        "\x1b[1m\x1b[3m\x1b[4m\x1b[2m\x1b[7m\x1b[9m\x1b[31m\x1b[44m" ~
+        "X" ~
+        "\x1b[49m\x1b[39m\x1b[29m\x1b[27m\x1b[22m\x1b[24m\x1b[23m\x1b[22m"
+    );
+}
+
+/// Empty string input.
+@("styled.emptyInput")
+@safe unittest
+{
+    assert(styledText(i"") == "");
+}
+
+/// Lone closing brace outside styled block is passed through.
+@("styled.loneClosingBrace")
+@safe unittest
+{
+    assert(styledText(i"a } b") == "a } b");
+}
+
+/// Multiple escaped brace pairs in sequence.
+@("styled.multipleEscapedBraces")
+@safe unittest
+{
+    assert(styledText(i"#{#{#}#}") == "{{}}");
+}
+
+/// Styled block containing only an interpolated expression (no literal text).
+@("styled.onlyInterpolation")
+@safe unittest
+{
+    string s = "hi";
+    assert(styledText(i"{bold $(s)}") == "\x1b[1mhi\x1b[22m");
+}
+
+/// Nested blocks where inner replaces the color (not using negation).
+@("styled.innerReplacesColor")
+@safe unittest
+{
+    // {red ... {green ...} ...} — green replaces red temporarily via inheritance
+    // green inherits from red's state, but since red is already there, green adds itself
+    auto result = styledText(i"{red A {green B} C}");
+    // Inner block: inherits [red], adds green → [red, green]
+    // emitOpenDiff: green is new → emit green open
+    // emitCloseDiff: green is new → emit green close
+    assert(result ==
+        "\x1b[31m" ~      // red ON
+        "A " ~
+        "\x1b[32m" ~      // green ON (added to inherited red)
+        "B" ~
+        "\x1b[39m" ~      // green OFF (close code for green = 39)
+        " C" ~
+        "\x1b[39m"        // red OFF
+    );
+}
+
+/// Negation with `~` on a style that uses the same close code as another
+/// active style (e.g., both bold and dim close with code 22).
+@("styled.negationSharedCloseCode")
+@safe unittest
+{
+    // bold and dim both have close code 22
+    auto result = styledText(i"{bold.dim text {~dim inner} text}");
+    assert(result ==
+        "\x1b[1m\x1b[2m" ~  // bold ON, dim ON
+        "text " ~
+        "\x1b[22m" ~        // dim OFF (close code 22)
+        "inner" ~
+        "\x1b[2m" ~         // dim ON (restored)
+        " text" ~
+        "\x1b[22m\x1b[22m"  // dim OFF, bold OFF
+    );
+}
+
+/// Style block immediately after an escaped brace.
+@("styled.styleAfterEscapedBrace")
+@safe unittest
+{
+    assert(styledText(i"#{{red text}") == "{\x1b[31mtext\x1b[39m");
+}
+
+/// Escaped brace immediately after a styled block.
+@("styled.escapedBraceAfterStyle")
+@safe unittest
+{
+    assert(styledText(i"{red text}#}") == "\x1b[31mtext\x1b[39m}");
+}
+
+/// Deeply nested with interleaved text at each level.
+@("styled.deepNestingInterleavedText")
+@safe unittest
+{
+    auto result = styledText(i"{bold a{italic b{underline c}d}e}");
+    assert(result ==
+        "\x1b[1m" ~      // bold ON
+        "a" ~
+        "\x1b[3m" ~      // italic ON
+        "b" ~
+        "\x1b[4m" ~      // underline ON
+        "c" ~
+        "\x1b[24m" ~     // underline OFF
+        "d" ~
+        "\x1b[23m" ~     // italic OFF
+        "e" ~
+        "\x1b[22m"       // bold OFF
+    );
+}
+
+/// Bright foreground colors produce the correct escape codes (90-97).
+@("styled.brightForegroundColors")
+@safe unittest
+{
+    assert(styledText(i"{brightRed text}") == "\x1b[91mtext\x1b[39m");
+    assert(styledText(i"{brightGreen text}") == "\x1b[92mtext\x1b[39m");
+    assert(styledText(i"{brightCyan text}") == "\x1b[96mtext\x1b[39m");
+}
+
+/// Bright background colors produce the correct escape codes (100-107).
+@("styled.brightBackgroundColors")
+@safe unittest
+{
+    assert(styledText(i"{bgBrightRed text}") == "\x1b[101mtext\x1b[49m");
+    assert(styledText(i"{bgBrightBlue text}") == "\x1b[104mtext\x1b[49m");
+}
+
+/// Negation of a background color restores the default background.
+@("styled.negateBackgroundColor")
+@safe unittest
+{
+    auto result = styledText(i"{bgRed outer {~bgRed inner} outer}");
+    assert(result ==
+        "\x1b[41m" ~   // bgRed ON
+        "outer " ~
+        "\x1b[49m" ~   // bgRed OFF (negated, close code 49)
+        "inner" ~
+        "\x1b[41m" ~   // bgRed ON (restored)
+        " outer" ~
+        "\x1b[49m"     // bgRed OFF
+    );
+}
+
+/// Only-negation spec (no positive styles) in a root block.
+@("styled.negationOnlyAtRoot")
+@safe unittest
+{
+    // ~bold at root has nothing to negate — content passes through unstyled
+    assert(styledText(i"{~bold text}") == "text");
+}
+
+/// Chained negations: remove multiple inherited styles at once.
+@("styled.chainedNegation")
+@safe unittest
+{
+    auto result = styledText(
+        i"{bold.italic.underline outer {~bold.~italic.~underline plain} outer}"
+    );
+    assert(result ==
+        "\x1b[1m\x1b[3m\x1b[4m" ~   // bold, italic, underline ON
+        "outer " ~
+        "\x1b[24m\x1b[23m\x1b[22m" ~ // underline OFF, italic OFF, bold OFF
+        "plain" ~
+        "\x1b[1m\x1b[3m\x1b[4m" ~   // bold, italic, underline ON (restored)
+        " outer" ~
+        "\x1b[24m\x1b[23m\x1b[22m"  // underline OFF, italic OFF, bold OFF
+    );
 }


### PR DESCRIPTION
## Summary

Refactors `styled_template` and `text_writers` modules for improved code quality, then adds a new `logger` module that leverages the IES-based `writeStyled` API. Also enhances `run_md_examples.d` with wildcard pattern support and glob-based CI integration.

### Changes

**styled_template fixes & cleanup** (`styled_template.d`)
- Fix push/pop desync (stack corruption on nesting overflow) and empty style block handling
- Reorder module layout per style guide: public API first, then implementation
- Improve code quality: `@safe` attributes, expression-based contracts, named constants (`maxStylesPerBlock`, `maxNestingDepth`)
- Change brace escape syntax from `{{`/`}}` to `#{`/`#}` — avoids ambiguity with nested closing braces and D source double-escaping
- Add comprehensive edge-case tests: text attributes, background colors, fg+bg combo, unknown styles, duplicate inheritance, max nesting depth, overflow nesting, max styles per block, shared close codes, chained negation, adjacent blocks, dot-separator edge cases

**text_writers enhancements** (`text_writers.d`)
- Add `@nogc` conversion traits (`hasNogcOutputRangeToString`, `hasNogcSinkToString`, `hasNogcStringCast`, etc.)
- Add generic `writeValue` dispatcher with best-effort `@nogc` support (bool → char → integral → float → string → output-range toString → sink toString → GC fallback)
- Add `writeEnumMemberName`: `@nogc` enum-to-string via static foreach
- Add `isLeafValue` canonical trait for non-recursive leaf types
- Add `writeStyledValue`: DbI-hooked leaf writer with optional styling, escaping, and enum rendering

**prettyprint refactor** (`prettyprint.d`)
- Unify leaf printing via hooked `writeStyledValue` from `text_writers.d`
- Replace 5 duplicated type dispatch functions (`coloredWriteNogc`, `coloredWriteEscaped`, `coloredWriteGC`, `coloredWrite`, `isNogcPrettyPrintable`) with a single `PrettyLeafHook` struct (~130 lines removed)
- Replace `formattedWrite` for truncation markers with `@nogc` `writeInteger`

**logger module** (new: `logger.d`)
- Add `DeltaTimeLogger` — a `std.logger.Logger` subclass with wall-clock time, Δt since start, and Δtᵢ since previous entry
- Uses `writeStyled` IES syntax for declarative ANSI styling (`{gray ...}`, `{yellow ...}`, `{bold.red ...}`)
- Add compile-time `colored` parameter to `writeStyled`: when false, style markup is parsed and stripped but no ANSI escape sequences are emitted
- Includes `initLogger` helper and `@nogc`-compatible duration/time formatting utilities

**Documentation**
- Add `libs/core-cli/examples/logger.d` demonstrating `DeltaTimeLogger`
- Add Logger section to README with usage example and expected output
- Update `docs/overview.md` with logger docs, fixed escape syntax, and new API entries
- Update AGENTS.md file tree with new modules

**run_md_examples enhancements** (`scripts/run_md_examples.d`)
- Add `<!-- md-example-expected -->` directive with `{{_}}` wildcard patterns for verifying dynamic output (timestamps, paths)
- Add `--glob` CLI option for git-aware markdown file discovery
- Add outer-fence tracking to skip nested code blocks inside markdown fences
- Integrate `--verify --glob "*.md"` as a CI step after tests