### PR TITLE
docs: Add tree-view case study and TUI library research

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -335,8 +335,20 @@ export default defineConfig({
                 link: "/research/tui-libraries/imtui",
               },
               {
+                text: "Snacks.nvim (Lua)",
+                link: "/research/tui-libraries/snacks-nvim",
+              },
+              {
+                text: "broot (Rust)",
+                link: "/research/tui-libraries/broot",
+              },
+              {
                 text: "Comparison",
                 link: "/research/tui-libraries/comparison",
+              },
+              {
+                text: "Tree-View Case Study",
+                link: "/research/tui-libraries/tree-view-case-study",
               },
             ],
           },

--- a/docs/research/tui-libraries/broot.md
+++ b/docs/research/tui-libraries/broot.md
@@ -576,3 +576,15 @@ The `Dam` parameter allows builds to be interrupted when the user types a new ch
 ### Key Takeaway
 
 Broot demonstrates that a tree view does not need to be a tree data structure. A flat array with depth annotations, parent references, and precomputed rendering hints is simpler, faster, and more flexible. The "tree as search result" paradigm -- where the tree structure is a function of the active filter -- is a powerful alternative to traditional expand/collapse navigation.
+
+---
+
+## See Also
+
+- [Tree-View Case Study][tree-view-case-study] — Comparative analysis of tree implementations across 13 libraries
+- [Ratatui][ratatui] — Rust TUI with a clean tree-widget architecture
+- [Comparison][comparison] — Cross-library design synthesis
+
+[tree-view-case-study]: tree-view-case-study.md
+[ratatui]: ratatui.md
+[comparison]: comparison.md

--- a/docs/research/tui-libraries/broot.md
+++ b/docs/research/tui-libraries/broot.md
@@ -1,0 +1,578 @@
+# Broot (Rust)
+
+A terminal tree navigator and file manager that treats the entire directory tree as a searchable, filterable entity. Its key innovation is the "tree as search result" paradigm: instead of navigating a dumb expand/collapse hierarchy, users type a fuzzy pattern and the tree reshapes itself to show only matching paths, with all necessary ancestor directories kept visible for context.
+
+| Field      | Value                                                        |
+| ---------- | ------------------------------------------------------------ |
+| Language   | Rust                                                         |
+| Repository | <https://github.com/Canop/broot>                             |
+| License    | MIT                                                          |
+| Author     | Denys Seguret (Canop)                                        |
+| Paradigm   | Flat-array tree with BFS construction, score-based filtering |
+
+---
+
+## Overview
+
+Broot is not a TUI framework -- it is a standalone terminal application. However, its internal architecture for representing, building, filtering, and rendering file trees is one of the most sophisticated in any terminal tool. It is studied here because it solves the exact problem Sparkles' tree view needs to address: displaying a potentially huge tree in a terminal viewport with real-time fuzzy filtering.
+
+The central architectural decision is a **flat array of lines** (`Vec<TreeLine>`) rather than a recursive tree structure. The tree is _rebuilt from the filesystem_ on every filter change, using a BFS traversal that scores, prunes, and flattens in a single pass. This eliminates the complexity of maintaining parent-child pointers, simplifies scrolling to array indexing, and makes the filtered tree a first-class data structure rather than a view over a hidden full tree.
+
+---
+
+## Architecture Overview
+
+```
+                                 +------------------+
+  User Input (pattern) -------->| TreeBuilder (BFS) |
+                                 +------------------+
+                                        |
+                      constructs BLines (intermediate arena)
+                                        |
+                                        v
+                                 +------------------+
+                                 |   Vec<TreeLine>   |  <-- flat array
+                                 +------------------+
+                                        |
+                          scroll offset + viewport height
+                                        |
+                                        v
+                                 +------------------+
+                                 | DisplayableTree  |  <-- renders to terminal
+                                 +------------------+
+```
+
+The architecture has three layers:
+
+1. **TreeBuilder** -- BFS traversal that reads the filesystem, applies pattern matching, scores candidates, and produces a flat `Vec<TreeLine>`.
+2. **Tree** -- owns the flat line array plus viewport state (scroll offset, selection index). Provides navigation, refresh, and selection management.
+3. **DisplayableTree** -- renders the visible portion of the flat array to the terminal, drawing branch connectors, highlighting matches, and showing a scrollbar.
+
+### Dual-Tree State in BrowserState
+
+The `BrowserState` (the main application state) maintains **two trees**:
+
+- **`tree`** -- the base (unfiltered) tree.
+- **`filtered_tree`** -- an optional second tree built when a search pattern is active.
+
+The `displayed_tree()` accessor returns `filtered_tree` when present, `tree` otherwise. This means filtering does not mutate the base tree; instead, a fresh tree is built from the filesystem with the pattern applied. Clearing the filter discards the filtered tree and returns to the base tree.
+
+---
+
+## Data Model
+
+### TreeLine -- The Flat Node
+
+Each line in the flat array is a `TreeLine`:
+
+```rust
+struct TreeLine {
+    // --- Identity ---
+    id: TreeLineId,                     // unique ID (usize)
+    parent_id: Option<TreeLineId>,      // parent reference
+    depth: u16,                         // nesting level
+
+    // --- Path ---
+    path: PathBuf,                      // full filesystem path
+    subpath: String,                    // relative displayable path
+    name: String,                       // display name (chars may be stripped)
+
+    // --- Classification ---
+    line_type: TreeLineType,            // File | Dir | SymLink | BrokenSymLink | Pruning
+    icon: Option<char>,                 // optional icon character
+
+    // --- Filtering & Scoring ---
+    score: i32,                         // 0 if no pattern active
+    direct_match: bool,                 // whether this line directly matched
+    has_error: bool,                    // access/read error
+
+    // --- Hierarchy ---
+    nb_kept_children: usize,            // filtered child count
+    unlisted: usize,                    // hidden children (Dir) or siblings (Pruning)
+
+    // --- Rendering ---
+    left_branches: Box<[bool]>,         // depth-sized array for tree connector drawing
+
+    // --- Extended Data ---
+    metadata: fs::Metadata,             // filesystem attributes
+    sum: Option<FileSum>,               // size aggregation (lazy)
+    git_status: Option<LineGitStatus>,  // version control status
+}
+```
+
+Key design points:
+
+- **No child pointers.** The only structural link is `parent_id`. Children are determined by sequential position in the flat array combined with depth values.
+- **`left_branches`** is a precomputed rendering hint: for each depth level, it records whether a vertical branch connector should be drawn (i.e., whether an ancestor at that depth has more siblings below).
+- **`unlisted`** supports the `Pruning` pseudo-line: a synthetic line that says "N more items not shown", collapsing invisible children into a count.
+- **`score`** is 0 when there is no active pattern, and positive when the line matched. Higher scores indicate better matches.
+
+### TreeLineType
+
+```rust
+enum TreeLineType {
+    File,
+    Dir,
+    SymLink { direct_target: String, final_is_dir: bool, final_target: PathBuf },
+    BrokenSymLink(String),
+    Pruning,        // synthetic "N unlisted" collapse marker
+}
+```
+
+The `Pruning` variant is architecturally significant. It is not a real filesystem entry -- it is a placeholder inserted during tree construction to represent children that were excluded by scoring or capacity limits. This keeps the user informed about what was pruned without wasting screen space.
+
+### TreeOptions -- Configuration
+
+```rust
+struct TreeOptions {
+    // Display
+    show_hidden: bool,
+    show_counts: bool,
+    show_dates: bool,
+    show_sizes: bool,
+    show_permissions: bool,
+    show_tree: bool,                    // tree vs flat listing
+    show_git_file_info: bool,
+    show_selection_mark: bool,
+    show_device_id: bool,
+    show_root_fs: bool,
+
+    // Filtering
+    only_folders: bool,
+    respect_git_ignore: bool,
+    filter_by_git_status: bool,
+    pattern: InputPattern,              // active search pattern
+    trim_root: bool,                    // cut out direct children of root
+
+    // Structure
+    max_depth: Option<u16>,             // recursion limit
+    sort: Sort,                         // sorting strategy
+    cols_order: ColsOrder,              // column display order
+    date_time_format: String,
+}
+```
+
+### Sort and Deep Display
+
+```rust
+enum Sort {
+    None,               // alphabetical, multi-level allowed
+    Count,              // by item count, single-level only
+    Date,               // by modification date, single-level only
+    Size,               // by file/directory size, single-level only
+    TypeDirsFirst,      // directories before files, multi-level allowed
+    TypeDirsLast,       // files before directories, multi-level allowed
+}
+```
+
+A critical design insight: **quantitative sorts (Count, Date, Size) flatten the tree to a single level.** The `prevent_deep_display()` method returns `true` for these sorts, because comparing sizes or dates across different nesting depths is meaningless. Only `None`, `TypeDirsFirst`, and `TypeDirsLast` preserve hierarchical display.
+
+---
+
+## Tree Building -- The BFS Algorithm
+
+Tree construction is the core of broot's architecture. It is handled by `TreeBuilder`, which performs a **breadth-first search** of the filesystem, scoring candidates against the active pattern, and producing a flat `Vec<TreeLine>`.
+
+### Intermediate Representation: BLine
+
+During construction, the builder works with `BLine` objects stored in an arena (`id_arena`):
+
+```rust
+struct BLine {
+    parent_id: Option<BId>,
+    path: PathBuf,
+    depth: u16,
+    file_type: fs::FileType,
+
+    // Build state
+    children: Vec<BId>,                 // sorted, filtered child references
+    next_child_idx: usize,              // iteration cursor
+
+    // Filtering
+    has_match: bool,                    // matches pattern
+    direct_match: bool,                 // directly matched (vs ancestor match)
+    score: i32,                         // match quality score
+    nb_kept_children: usize,            // surviving children after trim
+
+    // Context
+    has_error: bool,
+    git_ignore_chain: GitIgnoreChain,
+    special_handling: SpecialHandling,
+}
+```
+
+`BLine` differs from `TreeLine` in two ways:
+
+1. It has **child pointers** (`children: Vec<BId>`) because the builder needs to traverse the hierarchy.
+2. It stores **build-time state** (`next_child_idx`, `git_ignore_chain`) that is discarded after construction.
+
+### The Build Algorithm
+
+The `gather_lines` method implements BFS with early termination:
+
+```
+1. Initialize: push root directory into open_dirs queue
+2. While open_dirs is not empty:
+   a. Pop a directory from open_dirs
+   b. Read its entries via fs::read_dir
+   c. For each entry:
+      - Apply filters: hidden files, git-ignore, type (only_folders), symlink validation
+      - If pattern is active: compute score = pattern.score_of(candidate)
+      - If score > 0 or entry is a directory (kept for hierarchy): create BLine
+      - If entry is a directory: add to next_level_dirs
+   d. When current level is exhausted ("this depth is finished, we must go deeper"):
+      - Move next_level_dirs into open_dirs
+3. Stop when enough lines are gathered to fill the screen
+```
+
+### Early Termination Strategy
+
+Broot does **not** read the entire filesystem. It stops when it has enough lines:
+
+- **Without a pattern**: stops at `targeted_size` lines (approximately the screen height).
+- **With a pattern**: gathers `10 * targeted_size` lines before stopping, to allow better ranking among candidates.
+
+The `Dam` parameter enables **cancellation**: when the user types a new character, the current build is interrupted and a new build starts. This provides responsive real-time filtering even on large trees.
+
+### Depth Limits
+
+Enforced during BFS: `if self.options.max_depth.map_or(false, |max| child.depth > max)` -- children beyond the maximum depth are skipped entirely.
+
+### Scoring Formula
+
+During BFS, each candidate receives a score:
+
+```
+base_score = 10000 - depth
+if pattern matches:
+    score += pattern_score + 10
+    direct_match = true
+```
+
+Depth penalty ensures that shallower matches rank higher. The pattern score comes from the fuzzy matcher (see below). The `+10` bonus distinguishes direct matches from ancestor-only matches.
+
+### Trimming with SortableBId
+
+When more lines are gathered than can be displayed, `trim_excess` uses a **min-heap** of `SortableBId`:
+
+```rust
+struct SortableBId {
+    id: BId,
+    score: i32,
+}
+
+// Ord is INVERTED: lowest score at heap top
+impl Ord for SortableBId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.score.cmp(&self.score)  // reversed!
+    }
+}
+```
+
+The min-heap keeps the lowest-scoring nodes at the top. When the heap exceeds capacity, the lowest-scoring node is popped and discarded. This ensures the final tree contains the highest-scoring matches.
+
+### Conversion: BLine to TreeLine
+
+The `take_as_tree` method iterates the arena, converting surviving `BLine` entries into `TreeLine` objects:
+
+1. Only BLines with `has_match == true` (or necessary ancestors) are included.
+2. `left_branches` is computed by scanning ancestor chain.
+3. Pruning lines are inserted for directories with `unlisted > 0`.
+4. The result is `Vec<TreeLine>` -- the flat array owned by `Tree`.
+
+---
+
+## Pattern System -- Fuzzy Search
+
+Broot's pattern system is its defining feature. It supports multiple match modes composed with boolean operators.
+
+### Pattern Types
+
+| Type                  | Description                         |
+| --------------------- | ----------------------------------- |
+| `FuzzyPattern`        | Subsequence match with scoring      |
+| `ExactPattern`        | Literal substring match             |
+| `RegexPattern`        | Regular expression match            |
+| `ContentExactPattern` | Search inside file contents (exact) |
+| `ContentRegexPattern` | Search inside file contents (regex) |
+| `CompositePattern`    | Boolean combination of patterns     |
+
+### Fuzzy Matching Algorithm
+
+The `FuzzyPattern` implements subsequence matching with a sophisticated scoring system:
+
+**Match definition**: All pattern characters must appear in order in the candidate string, but need not be consecutive. Gaps ("holes") between matched characters are allowed but penalized.
+
+**Scoring constants**:
+
+| Constant           | Value    | Description                               |
+| ------------------ | -------- | ----------------------------------------- |
+| `BONUS_MATCH`      | 50,000   | Base bonus for any match                  |
+| `BONUS_EXACT`      | 1,000    | Exact length match (pattern == candidate) |
+| `BONUS_START`      | 10       | Pattern starts at position 0              |
+| `BONUS_START_WORD` | 5        | Pattern starts after `_`, ` `, `-`        |
+| Candidate length   | -1/char  | Penalty for long candidates               |
+| Match span         | -10/char | Penalty for spread-out matches            |
+| Holes              | -30/hole | Penalty for gaps between matches          |
+| Isolated chars     | -15/char | Penalty for single matched chars          |
+
+**Unicode and case handling**: Input is normalized through `secular::lower_lay_char`, providing case-insensitive and diacritic-insensitive matching. This allows "reveille" to match "REVEILLE" and handles Cyrillic case variants.
+
+**Tight match optimization**: The `tight_match_from_index` function finds the subsequence match with the smallest span. It limits holes based on pattern length (e.g., a 4-character pattern allows at most 2 holes).
+
+**Multi-match selection**: When multiple valid matches exist, the algorithm selects the one with the highest score. A perfect match (exact length + word boundary start) returns immediately without further searching.
+
+### Composite Patterns (Boolean Operators)
+
+`CompositePattern` uses a `BeTree<PatternOperator, Pattern>` expression tree:
+
+- **AND**: Both operands must match. Scores are summed. Short-circuits on `None`.
+- **OR**: Either operand suffices. Scores are summed if both match.
+- **NOT**: Inverts matching. Returns score 1 if the pattern does NOT match, `None` if it does.
+
+This allows queries like: fuzzy match on name AND exact match on extension AND NOT matching a gitignore pattern.
+
+### Pattern Interaction with Tree Building
+
+The pattern is evaluated during BFS, not after. This is critical for performance:
+
+1. During `gather_lines`, each filesystem entry is scored against the active pattern.
+2. Entries with `score == 0` (no match) are still included if they are directories -- because their children might match.
+3. After BFS completes, directories whose subtrees produced no matches are pruned.
+4. The remaining lines are sorted by score for display.
+
+This means the tree is **built filtered**. There is no separate "filter" pass over a pre-built tree. The tree structure itself is shaped by the search pattern.
+
+---
+
+## Tree State and Expand/Collapse
+
+### No Traditional Expand/Collapse
+
+Broot does not have a traditional expand/collapse model. Instead:
+
+- **With no pattern**: the tree is displayed to the depth that fits the screen, with `Pruning` lines showing where content was truncated.
+- **With a pattern**: the tree reshapes to show only matching paths and their ancestors. Deeper directories are automatically "expanded" if they contain matches.
+- **Explicit depth control**: users can increase or decrease `max_depth` to see more or fewer levels.
+
+### Pruning Lines
+
+When a directory has children that are not shown (either due to screen space limits or filtering), a `Pruning` line is inserted:
+
+```
+├── src/
+│   ├── main.rs
+│   └── 47 unlisted
+```
+
+The `unlisted` count on the Pruning line tells the user how many entries are hidden. This replaces the expand/collapse toggle found in traditional tree widgets.
+
+### Selection State
+
+Selection is stored as a simple index into the flat array:
+
+```rust
+struct Tree {
+    selection: usize,   // index into self.lines
+    // ...
+}
+```
+
+Navigation methods (`move_selection`, `try_select_path`, `try_select_first`, etc.) manipulate this index. The Pruning lines are **not selectable** -- `is_selectable()` returns false for them, so navigation skips over them.
+
+### State Preservation Across Rebuilds
+
+When the tree is rebuilt (due to filter change, refresh, or navigation), broot attempts to preserve the user's context:
+
+- `try_select_path()` searches the new tree for the previously selected path.
+- `try_select_best_match()` selects the highest-scoring match in the new tree.
+- `make_selection_visible()` adjusts scroll to keep selection in viewport.
+
+---
+
+## Scrolling and Viewport
+
+### Scroll Model
+
+Scrolling is handled by a simple offset into the flat array:
+
+```rust
+struct Tree {
+    scroll: usize,     // number of hidden lines above viewport
+    // ...
+}
+```
+
+The `DisplayableTree` renderer iterates from `scroll` to `scroll + viewport_height`, drawing one `TreeLine` per terminal row.
+
+### Rendering Loop
+
+```rust
+for y in 1..self.area.height {
+    let mut line_index = y as usize;
+    if line_index > 0 {
+        line_index += tree.scroll;
+    }
+    // render tree.lines[line_index]
+}
+```
+
+This is not virtual scrolling in the sense of lazy loading -- all lines exist in memory. But since broot's BFS stops early (at `targeted_size`), the total line count is bounded to roughly the screen height (or 10x screen height when filtering). The flat array is small enough that no virtualization is needed.
+
+### Scrollbar
+
+When `in_app` mode is active, `termimad::compute_scrollbar()` calculates the thumb position based on `scroll`, `total_lines`, and `viewport_height`. The scrollbar thumb character `"▐"` is drawn at the rightmost column.
+
+### Selection-Driven Scrolling
+
+`make_selection_visible()` adjusts `scroll` to ensure the selected line is within the viewport. Navigation methods call this automatically after changing selection.
+
+---
+
+## Branch Connector Drawing
+
+The `left_branches: Box<[bool]>` field on each `TreeLine` is a depth-sized boolean array. For each depth level, it records whether a vertical branch connector (`│`) should be drawn at that column.
+
+This is computed during `after_lines_changed()` by scanning the flat array:
+
+1. For each line, walk up the ancestor chain.
+2. At each depth, check if the ancestor has more siblings below it in the flat array.
+3. If yes, `left_branches[depth] = true` (draw `│`); if no, `left_branches[depth] = false` (draw space).
+
+The renderer uses this to draw the tree structure:
+
+```
+├── src/          left_branches = [true]
+│   ├── main.rs   left_branches = [true, true]
+│   └── lib.rs    left_branches = [true, false]
+└── Cargo.toml    left_branches = [false]
+```
+
+Unicode box-drawing characters:
+
+- `├──` -- entry with siblings below
+- `└──` -- last entry at this depth
+- `│  ` -- vertical connector for ancestor with siblings below
+
+---
+
+## Git Integration
+
+Git status is computed asynchronously (`ComputationResult<TreeGitStatus>`) and stored at the tree level. Individual lines carry `Option<LineGitStatus>` for per-file status display.
+
+The `filter_by_git_status` option narrows the tree to only files with non-null git status (modified, staged, etc.), turning broot into a git-aware file selector.
+
+---
+
+## Column-Based Rendering
+
+The `DisplayableTree` renderer processes columns in a configurable order:
+
+| Column     | Content                        |
+| ---------- | ------------------------------ |
+| Mark       | Selection indicator            |
+| Git        | Git status character           |
+| Branch     | Tree connectors                |
+| DeviceId   | Filesystem device              |
+| Permission | Unix rwx permissions           |
+| Date       | Modification timestamp         |
+| Size       | File/directory size            |
+| Count      | Item count                     |
+| Name       | Filename with match highlights |
+
+The `visible_cols` vector is filtered based on `TreeOptions` (e.g., `show_sizes`, `show_dates`). Each column's `void_len` determines spacing between columns.
+
+Match highlighting is applied during Name column rendering:
+
+1. The path is split into parent directory and filename components.
+2. `char_match_style` is applied to characters that matched the fuzzy pattern.
+3. Long paths are truncated with ellipsis.
+
+---
+
+## Build Report
+
+After tree construction, `BuildReport` records filtering statistics:
+
+```rust
+struct BuildReport {
+    gitignored_count: usize,    // files excluded by .gitignore
+    hidden_count: usize,        // files excluded as hidden (dot-prefix)
+    error_count: usize,         // files excluded due to access errors
+}
+```
+
+Each file is counted in at most one category. This allows broot to display a summary like "12 gitignored, 3 hidden" in the status bar.
+
+---
+
+## Key Architectural Insights
+
+### 1. Flat Array Over Recursive Tree
+
+Broot's most important design decision is representing the tree as `Vec<TreeLine>` rather than a recursive structure. This provides:
+
+- **O(1) selection by index**: no tree traversal needed.
+- **Trivial scrolling**: viewport is a slice of the array.
+- **Simple rendering**: iterate the array, draw one line per row.
+- **No pointer management**: parent linkage is optional metadata, not a structural requirement.
+
+The cost is that tree operations like "find all children of node X" require a linear scan. But since the array is small (bounded to ~screen height), this is fast in practice.
+
+### 2. Tree as Search Result
+
+Traditional tree views have a fixed structure that users navigate with expand/collapse. Broot inverts this: the tree structure is a **function of the search pattern**. Each keystroke triggers a fresh BFS that produces a new flat array showing only relevant paths.
+
+This eliminates the "lost in deep hierarchy" problem. Users never need to manually expand directories to find a file -- they type part of its name and the tree reshapes to show it.
+
+### 3. Build-Time Filtering
+
+Filtering happens during tree construction, not as a post-processing step. The BFS skips non-matching entries (except directories needed for hierarchy), scores matches, and trims excess lines -- all in one pass. This is more efficient than building a full tree and then filtering it.
+
+### 4. Pruning as First-Class Concept
+
+The `Pruning` line type is a smart design. Rather than silently hiding content, broot shows how much was hidden. This keeps the user informed and provides a visual cue that more content exists. The Pruning line is not selectable, so it doesn't interfere with navigation.
+
+### 5. Dual-Tree State
+
+Keeping the base tree and filtered tree as separate objects avoids mutation and makes it trivial to restore the unfiltered view. The `displayed_tree()` accessor abstracts this behind a simple API.
+
+### 6. Early Termination with Score-Based Ranking
+
+BFS stops when enough lines are gathered, and excess lines are pruned via a min-heap. This ensures:
+
+- Bounded memory usage regardless of filesystem size.
+- Bounded build time regardless of directory depth.
+- Best matches are kept (highest-scoring lines survive the heap).
+
+### 7. Cancellable Builds
+
+The `Dam` parameter allows builds to be interrupted when the user types a new character. This provides responsive real-time filtering: each keystroke cancels the previous build and starts a new one.
+
+---
+
+## Relevance for Sparkles
+
+### Directly Applicable Patterns
+
+- **Flat array representation**: The `Vec<TreeLine>` model maps directly to a D `TreeLine[]` or `SmallBuffer!(TreeLine, N)`. This is the simplest correct representation for a scrollable, selectable tree view.
+
+- **Build-time filtering**: Rather than building a full tree and hiding non-matching nodes, build a filtered tree from scratch. This avoids the complexity of maintaining visibility state and parent-chain invariants.
+
+- **Pruning lines**: Inserting synthetic "N unlisted" lines is a user-friendly way to handle truncation. Sparkles should adopt this pattern.
+
+- **Score-based ranking**: The `10000 - depth + pattern_score` formula is a simple but effective way to rank matches. Shallower results are preferred, with pattern quality as a tiebreaker.
+
+- **Precomputed branch connectors**: The `left_branches` array per line eliminates the need to look up ancestors during rendering. This is especially valuable in `@nogc` D code where dynamic lookups are constrained.
+
+### Design Differences to Consider
+
+- **Broot rebuilds from filesystem on every keystroke.** For Sparkles, the data source may not be the filesystem, and rebuilding from scratch may not be appropriate. A persistent tree with incremental filtering may be needed.
+
+- **Broot's flat array is ephemeral.** It is rebuilt frequently and never persisted. Sparkles may need a stable tree identity across rebuilds (e.g., for animation or state preservation).
+
+- **Broot has no expand/collapse toggle.** Users control depth via max_depth, not per-node toggles. A Sparkles tree view may need both: broot-style pattern filtering AND traditional per-node expand/collapse for manual exploration.
+
+### Key Takeaway
+
+Broot demonstrates that a tree view does not need to be a tree data structure. A flat array with depth annotations, parent references, and precomputed rendering hints is simpler, faster, and more flexible. The "tree as search result" paradigm -- where the tree structure is a function of the active filter -- is a powerful alternative to traditional expand/collapse navigation.

--- a/docs/research/tui-libraries/comparison.md
+++ b/docs/research/tui-libraries/comparison.md
@@ -1,6 +1,8 @@
 # TUI Library Comparison & Design Recommendations
 
-A cross-library synthesis of thirteen TUI frameworks -- Ratatui (Rust), Ink (JavaScript), Textual (Python), Bubble Tea (Go), Brick (Haskell), Notcurses (C), FTXUI (C++), Cursive (Rust), Mosaic (Kotlin), Nottui (OCaml), libvaxis (Zig), tview (Go), and ImTui (C++) -- with concrete design recommendations for Sparkles.
+A cross-library synthesis of thirteen TUI frameworks -- [Ratatui][ratatui] (Rust), [Ink][ink] (JavaScript), [Textual][textual] (Python), [Bubble Tea][bubbletea] (Go), [Brick][brick] (Haskell), [Notcurses][notcurses] (C), [FTXUI][ftxui] (C++), [Cursive][cursive] (Rust), [Mosaic][mosaic] (Kotlin), [Nottui][nottui] (OCaml), [libvaxis][libvaxis] (Zig), [tview][tview] (Go), and [ImTui][imtui] (C++) -- with concrete design recommendations for Sparkles.
+
+For specialized analysis of tree-view components across libraries, see the [Tree-View Case Study][tree-view-case-study].
 
 ---
 
@@ -1033,3 +1035,22 @@ Rationale:
 - **Dependency cost.** Notcurses has a non-trivial build chain. Building from scratch in D keeps the dependency graph minimal.
 
 - **Selective borrowing.** Specific innovations should be adopted: inline glyph cluster packing (via `SmallBuffer!(char, 8)`), packed cell representation, Kitty keyboard protocol support, and synchronized output. These can be implemented natively in D.
+
+---
+
+## References
+
+[ratatui]: ratatui.md
+[ink]: ink.md
+[textual]: textual.md
+[bubbletea]: bubbletea.md
+[brick]: brick.md
+[notcurses]: notcurses.md
+[ftxui]: ftxui.md
+[cursive]: cursive.md
+[mosaic]: mosaic.md
+[nottui]: nottui.md
+[libvaxis]: libvaxis.md
+[tview]: tview.md
+[imtui]: imtui.md
+[tree-view-case-study]: tree-view-case-study.md

--- a/docs/research/tui-libraries/index.md
+++ b/docs/research/tui-libraries/index.md
@@ -167,21 +167,43 @@ A breadth-first survey of terminal user interface (TUI) libraries across program
 
 The following libraries are analyzed in depth:
 
-- **[Ratatui](ratatui.md)** — Rust immediate-mode TUI with constraint-based layout
-- **[Ink](ink.md)** — React for the terminal (JavaScript)
-- **[Textual](textual.md)** — CSS-styled retained-mode framework (Python)
-- **[Bubble Tea](bubbletea.md)** — Elm Architecture for terminals (Go)
-- **[Brick](brick.md)** — Pure functional declarative TUI (Haskell)
-- **[Notcurses](notcurses.md)** — Modern ncurses successor (C)
-- **[FTXUI](ftxui.md)** — Functional DOM-like components with flexbox layout (C++)
-- **[Cursive](cursive.md)** — Retained-mode callback-based view hierarchy (Rust)
-- **[Mosaic](mosaic.md)** — Jetpack Compose runtime for terminals (Kotlin)
-- **[Nottui](nottui.md)** — Incremental computation / functional reactive TUI (OCaml)
-- **[libvaxis](libvaxis.md)** — comptime-powered, allocator-aware terminal library (Zig)
-- **[tview](tview.md)** — Retained widget tree with flex layout (Go)
-- **[ImTui](imtui.md)** — Dear ImGui paradigm adapted for terminals (C++)
-- **[Snacks.nvim](snacks-nvim.md)** — Neovim UI toolkit built on floating windows and layouts
+- **[Ratatui][ratatui]** — Rust immediate-mode TUI with constraint-based layout
+- **[Ink][ink]** — React for the terminal (JavaScript)
+- **[Textual][textual]** — CSS-styled retained-mode framework (Python)
+- **[Bubble Tea][bubbletea]** — Elm Architecture for terminals (Go)
+- **[Brick][brick]** — Pure functional declarative TUI (Haskell)
+- **[Notcurses][notcurses]** — Modern ncurses successor (C)
+- **[FTXUI][ftxui]** — Functional DOM-like components with flexbox layout (C++)
+- **[Cursive][cursive]** — Retained-mode callback-based view hierarchy (Rust)
+- **[Mosaic][mosaic]** — Jetpack Compose runtime for terminals (Kotlin)
+- **[Nottui][nottui]** — Incremental computation / functional reactive TUI (OCaml)
+- **[libvaxis][libvaxis]** — comptime-powered, allocator-aware terminal library (Zig)
+- **[tview][tview]** — Retained widget tree with flex layout (Go)
+- **[ImTui][imtui]** — Dear ImGui paradigm adapted for terminals (C++)
+- **[Snacks.nvim][snacks-nvim]** — Neovim UI toolkit built on floating windows and layouts
 
-See the **[Comparison](comparison.md)** for cross-library synthesis and design recommendations for Sparkles.
+## Comparative & Specialized Studies
 
-See the **[Tree-View Case Study](tree-view-case-study.md)** for a focused analysis of tree-view implementations across libraries.
+See the **[Comparison][comparison]** for cross-library synthesis and design recommendations for Sparkles.
+
+See the **[Tree-View Case Study][tree-view-case-study]** for a focused analysis of tree-view implementations across 13 libraries, including detailed studies of [snacks.nvim][snacks-nvim], [ratatui][ratatui], [Textual][textual], Rich (Python), [broot][broot], cursive_tree_view (Rust), and stlab::forest (C++).
+
+## References
+
+[ratatui]: ratatui.md
+[ink]: ink.md
+[textual]: textual.md
+[bubbletea]: bubbletea.md
+[brick]: brick.md
+[notcurses]: notcurses.md
+[ftxui]: ftxui.md
+[cursive]: cursive.md
+[mosaic]: mosaic.md
+[nottui]: nottui.md
+[libvaxis]: libvaxis.md
+[tview]: tview.md
+[imtui]: imtui.md
+[snacks-nvim]: snacks-nvim.md
+[broot]: broot.md
+[comparison]: comparison.md
+[tree-view-case-study]: tree-view-case-study.md

--- a/docs/research/tui-libraries/index.md
+++ b/docs/research/tui-libraries/index.md
@@ -34,6 +34,12 @@ A breadth-first survey of terminal user interface (TUI) libraries across program
 | **Terminal Kit**  | Hybrid              | Imperative + widgets | Mid-level   | Maintained   | [repo](https://github.com/cronvel/terminal-kit)   |
 | **Yoga (layout)** | N/A (layout engine) | Flexbox              | Low-level   | Active       | [repo](https://github.com/nicolo-ribaudo/yoga)    |
 
+## Neovim / Lua
+
+| Library                           | Rendering Model            | Architecture              | Abstraction | Status | Links                                                                                                      |
+| --------------------------------- | -------------------------- | ------------------------- | ----------- | ------ | ---------------------------------------------------------------------------------------------------------- |
+| **[Snacks.nvim](snacks-nvim.md)** | Retained (buffers/windows) | Event-driven plugin suite | High-level  | Active | [repo](https://github.com/folke/snacks.nvim) · [docs](https://github.com/folke/snacks.nvim/tree/main/docs) |
+
 ## Go
 
 | Library                        | Rendering Model | Architecture    | Abstraction | Status     | Links                                              |
@@ -174,5 +180,8 @@ The following libraries are analyzed in depth:
 - **[libvaxis](libvaxis.md)** — comptime-powered, allocator-aware terminal library (Zig)
 - **[tview](tview.md)** — Retained widget tree with flex layout (Go)
 - **[ImTui](imtui.md)** — Dear ImGui paradigm adapted for terminals (C++)
+- **[Snacks.nvim](snacks-nvim.md)** — Neovim UI toolkit built on floating windows and layouts
 
 See the **[Comparison](comparison.md)** for cross-library synthesis and design recommendations for Sparkles.
+
+See the **[Tree-View Case Study](tree-view-case-study.md)** for a focused analysis of tree-view implementations across libraries.

--- a/docs/research/tui-libraries/snacks-nvim.md
+++ b/docs/research/tui-libraries/snacks-nvim.md
@@ -590,3 +590,15 @@ The explorer's `snapshot()` / `changed()` pattern captures specific fields of a 
 ### Key Limitation
 
 Snacks relies entirely on Neovim's window system and cannot run outside the editor. Its abstractions are useful references, but Sparkles must implement equivalent primitives (surfaces, z-ordering, backdrop blending, event dispatch) directly against terminal escape sequences.
+
+---
+
+## See Also
+
+- [Tree-View Case Study][tree-view-case-study] — Detailed snacks.nvim explorer analysis and comparative study with 13 libraries
+- [Comparison][comparison] — Cross-library design synthesis and recommendations
+- [Ratatui][ratatui] — Alternative tree-view design with clean separation of data and state
+
+[tree-view-case-study]: tree-view-case-study.md
+[comparison]: comparison.md
+[ratatui]: ratatui.md

--- a/docs/research/tui-libraries/snacks-nvim.md
+++ b/docs/research/tui-libraries/snacks-nvim.md
@@ -1,0 +1,592 @@
+# Snacks.nvim (Neovim)
+
+A Neovim plugin suite that bundles UI primitives (floating windows, layouts, pickers, notifications) into a cohesive toolkit for building terminal UIs inside the editor.
+
+| Field        | Value                                                                 |
+| ------------ | --------------------------------------------------------------------- |
+| Language     | Lua (Neovim plugin)                                                   |
+| Repository   | <https://github.com/folke/snacks.nvim>                                |
+| License      | Apache 2.0                                                            |
+| Author       | Folke Lemaitre                                                        |
+| Latest       | 2.30.0                                                                |
+| Requirements | Neovim >= 0.9.4                                                       |
+| Paradigm     | Event-driven, editor-embedded UI toolkit built on buffers and windows |
+
+---
+
+## Overview
+
+Snacks.nvim is not a standalone TUI framework. Instead, it treats Neovim itself as the rendering engine, using buffers, floating windows, splits, highlight groups, and keymaps to construct UI surfaces. The project ships as a collection of small plugins, but the UI-focused modules (window management, layouts, pickers, notifications, input prompts, dashboards, file explorer) effectively form a reusable toolkit for building interactive interfaces inside the editor.
+
+The value of Snacks for TUI research is its **editor-embedded** model: it demonstrates how a sophisticated UI can be layered on top of Neovim's retained window system rather than a raw terminal grid. This is a growing pattern in the Neovim ecosystem, where plugins build complex UIs without owning the terminal loop directly.
+
+### Module inventory
+
+Snacks ships 28+ modules. Grouped by function:
+
+| Category      | Modules                                                                         |
+| ------------- | ------------------------------------------------------------------------------- |
+| **Core UI**   | `win`, `layout`, `animate`, `scroll`, `statuscolumn`, `indent`, `scope`, `dim`  |
+| **Surfaces**  | `picker`, `explorer`, `notifier`, `dashboard`, `input`, `scratch`, `terminal`   |
+| **Utilities** | `git`, `gitbrowse`, `debug`, `toggle`, `rename`, `bufdelete`, `words`, `keymap` |
+| **Visual**    | `image`, `zen`, `dim`, `indent`                                                 |
+| **Meta**      | `health`, `compat`, `bigfile`, `quickfile`                                      |
+
+The multi-file modules (`picker/`, `explorer/`, `animate/`, `image/`, `profiler/`, `gh/`, `util/`) are internally structured as packages with subdirectories.
+
+---
+
+## Architecture
+
+### Lazy Loading via Metatable `__index`
+
+The top-level `Snacks` global is a table with a `__index` metamethod that `require()`s modules on first access:
+
+```lua
+setmetatable(M, {
+  __index = function(t, k)
+    t[k] = require("snacks." .. k)
+    return rawget(t, k)
+  end,
+})
+_G.Snacks = M
+```
+
+This means `Snacks.win`, `Snacks.picker`, `Snacks.notifier`, etc. are loaded lazily -- zero cost until touched. The same pattern recurs inside larger modules (e.g. `snacks.image` lazy-loads `snacks.image.terminal`, `snacks.image.placement`, etc.).
+
+### Event-Driven Setup
+
+`Snacks.setup()` registers autocmds that trigger module initialization on specific Neovim events:
+
+| Event         | Modules loaded                                             |
+| ------------- | ---------------------------------------------------------- |
+| `UIEnter`     | `dashboard`, `scroll`, `input`, `scope`, `picker`          |
+| `BufReadPre`  | `bigfile`, `image`                                         |
+| `BufReadPost` | `quickfile`, `indent`                                      |
+| `BufEnter`    | `explorer`                                                 |
+| `LspAttach`   | `words`                                                    |
+| `BufReadCmd`  | `image` (for image file patterns), `gh` (for `gh://` URIs) |
+
+Each module can be enabled or disabled via configuration. The `setup()` function merges user options with defaults, marks modules as `enabled` if their config key is present, and fires deferred autocmds.
+
+### Configuration System
+
+Configuration follows a three-layer merge pattern:
+
+1. **Module defaults** -- hardcoded in each module.
+2. **User config** -- passed to `Snacks.setup(opts)`, stored in a shared `config` table.
+3. **Call-site overrides** -- passed to individual constructors.
+
+`Snacks.config.get(snack, defaults, ...)` performs a deep merge across these layers. A special `example` field can pull named config presets from `docs/examples/`, allowing configuration by reference.
+
+The merge function (`Snacks.config.merge`) does recursive table merging with `force` semantics, similar to `vim.tbl_deep_extend("force", ...)` but extended to handle non-table values and list-vs-dict detection.
+
+---
+
+## Window Abstraction (`Snacks.win`)
+
+`Snacks.win` is the foundation for every visual element. It wraps Neovim's `nvim_open_win`, `nvim_win_set_config`, buffer creation, keymaps, and autocmds into a single managed object.
+
+### Configuration Schema
+
+The `snacks.win.Config` type extends Neovim's `vim.api.keyset.win_config` with:
+
+| Field                    | Type / Description                                                                                             |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `position`               | `"float"` \| `"top"` \| `"bottom"` \| `"left"` \| `"right"` \| `"current"`                                     |
+| `width/height`           | Absolute (integer), relative (0..1 fraction of parent), or `0` (full). Can also be a `fun(self) -> number`.    |
+| `min_width/max_width`    | Clamp values                                                                                                   |
+| `row/col`                | Same absolute/relative/function scheme. Negative values anchor from the opposite edge. `nil` centers.          |
+| `border`                 | Standard Neovim borders plus custom presets: `"top"`, `"bottom"`, `"hpad"`, `"vpad"`, `"top_bottom"`, `"bold"` |
+| `backdrop`               | Number (blend opacity) or `{bg, blend, transparent}`. Creates a separate dimmed window behind the float.       |
+| `style`                  | Name of a registered style preset (see below).                                                                 |
+| `keys`                   | Table of key mappings. Values can be action names, functions, or full keymap specs.                            |
+| `actions`                | Named action functions that keys can reference by string.                                                      |
+| `wo/bo`                  | Window and buffer option overrides.                                                                            |
+| `on_buf/on_win/on_close` | Lifecycle callbacks.                                                                                           |
+| `fixbuf`                 | Prevents other buffers from being opened in this window (swaps them to a "main" window instead).               |
+| `stack`                  | When true, multiple split windows with the same position are stacked perpendicular to each other.              |
+| `resize`                 | Auto-resize on `VimResized` events.                                                                            |
+
+### Dimension Resolution
+
+The `dim()` method resolves dimensions against a parent size:
+
+- `0` → full parent size minus border.
+- `0 < x < 1` → fraction of parent size minus border.
+- `≥ 1` → absolute cells.
+- Functions are called with `self` and expected to return a number.
+
+Positions follow the same rules: `nil` centers, negative values anchor from the far edge, `0 < p < 1` is a relative offset.
+
+### Lifecycle
+
+1. **`new(opts)`** -- resolves styles, merges defaults for float/split/minimal, processes keymaps, registers autocmds.
+2. **`show()`** -- creates buffer (`open_buf`), applies buffer options, fires `on_buf`, creates window (`open_win`), applies window options, fires `on_win`, attaches keymaps.
+3. **`update()`** -- re-applies options and (for floats) reconfigures position/size via `nvim_win_set_config`.
+4. **`hide()`** -- closes the window but keeps the buffer for reuse.
+5. **`close()`** -- destroys both window and buffer, cleans up autocmds and backdrop.
+6. **`toggle()`** -- cycles between show/hide.
+
+### Buffer Fixation
+
+`fixbuf` is an interesting pattern: when another buffer is opened in this window (e.g., by `:edit`), Snacks intercepts `BufWinEnter`, moves the new buffer to a "main" window, and restores the original buffer. This keeps sidebars, explorers, and picker windows pinned.
+
+### Backdrop
+
+Backdrops are implemented as a separate `Snacks.win` instance with:
+
+- `zindex` one below the parent.
+- Full editor size (`width=0, height=0`).
+- A dynamically created highlight group (`SnacksBackdrop_{hex}`) with the specified background color and `winblend`.
+- Transparency-aware: skipped entirely when the colorscheme is transparent.
+
+### Split Stacking
+
+When `stack=true`, opening a second split with the same position finds an existing Snacks window in that position and splits _perpendicular_ to it. For example, two `bottom` splits are stacked side-by-side. After creation, `equalize()` distributes space evenly.
+
+### Style Resolution
+
+`Snacks.win.resolve(...)` walks a chain of style names. Each style can reference another style, and the chain is followed until all styles are flattened into a single config. The resolution is stack-based to handle transitive style references.
+
+Built-in styles include `"float"` (backdrop=60, 90% size, z=50), `"split"` (40% height/width), `"minimal"` (disables cursorline, line numbers, signs, wrap, etc.), and `"help"` (bottom-aligned, 30% height, no backdrop).
+
+---
+
+## Layout Composition (`Snacks.layout`)
+
+The layout module implements a **box-tree model** for multi-window arrangements. It manages a tree of horizontal/vertical boxes, where leaf nodes reference named `Snacks.win` instances.
+
+### Layout Specification
+
+A layout is described as a nested Lua table:
+
+```lua
+{
+  box = "horizontal",
+  width = 0.8,
+  height = 0.8,
+  { win = "input", height = 1 },
+  {
+    box = "vertical",
+    { win = "list", width = 0.4 },
+    { win = "preview" },
+  },
+}
+```
+
+- **`box`** nodes have a direction (`"horizontal"` or `"vertical"`) and contain child widgets.
+- **`win`** leaves reference named windows from a `wins` table passed at construction time.
+- Any `snacks.win.Config` field can appear on a node (e.g., `width`, `height`, `border`).
+
+### Layout Algorithm
+
+The algorithm in `update_box()` follows a **fixed-then-flex** distribution:
+
+1. **Fixed children** -- children with explicit `width`/`height` > 0 are resolved first. Their size is subtracted from the available space.
+2. **Flex children** -- children with `width`/`height` = 0 (or absent) share the remaining space equally (`floor(free / flex_count)`).
+3. **Positioning** -- offsets are accumulated along the main axis.
+4. **Root adjustment** -- if there is leftover space, the root box shrinks to fit.
+
+Borders are accounted for by computing `border_size()` on fake `Snacks.win` instances and adjusting the parent coordinate frame.
+
+### Box Windows
+
+Each box node with a border (or the root) gets its own `Snacks.win` instance as a background. These `box_wins` are created at construction time with `focusable=false`, `enter=false`, and increasing `zindex` by depth. Child windows are then positioned `relative="win"` to the root box window.
+
+### Split vs Float
+
+When the root layout has `position` other than `"float"`, the layout wraps the tree in an extra vertical box. The outer box becomes a native Neovim split; inner windows are floats positioned relative to it. This allows the layout to act like a sidebar while retaining the full box-tree composition.
+
+### Resizing
+
+The layout responds to `WinResized` by comparing `screenpos` snapshots and re-running `update()`. When a child window is manually resized, the layout detects the size delta and adjusts the root window to accommodate, then re-runs layout.
+
+### Fullscreen Toggle
+
+`maximize()` toggles `opts.fullscreen`, which sets `width=0, height=0, col=0, row=0` on the root before layout, making it fill the editor.
+
+### Hidden Windows
+
+Windows can be toggled in/out of the layout via `toggle(win)`. Hidden windows are excluded from the box tree during layout but can be restored. This is used by the picker to show/hide the preview pane.
+
+---
+
+## Picker (`Snacks.picker`)
+
+The picker is the most complex module. It's a full fuzzy-finder engine composed of several cooperating subsystems.
+
+### Picker Object
+
+A `Snacks.Picker` instance aggregates:
+
+| Component | Type / Role                                                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `finder`  | Async item producer. Wraps a source function into a coroutine-based pipeline.                                                   |
+| `matcher` | Scores items against the query pattern. Supports fuzzy, exact, prefix, suffix, inverse, word, field-scoped, and regex matching. |
+| `list`    | Virtual-scroll list with cursor management. Renders only visible items into a buffer.                                           |
+| `input`   | Text input window for the search query.                                                                                         |
+| `preview` | Preview pane that shows context for the selected item.                                                                          |
+| `layout`  | A `Snacks.layout` instance that arranges input, list, and preview.                                                              |
+| `sort`    | Comparator function from config.                                                                                                |
+| `history` | Per-source search history with persistence.                                                                                     |
+
+### Async Runtime
+
+The picker has its own cooperative multitasking system built on Lua coroutines (`snacks.picker.util.async`):
+
+- **`Async.new(fn)`** wraps a function in a coroutine and adds it to an active queue.
+- A **`uv_check_t`** handle drives the event loop: on each libuv check event, it resumes active coroutines within a **budget** (default 10ms).
+- **`yielder(ms)`** returns a throttled yield function that only actually yields when the time budget is exceeded (checked every 100 iterations).
+- **`suspend()`/`resume()`** moves coroutines between active and suspended queues.
+- **`schedule(fn)`** suspends the current coroutine, runs `fn` on the main thread via `vim.schedule`, and resumes with the result.
+
+This gives the picker non-blocking behavior: the finder and matcher run as cooperative tasks that periodically yield control back to Neovim's event loop, keeping the UI responsive during large searches.
+
+### Matcher Architecture
+
+The matcher implements fzf-compatible query syntax:
+
+| Syntax      | Meaning                      |
+| ----------- | ---------------------------- |
+| `foo`       | Fuzzy match                  |
+| `'foo`      | Exact substring match        |
+| `'foo'`     | Exact word boundary match    |
+| `^foo`      | Exact prefix match           |
+| `foo$`      | Exact suffix match           |
+| `!foo`      | Inverse match (exclude)      |
+| `a b`       | AND (both must match)        |
+| `a \| b`    | OR (at least one must match) |
+| `field:pat` | Match only the named field   |
+| `file:3:5`  | File path with line:col jump |
+
+Internally, the query string is parsed into `Mods[][]` (a 2D array representing AND-of-ORs). Each `Mods` object stores: `pattern`, `chars` (pre-split for fuzzy), `ignorecase`, `fuzzy`, `regex`, `inverse`, `exact_prefix`, `exact_suffix`, `word`, `field`, and an **entropy** score.
+
+**Entropy-based ordering**: Mods are sorted by entropy (a heuristic for selectivity). Higher entropy patterns are checked first in the AND chain, so unlikely-to-match patterns short-circuit early. Within OR groups, lower entropy (more likely to match) patterns are checked first.
+
+**Scoring**: The scoring system is ported from fzf (`snacks.picker.core.score`). It uses:
+
+- Character class detection (white, nonword, delimiter, lower, upper, letter, number).
+- Bonus matrices for boundary matches, camelCase transitions, consecutive characters.
+- Constants matching fzf: `SCORE_MATCH=16`, `SCORE_GAP_START=-3`, `SCORE_GAP_EXTENSION=-1`.
+- Path separator awareness: bonus for matches after `/`.
+
+**Fuzzy matching**: Forward scan finds the first match positions, computing score incrementally. Then it retries from `from+1` repeatedly to find the highest-scoring alignment.
+
+**Frecency**: Optional frecency scoring boosts recently/frequently accessed files using a logarithmic decay: `score += (1 - 1/(1 + frecency)) * 8`.
+
+**Incremental matching**: When the new pattern is a prefix of the old one (subset detection), the matcher skips items that already failed the previous pattern. Items are processed in priority order: topk first, then previous matches, then the rest. The matcher runs as an async task that suspends when it catches up with the finder.
+
+### Virtual-Scroll List
+
+The list (`snacks.picker.core.list`) implements its own scrolling rather than using Neovim's native window scrolling:
+
+- Maintains `top` (first visible index) and `cursor` (selected index).
+- Renders only the visible window of items into the buffer using `nvim_buf_set_lines` and `nvim_buf_set_extmark` for highlights.
+- Supports **reverse** mode (items grow upward) by translating between idx and row coordinates.
+- Tracks a **topk min-heap** (capacity 1000) of the best-scoring items for instant first results.
+- Mouse scroll events are intercepted via `vim.on_key` and translated to list scroll operations.
+- A separate `Matcher` instance is used to compute highlight positions for the visible items only, avoiding the cost of computing positions for all items.
+
+### Item Model
+
+A picker item (`snacks.picker.Item`) carries:
+
+| Field         | Description                                           |
+| ------------- | ----------------------------------------------------- |
+| `text`        | Primary searchable text.                              |
+| `score`       | Current match score (0 = no match).                   |
+| `idx`         | Original index from the finder.                       |
+| `file`        | File path (for file-oriented sources).                |
+| `pos`         | Cursor position `{line, col}` for jumping.            |
+| `buf`         | Associated buffer number.                             |
+| `parent`      | Parent item (for tree sources like the explorer).     |
+| `frecency`    | Cached frecency score.                                |
+| `match_tick`  | Matcher generation that last processed this item.     |
+| `match_topk`  | Whether this item was in the topk set.                |
+| Custom fields | Sources can add any field (e.g., `severity`, `kind`). |
+
+---
+
+## Explorer (`Snacks.explorer`)
+
+The file explorer is described in the codebase as "a picker in disguise" -- it reuses the picker infrastructure with a tree-shaped data source.
+
+### Tree Data Model
+
+The tree (`snacks.explorer.tree`) is a singleton that maintains a hierarchy of `Node` objects:
+
+```
+Node {
+  path, name, type, dir, open, expanded, hidden, ignored,
+  parent, last, children, status, dir_status, severity, utime
+}
+```
+
+- **`open`** -- whether the user has toggled this directory open.
+- **`expanded`** -- whether the children have been read from the filesystem (`uv.fs_scandir`).
+- **`children`** -- a string-keyed table of child nodes.
+- **`hidden`** -- names starting with `.`.
+- **`status`/`dir_status`** -- merged git status.
+- **`severity`** -- LSP diagnostic severity.
+
+The tree is expanded lazily: `expand(node)` calls `uv.fs_scandir` to read directory entries, creates child nodes, and removes stale entries. The `walk()` method performs a depth-first traversal with sorted children (directories first, then alphabetical).
+
+### Git Integration
+
+`snacks.explorer.git` provides per-directory git status by running `git status --porcelain=v2`. Status is merged upward: a directory's status is the "worst" status among its children. The git module also tracks dirty state for incremental refresh.
+
+### Diagnostics
+
+`snacks.explorer.diagnostics` aggregates LSP diagnostics by file path and propagates severity up to parent directories, so folders containing errors show an error indicator.
+
+### Filtering
+
+The tree walker accepts a filter configuration (`hidden`, `ignored`, `exclude`, `include` globs). Glob matching uses a compiled globber utility from `snacks.picker.util`. The `include` filter takes precedence -- if a file matches an include glob, it's shown even if it would otherwise be hidden.
+
+### File Operations
+
+The actions module (`snacks.explorer.actions`) handles:
+
+- Create, delete, rename, copy, move.
+- System trash integration (tries `trash`, `gio trash`, `kioclient5`, `kioclient`, PowerShell's `SendToRecycleBin`).
+- Reveal (expand tree to show a specific file).
+
+### Snapshot Diffing
+
+`Tree:snapshot(node, fields)` captures the current state of a subtree (selected fields for each node). `Tree:changed(node, snapshot)` compares against a previous snapshot to detect whether a re-render is needed. This avoids redundant finder/layout cycles when nothing has changed.
+
+---
+
+## Notification System (`Snacks.notifier`)
+
+### Architecture
+
+The notifier is a singleton that maintains two collections:
+
+- **`queue`** -- currently visible/pending notifications.
+- **`history`** -- all past notifications (for the history viewer).
+
+A `uv_timer_t` fires at `refresh` interval (default 50ms), triggering `process()` → `update()` → `layout()`.
+
+### Notification Lifecycle
+
+1. **`add(opts)`** -- creates or updates a notification. Assigns an auto-incrementing ID, resolves the level, sets the icon, and records timestamps with nanosecond precision.
+2. **`update()`** -- removes expired notifications. A notification stays visible if: it hasn't been shown yet, timeout is 0, it's the current window/buffer, a custom `keep` predicate returns true, or it hasn't timed out yet.
+3. **`render(notif)`** -- creates/reuses a `Snacks.win`, clears the buffer, invokes the style renderer, computes wrapped height, and applies `more_format` footer if content is truncated.
+4. **`layout()`** -- positions all visible notifications using a slot-based algorithm.
+
+### Slot-Based Layout
+
+The layout system uses a boolean array (`rows[]`) representing every editor row. Initially all rows are marked free, then margins, tabline, and statusline rows are marked occupied. For each notification (sorted by level then time):
+
+1. `layout.find(height, wanted_row)` scans for a contiguous block of `height` free rows, searching top-down or bottom-up based on `top_down` config.
+2. If found, the rows are marked occupied (plus any gap), and the notification window is positioned at `col = columns - width - margin.right`, `row = found_row - 1`.
+3. If no slot is found, the notification is hidden and retried later.
+
+This gives a notification-stack behavior similar to macOS or VS Code toast notifications.
+
+### Render Styles
+
+Three built-in render styles:
+
+- **`compact`** -- title in the border, message in the body.
+- **`minimal`** -- no border, icon as a right-aligned virtual text overlay.
+- **`fancy`** -- icon + title on line 1, horizontal rule on line 2, message below. Time displayed via right-aligned virtual text.
+
+Each style is a function `(buf, notif, ctx)` that writes lines and extmarks into the notification buffer.
+
+---
+
+## Animation System (`Snacks.animate`)
+
+### Design
+
+The animation module provides a generic `from → to` interpolation engine:
+
+1. **`Animation.new(opts)`** -- creates an animation with easing function, duration, and optional int rounding.
+2. **`start(from, to, cb)`** -- precomputes all step values into an array, then starts a `uv_timer_t` at the computed step interval.
+3. Each timer tick calls `step()`, which invokes the callback with the current value and a context `{anim, prev, done}`.
+4. **`stop()`** halts the timer and clears the step array.
+
+### Duration Model
+
+Duration can be specified as:
+
+- `step` -- ms per unit of change.
+- `total` -- max total duration.
+- When both are specified, the minimum wins.
+
+For linear+integer animations, the step size is quantized to whole numbers to avoid sub-pixel jitter.
+
+### Easing
+
+The `snacks.animate.easing` module provides 45+ easing functions following the standard `(t, b, c, d)` signature (time, begin, change, duration). These include linear, quadratic, cubic, elastic, bounce, back, etc.
+
+### Integration
+
+Animation is used by:
+
+- **`scroll`** -- smooth scrolling with configurable easing and a fast-repeat mode.
+- **`indent`** -- animated scope highlighting that grows outward from the cursor.
+- **`dim`** -- animated dimming of out-of-scope code.
+
+The `Snacks.animate.enabled({buf, name})` check allows per-buffer or per-feature animation toggle via variables.
+
+---
+
+## Smooth Scrolling (`Snacks.scroll`)
+
+The scroll module intercepts Neovim's native scrolling and replaces it with animated transitions:
+
+- Tracks per-window `State` objects containing `current` view, `target` view, and an active `Animation`.
+- Detects scroll events by comparing `winsaveview()` snapshots.
+- When a scroll target changes, creates an animation from current `topline` to target `topline`.
+- During animation, each step sets `scrolloff=0`, computes the interpolated position, and calls `winrestview()`.
+- Supports a `animate_repeat` config for faster animation when scrolling rapidly (triggered after a configurable delay).
+
+---
+
+## Dashboard (`Snacks.dashboard`)
+
+The dashboard renders a declarative startup screen:
+
+- **Sections** are described as nested Lua tables with `section`, `key`, `action`, `icon`, `text`, etc.
+- Built-in section generators: `header`, `keys`, `recent_files`, `projects`, `session`.
+- The rendering engine resolves sections recursively, applies formatters (icon, footer, header, title, key, desc, file), and lays out blocks with alignment, padding, and gap control.
+- Multi-pane support: the `pane_gap` and `col`/`row` options allow side-by-side layout.
+- The dashboard lives in a normal buffer with extmarks for highlighting, making it a first-class Neovim buffer that responds to keymaps.
+
+---
+
+## Image Rendering (`Snacks.image`)
+
+The image module enables inline image display using the **Kitty Graphics Protocol**:
+
+- Supports kitty, wezterm, and ghostty terminals.
+- Handles format conversion (ImageMagick) for non-PNG formats, videos, PDFs.
+- Two display modes:
+  - **Inline** -- uses unicode placeholder characters in the buffer. The terminal renders the image behind these placeholders.
+  - **Float** -- shows images in floating windows positioned near the reference in the document.
+- Integrates with Treesitter to find image references in markdown, HTML, and other document types.
+- The `snacks.image.placement` module manages the relationship between image data and display positions.
+
+---
+
+## Scope Detection (`Snacks.scope`)
+
+The scope module detects the current code scope at the cursor:
+
+- **Treesitter-based** -- walks the syntax tree to find the enclosing block (function, class, if, for, etc.).
+- **Indent-based fallback** -- when Treesitter isn't available, detects scope by indent level changes.
+- Configuration: `min_size`, `max_size`, `cursor` (use cursor column), `edge` (include surrounding lines), `siblings` (expand with adjacent single-line scopes).
+- Fires callbacks on scope change, used by `indent` and `dim` for visual effects.
+
+---
+
+## Indent Guides (`Snacks.indent`)
+
+Renders vertical indent guides and scope highlights:
+
+- Uses Neovim's decoration provider API (`nvim_set_decoration_provider`) for efficient per-line rendering.
+- Indent guides are drawn as `│` characters via `virt_text` extmarks.
+- Scope highlighting can be rendered as:
+  - **Scope** -- a single highlighted vertical line for the current scope.
+  - **Chunk** -- box-drawing characters (`┌`, `└`, `─`, `│`) that visually wrap the scope.
+- Animated scope transitions: when the scope changes, the highlight grows outward from the cursor position using the animation system.
+
+---
+
+## Focus Dimming (`Snacks.dim`)
+
+Dims code outside the current scope:
+
+- Attaches to the scope listener.
+- On each redraw, sets extmarks with `SnacksDim` highlight (linked to `DiagnosticUnnecessary`) on lines outside the active scope.
+- Animated: when the scope changes, the dimming boundary smoothly transitions using easing.
+
+---
+
+## Zen Mode (`Snacks.zen`)
+
+Provides a distraction-free editing mode:
+
+- Toggleable via `Snacks.zen()`.
+- Hides UI chrome (statusline, tabline, etc.) and optionally dims surrounding windows.
+- Uses the `dim` module for the dimming effect.
+
+---
+
+## Patterns and Techniques
+
+### Cooperative Async via Coroutines
+
+The `snacks.picker.util.async` module is a bespoke cooperative scheduler worth studying:
+
+- Uses a `uv_check_t` handle (runs once per libuv iteration) as the execution driver.
+- Active coroutines are processed round-robin within a time budget.
+- `yielder()` amortizes yield checks: only checks `uv.hrtime()` every 100 iterations, avoiding measurement overhead in tight loops.
+- Coroutines can `suspend()` to wait for external events (e.g., `vim.schedule` results), moving to a separate suspended queue.
+- The `wake()` pattern allows one coroutine to await another's completion.
+
+This is relevant for Sparkles because it shows how to build responsive async UIs without threads, using only coroutines and event loop integration.
+
+### Configuration as Inheritance Chain
+
+Style resolution (`Snacks.win.resolve`) walks a chain of named styles, each potentially referencing another. This is reminiscent of CSS class composition but much simpler -- just recursive table merging. The pattern allows modules to define specialized styles that inherit from generic ones:
+
+```
+notification → float → minimal → defaults
+```
+
+### Z-Index Management
+
+`Snacks.win.zindex()` scans existing windows and returns a z-index above all current Snacks windows (with a +2 gap). Layout children get `zindex = root + depth + 1`, ensuring correct stacking. Backdrops are always `zindex - 1` below their parent.
+
+### Buffer as Canvas
+
+Throughout Snacks, buffers are used as rendering targets:
+
+- Lines are set with `nvim_buf_set_lines`.
+- Rich formatting uses `nvim_buf_set_extmark` with `virt_text`, `virt_text_pos`, `hl_group`, and `priority`.
+- The `winhighlight` window option remaps highlight groups per-window, enabling different visual themes for different surfaces.
+
+This "buffer as canvas" pattern is the fundamental rendering primitive, replacing the cell-grid model of standalone TUI frameworks.
+
+### TopK with Min-Heap
+
+The picker list maintains a min-heap of the top 1000 scoring items. When the matcher produces a new high-scoring result, it's inserted into the heap. On the next render, topk items are processed first, giving instant initial results even while the full match is still running.
+
+### Snapshot-Based Change Detection
+
+The explorer's `snapshot()` / `changed()` pattern captures specific fields of a subtree and does a structural comparison. This is a simple alternative to dirty flags or reactive dependencies -- take a snapshot before, take one after, and compare.
+
+---
+
+## Relevance for Sparkles
+
+### Directly Applicable Patterns
+
+- **Box-tree layout model**: The layout algorithm in `Snacks.layout` (fixed-then-flex distribution, border accounting, nested box composition) is directly applicable to a tree view layout system. The specification format (nested tables with `box`/`win` discriminator) is ergonomic and could map to D structs.
+
+- **Cooperative async with time budgets**: The coroutine-based scheduler with `yielder()` and budget-based round-robin is a pattern that could be adapted for D fibers. The key insight is amortizing time checks (every 100 iterations) to avoid `hrtime()` overhead.
+
+- **Virtual-scroll list**: The picker list's approach of rendering only visible items, maintaining cursor/top state independently, and using a topk heap for fast initial display is directly relevant to a tree view that may have thousands of nodes.
+
+- **Explorer as picker-with-tree-source**: The explorer shows that a tree view can be implemented as a flat list with indent + expand/collapse state, reusing generic list/filter/action infrastructure rather than building a separate tree widget.
+
+- **Snapshot-based dirty detection**: A lightweight alternative to reactive change propagation, useful when the data model is simple and changes are infrequent relative to checks.
+
+### Design Insights
+
+- **Style registry**: Named presets with inheritance chains provide theming without a full CSS system. For Sparkles, this could be a `StyleConfig` struct with merge semantics.
+
+- **Configuration layering**: The three-layer merge (defaults → global → call-site) with `merge()` and `example` references is a good ergonomic pattern for configurable components.
+
+- **Buffer fixation**: The `fixbuf` pattern of intercepting buffer changes and redirecting them is relevant for any persistent panel in a terminal UI.
+
+- **Notification slot allocation**: The boolean row-array approach is simple and effective for stacking popups without overlap.
+
+### Key Limitation
+
+Snacks relies entirely on Neovim's window system and cannot run outside the editor. Its abstractions are useful references, but Sparkles must implement equivalent primitives (surfaces, z-ordering, backdrop blending, event dispatch) directly against terminal escape sequences.

--- a/docs/research/tui-libraries/tree-view-case-study.md
+++ b/docs/research/tui-libraries/tree-view-case-study.md
@@ -1,6 +1,6 @@
 # Tree-View Case Study
 
-A comparative analysis of tree-view implementations in TUI libraries, evaluating their designs through the lens of [Sean Parent's principles](../sean-parent/index.md) (value semantics, avoiding incidental data structures, separating algorithms from data) and the project's D guidelines ([Design by Introspection](../../guidelines/design-by-introspection-01-guidelines.md), [functional/declarative style](../../guidelines/functional-declarative-programming-guidelines.md)). The two primary references are **snacks.nvim's explorer** and **ratatui-tree-widget**, with cross-references to other libraries from the [TUI catalog](index.md).
+A comparative analysis of tree-view implementations in TUI libraries, evaluating their designs through the lens of [Sean Parent's principles][sean-parent-index] (value semantics, avoiding incidental data structures, separating algorithms from data) and the project's D guidelines ([Design by Introspection][dbi-guidelines], [functional/declarative style][functional-guidelines]). The two primary references are **snacks.nvim's explorer** and **ratatui-tree-widget**, with cross-references to other libraries from the [TUI catalog][tui-index].
 
 ## Contents
 
@@ -338,13 +338,13 @@ The scroll viewport handles variable-height items. The ensure-selected-in-view l
 
 ## 4. Cross-Library Tree Patterns
 
-Coverage of tree-related patterns from other studied libraries. See the [TUI catalog](index.md) and [comparison](comparison.md) for full details.
+Coverage of tree-related patterns from other studied libraries. See the [TUI catalog][tui-index] and [comparison][comparison] for full details.
 
-### [ImTui](imtui.md) / Dear ImGui (C++)
+### [ImTui][imtui] / Dear ImGui (C++)
 
 Immediate-mode tree via `ImGui::TreeNode()` / `TreePop()`. There is no data model — the tree structure is implicit in the call sequence. Expand/collapse state is managed by ImGui's internal hot/active state keyed by string IDs. This is the simplest possible tree API but offers no model for external algorithms to operate on.
 
-### [Textual](textual.md) (Python)
+### [Textual][textual] (Python)
 
 Textual provides built-in `Tree[TreeDataType]` and `TreeNode[TreeDataType]` widgets with a rich feature set.
 
@@ -386,9 +386,9 @@ Four character sets are provided: ASCII, Unicode, Bold Unicode (`┣━━`/`┗
 
 This four-state model with per-depth-level accumulation is the canonical algorithm for tree guide rendering.
 
-### broot (Rust) — Tree as search result
+### [broot][broot] (Rust) — Tree as search result
 
-[broot](https://github.com/Canop/broot) is a terminal file navigator that treats the tree as a function of the search pattern. Its architecture is fundamentally different from expand/collapse-based trees.
+A terminal file navigator that treats the tree as a function of the search pattern. Its architecture is fundamentally different from expand/collapse-based trees. (See [detailed broot study][broot].)
 
 **Data model.** The tree is a flat `Vec<TreeLine>` — no recursive structure. Each `TreeLine` stores `id`, `parent_id: Option<usize>`, `depth: u16`, `score: i32`, and `left_branches: Box<[bool]>`. There are no child pointers. The `left_branches` array is precomputed during construction: `left_branches[d]` is `true` if the ancestor at depth `d` has more siblings below, determining whether a vertical continuation line (`│`) should be drawn at that depth.
 
@@ -402,7 +402,7 @@ This four-state model with per-depth-level accumulation is the canonical algorit
 
 ### cursive_tree_view (Rust)
 
-[cursive_tree_view](https://github.com/BonsaiDen/cursive_tree_view) is a tree-view widget for the Cursive TUI framework that validates the flat-array approach to tree storage.
+A tree-view widget for the [Cursive][cursive] TUI framework that validates the flat-array approach to tree storage.
 
 **Data model.** The tree is stored as a flat `Vec<TreeNode<T>>` where `T: Display + Debug`. Each `TreeNode` stores `value: T`, `level: usize` (depth), `is_collapsed: bool`, `children: usize` (descendant count), and `height: usize` (subtree size including self). Parent-child relationships are implicit — a node's children occupy the contiguous indices immediately after it. Parent lookup is a backward scan for the first entry with a strictly lower `level`.
 
@@ -423,7 +423,7 @@ All public API methods use row indices. Internal conversion between the two is O
 
 ### stlab::forest (C++) — Sean Parent's tree container
 
-[stlab::forest](https://github.com/stlab/libraries) is Sean Parent's own answer to the "incidental data structure" problem for trees.
+Sean Parent's own answer to the "incidental data structure" problem for trees.
 
 **Node structure.** Each node stores a 2×2 link array: `_nodes[leading|trailing][prior|next]`. The leading edge represents "entering" a node (pre-order visit); the trailing edge represents "leaving" (post-order visit). This dual-edge model is the central abstraction — every node is visited twice in a fullorder traversal.
 
@@ -445,23 +445,23 @@ The `depth_fullorder_iterator` filtered to leading edges is directly applicable 
 
 **Relevance.** stlab::forest solves the ownership and value semantics problems but uses individual heap allocations, trading cache locality for O(1) structural modification and stable iterators. The flat-array approach (contiguous `Node[]` with indices) reverses this tradeoff: better cache locality and `@nogc` friendliness, but O(n) insertion.
 
-### [Brick](brick.md) (Haskell)
+### [Brick][brick] (Haskell)
 
 No built-in tree widget. Functional combinators (`vBox`, `padLeft`) compose a tree visually. The tree model is user-defined — Brick provides the layout primitives, and the application builds tree display from those primitives. This is the most "library, not framework" approach.
 
-### [Bubble Tea](bubbletea.md) (Go)
+### [Bubble Tea][bubbletea] (Go)
 
 No built-in tree widget. Community `bubbles/tree` follows the MVU pattern: the model stores a flat list of visible nodes annotated with depth. Expand/collapse dispatches an update message that recomputes the flat list. Pure functional approach where the view is derived from the model.
 
-### [tview](tview.md) (Go)
+### [tview][tview] (Go)
 
 `TreeView` widget with `TreeNode` model. Nodes have a `reference` field (user data), `children` slice, and `expanded` boolean. Virtual scrolling via a `GetChildren` callback enables lazy loading. The expand/collapse state lives directly on the node — mixing data and view state.
 
-### [FTXUI](ftxui.md) (C++)
+### [FTXUI][ftxui] (C++)
 
 No built-in tree widget. Flexbox layout + `Collapsible()` component can compose one. `Collapsible(label, child)` toggles visibility of its child on click. Building a full tree requires nesting collapsibles, which is verbose but gives full control over rendering.
 
-### [Nottui](nottui.md) (OCaml)
+### [Nottui][nottui] (OCaml)
 
 Incremental reactive model ideal for trees. Reactive variables (`Lwd.var`) for expand/collapse state trigger minimal recomputation of only the affected subtree. The DAG-based computation model means expanding a deep node doesn't recompute siblings. This is architecturally the most sophisticated approach for large trees.
 
@@ -503,7 +503,7 @@ Incremental reactive model ideal for trees. Reactive variables (`Lwd.var`) for e
 
 ### Avoiding incidental data structures
 
-> "An incidental data structure is a data structure where there is no object representing the structure as a whole." — [Data Structures](../sean-parent/data-structures.md)
+> "An incidental data structure is a data structure where there is no object representing the structure as a whole." — [Data Structures][sean-parent-ds]
 
 **Snacks' `Tree`** is an incidental data structure in Sean Parent's sense. The `parent` field on each `Node` is a direct Lua reference creating a doubly-linked tree. There is a "whole" object (`Tree`), but the `nodes` table (a path → node lookup) and the `parent` back-references create multiple overlapping ways to traverse the structure. Copying the tree would require deep-copying all nodes and re-wiring parent references — which Snacks doesn't support.
 
@@ -525,7 +525,7 @@ struct Tree(Identifier) {
 
 ### Value semantics
 
-> "Value semantics are the cleanest way to implement Whole-Part relationships." — [Value Semantics](../sean-parent/value-semantics.md)
+> "Value semantics are the cleanest way to implement Whole-Part relationships." — [Value Semantics][sean-parent-vs]
 
 **ratatui-tree-widget** achieves value semantics well. `TreeItem` derives `Clone`; the entire tree can be copied as a value. `TreeState` is also a regular type with `Default`. This enables easy testing (construct a tree, copy it, modify the copy, compare) and undo/redo (snapshot the tree before modification).
 
@@ -535,7 +535,7 @@ For D, the tree should be a regular copyable value. With flat storage (`Node[]`)
 
 ### Separate algorithms from data
 
-> "Algorithms are more fundamental than the data structures on which they operate." — [Generic Programming](../sean-parent/generic-programming.md)
+> "Algorithms are more fundamental than the data structures on which they operate." — [Generic Programming][sean-parent-gp]
 
 **ratatui-tree-widget's `flatten()`** is a free function taking data + state → flat list. This is the right pattern — the algorithm is separate from both the data model and the interaction state. It can be tested independently, reused with different state, and composed with other operations.
 
@@ -557,13 +557,13 @@ The ratatui pattern is the one to follow.
 
 ### Regular types
 
-> "A type is regular if it behaves like int." — [Regular Types](../sean-parent/regular-types.md)
+> "A type is regular if it behaves like int." — [Regular Types][sean-parent-rt]
 
 **ratatui-tree-widget's Identifier constraint** (`Clone + PartialEq + Eq + Hash`) defines the minimum interface for a node identifier to be usable in sets and maps, comparable, and copyable. This maps directly to D's `opEquals` and `toHash`.
 
 **Snacks nodes** are identity-based — two nodes are the "same" if they are the same Lua table (reference equality). Path strings serve as external identifiers but nodes themselves don't have value equality.
 
-For D, node identifiers should be regular types satisfying the [Regular Types](../sean-parent/regular-types.md) requirements.
+For D, node identifiers should be regular types satisfying the [Regular Types][sean-parent-rt] requirements.
 
 ### Sean Parent's own tree: stlab::forest
 
@@ -587,7 +587,7 @@ Follow ratatui's separation: `TreeItem` (data), `TreeState` (interaction), and `
 
 ### 2. Flat storage with index-based relationships
 
-Follow [Sean Parent's guidance on data structures](../sean-parent/data-structures.md): store all nodes in a contiguous `Node[]` array with parent/child/sibling indices rather than recursive pointer-based trees. This gives better cache locality than ratatui's recursive `Vec<Self>` and avoids the incidental structure of Snacks' parent references.
+Follow [Sean Parent's guidance on data structures][sean-parent-ds]: store all nodes in a contiguous `Node[]` array with parent/child/sibling indices rather than recursive pointer-based trees. This gives better cache locality than ratatui's recursive `Vec<Self>` and avoids the incidental structure of Snacks' parent references.
 
 ### 3. Separate data model from view state
 
@@ -603,15 +603,15 @@ Follow both references: nodes are identified by a `Identifier[]` path from root.
 
 ### 6. DbI for node capabilities
 
-Follow the project's [Design by Introspection guidelines](../../guidelines/design-by-introspection-01-guidelines.md): use optional primitives for `hasChildren`, `hasIcon`, `hasStatus`, etc. A tree of file-system entries has different capabilities than a tree of AST nodes — DbI lets the renderer adapt without separate type hierarchies.
+Follow the project's [Design by Introspection guidelines][dbi-guidelines]: use optional primitives for `hasChildren`, `hasIcon`, `hasStatus`, etc. A tree of file-system entries has different capabilities than a tree of AST nodes — DbI lets the renderer adapt without separate type hierarchies.
 
 ### 7. Output range rendering
 
-Follow the project's [functional/declarative guidelines](../../guidelines/functional-declarative-programming-guidelines.md): the tree renderer writes to any output range, not just stdout. This enables rendering to `SmallBuffer`, `appender!string`, or a terminal buffer.
+Follow the project's [functional/declarative guidelines][functional-guidelines]: the tree renderer writes to any output range, not just stdout. This enables rendering to `SmallBuffer`, `appender!string`, or a terminal buffer.
 
 ### 8. Value semantics
 
-Follow ratatui + [Sean Parent's value semantics](../sean-parent/value-semantics.md): the entire tree is copyable. With flat storage, this is a single array copy. Enables snapshot-based testing, undo/redo, and the snapshot-diffing pattern Snacks demonstrates.
+Follow ratatui + [Sean Parent's value semantics][sean-parent-vs]: the entire tree is copyable. With flat storage, this is a single array copy. Enables snapshot-based testing, undo/redo, and the snapshot-diffing pattern Snacks demonstrates.
 
 ### 9. `@nogc` path
 
@@ -632,3 +632,26 @@ Follow stlab::forest's `depth_fullorder_iterator` pattern: provide a `depthFirst
 ### 13. Tree-as-search-result paradigm
 
 broot demonstrates that a tree view does not require persistent expand/collapse state. An alternative mode where the visible tree is rebuilt as a function of `(data_source, search_pattern, depth_limit)` can coexist with traditional expand/collapse. The tree data model should be cheap enough to construct that rebuilding per-keystroke is viable — flat storage with precomputed guide state makes this feasible.
+
+---
+
+## References
+
+[tui-index]: index.md
+[comparison]: comparison.md
+[broot]: broot.md
+[cursive]: cursive.md
+[textual]: textual.md
+[brick]: brick.md
+[bubbletea]: bubbletea.md
+[tview]: tview.md
+[ftxui]: ftxui.md
+[nottui]: nottui.md
+[imtui]: imtui.md
+[sean-parent-index]: ../sean-parent/index.md
+[sean-parent-ds]: ../sean-parent/data-structures.md
+[sean-parent-vs]: ../sean-parent/value-semantics.md
+[sean-parent-rt]: ../sean-parent/regular-types.md
+[sean-parent-gp]: ../sean-parent/generic-programming.md
+[dbi-guidelines]: ../../guidelines/design-by-introspection-01-guidelines.md
+[functional-guidelines]: ../../guidelines/functional-declarative-programming-guidelines.md

--- a/docs/research/tui-libraries/tree-view-case-study.md
+++ b/docs/research/tui-libraries/tree-view-case-study.md
@@ -1,0 +1,634 @@
+# Tree-View Case Study
+
+A comparative analysis of tree-view implementations in TUI libraries, evaluating their designs through the lens of [Sean Parent's principles](../sean-parent/index.md) (value semantics, avoiding incidental data structures, separating algorithms from data) and the project's D guidelines ([Design by Introspection](../../guidelines/design-by-introspection-01-guidelines.md), [functional/declarative style](../../guidelines/functional-declarative-programming-guidelines.md)). The two primary references are **snacks.nvim's explorer** and **ratatui-tree-widget**, with cross-references to other libraries from the [TUI catalog](index.md).
+
+## Contents
+
+1. [Introduction](#1-introduction)
+2. [Snacks.nvim Explorer — Deep Dive](#2-snacksnvim-explorer--deep-dive)
+3. [ratatui-tree-widget — Deep Dive](#3-ratatui-tree-widget--deep-dive)
+4. [Cross-Library Tree Patterns](#4-cross-library-tree-patterns)
+5. [Comparative Analysis](#5-comparative-analysis)
+6. [Analysis Through Sean Parent's Principles](#6-analysis-through-sean-parents-principles)
+7. [Design Principles for Sparkles Tree-View](#7-design-principles-for-sparkles-tree-view)
+
+---
+
+## 1. Introduction
+
+This document is a case study informing the design of a generic tree-view component for Sparkles. It examines how existing TUI libraries solve the core problems of tree display:
+
+- **Data model** — how tree nodes are represented and related
+- **Traversal** — how the tree is walked for rendering
+- **Flatten** — how a hierarchical structure becomes a linear list of visible rows
+- **Expand/collapse** — where the "opened" state lives and how it affects traversal
+- **Filtering** — how nodes are included or excluded
+- **Virtual scroll** — how large trees render only visible rows
+- **Status decoration** — how per-node metadata (git, diagnostics) propagates
+
+The two primary case studies — snacks.nvim's explorer and ratatui-tree-widget — represent opposite ends of the design spectrum. Snacks is a large, feature-rich file explorer embedded in Neovim that reuses picker infrastructure. ratatui-tree-widget is a small, focused Rust library that cleanly separates data, state, and rendering into three types. Both have lessons for a D implementation.
+
+---
+
+## 2. Snacks.nvim Explorer — Deep Dive
+
+Source: `/home/petar/code/repos/neovim/snacks.nvim/lua/snacks/explorer/`
+
+### "A picker in disguise"
+
+The explorer's `init.lua` declares itself:
+
+```lua
+M.meta = {
+  desc = "A file explorer (picker in disguise)",
+}
+```
+
+Rather than implementing its own list rendering, scrolling, filtering, and input handling, the explorer reuses the picker infrastructure (finder → matcher → list → layout). The tree is a data source that produces a flat stream of items for the picker to display. This means the explorer gets fuzzy matching, virtual-scroll rendering, keyboard navigation, and preview for free. The trade-off is that the tree data model must conform to the picker's item interface.
+
+### Tree data model
+
+`explorer/tree.lua` defines a singleton `Tree` with `Node` objects:
+
+```lua
+---@class snacks.picker.explorer.Node
+---@field path string
+---@field name string
+---@field type "file"|"directory"|"link"|...
+---@field dir? boolean
+---@field open? boolean           -- user intent: should this directory be expanded?
+---@field expanded? boolean       -- filesystem state: have children been read?
+---@field hidden? boolean         -- name starts with "."
+---@field ignored? boolean        -- git-ignored
+---@field status? string          -- merged git status
+---@field severity? number        -- LSP diagnostic severity
+---@field parent? Node            -- back-reference
+---@field children table<string, Node>  -- name-keyed child table
+---@field last? boolean           -- is last child of parent (for tree-drawing glyphs)
+---@field utime? number           -- expansion timestamp
+```
+
+The tree is a singleton — `tree.lua` returns `Tree.new()` at module scope, so all explorer instances share the same tree. Nodes are identified by their filesystem path (stored in `Tree.nodes` as a `path → Node` lookup table). The `parent` field is a direct Lua reference to the parent node, creating a doubly-linked tree.
+
+### Lazy expansion
+
+The `open` and `expanded` fields represent two different concepts:
+
+- **`open`** — user intent. Set by `Tree:open(path)`, cleared by `Tree:close(path)`. Indicates the user wants this directory expanded.
+- **`expanded`** — filesystem state. Set by `Tree:expand(node)` after `uv.fs_scandir` reads the directory contents. Cleared on refresh.
+
+This separation allows the tree to know which directories _should_ be expanded without having read them yet. `Tree:get()` lazily expands directories during the walk:
+
+```lua
+if n.dir and n.open and not n.expanded and opts.expand ~= false then
+  self:expand(n)
+end
+```
+
+`expand()` calls `uv.fs_scandir` to read directory entries, creates child nodes via `Tree:child()`, and removes stale entries no longer on disk.
+
+### Tree → flat list conversion
+
+`Tree:get(cwd, cb, opts)` is the bridge between the tree and the picker. It walks the tree depth-first, calling `cb(node)` for each visible node. The picker's finder wraps this into a flat item stream:
+
+```lua
+Tree:get(ctx.filter.cwd, function(node)
+  local item = {
+    file = node.path,
+    dir = node.dir,
+    open = node.open,
+    parent = parent,  -- reference to parent item (for indentation)
+    status = ...,
+    severity = ...,
+  }
+  cb(item)
+end, filter_opts)
+```
+
+The picker list receives these items as a flat sequence. Indentation is derived from the `parent` chain — the formatter walks `item.parent` references to compute depth.
+
+### DFS walk with sorting
+
+`Tree:walk(node, fn, opts)` performs the depth-first traversal. Children are sorted inline: directories first, then alphabetical by name:
+
+```lua
+local children = vim.tbl_values(node.children)
+table.sort(children, function(a, b)
+  if a.dir ~= b.dir then
+    return a.dir  -- directories first
+  end
+  return a.name < b.name
+end)
+```
+
+The walk yields each directory node before descending into its children (pre-order). The `fn` callback returns `false` to skip a subtree or `true` to abort the entire walk.
+
+### Filtering
+
+`Tree:filter(filter)` returns a predicate function. The filter respects `hidden`, `ignored`, and `exclude`/`include` globs. The `include` list takes precedence — a file matching an include glob is shown even if it's hidden or ignored:
+
+```lua
+return function(node)
+  if include and include(node.path) then return true end
+  if node.hidden and not filter.hidden then return false end
+  if node.ignored and not filter.ignored then return false end
+  if exclude and exclude(node.path) then return false end
+  return true
+end
+```
+
+### Git status propagation
+
+`explorer/git.lua` runs `git status --porcelain=v1 -z` asynchronously via `uv.spawn`, parses the output, and applies per-file status to tree nodes. Status is propagated upward to parent directories:
+
+```lua
+for dir in Snacks.picker.util.parents(path, cwd) do
+  add_git_status(dir, s.status)
+end
+```
+
+The `add_git_status` function merges statuses — a directory's status is the "worst" status among its children. Before applying new status, the module takes a snapshot of current `status` and `ignored` fields; after applying, it compares via `Tree:changed()` to determine if a re-render is needed.
+
+### Diagnostics propagation
+
+`explorer/diagnostics.lua` follows the same pattern: it reads `vim.diagnostic.get()`, applies severity to file nodes, and propagates the minimum severity upward to parent directories. The snapshot/changed mechanism avoids unnecessary re-renders.
+
+### File watching
+
+`explorer/watch.lua` uses `uv_fs_event_t` handles:
+
+- Open directories get a watch that triggers `Tree:refresh(path)` + debounced picker refresh.
+- The `.git/index` file gets a watch that triggers `Git.refresh()` on index changes.
+- Watches are reconciled on each `watch()` call — unused watches (for closed directories) are stopped.
+
+The refresh is debounced at 100ms via a `uv_timer_t` to batch rapid filesystem changes.
+
+### Search mode
+
+When the user types a search query, the explorer switches from tree-walk finder to an `fd`-based finder:
+
+```lua
+if state:setup(ctx) then
+  ctx.picker.matcher.opts.keep_parents = true
+  return M.search(opts, ctx)
+end
+```
+
+The search finder runs `fd --type d --path-separator /` to find files and directories matching the query. Parent directories of matched files are synthesized as "internal" items so the tree structure is preserved. The matcher is configured with `keep_parents=true` to avoid filtering out ancestor directories of matched files.
+
+Hierarchical sort keys ensure correct visual ordering in search results:
+
+```lua
+if item.dir then
+  item.sort = parent.sort .. "!" .. basename .. " "
+else
+  item.sort = parent.sort .. "#" .. basename .. " "
+end
+```
+
+The `!` prefix for directories sorts them before `#`-prefixed files at each level.
+
+### Snapshot diffing
+
+`Tree:snapshot(node, fields)` captures the current state of a subtree as a `{node → [field_values]}` table. `Tree:changed(node, snapshot)` compares against a previous snapshot. This is used in both git and diagnostics modules to detect whether the tree state has actually changed, avoiding unnecessary picker refresh cycles.
+
+---
+
+## 3. ratatui-tree-widget — Deep Dive
+
+Source: `/home/petar/code/repos/rust/tui-rs-tree-widget/src/`
+
+### Three-layer architecture
+
+ratatui-tree-widget cleanly separates concerns into three types:
+
+| Type                          | File            | Role                                               |
+| ----------------------------- | --------------- | -------------------------------------------------- |
+| `TreeItem<'text, Identifier>` | `tree_item.rs`  | Data model — tree structure and content            |
+| `TreeState<Identifier>`       | `tree_state.rs` | Interaction state — opened, selected, scroll       |
+| `Tree<'a, Identifier>`        | `lib.rs`        | Rendering widget — visual configuration and output |
+
+This separation is the library's central design insight. The data model knows nothing about selection or rendering. The state knows nothing about visual symbols or styles. The widget borrows both and produces output.
+
+### TreeItem — data model
+
+```rust
+#[derive(Debug, Clone)]
+pub struct TreeItem<'text, Identifier> {
+    pub(super) identifier: Identifier,
+    pub(super) text: Text<'text>,
+    pub(super) children: Vec<Self>,
+}
+```
+
+Key design choices:
+
+- **Generic Identifier** constrained to `Clone + PartialEq + Eq + Hash`. This enables path-based identification (e.g., `vec!["src", "main.rs"]`) without committing to a specific type. The constraint set matches what D would express as `opEquals` + `toHash`.
+- **Unique-sibling enforcement**: Both `new()` and `add_child()` collect child identifiers into a `HashSet` and reject duplicates with an error. This is an invariant enforced at construction time.
+- **Recursive ownership**: Children are `Vec<Self>`, making the tree a value type. `#[derive(Clone)]` gives the entire tree copy semantics.
+- **Variable-height items**: `height()` delegates to `Text::height()`, supporting multi-line tree items.
+
+The identifier is deliberately separate from the display text — the doc comment uses a filename analogy: `main.rs` is the identifier while `main` might be the displayed text.
+
+### TreeState — interaction state
+
+```rust
+pub struct TreeState<Identifier> {
+    pub(super) offset: usize,
+    pub(super) opened: HashSet<Vec<Identifier>>,
+    pub(super) selected: Vec<Identifier>,
+    pub(super) ensure_selected_in_view_on_next_render: bool,
+
+    pub(super) last_area: Rect,
+    pub(super) last_biggest_index: usize,
+    pub(super) last_identifiers: Vec<Vec<Identifier>>,
+    pub(super) last_rendered_identifiers: Vec<(u16, Vec<Identifier>)>,
+}
+```
+
+The critical design: **opened nodes are stored as a `HashSet<Vec<Identifier>>`** — a set of full paths from root. This is not a field on the tree nodes themselves. The opened set is purely interaction state.
+
+The `selected` field is a single `Vec<Identifier>` representing the path to the currently selected node.
+
+Navigation methods operate on the cached `last_identifiers` from the previous render:
+
+- **`key_up()`/`key_down()`** — move selection by one position in the flattened list.
+- **`key_left()`** — close the current node if open; if already closed, select the parent (pop from `selected`).
+- **`key_right()`** — open the current node.
+- **`toggle_selected()`** — toggle open/close.
+- **`select_relative(F)`** — apply a user-defined function to compute the new index.
+
+Mouse support uses `last_rendered_identifiers` — a list of `(y_coordinate, identifier)` pairs cached from the previous render:
+
+- **`rendered_at(Position)`** — reverse-lookup: find which node was rendered at a screen position.
+- **`click_at(Position)`** — select the node at a position; if already selected, toggle it.
+
+### Flatten — the bridge algorithm
+
+```rust
+pub struct Flattened<'text, Identifier> {
+    pub identifier: Vec<Identifier>,
+    pub item: &'text TreeItem<'text, Identifier>,
+}
+
+pub fn flatten<'text, Identifier>(
+    open_identifiers: &HashSet<Vec<Identifier>>,
+    items: &'text [TreeItem<'text, Identifier>],
+    current: &[Identifier],
+) -> Vec<Flattened<'text, Identifier>>
+```
+
+This is a **free function**, not a method on `TreeItem` or `TreeState`. It takes the opened set and the tree data as inputs and produces a flat list of visible nodes. The algorithm:
+
+1. Iterate over sibling items.
+2. For each item, build its full path by appending its identifier to `current`.
+3. Check if `open_identifiers` contains this path. If so, recursively flatten children.
+4. Emit the item, then emit any child results.
+
+Depth is derived, not stored: `depth() = identifier.len() - 1`. A top-level item has a path of length 1, so depth 0.
+
+The flatten function is pure — given the same tree and opened set, it always produces the same output. This makes it testable in isolation:
+
+```rust
+#[test]
+fn depth_works() {
+    let mut open = HashSet::new();
+    open.insert(vec!["b"]);
+    open.insert(vec!["b", "d"]);
+    let depths = flatten(&open, &TreeItem::example(), &[])
+        .into_iter()
+        .map(|flattened| flattened.depth())
+        .collect::<Vec<_>>();
+    assert_eq!(depths, [0, 0, 1, 1, 2, 2, 1, 0]);
+}
+```
+
+### Tree — rendering widget
+
+```rust
+pub struct Tree<'a, Identifier> {
+    items: &'a [TreeItem<'a, Identifier>],
+    block: Option<Block<'a>>,
+    scrollbar: Option<Scrollbar<'a>>,
+    style: Style,
+    highlight_style: Style,
+    highlight_symbol: &'a str,
+    node_closed_symbol: &'a str,    // default: "▶ "
+    node_open_symbol: &'a str,      // default: "▼ "
+    node_no_children_symbol: &'a str, // default: "  "
+}
+```
+
+The widget **borrows** `&[TreeItem]` — it does not own the data. Visual configuration is set via builder methods. It implements ratatui's `StatefulWidget` trait, meaning `render()` takes a `&mut TreeState`.
+
+The render pipeline:
+
+1. **Flatten**: `state.flatten(items)` produces the flat list of visible nodes.
+2. **Compute scroll viewport**: Forward-scan from `offset`, accumulate item heights until the area is filled. If `ensure_selected_in_view` is set, expand the window to include the selected item.
+3. **Render visible items**: For each item in the viewport:
+   - Write highlight symbol (if selected).
+   - Write indent: `depth * 2` spaces.
+   - Write node symbol: leaf (`"  "`), open (`"▼ "`), or closed (`"▶ "`).
+   - Write the item's text content.
+4. **Cache state**: Store `last_identifiers` and `last_rendered_identifiers` for next-frame navigation.
+
+The scroll viewport handles variable-height items. The ensure-selected-in-view logic expands the viewport in both directions, potentially adjusting `start` upward to keep the selected item visible.
+
+---
+
+## 4. Cross-Library Tree Patterns
+
+Coverage of tree-related patterns from other studied libraries. See the [TUI catalog](index.md) and [comparison](comparison.md) for full details.
+
+### [ImTui](imtui.md) / Dear ImGui (C++)
+
+Immediate-mode tree via `ImGui::TreeNode()` / `TreePop()`. There is no data model — the tree structure is implicit in the call sequence. Expand/collapse state is managed by ImGui's internal hot/active state keyed by string IDs. This is the simplest possible tree API but offers no model for external algorithms to operate on.
+
+### [Textual](textual.md) (Python)
+
+Textual provides built-in `Tree[TreeDataType]` and `TreeNode[TreeDataType]` widgets with a rich feature set.
+
+**Data model.** `TreeNode` stores `_id: NodeID` (auto-incrementing int), `_label: Text` (Rich styled text), `data: TreeDataType | None` (generic user payload), `_parent`, `_children: list[TreeNode]`, `_expanded: bool`, and `_allow_expand: bool`. A global `_tree_nodes: dict[NodeID, TreeNode]` provides O(1) lookup by ID.
+
+**Flatten pipeline.** The `_build()` method performs lazy DFS, producing a flat list of `_TreeLine` objects. Each `_TreeLine` contains a `path: list[TreeNode]` (full ancestor chain from root) and a `last: bool` flag. The `path` list drives guide character rendering — at each depth level, the renderer selects a guide based on whether the ancestor at that depth was the last child of its parent. The flat list is cached in `_tree_lines_cached` and invalidated (set to `None`) on any structural change.
+
+**Two-level caching.** Beyond the structural cache, an `LRUCache[LineCacheKey, Strip]` caches rendered lines. The cache key incorporates the node's `_updates` counter, hover state, selected state, and available width. A node label change increments only that node's counter, invalidating its cached line without rebuilding the entire flat list.
+
+**Virtual scroll.** `Tree` extends `ScrollView`, inheriting virtual scrolling. It advertises a `virtual_size` based on total line count and maximum width. Only lines within the viewport trigger `render_line(y)` calls.
+
+**Lazy loading (DirectoryTree).** `DirectoryTree` extends `Tree[DirEntry]` and adds a queue-based background worker: expanding a directory pushes it to `_load_queue`, a `@work(thread=True)` coroutine dequeues and populates children via filesystem reads. State preservation on reload captures expanded paths and cursor position, re-expands after repopulating, and restores cursor to the nearest valid position.
+
+**Expand/collapse state** lives on the node (`_expanded` bool) — not separated into an external state object. This is the canonical retained-mode pattern but limits the tree to a single visual state.
+
+### Rich (Python) — Tree rendering
+
+Rich's `Tree` is a non-interactive renderable — it produces styled text output, not a navigable widget. Its guide character rendering algorithm is the clearest model among all studied libraries.
+
+**Data model.** Each `Tree` node holds a `label` (any Rich renderable), `children: list[Tree]`, `style`/`guide_style`, and `expanded: bool`. Styles cascade from parent to child by default.
+
+**Guide character model.** Four positional constants indexed as a tuple:
+
+| Index | Name     | Meaning                                                 |
+| ----- | -------- | ------------------------------------------------------- |
+| 0     | SPACE    | Empty gap (no vertical line needed)                     |
+| 1     | CONTINUE | Vertical continuation line (`│`) — sibling exists below |
+| 2     | FORK     | Branch point (`├──`) — this node has a sibling below    |
+| 3     | END      | Terminal branch (`└──`) — last child                    |
+
+Four character sets are provided: ASCII, Unicode, Bold Unicode (`┣━━`/`┗━━`), and Double Unicode (`╠══`/`╚══`). The guide set is selected by inspecting the `guide_style` — bold style yields bold guides, underline2 yields double-line guides.
+
+**Rendering algorithm.** A stack-based DFS with a `levels` list accumulator. For each visible node:
+
+1. Build prefix by concatenating `levels[0..depth]` — this gives the vertical connectors for all ancestor levels.
+2. At the current depth, select FORK (not last child) or END (last child).
+3. Update `levels[depth]` to CONTINUE (more siblings) or SPACE (was last child).
+4. For multi-line labels, the first line gets the FORK/END connector; subsequent lines get the appropriate CONTINUE/SPACE prefix at the current depth.
+
+This four-state model with per-depth-level accumulation is the canonical algorithm for tree guide rendering.
+
+### broot (Rust) — Tree as search result
+
+[broot](https://github.com/Canop/broot) is a terminal file navigator that treats the tree as a function of the search pattern. Its architecture is fundamentally different from expand/collapse-based trees.
+
+**Data model.** The tree is a flat `Vec<TreeLine>` — no recursive structure. Each `TreeLine` stores `id`, `parent_id: Option<usize>`, `depth: u16`, `score: i32`, and `left_branches: Box<[bool]>`. There are no child pointers. The `left_branches` array is precomputed during construction: `left_branches[d]` is `true` if the ancestor at depth `d` has more siblings below, determining whether a vertical continuation line (`│`) should be drawn at that depth.
+
+**Construction via BFS with scoring.** `TreeBuilder` performs breadth-first filesystem traversal with two queues (`open_dirs` for the current level, `next_level_dirs` for the next). Each entry is scored against the active search pattern. The builder stops early at `targeted_size` (roughly screen height) without a pattern, or `10 * targeted_size` with a pattern. Excess entries are pruned via a min-heap (`SortableBId`) — the lowest-scoring entries are discarded first. An intermediate `BLine` arena with child pointers is used during construction but discarded when the final `Vec<TreeLine>` is produced.
+
+**"Tree as search result" paradigm.** Filtering is not post-processing over a pre-built tree. The pattern is evaluated during BFS construction. Subtrees with no matches are pruned entirely. Each keystroke rebuilds the tree structure from the filesystem — the tree is always a function of `(filesystem_state, search_pattern, depth_limit)`.
+
+**No expand/collapse.** broot has no per-node expand/collapse state. Depth is controlled globally via `max_depth`. Truncated content is shown as synthetic `Pruning` lines ("N unlisted") that are not selectable. A dual-tree model — `tree` (base) and optional `filtered_tree` — supports toggling between filtered and unfiltered views.
+
+**No virtual scroll.** The BFS early-termination strategy bounds the line count to approximately screen height, so virtual scrolling is unnecessary. Scrolling is a simple `scroll: usize` offset. A `Dam` cancellation mechanism interrupts builds when the user types, keeping the UI responsive on large filesystems.
+
+### cursive_tree_view (Rust)
+
+[cursive_tree_view](https://github.com/BonsaiDen/cursive_tree_view) is a tree-view widget for the Cursive TUI framework that validates the flat-array approach to tree storage.
+
+**Data model.** The tree is stored as a flat `Vec<TreeNode<T>>` where `T: Display + Debug`. Each `TreeNode` stores `value: T`, `level: usize` (depth), `is_collapsed: bool`, `children: usize` (descendant count), and `height: usize` (subtree size including self). Parent-child relationships are implicit — a node's children occupy the contiguous indices immediately after it. Parent lookup is a backward scan for the first entry with a strictly lower `level`.
+
+**Dual index spaces.** The crate maintains two identification schemes:
+
+- **Item index** — position in the flat `Vec`. Stable across collapse/expand.
+- **Row** — position in the visible display. Changes when nodes above are collapsed/expanded.
+
+All public API methods use row indices. Internal conversion between the two is O(n): `row_to_item_index()` walks the array, skipping collapsed subtrees.
+
+**Collapse mechanics.** Collapsed nodes remain in the `Vec` — they are skipped during rendering, not removed. The `collapsed_height` field caches how many rows are hidden. Height changes propagate upward via `traverse_up()`, which walks ancestors to adjust their counts.
+
+**Rendering.** The `draw()` method performs a single forward scan of the `Vec`, incrementing by `node.len()` to skip collapsed subtrees. Each node renders at `level * 2` indentation with symbols: `"▸"` (collapsed), `"▾"` (expanded), `"◦"` (leaf).
+
+**Placement-based insertion.** An enum `Placement { After, Before, FirstChild, LastChild, Parent }` specifies where new nodes are inserted relative to a target row.
+
+**Tradeoffs.** Row-based public identification is fragile — insert/remove above a node changes its row index. No stable node IDs exist. Parent lookup is O(siblings). But cache-friendly iteration, simple serialization, and no recursive types are significant advantages for `@nogc` constraints.
+
+### stlab::forest (C++) — Sean Parent's tree container
+
+[stlab::forest](https://github.com/stlab/libraries) is Sean Parent's own answer to the "incidental data structure" problem for trees.
+
+**Node structure.** Each node stores a 2×2 link array: `_nodes[leading|trailing][prior|next]`. The leading edge represents "entering" a node (pre-order visit); the trailing edge represents "leaving" (post-order visit). This dual-edge model is the central abstraction — every node is visited twice in a fullorder traversal.
+
+**Memory layout.** Nodes are individually heap-allocated and linked into a circular doubly-linked structure anchored by a sentinel tail node. This gives O(1) insert/erase via splice but poor cache locality due to pointer chasing.
+
+**Iterator hierarchy.** The forest provides five iterator types, all derived from fullorder:
+
+| Iterator                              | Description                                                             |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| `forest_iterator` (fullorder)         | Visits every node twice (leading then trailing)                         |
+| `child_iterator`                      | Immediate children of a node                                            |
+| `edge_iterator<leading>` (preorder)   | Leading edges only                                                      |
+| `edge_iterator<trailing>` (postorder) | Trailing edges only                                                     |
+| `depth_fullorder_iterator`            | Fullorder with depth tracking (leading increments, trailing decrements) |
+
+The `depth_fullorder_iterator` filtered to leading edges is directly applicable to tree rendering — it yields `(node, depth)` pairs in preorder, exactly what a tree renderer needs for indentation.
+
+**Value semantics on the container.** `forest<T>` supports deep copy via traversal-based reconstruction and move. There is a single "whole" object with clear ownership. No parent pointers on nodes — parent navigation is implicit in the traversal order.
+
+**Relevance.** stlab::forest solves the ownership and value semantics problems but uses individual heap allocations, trading cache locality for O(1) structural modification and stable iterators. The flat-array approach (contiguous `Node[]` with indices) reverses this tradeoff: better cache locality and `@nogc` friendliness, but O(n) insertion.
+
+### [Brick](brick.md) (Haskell)
+
+No built-in tree widget. Functional combinators (`vBox`, `padLeft`) compose a tree visually. The tree model is user-defined — Brick provides the layout primitives, and the application builds tree display from those primitives. This is the most "library, not framework" approach.
+
+### [Bubble Tea](bubbletea.md) (Go)
+
+No built-in tree widget. Community `bubbles/tree` follows the MVU pattern: the model stores a flat list of visible nodes annotated with depth. Expand/collapse dispatches an update message that recomputes the flat list. Pure functional approach where the view is derived from the model.
+
+### [tview](tview.md) (Go)
+
+`TreeView` widget with `TreeNode` model. Nodes have a `reference` field (user data), `children` slice, and `expanded` boolean. Virtual scrolling via a `GetChildren` callback enables lazy loading. The expand/collapse state lives directly on the node — mixing data and view state.
+
+### [FTXUI](ftxui.md) (C++)
+
+No built-in tree widget. Flexbox layout + `Collapsible()` component can compose one. `Collapsible(label, child)` toggles visibility of its child on click. Building a full tree requires nesting collapsibles, which is verbose but gives full control over rendering.
+
+### [Nottui](nottui.md) (OCaml)
+
+Incremental reactive model ideal for trees. Reactive variables (`Lwd.var`) for expand/collapse state trigger minimal recomputation of only the affected subtree. The DAG-based computation model means expanding a deep node doesn't recompute siblings. This is architecturally the most sophisticated approach for large trees.
+
+---
+
+## 5. Comparative Analysis
+
+| Dimension             | Snacks.nvim                       | ratatui-tree-widget               | broot                            | cursive_tree_view                        | Textual                  | Rich                            | stlab::forest                   |
+| --------------------- | --------------------------------- | --------------------------------- | -------------------------------- | ---------------------------------------- | ------------------------ | ------------------------------- | ------------------------------- |
+| **Data model**        | Singleton tree + flat stream      | `TreeItem` tree (recursive `Vec`) | Flat `Vec<TreeLine>`             | Flat `Vec<TreeNode>`                     | `TreeNode` widget tree   | Recursive `Tree` renderable     | Circular linked nodes           |
+| **Ownership**         | Singleton, shared refs            | User-owned, borrowed by widget    | Owned flat array                 | Owned flat array                         | Framework-owned          | User-owned                      | Container owns all nodes        |
+| **State separation**  | Mixed (`open`/`expanded` on Node) | Clean (`TreeState` separate)      | No expand/collapse state         | `is_collapsed` on node                   | `_expanded` on node      | `expanded` on node              | No built-in state (data only)   |
+| **Identification**    | Path string                       | Generic `Vec<Identifier>` path    | Array index + `parent_id`        | Row index (unstable)                     | `NodeID` (auto-int)      | None (render-only)              | Iterator position               |
+| **Flatten algorithm** | `Tree:get()` + callback           | Free function `flatten()`         | BFS construction with scoring    | Forward scan skipping collapsed          | Lazy DFS in `_build()`   | Stack-based DFS render          | `depth_fullorder_iterator`      |
+| **Expand/collapse**   | Mutable `open` + re-flatten       | `HashSet<Vec<Id>>` in `TreeState` | None (global depth limit)        | `is_collapsed` bool + height propagation | `_expanded` bool         | `expanded` bool                 | N/A (data container)            |
+| **Filtering**         | Predicate on walk                 | User filters before passing       | During BFS construction (scored) | N/A                                      | CSS + filter             | N/A                             | Standard algorithm on iterators |
+| **Virtual scroll**    | Picker list                       | `offset` + forward-scan           | Not needed (bounded array)       | Cursive framework handles                | `ScrollView` inheritance | N/A (renderable)                | N/A (data container)            |
+| **Guide characters**  | Picker formatter                  | Node symbols only (▶/▼)          | Precomputed `left_branches`      | Symbols only (▸/▾/◦)                     | DFS-built guide path     | Four-state `levels` accumulator | N/A (data container)            |
+| **Search/filter**     | `fd` + `keep_parents`             | N/A                               | Tree = f(pattern)                | N/A                                      | Built-in                 | N/A                             | N/A                             |
+| **Cache locality**    | Poor (Lua tables)                 | Poor (recursive heap `Vec`)       | Excellent (flat `Vec`)           | Excellent (flat `Vec`)                   | Poor (object graph)      | Poor (recursive list)           | Poor (individual alloc)         |
+
+### Key observations
+
+**State separation is the clearest differentiator.** ratatui-tree-widget's `TreeState` is separate from `TreeItem` — you can have multiple states for the same tree (e.g., two views with different open sets). Snacks, Textual, and cursive_tree_view all mix expand/collapse state directly on nodes, meaning the tree can only have one visual state at a time. stlab::forest is purely a data container with no built-in visual state — the cleanest separation of all, but at the cost of providing no UI primitives.
+
+**Flatten as a pure function vs. a method-with-side-effects.** ratatui's `flatten()` is a free function taking immutable data + state → flat list. Snacks' `Tree:get()` is a method on the singleton that lazily expands directories during traversal (a side effect). broot eliminates the question entirely by building the flat list directly — there is no tree-to-flat conversion because the tree _is_ flat. The pure function approach (ratatui) or direct flat construction (broot) are both more testable than the method-with-side-effects approach.
+
+**Two approaches to flat storage.** cursive_tree_view and broot both store trees as flat arrays, but with different designs. cursive_tree_view uses `level` + sequential position with collapsed nodes remaining in the array (skipped during render). broot discards children entirely — the array contains only visible nodes, rebuilt from scratch on each keystroke. cursive_tree_view optimizes for dynamic expand/collapse; broot optimizes for search-driven exploration.
+
+**Guide character rendering.** Rich's four-state model (SPACE, CONTINUE, FORK, END) with a per-depth `levels` accumulator is the most explicit algorithm. broot precomputes the equivalent information as `left_branches: Box<[bool]>` during construction, avoiding any per-render computation. Textual stores the full ancestor `path` list on each `_TreeLine` and derives guides at render time. ratatui-tree-widget uses only node symbols (▶/▼/spaces), not connecting lines — the simplest approach but least visually informative.
+
+**Identification strategy.** ratatui's generic `Vec<Identifier>` is the most general. Textual's `NodeID` (auto-incrementing int with global lookup table) is efficient but framework-specific. cursive_tree_view's row-based identification is fragile across mutations. broot uses array indices which are unstable across rebuilds but this doesn't matter because the tree is rebuilt on every keystroke.
+
+**Feature richness vs. architectural clarity.** Snacks has git integration, diagnostics propagation, file watching, search mode, and snapshot diffing — features a real file explorer needs. ratatui-tree-widget is minimal but architecturally clean. broot demonstrates that a radically different paradigm (tree-as-search-result) can be highly effective. A good design should achieve the clean separation of ratatui while being extensible enough to support both traditional expand/collapse and broot-style search-driven views.
+
+---
+
+## 6. Analysis Through Sean Parent's Principles
+
+### Avoiding incidental data structures
+
+> "An incidental data structure is a data structure where there is no object representing the structure as a whole." — [Data Structures](../sean-parent/data-structures.md)
+
+**Snacks' `Tree`** is an incidental data structure in Sean Parent's sense. The `parent` field on each `Node` is a direct Lua reference creating a doubly-linked tree. There is a "whole" object (`Tree`), but the `nodes` table (a path → node lookup) and the `parent` back-references create multiple overlapping ways to traverse the structure. Copying the tree would require deep-copying all nodes and re-wiring parent references — which Snacks doesn't support.
+
+**ratatui-tree-widget's `TreeItem`** is closer to a proper tree — `children: Vec<Self>` with `#[derive(Clone)]` makes it a value type that can be copied. However, the recursive `Vec<Self>` still involves pointer chasing (each `Vec` is heap-allocated). For cache locality, a flat vector with parent/child indices would be better:
+
+```d
+// Flat storage (Sean Parent's preferred approach)
+struct Tree(Identifier) {
+    struct Node {
+        Identifier id;
+        string text;
+        size_t parent;        // index into nodes[]
+        size_t firstChild;    // index into nodes[]
+        size_t nextSibling;   // index into nodes[]
+    }
+    Node[] nodes;
+}
+```
+
+### Value semantics
+
+> "Value semantics are the cleanest way to implement Whole-Part relationships." — [Value Semantics](../sean-parent/value-semantics.md)
+
+**ratatui-tree-widget** achieves value semantics well. `TreeItem` derives `Clone`; the entire tree can be copied as a value. `TreeState` is also a regular type with `Default`. This enables easy testing (construct a tree, copy it, modify the copy, compare) and undo/redo (snapshot the tree before modification).
+
+**Snacks' `Tree`** is a mutable singleton. It cannot be copied. The `snapshot()`/`changed()` methods are a workaround — they capture specific fields for comparison without actually copying the tree. This is a pragmatic solution for a Lua environment where deep copying is expensive, but it's not value semantics.
+
+For D, the tree should be a regular copyable value. With flat storage (`Node[]`), copy is a single array duplication — no recursive traversal needed.
+
+### Separate algorithms from data
+
+> "Algorithms are more fundamental than the data structures on which they operate." — [Generic Programming](../sean-parent/generic-programming.md)
+
+**ratatui-tree-widget's `flatten()`** is a free function taking data + state → flat list. This is the right pattern — the algorithm is separate from both the data model and the interaction state. It can be tested independently, reused with different state, and composed with other operations.
+
+**Snacks' `Tree:walk()`/`Tree:get()`** are methods on the singleton. They conflate traversal with lazy expansion (a side effect) and filtering (a concern of the view layer). Separating these would mean: a pure traversal function, a separate expansion function, and filtering as a composable predicate.
+
+For D, tree operations should be free functions with range interfaces. A `flatten` function should take a tree and an opened set and return a range of `Flattened(depth, nodeRef)` structs.
+
+### Separate data from visual state
+
+**ratatui-tree-widget** cleanly separates `TreeItem` (data) from `TreeState` (opened, selected, offset). The widget borrows both at render time. This means you can:
+
+- Have multiple `TreeState` instances for the same data (e.g., two views).
+- Serialize/deserialize `TreeState` independently.
+- Test data operations without visual state.
+
+**Snacks** mixes them: `open` (visual state) lives on `Node` alongside `path`/`type` (data). The `status` and `severity` fields are also decoration (from git and LSP) rather than intrinsic node data.
+
+The ratatui pattern is the one to follow.
+
+### Regular types
+
+> "A type is regular if it behaves like int." — [Regular Types](../sean-parent/regular-types.md)
+
+**ratatui-tree-widget's Identifier constraint** (`Clone + PartialEq + Eq + Hash`) defines the minimum interface for a node identifier to be usable in sets and maps, comparable, and copyable. This maps directly to D's `opEquals` and `toHash`.
+
+**Snacks nodes** are identity-based — two nodes are the "same" if they are the same Lua table (reference equality). Path strings serve as external identifiers but nodes themselves don't have value equality.
+
+For D, node identifiers should be regular types satisfying the [Regular Types](../sean-parent/regular-types.md) requirements.
+
+### Sean Parent's own tree: stlab::forest
+
+`stlab::forest` is Sean Parent's direct implementation of a tree container that avoids incidental data structures. It provides a single "whole" object with clear ownership, deep copy via traversal-based reconstruction, and a standard iterator interface.
+
+However, `stlab::forest` uses individual heap-allocated nodes with pointer-based circular linking. This achieves O(1) structural modification and stable iterators but at the cost of cache locality. The flat-array approach recommended in [Section 7](#7-design-principles-for-sparkles-tree-view) reverses this tradeoff — better cache locality and `@nogc` friendliness, but O(n) insertion.
+
+The key takeaway from `stlab::forest` is not its memory layout but its **traversal model**. The fullorder traversal (visiting each node twice — on leading and trailing edges) naturally supports `depth_fullorder_iterator`, which yields `(node, depth)` pairs in preorder. This is exactly what a tree renderer needs for indentation. A D implementation should provide an equivalent `depthFirst` range adaptor regardless of the underlying storage model.
+
+The 2×2 link array (`_nodes[leading|trailing][prior|next]`) is an elegant encoding of tree relationships, but it is optimized for dynamic trees with frequent structural modification — a use case less relevant for tree _views_, which typically receive an already-built tree and focus on display and navigation.
+
+---
+
+## 7. Design Principles for Sparkles Tree-View
+
+Synthesizing the findings from both case studies, cross-library patterns, and Sean Parent's principles:
+
+### 1. Three-layer architecture
+
+Follow ratatui's separation: `TreeItem` (data), `TreeState` (interaction), and `TreeRenderer` (visual output). Each layer has a single responsibility and no knowledge of the others' internals.
+
+### 2. Flat storage with index-based relationships
+
+Follow [Sean Parent's guidance on data structures](../sean-parent/data-structures.md): store all nodes in a contiguous `Node[]` array with parent/child/sibling indices rather than recursive pointer-based trees. This gives better cache locality than ratatui's recursive `Vec<Self>` and avoids the incidental structure of Snacks' parent references.
+
+### 3. Separate data model from view state
+
+Follow ratatui's pattern: the opened set, selection, and scroll position live in `TreeState`, not on nodes. This enables multiple views of the same tree data and clean serialization of view state.
+
+### 4. Flatten as a free function
+
+Follow ratatui's `flatten()` pattern: a pure free function `flatten(tree, state) → range of Flattened(depth, nodeRef)`. No side effects, no lazy expansion mixed in. Testable and composable.
+
+### 5. Path-based identification
+
+Follow both references: nodes are identified by a `Identifier[]` path from root. The `Identifier` type is generic with `opEquals`/`toHash` constraints, matching ratatui's `Clone + PartialEq + Eq + Hash` and Sean Parent's [Regular Types](../sean-parent/regular-types.md).
+
+### 6. DbI for node capabilities
+
+Follow the project's [Design by Introspection guidelines](../../guidelines/design-by-introspection-01-guidelines.md): use optional primitives for `hasChildren`, `hasIcon`, `hasStatus`, etc. A tree of file-system entries has different capabilities than a tree of AST nodes — DbI lets the renderer adapt without separate type hierarchies.
+
+### 7. Output range rendering
+
+Follow the project's [functional/declarative guidelines](../../guidelines/functional-declarative-programming-guidelines.md): the tree renderer writes to any output range, not just stdout. This enables rendering to `SmallBuffer`, `appender!string`, or a terminal buffer.
+
+### 8. Value semantics
+
+Follow ratatui + [Sean Parent's value semantics](../sean-parent/value-semantics.md): the entire tree is copyable. With flat storage, this is a single array copy. Enables snapshot-based testing, undo/redo, and the snapshot-diffing pattern Snacks demonstrates.
+
+### 9. `@nogc` path
+
+Follow the project guidelines: tree traversal and rendering should work with `SmallBuffer` and avoid GC allocation. The flat storage model (contiguous `Node[]`) is naturally `@nogc`-friendly — no recursive heap allocation needed during traversal.
+
+### 10. Lazy children
+
+Follow Snacks' pattern of separating user intent (`open`) from loaded state (`expanded`): children can be loaded on demand via a callback or range. The tree data model should support both eagerly-populated trees (for in-memory data) and lazily-populated trees (for filesystem or network sources).
+
+### 11. Four-state guide character model
+
+Follow Rich's rendering algorithm: a `levels` array tracks the guide state (SPACE, CONTINUE, FORK, END) at each depth. For each visible node, the prefix is built by concatenating `levels[0..depth]`, then updating `levels[depth]` based on whether the node is the last child. broot's precomputed `left_branches: Box<[bool]>` demonstrates that this can be computed once during flatten rather than per-render, which is more efficient for static or infrequently-changing trees.
+
+### 12. Depth-first range adaptor
+
+Follow stlab::forest's `depth_fullorder_iterator` pattern: provide a `depthFirst` range adaptor that yields `(depth, nodeRef, isLastChild)` tuples. This gives the renderer everything it needs for guide characters and indentation in a single traversal. The `isLastChild` field enables Rich's four-state algorithm without requiring backward lookups.
+
+### 13. Tree-as-search-result paradigm
+
+broot demonstrates that a tree view does not require persistent expand/collapse state. An alternative mode where the visible tree is rebuilt as a function of `(data_source, search_pattern, depth_limit)` can coexist with traditional expand/collapse. The tree data model should be cheap enough to construct that rebuilding per-keystroke is viable — flat storage with precomputed guide state makes this feasible.


### PR DESCRIPTION
## Summary

- Add `tree-view-case-study.md` — a comparative analysis of tree-view implementations across 13 TUI libraries (snacks.nvim, ratatui-tree-widget, Textual, Rich, broot, cursive_tree_view, stlab::forest, ImTui, Brick, Bubble Tea, tview, FTXUI, Nottui)
- Add `broot.md` — detailed study of broot's flat-array tree and "tree as search result" paradigm
- Add `snacks-nvim.md` — detailed study of snacks.nvim's explorer architecture
- Update `index.md` with cross-references to the new case study

The case study includes a 7-column comparative analysis table, evaluation through Sean Parent's principles (value semantics, incidental data structures, algorithm/data separation), and 13 design principles for the Sparkles tree-view component.

## Test plan

- [x] Verify all markdown cross-reference links resolve correctly
- [x] Verify document renders correctly on GitHub