### PR TITLE
docs(guidelines): cross-link research docs, convert to reference-style links, add code block language identifiers

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -134,6 +134,14 @@ export default defineConfig({
                     link: "/research/algebraic-effects/comparison",
                   },
                   {
+                    text: "Evolution",
+                    link: "/research/algebraic-effects/evolution",
+                  },
+                  {
+                    text: "Parallelism",
+                    link: "/research/algebraic-effects/parallelism",
+                  },
+                  {
                     text: "Papers",
                     link: "/research/algebraic-effects/papers",
                   },
@@ -197,6 +205,18 @@ export default defineConfig({
                     text: "mtl",
                     link: "/research/algebraic-effects/haskell-mtl",
                   },
+                  {
+                    text: "eff",
+                    link: "/research/algebraic-effects/haskell-eff",
+                  },
+                  {
+                    text: "theseus",
+                    link: "/research/algebraic-effects/haskell-theseus",
+                  },
+                  {
+                    text: "heftia",
+                    link: "/research/algebraic-effects/haskell-heftia",
+                  },
                 ],
               },
               {
@@ -214,6 +234,10 @@ export default defineConfig({
                   {
                     text: "Kyo",
                     link: "/research/algebraic-effects/scala-kyo",
+                  },
+                  {
+                    text: "Ox",
+                    link: "/research/algebraic-effects/scala-ox",
                   },
                   {
                     text: "Scala 3 Capabilities",
@@ -258,6 +282,16 @@ export default defineConfig({
                 ],
               },
               {
+                text: "Swift",
+                collapsed: true,
+                items: [
+                  {
+                    text: "Swift Effects",
+                    link: "/research/algebraic-effects/swift-effects",
+                  },
+                ],
+              },
+              {
                 text: "Industry Platforms",
                 collapsed: true,
                 items: [
@@ -274,6 +308,10 @@ export default defineConfig({
                     link: "/research/algebraic-effects/wasmfx",
                   },
                 ],
+              },
+              {
+                text: "Other Implementations",
+                link: "/research/algebraic-effects/other-implementations",
               },
             ],
           },

--- a/docs/research/algebraic-effects/comparison.md
+++ b/docs/research/algebraic-effects/comparison.md
@@ -19,11 +19,11 @@ Many production systems called "effect systems" are not full algebraic handler s
 
 Every effect system navigates tension between several competing concerns. No system achieves all simultaneously.
 
-| Concern            | Best-in-class                                                           | What it costs                                                                                   |
-| ------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Performance**    | effectful, eff, Koka (evidence passing), OCaml 5 (native continuations) | Loses pure interpretation (effectful); stalled development (eff); untyped effects (OCaml 5)     |
-| **Expressiveness** | heftia, Koka (row-polymorphic), Effect-TS                               | Conceptual complexity; newer/less battle-tested; runtime overhead (Effect-TS generators)        |
-| **Simplicity**     | bluefin, Ox, OCaml 5 Eio                                                | Explicit handle threading (bluefin); no effect handlers (Ox); no static effect typing (OCaml 5) |
+| Concern            | Best-in-class                                                                   | What it costs                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Performance**    | [effectful], [eff], [Koka] (evidence passing), [OCaml 5] (native continuations) | Loses pure interpretation (effectful); stalled development (eff); untyped effects (OCaml 5)     |
+| **Expressiveness** | [heftia], [Koka] (row-polymorphic), [Effect (TypeScript)]                       | Conceptual complexity; newer/less battle-tested; runtime overhead (Effect-TS generators)        |
+| **Simplicity**     | [bluefin], [Ox], [OCaml 5] Eio                                                  | Explicit handle threading (bluefin); no effect handlers (Ox); no static effect typing (OCaml 5) |
 
 ---
 
@@ -31,17 +31,17 @@ Every effect system navigates tension between several competing concerns. No sys
 
 | System / Family                                                    | Effect Typing                                      | Full Handlers?                          | Continuation Strategy                         | Key Strengths                                                         | Current Limits                                                 |
 | ------------------------------------------------------------------ | -------------------------------------------------- | --------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------- |
-| **Koka**                                                           | Row-polymorphic effect types with inference        | Yes                                     | Selective CPS + evidence-style compilation    | Strong theory/implementation alignment; practical effect inference    | Smaller ecosystem than mainstream platforms                    |
-| **Eff / Effekt / research languages**                              | Varies, usually explicit effects                   | Yes                                     | Interpreter or compiler-specific              | Clean semantics and experimentation velocity                          | Research-oriented tooling/ecosystem                            |
-| **OCaml 5 runtime + Eio**                                          | Runtime effects (no effect rows in function types) | Yes (runtime handlers)                  | Native one-shot continuations/fibers          | Direct style, strong multicore story, production language integration | Static effect typing remains an open language-design direction |
-| **Haskell effectful / cleff**                                      | Type-level effect lists                            | Not full algebraic handlers (by design) | Reader/environment dispatch over `IO`         | Excellent practical performance and ecosystem interop                 | No general continuation-based algebraic effects                |
-| **Haskell continuation-backed libraries (`eff`, `bluefin-algae`)** | Library-specific                                   | Closer to full handlers                 | GHC delimited continuation primops            | Runtime-backed control effects in Haskell                             | API/maintenance maturity varies across libraries               |
-| **Haskell hefty-style line (`heftia`)**                            | Algebraic + higher-order structure                 | Yes                                     | Elaborate HO effects before FO interpretation | Strong soundness story for HO interactions                            | Newer ecosystem; higher conceptual load                        |
-| **Scala ZIO / Cats Effect**                                        | Typed channels/typeclasses                         | No (not algebraic handlers)             | Fiber runtime on JVM                          | Production-grade concurrency/runtime tooling                          | Different abstraction goal than algebraic handlers             |
-| **Scala Kyo**                                                      | Open effect channels                               | Handler-inspired algebraic model        | Runtime/library-specific                      | Direct-style ergonomics with effect tracking                          | Rapidly evolving API/model compared with mature stacks         |
-| **Scala 3 capabilities/capture checking**                          | Capability/capture types                           | N/A (language capability system)        | Language-level type discipline                | Promising static reasoning for authority/effects                      | Experimental status in Scala 3.8                               |
-| **Effect (TypeScript)**                                            | `Effect<A, E, R>` style channels                   | Handler-inspired library model          | Generator/runtime encoding                    | Strong industrial ergonomics in JS/TS ecosystem                       | Runtime overhead model differs from native runtimes            |
-| **WasmFX / stack-switching targets**                               | Low-level typed continuation substrate             | Target-level primitives                 | Runtime/VM continuation support               | Cross-language compilation path for handlers                          | Proposal/toolchain maturity still evolving                     |
+| **[Koka]**                                                         | Row-polymorphic effect types with inference        | Yes                                     | Selective CPS + evidence-style compilation    | Strong theory/implementation alignment; practical effect inference    | Smaller ecosystem than mainstream platforms                    |
+| **[Eff] / Effekt / research languages**                            | Varies, usually explicit effects                   | Yes                                     | Interpreter or compiler-specific              | Clean semantics and experimentation velocity                          | Research-oriented tooling/ecosystem                            |
+| **[OCaml 5] runtime + [Eio]**                                      | Runtime effects (no effect rows in function types) | Yes (runtime handlers)                  | Native one-shot continuations/fibers          | Direct style, strong multicore story, production language integration | Static effect typing remains an open language-design direction |
+| **[Haskell effectful] / [cleff]**                                  | Type-level effect lists                            | Not full algebraic handlers (by design) | Reader/environment dispatch over `IO`         | Excellent practical performance and ecosystem interop                 | No general continuation-based algebraic effects                |
+| **Haskell continuation-backed libraries ([eff], [bluefin-algae])** | Library-specific                                   | Closer to full handlers                 | GHC delimited continuation primops            | Runtime-backed control effects in Haskell                             | API/maintenance maturity varies across libraries               |
+| **Haskell hefty-style line ([heftia], [Theseus])**                 | Algebraic + higher-order structure                 | Yes                                     | Elaborate HO effects before FO interpretation | Strong soundness story for HO interactions                            | Newer ecosystem; higher conceptual load                        |
+| **[Scala ZIO] / [Cats Effect]**                                    | Typed channels/typeclasses                         | No (not algebraic handlers)             | Fiber runtime on JVM                          | Production-grade concurrency/runtime tooling                          | Different abstraction goal than algebraic handlers             |
+| **[Scala Kyo]**                                                    | Open effect channels                               | Handler-inspired algebraic model        | Runtime/library-specific                      | Direct-style ergonomics with effect tracking                          | Rapidly evolving API/model compared with mature stacks         |
+| **[Scala 3 capabilities] / capture checking**                      | Capability/capture types                           | N/A (language capability system)        | Language-level type discipline                | Promising static reasoning for authority/effects                      | Experimental status in Scala 3.8                               |
+| **[Effect (TypeScript)]**                                          | `Effect<A, E, R>` style channels                   | Handler-inspired library model          | Generator/runtime encoding                    | Strong industrial ergonomics in JS/TS ecosystem                       | Runtime overhead model differs from native runtimes            |
+| **[WasmFX] / stack-switching targets**                             | Low-level typed continuation substrate             | Target-level primitives                 | Runtime/VM continuation support               | Cross-language compilation path for handlers                          | Proposal/toolchain maturity still evolving                     |
 
 ---
 
@@ -86,19 +86,19 @@ Every effect system navigates tension between several competing concerns. No sys
 
 A critical issue that separates effect systems is the **soundness of higher-order effects**. When a higher-order effect (like `catch` or `local`) scopes over a computation that uses algebraic effects (like `NonDet` or `Coroutine`), the interaction can produce incorrect results. Different libraries give different answers, and some give inconsistent answers depending on handler ordering.
 
-| Library       | Higher-Order Effects   | Algebraic Effects         | Sound Interaction                                                                       |
-| ------------- | ---------------------- | ------------------------- | --------------------------------------------------------------------------------------- |
-| polysemy      | Yes (Tactics)          | Partial                   | **No** -- documented unsound cases                                                      |
-| fused-effects | Yes (carriers)         | Partial                   | **No** -- same class of issues                                                          |
-| effectful     | Yes                    | **No** (no continuations) | N/A (avoids the problem)                                                                |
-| cleff         | Yes                    | **No**                    | N/A                                                                                     |
-| eff           | Yes                    | **Yes**                   | **Yes** -- consistent delimited control semantics                                       |
-| heftia        | Yes                    | **Yes**                   | **Yes** -- elaboration ensures soundness                                                |
-| Theseus       | Yes                    | **Yes**                   | **Yes** -- order-independent interpretation                                             |
-| Koka          | N/A (first-order only) | **Yes**                   | N/A -- no higher-order effects; first-order algebraic effects are sound by construction |
-| OCaml 5       | N/A                    | **Yes** (untyped)         | N/A -- no static guarantees; soundness is the programmer's responsibility               |
-| Eff           | N/A (first-order only) | **Yes**                   | N/A -- reference semantics by Plotkin/Pretnar                                           |
-| Frank         | Yes (multihandlers)    | **Yes**                   | **Yes** -- ambient ability with CBPV ensures consistent semantics                       |
+| Library         | Higher-Order Effects   | Algebraic Effects         | Sound Interaction                                                                       |
+| --------------- | ---------------------- | ------------------------- | --------------------------------------------------------------------------------------- |
+| [polysemy]      | Yes (Tactics)          | Partial                   | **No** -- documented unsound cases                                                      |
+| [fused-effects] | Yes (carriers)         | Partial                   | **No** -- same class of issues                                                          |
+| [effectful]     | Yes                    | **No** (no continuations) | N/A (avoids the problem)                                                                |
+| [cleff]         | Yes                    | **No**                    | N/A                                                                                     |
+| [eff]           | Yes                    | **Yes**                   | **Yes** -- consistent delimited control semantics                                       |
+| [heftia]        | Yes                    | **Yes**                   | **Yes** -- elaboration ensures soundness                                                |
+| [Theseus]       | Yes                    | **Yes**                   | **Yes** -- order-independent interpretation                                             |
+| [Koka]          | N/A (first-order only) | **Yes**                   | N/A -- no higher-order effects; first-order algebraic effects are sound by construction |
+| [OCaml 5]       | N/A                    | **Yes** (untyped)         | N/A -- no static guarantees; soundness is the programmer's responsibility               |
+| [Eff]           | N/A (first-order only) | **Yes**                   | N/A -- reference semantics by Plotkin/Pretnar                                           |
+| [Frank]         | Yes (multihandlers)    | **Yes**                   | **Yes** -- ambient ability with CBPV ensures consistent semantics                       |
 
 The effectful/cleff approach sidesteps the problem entirely by not supporting algebraic effects (no continuation capture). This is a pragmatic choice that works well for most applications.
 
@@ -134,21 +134,21 @@ OCaml and GHC runtime support, plus Wasm target work, suggest long-term success 
 
 ### If your primary goal is production reliability today
 
-- Haskell: `effectful`/`cleff` when continuation-heavy algebraic semantics are not required
-- Scala: ZIO or Cats Effect for mature runtime ecosystems
-- OCaml: Eio on OCaml 5 for direct-style concurrent systems
+- Haskell: [effectful]/[cleff] when continuation-heavy algebraic semantics are not required
+- Scala: [ZIO] or [Cats Effect] for mature runtime ecosystems
+- OCaml: [Eio] on [OCaml 5] for direct-style concurrent systems
 
 ### If your primary goal is semantic expressiveness of handlers
 
-- Koka and research languages (Eff/Effekt)
-- Haskell hefty-style research line for sound HO composition
-- Experimental continuation-backed Haskell libraries
+- [Koka] and research languages ([Eff]/Effekt)
+- Haskell hefty-style research line ([heftia], [Theseus]) for sound HO composition
+- Experimental continuation-backed Haskell libraries ([eff], [bluefin-algae])
 
 ### If your primary goal is language/runtime research
 
-- Parallel handlers (`lambda^p`)
-- Affine and temporal effect calculi
-- Wasm continuation targets and cross-language lowering
+- [Parallel handlers] (`lambda^p`)
+- Affine and temporal effect calculi (see [Key Papers])
+- [WasmFX] continuation targets and cross-language lowering
 
 ---
 
@@ -162,18 +162,59 @@ OCaml and GHC runtime support, plus Wasm target work, suggest long-term success 
 
 ## Sources
 
-- [Hefty Algebras (POPL 2023)](https://doi.org/10.1145/3571255)
-- [Effect Handlers, Evidently (ICFP 2020)](https://doi.org/10.1145/3408981)
-- [Generalized Evidence Passing (ICFP 2021)](https://doi.org/10.1145/3473576)
-- [Retrofitting Effect Handlers onto OCaml (PLDI 2021)](https://doi.org/10.1145/3453483.3454039)
-- [Parallel Algebraic Effect Handlers (ICFP 2024)](https://doi.org/10.1145/3674651)
-- [A Framework for Higher-Order Effects and Handlers (ICFP 2024)](https://doi.org/10.1145/3674632)
-- [Abstracting Effect Systems for Algebraic Effect Handlers (ICFP 2024)](https://doi.org/10.1145/3674630)
-- [Affect: Affine Algebraic Effect Handlers (POPL 2025)](https://doi.org/10.1145/3704831)
-- [Algebraic Temporal Effects (POPL 2025)](https://doi.org/10.1145/3704853)
-- [Asymptotic Speedup via Effect Handlers (POPL 2025)](https://doi.org/10.1145/3704871)
-- [OCaml 5.3.0 release notes](https://ocaml.org/releases/5.3.0)
-- [GHC 9.6.1 release notes](https://downloads.haskell.org/~ghc/9.6.5/docs/users_guide/9.6.1-notes.html)
-- [Scala 3.8 release announcement (2026-01-21)](https://www.scala-lang.org/blog/2026/01/21/scala-3.8.html)
-- [WebAssembly stack-switching proposal repo](https://github.com/WebAssembly/stack-switching)
-- [effects-bibliography](https://github.com/yallop/effects-bibliography)
+- [Hefty Algebras (POPL 2023)]
+- [Effect Handlers, Evidently (ICFP 2020)]
+- [Generalized Evidence Passing (ICFP 2021)]
+- [Retrofitting Effect Handlers onto OCaml (PLDI 2021)]
+- [Parallel Algebraic Effect Handlers (ICFP 2024)]
+- [A Framework for Higher-Order Effects and Handlers (ICFP 2024)]
+- [Abstracting Effect Systems for Algebraic Effect Handlers (ICFP 2024)]
+- [Affect: Affine Algebraic Effect Handlers (POPL 2025)]
+- [Algebraic Temporal Effects (POPL 2025)]
+- [Asymptotic Speedup via Effect Handlers (POPL 2025)]
+- [OCaml 5.3.0 release notes]
+- [GHC 9.6.1 release notes]
+- [Scala 3.8 release announcement (2026-01-21)]
+- [WebAssembly stack-switching proposal repo]
+- [effects-bibliography]
+
+<!-- References -->
+
+[Hefty Algebras (POPL 2023)]: https://doi.org/10.1145/3571255
+[Effect Handlers, Evidently (ICFP 2020)]: https://doi.org/10.1145/3408981
+[Generalized Evidence Passing (ICFP 2021)]: https://doi.org/10.1145/3473576
+[Retrofitting Effect Handlers onto OCaml (PLDI 2021)]: https://doi.org/10.1145/3453483.3454039
+[Parallel Algebraic Effect Handlers (ICFP 2024)]: https://doi.org/10.1145/3674651
+[A Framework for Higher-Order Effects and Handlers (ICFP 2024)]: https://doi.org/10.1145/3674632
+[Abstracting Effect Systems for Algebraic Effect Handlers (ICFP 2024)]: https://doi.org/10.1145/3674630
+[Affect: Affine Algebraic Effect Handlers (POPL 2025)]: https://doi.org/10.1145/3704831
+[Algebraic Temporal Effects (POPL 2025)]: https://doi.org/10.1145/3704853
+[Asymptotic Speedup via Effect Handlers (POPL 2025)]: https://doi.org/10.1145/3704871
+[OCaml 5.3.0 release notes]: https://ocaml.org/releases/5.3.0
+[GHC 9.6.1 release notes]: https://downloads.haskell.org/~ghc/9.6.5/docs/users_guide/9.6.1-notes.html
+[Scala 3.8 release announcement (2026-01-21)]: https://www.scala-lang.org/blog/2026/01/21/scala-3.8.html
+[WebAssembly stack-switching proposal repo]: https://github.com/WebAssembly/stack-switching
+[effects-bibliography]: https://github.com/yallop/effects-bibliography
+[effectful]: haskell-effectful.md
+[eff]: haskell-eff.md
+[Koka]: koka.md
+[OCaml 5]: ocaml-effects.md
+[heftia]: haskell-heftia.md
+[Effect (TypeScript)]: typescript-effect.md
+[bluefin]: haskell-bluefin.md
+[Ox]: scala-ox.md
+[Eio]: ocaml-eio.md
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[cleff]: haskell-cleff.md
+[bluefin-algae]: haskell-bluefin.md
+[Theseus]: haskell-theseus.md
+[Eff]: eff-lang.md
+[Frank]: frank.md
+[ZIO]: scala-zio.md
+[Cats Effect]: scala-cats-effect.md
+[Scala Kyo]: scala-kyo.md
+[Scala 3 capabilities]: scala-capabilities.md
+[WasmFX]: wasmfx.md
+[Parallel handlers]: parallelism.md
+[Key Papers]: papers.md

--- a/docs/research/algebraic-effects/eff-lang.md
+++ b/docs/research/algebraic-effects/eff-lang.md
@@ -6,8 +6,8 @@ The first programming language designed specifically around algebraic effects an
 | ------------- | --------------------------------------------------------------------------- |
 | Language      | Eff                                                                         |
 | License       | BSD-2-Clause                                                                |
-| Repository    | [github.com/matijapretnar/eff](https://github.com/matijapretnar/eff)        |
-| Documentation | [eff-lang.org](https://www.eff-lang.org/)                                   |
+| Repository    | [github.com/matijapretnar/eff]                                              |
+| Documentation | [eff-lang.org]                                                              |
 | Key Authors   | Andrej Bauer, Matija Pretnar (University of Ljubljana)                      |
 | Encoding      | Native algebraic effect handlers with first-class effects and continuations |
 
@@ -238,11 +238,24 @@ Resources can be overridden by enclosing handlers, allowing redirection (e.g., s
 
 ## Sources
 
-- [Eff GitHub repository](https://github.com/matijapretnar/eff)
-- [Eff language website](https://www.eff-lang.org/)
-- [Programming with Algebraic Effects and Handlers (Bauer, Pretnar 2012)](https://arxiv.org/abs/1203.1539)
-- [An Effect System for Algebraic Effects and Handlers (Bauer, Pretnar 2013)](https://arxiv.org/abs/1306.6316)
-- [Handlers of Algebraic Effects (Plotkin, Pretnar 2009)](https://link.springer.com/chapter/10.1007/978-3-642-00590-9_7)
-- [An Introduction to Algebraic Effects and Handlers (Pretnar 2015)](https://www.eff-lang.org/handlers-tutorial.pdf)
-- [Handling Algebraic Effects (Plotkin, Pretnar 2013, LMCS journal version)](<https://doi.org/10.2168/LMCS-9(4:23)2013>)
-- [Eff Directly in OCaml (Kiselyov, Sivaramakrishnan 2018)](https://arxiv.org/abs/1812.11664)
+- [Eff GitHub repository]
+- [Eff language website]
+- [Programming with Algebraic Effects and Handlers (Bauer, Pretnar 2012)]
+- [An Effect System for Algebraic Effects and Handlers (Bauer, Pretnar 2013)]
+- [Handlers of Algebraic Effects (Plotkin, Pretnar 2009)]
+- [An Introduction to Algebraic Effects and Handlers (Pretnar 2015)]
+- [Handling Algebraic Effects (Plotkin, Pretnar 2013, LMCS journal version)]
+- [Eff Directly in OCaml (Kiselyov, Sivaramakrishnan 2018)]
+
+<!-- References -->
+
+[github.com/matijapretnar/eff]: https://github.com/matijapretnar/eff
+[eff-lang.org]: https://www.eff-lang.org/
+[Eff GitHub repository]: https://github.com/matijapretnar/eff
+[Eff language website]: https://www.eff-lang.org/
+[Programming with Algebraic Effects and Handlers (Bauer, Pretnar 2012)]: https://arxiv.org/abs/1203.1539
+[An Effect System for Algebraic Effects and Handlers (Bauer, Pretnar 2013)]: https://arxiv.org/abs/1306.6316
+[Handlers of Algebraic Effects (Plotkin, Pretnar 2009)]: https://link.springer.com/chapter/10.1007/978-3-642-00590-9_7
+[An Introduction to Algebraic Effects and Handlers (Pretnar 2015)]: https://www.eff-lang.org/handlers-tutorial.pdf
+[Handling Algebraic Effects (Plotkin, Pretnar 2013, LMCS journal version)]: https://doi.org/10.2168/LMCS-9(4:23)2013
+[Eff Directly in OCaml (Kiselyov, Sivaramakrishnan 2018)]: https://arxiv.org/abs/1812.11664

--- a/docs/research/algebraic-effects/evolution.md
+++ b/docs/research/algebraic-effects/evolution.md
@@ -51,7 +51,7 @@ Key result: programs can describe effects abstractly; handlers define concrete b
 
 Two streams matured:
 
-1. **Language designs** (Eff, Koka, later Effekt/Frank) demonstrated usable effect syntax and typing.
+1. **Language designs** (Eff, [Koka], later Effekt/[Frank]) demonstrated usable effect syntax and typing.
 2. **Library encodings** (especially in Haskell) explored free/freer and higher-order effect encodings.
 
 Row-polymorphic effect types and type-directed compilation were major breakthroughs in this period.
@@ -77,17 +77,18 @@ This strongly influenced practical systems and narrowed the performance gap with
 ### OCaml
 
 - PLDI 2021 formalized the retrofit strategy.
-- OCaml 5 delivered one-shot handlers in the runtime.
+- [OCaml 5] delivered one-shot handlers in the runtime.
 - OCaml 5.3 (released January 8, 2025) added direct deep-handler syntax (`match ... with effect ...`).
 - OCaml 5.4 (released October 9, 2025) continues maturation of the runtime/tooling release train.
+- [Eio] provides effects-based direct-style I/O built on OCaml 5's runtime.
 
 ### GHC
 
-Delimited continuation primops from Proposal #313 became available in released toolchains (notably the 9.6 line), enabling library experimentation with runtime-backed control operations.
+Delimited continuation primops from Proposal #313 became available in released toolchains (notably the 9.6 line), enabling library experimentation with runtime-backed control operations for libraries like [eff] and [bluefin-algae].
 
 ### WebAssembly
 
-WasmFX (OOPSLA 2023) and the stack-switching proposal line position typed continuations/stack control as a cross-language compilation substrate.
+[WasmFX] (OOPSLA 2023) and the stack-switching proposal line position typed continuations/stack control as a cross-language compilation substrate.
 
 ---
 
@@ -97,12 +98,13 @@ Recent work shifts from "can handlers work?" to "which guarantees and performanc
 
 ### 1. Sound higher-order effects
 
-- Hefty Algebras (POPL 2023) separates higher-order elaboration from first-order interpretation.
+- [Hefty Algebras] (POPL 2023) separates higher-order elaboration from first-order interpretation, implemented in the [heftia] library.
+- [Theseus] (2025) provides an alternative approach to sound higher-order effects using higher-order Freer monads.
 - Follow-up work studies abstractions over handler frameworks and modularity properties.
 
 ### 2. Parallelism and multicore semantics
 
-- Parallel Algebraic Effect Handlers (ICFP 2024) introduces `lambda^p` and a path to parallel handling.
+- [Parallel Algebraic Effect Handlers] (ICFP 2024) introduces `lambda^p` and a path to parallel handling.
 - Work on asymptotic speedups through handlers and multicore runtime models expands this direction.
 
 ### 3. Resource-sensitive effects
@@ -137,13 +139,13 @@ Free monads represent effects as data, building a syntax tree interpreted by han
 
 ### Generation 3: Fused Effects and Higher-Order Effects (~2018-2019)
 
-fused-effects encoded effects as higher-order functors and fused sequential handlers at compile time via typeclass instances. polysemy (2019) added higher-order effects via the Tactics API but prioritized ergonomics over performance.
+[fused-effects] encoded effects as higher-order functors and fused sequential handlers at compile time via typeclass instances. [polysemy] (2019) added higher-order effects via the Tactics API but prioritized ergonomics over performance.
 
 **Key data point:** The GitHub Semantic team reported a 250x improvement switching from free monads to fused-effects. Sandy Maguire later documented polysemy's performance issues in "Polysemy: Mea Culpa."
 
 ### Generation 4: ReaderT IO (~2020+)
 
-effectful and cleff embraced `IO` as the base monad, building extensible environments on top with O(1) integer-indexed dispatch.
+[effectful] and [cleff] embraced `IO` as the base monad, building extensible environments on top with O(1) integer-indexed dispatch.
 
 **Key insight:** Michael Snoyman's observation that most Haskell applications end up in `IO` anyway, so making the base monad concrete enables dramatic optimizations. effectful's static dispatch is on par with hand-written `ST` code. This generation essentially closed the performance gap.
 
@@ -151,14 +153,14 @@ effectful and cleff embraced `IO` as the base monad, building extensible environ
 
 ### Generation 5: Delimited Continuations and Sound HO Effects (~2022+)
 
-Alexis King's GHC Proposal #313 added `prompt#` and `control0#` primops. The eff library demonstrated native continuation performance wins. heftia (2024) implemented hefty algebras for fully sound higher-order + algebraic effects. bluefin-algae uses the primops to add algebraic effects to Bluefin's value-level handles.
+Alexis King's GHC Proposal #313 added `prompt#` and `control0#` primops. The [eff] library demonstrated native continuation performance wins. [heftia] (2024) implemented hefty algebras for fully sound higher-order + algebraic effects. [bluefin-algae] uses the primops to add algebraic effects to [Bluefin]'s value-level handles.
 
 **Current landscape (2026):** The Haskell ecosystem now offers four distinct strategies:
 
-1. **effectful/cleff**: Maximum performance, pragmatic IO-based semantics, no algebraic effects
-2. **heftia**: Sound semantics, all features, prioritizes theoretical rigor
-3. **bluefin + bluefin-algae**: Simple mental model (handles), algebraic effects via primops
-4. **eff**: Demonstrates native continuation performance (development stalled, but primops continue to be used)
+1. **[effectful]/[cleff]**: Maximum performance, pragmatic IO-based semantics, no algebraic effects
+2. **[heftia]**: Sound semantics, all features, prioritizes theoretical rigor
+3. **[bluefin] + bluefin-algae**: Simple mental model (handles), algebraic effects via primops
+4. **[eff]**: Demonstrates native continuation performance (development stalled, but primops continue to be used)
 
 ---
 
@@ -186,23 +188,63 @@ Different ecosystems currently optimize different subsets of these properties.
 
 ## Sources
 
-- [Notions of Computation and Monads (1991)](<https://doi.org/10.1016/0890-5401(91)90052-4>)
-- [Algebraic Operations and Generic Effects (2003)](<https://doi.org/10.1016/S1571-0661(04)80969-2>)
-- [Handlers of Algebraic Effects (2009)](https://doi.org/10.1007/978-3-642-00590-9_7)
-- [Effect Handlers in Scope (2014)](https://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf)
-- [Fusion for Free (2015)](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf)
-- [Freer Monads, More Extensible Effects (2015)](https://doi.org/10.1145/2804302.2804319)
-- [Algebraic Effects for Functional Programming (2016)](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf)
-- [Type Directed Compilation of Row-Typed Algebraic Effects (2017)](https://doi.org/10.1145/3009837.3009872)
-- [Effect Handlers, Evidently (2020)](https://doi.org/10.1145/3408981)
-- [Generalized Evidence Passing (2021)](https://doi.org/10.1145/3473576)
-- [Retrofitting Effect Handlers onto OCaml (2021)](https://doi.org/10.1145/3453483.3454039)
-- [Hefty Algebras (2023)](https://doi.org/10.1145/3571255)
-- [Continuing WebAssembly with Effect Handlers (2023)](https://doi.org/10.1145/3622814)
-- [Parallel Algebraic Effect Handlers (2024)](https://doi.org/10.1145/3674651)
-- [Polysemy: Mea Culpa](https://reasonablypolymorphic.com/blog/mea-culpa/) -- Sandy Maguire
-- [GHC Proposal #313](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst)
-- [Effects Bibliography (living index)](https://github.com/yallop/effects-bibliography)
-- [OCaml 5.3.0 release (2025-01-08)](https://ocaml.org/releases/5.3.0)
-- [OCaml releases index (includes 5.4.0, 2025-10-09)](https://ocaml.org/releases/)
-- [GHC 9.6.1 release notes (delimited continuation primops)](https://downloads.haskell.org/~ghc/9.6.5/docs/users_guide/9.6.1-notes.html)
+- [Notions of Computation and Monads (1991)]
+- [Algebraic Operations and Generic Effects (2003)]
+- [Handlers of Algebraic Effects (2009)]
+- [Effect Handlers in Scope (2014)]
+- [Fusion for Free (2015)]
+- [Freer Monads, More Extensible Effects (2015)]
+- [Algebraic Effects for Functional Programming (2016)]
+- [Type Directed Compilation of Row-Typed Algebraic Effects (2017)]
+- [Effect Handlers, Evidently (2020)]
+- [Generalized Evidence Passing (2021)]
+- [Retrofitting Effect Handlers onto OCaml (2021)]
+- [Hefty Algebras (2023)]
+- [Continuing WebAssembly with Effect Handlers (2023)]
+- [Parallel Algebraic Effect Handlers (2024)]
+- [Polysemy: Mea Culpa] -- Sandy Maguire
+- [GHC Proposal #313]
+- [Effects Bibliography (living index)]
+- [OCaml 5.3.0 release (2025-01-08)]
+- [OCaml releases index (includes 5.4.0, 2025-10-09)]
+- [GHC 9.6.1 release notes (delimited continuation primops)]
+
+<!-- References -->
+
+[Notions of Computation and Monads (1991)]: https://doi.org/10.1016/0890-5401(91)90052-4
+[Algebraic Operations and Generic Effects (2003)]: https://doi.org/10.1016/S1571-0661(04)80969-2
+[Handlers of Algebraic Effects (2009)]: https://doi.org/10.1007/978-3-642-00590-9_7
+[Effect Handlers in Scope (2014)]: https://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf
+[Fusion for Free (2015)]: https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf
+[Freer Monads, More Extensible Effects (2015)]: https://doi.org/10.1145/2804302.2804319
+[Algebraic Effects for Functional Programming (2016)]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf
+[Type Directed Compilation of Row-Typed Algebraic Effects (2017)]: https://doi.org/10.1145/3009837.3009872
+[Effect Handlers, Evidently (2020)]: https://doi.org/10.1145/3408981
+[Generalized Evidence Passing (2021)]: https://doi.org/10.1145/3473576
+[Retrofitting Effect Handlers onto OCaml (2021)]: https://doi.org/10.1145/3453483.3454039
+[Hefty Algebras (2023)]: https://doi.org/10.1145/3571255
+[Continuing WebAssembly with Effect Handlers (2023)]: https://doi.org/10.1145/3622814
+[Parallel Algebraic Effect Handlers (2024)]: https://doi.org/10.1145/3674651
+[Polysemy: Mea Culpa]: https://reasonablypolymorphic.com/blog/mea-culpa/
+[GHC Proposal #313]: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst
+[Effects Bibliography (living index)]: https://github.com/yallop/effects-bibliography
+[OCaml 5.3.0 release (2025-01-08)]: https://ocaml.org/releases/5.3.0
+[OCaml releases index (includes 5.4.0, 2025-10-09)]: https://ocaml.org/releases/
+[GHC 9.6.1 release notes (delimited continuation primops)]: https://downloads.haskell.org/~ghc/9.6.5/docs/users_guide/9.6.1-notes.html
+[Koka]: koka.md
+[Frank]: frank.md
+[OCaml 5]: ocaml-effects.md
+[Eio]: ocaml-eio.md
+[WasmFX]: wasmfx.md
+[Hefty Algebras]: papers.md
+[heftia]: haskell-heftia.md
+[Theseus]: haskell-theseus.md
+[Parallel Algebraic Effect Handlers]: parallelism.md
+[fused-effects]: haskell-fused-effects.md
+[polysemy]: haskell-polysemy.md
+[effectful]: haskell-effectful.md
+[cleff]: haskell-cleff.md
+[eff]: haskell-eff.md
+[bluefin-algae]: haskell-bluefin.md
+[Bluefin]: haskell-bluefin.md
+[bluefin]: haskell-bluefin.md

--- a/docs/research/algebraic-effects/frank.md
+++ b/docs/research/algebraic-effects/frank.md
@@ -1,15 +1,15 @@
 # Frank
 
-A strict functional programming language with a bidirectional effect type system, multihandlers, and ambient abilities, designed from the ground up around algebraic effect handlers.
+A functional programming language with algebraic effect handlers and **ambient ability polymorphism**. Frank eliminates the distinction between effectful and pure functions, making effects implicit in the type system through "abilities."
 
-| Field         | Value                                                                                                                                                                                                            |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Language      | Frank                                                                                                                                                                                                            |
-| License       | GPL-3.0                                                                                                                                                                                                          |
-| Repository    | [github.com/frank-lang/frank](https://github.com/frank-lang/frank)                                                                                                                                               |
-| Documentation | [arXiv paper](https://arxiv.org/abs/1611.09259) / [JFP extended version](https://www.cambridge.org/core/journals/journal-of-functional-programming/article/doo-bee-doo-bee-doo/DEC5F8FDABF7DE3088270E07392320DD) |
-| Key Authors   | Conor McBride, Sam Lindley, Craig McLaughlin                                                                                                                                                                     |
-| Encoding      | Multihandlers with ambient ability propagation over a call-by-push-value foundation                                                                                                                              |
+| Field         | Value                                                   |
+| ------------- | ------------------------------------------------------- |
+| Language      | Frank                                                   |
+| License       | BSD-3-Clause (inferred)                                 |
+| Repository    | [github.com/frank-lang/frank]                           |
+| Documentation | [Frank GitHub docs]                                     |
+| Key Authors   | Sam Lindley, Conor McBride, Craig McLaughlin            |
+| Encoding      | Ambient ability polymorphism; call-by-push-value (CBPV) |
 
 ---
 
@@ -17,259 +17,209 @@ A strict functional programming language with a bidirectional effect type system
 
 ### What It Solves
 
-Traditional effect handler systems treat handlers as a separate construct from functions, and effect types accumulate outward from sub-expressions. This creates syntactic overhead (explicit handler wrapping, monadic do-notation) and conceptual friction between pure functions and effectful computations. Frank eliminates this gap by generalizing function abstraction itself: a function is simply a handler that interprets no commands. There is no separate handler construct, no monadic notation, and no explicit effect variables in source code.
+Frank addresses the "effect annotation burden" problem: in most effect systems, programmers must explicitly track and combine effect annotations. Frank makes effects **implicit** through ambient abilities that propagate automatically through the typing context. This eliminates the `lift` operations and effect tracking boilerplate common in other systems.
 
 ### Design Philosophy
 
-Frank follows a "do be do be do" philosophy -- computations alternate between _doing_ (performing effects) and _being_ (returning values). This is formalized through a call-by-push-value (CBPV) foundation where values _are_ and computations _do_. The language is strict (call-by-value for arguments), but suspended computations are explicit and distinct from values, enabling controlled laziness.
+Frank is built on **Call-by-Push-Value (CBPV)**, a lambda calculus variant that cleanly separates values (computation producers) from computations (effect producers). Handlers in Frank use **multihandlers** -- pattern matching on multiple operations simultaneously.
 
-Effect polymorphism is handled through _ambient ability_ propagation: rather than each sub-expression declaring its own effect set that must be unified outward, the environment declares what effects are available, and this ambient ability propagates inward. Effect variables never appear in Frank source code -- polymorphism is entirely implicit.
-
-The paper describing Frank is titled "Do Be Do Be Do" (Lindley, McBride, McLaughlin, POPL 2017), with an extended version "Doo Bee Doo Bee Doo" published in the Journal of Functional Programming (2020, with Lukas Convent as additional author).
+The language demonstrates that effect polymorphism can be entirely invisible in source code while remaining rigorous in the type system.
 
 ---
 
 ## Core Abstractions and Types
 
-### Value Types vs Computation Types
+### Ambient Abilities
 
-Frank distinguishes values from computations following Levy's call-by-push-value:
-
-```frank
--- Value types: data that "is"
-data Bool = tt | ff
-data List X = nil | X :: (List X)
-data Pair X Y = pair X Y
-
--- Computation types: processes that "do"
--- {[E1, E2, ...] T} is a suspended computation
--- that may perform effects E1, E2, ... and returns T
-```
-
-A value of type `{[E] T}` is not a `T` -- it is the _ability to compute_ a `T` while potentially performing effects in `E`. The `!` operator forces a suspended computation:
+In Frank, effects appear as **abilities** in the type system:
 
 ```frank
--- f! forces the thunk f
--- f x is sugar for f! x when f is a suspended function
+-- A function that uses the State ability
+get : Int -> Int [State Int]
+
+-- A function that uses multiple abilities
+process : Int -> Int [State Int, Console]
 ```
 
-### Interfaces (Effect Signatures)
-
-Interfaces declare the commands an effect provides:
+Crucially, **ability polymorphism is invisible**. The function `map` has type:
 
 ```frank
-interface Send X = send : X -> Unit
-interface Receive X = receive : X
-interface Abort = aborting : Zero
-interface State S = get : S
-                  | put : S -> Unit
-interface Console = inch : Char
-                  | ouch : Char -> Unit
+map : {A -> B} -> List A -> List B
 ```
 
-Each command signature specifies argument types and a return type. The return type is what the handler must supply to the continuation when it intercepts the command.
+It says nothing about effects! The type system infers that `map` has whatever abilities its function argument has. This is **ambient polymorphism** -- the abilities "float" through the context without explicit annotation.
 
-### Operators and Handlers
+### Multihandlers
 
-In Frank, every function is an _operator_. An operator that handles no effects is an ordinary function. An operator that handles effects from one or more computation arguments is a _handler_ (or _multihandler_):
+Frank handlers can pattern-match on multiple operations at once:
 
 ```frank
--- An ordinary function (no effects handled)
-not : Bool -> Bool
-not tt = ff
-not ff = tt
-
--- A unary handler: handles State commands
-state : S -> <State S>X -> X
-state _ x             = x
-state s <get -> k>    = state s (k s)
-state s <put s' -> k> = state s' (k unit)
+handle : Int -> Int [State Int, Error] -> Int
+handle seed computation =
+  on computation
+    return x -> x
+    {get -> k} -> handle !k state
+    {put x -> k} -> handle !k x
+    {raise e -> k} -> -1  -- default value on error
 ```
+
+The `{op -> k}` syntax binds the continuation as `k`. Note the `!k` syntax for forcing thunks (CBPV explicit computation forcing).
+
+### Call-by-Push-Value
+
+Frank uses CBPV as its core calculus:
+
+- **Values** (type `A`) are inert data: integers, functions, thunks
+- **Computations** (type `F A` or `A -> B`) can perform effects
+- **Thunking** (`thunk`) suspends a computation into a value
+- **Forcing** (`!`) executes a thunked computation
+
+This separation makes effect boundaries explicit in the operational semantics while keeping types clean.
 
 ---
 
 ## How Effects Are Declared
 
-### Interface Declarations
-
-Effects are declared as interfaces at the top level. An interface specifies a collection of _commands_ with their signatures:
+Effects are declared as **ability signatures**:
 
 ```frank
-interface Send X = send : X -> Unit
-interface Receive X = receive : X
+ability State S where
+  get : S
+  put : S -> Unit
+
+ability Console where
+  print : String -> Unit
+  read : String
 ```
 
-Here `Send X` provides a single command `send` that takes a value of type `X` and returns `Unit`. `Receive X` provides `receive` which takes no arguments and returns an `X`.
-
-### Ambient Ability
-
-The key innovation is that effects are tracked via the _ambient ability_ -- the set of effects currently available in the typing context. When a computation type is written as `[E1, E2]T`, the effects `E1` and `E2` are what the computation is _allowed_ to perform. The ambient ability propagates inward through the typing rules:
-
-```frank
--- [Console]Unit means: may use Console commands, returns Unit
--- [0]T means: may use the ambient ability (implicit polymorphism)
--- []T means: pure, no effects allowed
-
-map : {X -> [0]Y} -> List X -> [0]List Y
-map f nil        = nil
-map f (x :: xs)  = f x :: map f xs
-```
-
-The `[0]` annotation means "whatever the ambient ability is." This is Frank's effect polymorphism -- `map` works with any effects because it inherits the ambient ability implicitly. There are no named effect variables.
-
-### Computation Types in Signatures
-
-Function arguments that are computations (thunks) carry their own ability annotations:
-
-```frank
--- A function taking a computation that may use Console
-withConsole : {[Console]Unit} -> [IO]Unit
-```
+Each operation declares its value type and (implicitly) its continuation type. The `State` ability is parameterized by the state type `S`.
 
 ---
 
 ## How Handlers/Interpreters Work
 
-### Unary Handlers
+### Shallow vs Deep Handlers
 
-A handler interprets commands from a computation argument by pattern matching on command requests and their continuations:
+Frank supports both:
 
-```frank
-state : S -> <State S>X -> X
-state _ x             = x           -- pure return: just give back x
-state s <get -> k>    = state s (k s)     -- resume with current state
-state s <put s' -> k> = state s' (k unit) -- update state, resume
-```
-
-The pattern `<get -> k>` matches a `get` command, binding the continuation to `k`. Calling `k s` resumes the computation with value `s` as the result of `get`.
-
-### Multihandlers
-
-Multihandlers are Frank's distinctive feature. They take multiple computation arguments and can simultaneously interpret commands from several sources:
+**Shallow handlers** handle one operation and return:
 
 ```frank
-pipe : <Send X>Unit -> <Receive X>Y -> [Abort]Y
-pipe <send x -> s> <receive -> r> = pipe (s unit) (r x)
-pipe <send _ -> _> y              = y
-pipe unit          y              = y
-pipe _             <receive -> _> = aborting!
+handleOnce : Int [State Int] -> Int [State Int]
+handleOnce computation =
+  on computation
+    return x -> x
+    {get -> k} -> !k 42  -- resume with 42 once
 ```
 
-This `pipe` operator connects a producer (performing `Send X`) with a consumer (performing `Receive X`). When the producer sends a value and the consumer requests one, the handler feeds the sent value to the consumer's continuation and resumes both. This is the canonical example showing how multihandlers enable concurrent-style composition without threads or channels.
-
-### Using Handlers
+**Deep handlers** recursively handle all operations:
 
 ```frank
--- Define a producer and consumer
-sends : List X -> [Send X]Unit
-sends nil        = unit
-sends (x :: xs)  = send x; sends xs
-
-catter : [Receive (List Char)]List (List Char)
-catter = case receive! of
-           nil -> nil
-           xs  -> xs :: catter!
-
--- Compose with pipe
-main : [Abort]List (List Char)
-main = pipe (sends ["do", "be", "do"]!) catter!
+runState : S -> A [State S] -> Pair S A
+runState initial computation =
+  on computation
+    return x -> (initial, x)
+    {get -> k} -> runState initial (!k initial)
+    {put s -> k} -> runState s (!k unit)
 ```
 
----
+### Composition via Nesting
 
-## Performance Approach
+Multiple handlers nest naturally:
 
-Frank is primarily a research language, and its implementation prioritizes clarity of semantics over raw performance. The compiler (written in Haskell) compiles Frank to an intermediate language called Shonky, which is then interpreted.
+```frank
+runProgram : Int [State Int, Error] -> Int
+runProgram = handleError << runState 0
+```
 
-Key characteristics of the current implementation:
-
-- **Interpreted execution**: Frank programs compile to Shonky code and are interpreted, not compiled to native code
-- **Continuation-based handlers**: Effect handling uses first-class continuations, which incur allocation overhead per command invocation
-- **No optimization passes**: The compiler performs type checking and desugaring but does not apply significant optimizations
-- **Research focus**: Performance work has not been a priority; the implementation serves as a proof of concept for the type system and semantics described in the paper
-
-The formal semantics (Core Frank) uses a small-step operational semantics with evaluation contexts, providing a clear theoretical foundation even if runtime performance is modest.
+The order of nesting determines semantics, but Frank's ability system ensures this is always explicit in the types.
 
 ---
 
 ## Composability Model
 
-### Effect Composition via Ambient Ability
+### Ability Polymorphism
 
-Multiple effects compose naturally through the ambient ability. A computation that needs both `State` and `Console` simply lists both in its type:
+The signature of `map` in most effect systems is:
 
-```frank
-interactive : [State Int, Console]Unit
-interactive = ouch (intToChar (get!)); put (get! + 1)
+```haskell
+-- In most effect systems
+map :: (a -> b) -> List a -> List b        -- loses effect information
+mapM :: Monad m => (a -> m b) -> List a -> m (List b)  -- separate monadic version
 ```
 
-### Multihandler Composition
-
-Multihandlers enable composition patterns that are difficult or impossible with unary handlers. The `pipe` example composes a producer and consumer, but the pattern extends to any number of interacting computations:
+In Frank:
 
 ```frank
--- A spacer that intercepts strings and adds spaces
-spacer : <Receive (List Char)>(List Char) ->
-         [Send (List Char)]Unit
-spacer <receive -> r> = send " "; send (r!)
-spacer x              = send x
-
--- Compose three stages
-main : [Abort]List (List Char)
-main = pipe (sends ["do","be","do"]!)
-            (pipe spacer! catter!)
+-- One function handles both pure and effectful cases
+map : {A -> B} -> List A -> List B
 ```
 
-### Adaptors and Effect Encapsulation
+The type system tracks abilities automatically. If the function argument uses `State`, then `map` applied to it requires `State`.
 
-Frank introduces _adaptors_ (also called _adjustments_) to manage effect routing. An adaptor remaps the ambient ability for a sub-computation, enabling:
+### No Lift Operations
 
-- **Effect masking**: hiding an effect from a sub-computation
-- **Effect reordering**: changing which handler catches which command
-- **Effect encapsulation**: preventing internal effects from polluting external interfaces
-
-Adaptors are essential for building reusable components. Without them, composing handlers from smaller pieces can cause "effect pollution" where internal implementation effects leak into the public type signature.
+Unlike monad transformer stacks that require `lift` to access effects from deeper layers, Frank's abilities propagate implicitly. There is no "stack" -- abilities are a flat set that the type system tracks.
 
 ---
 
 ## Strengths
 
-- **Multihandlers** are a unique and powerful abstraction that enables simultaneous interpretation of commands from multiple sources, supporting patterns like pipes, concurrent interleavings, and actor-style communication
 - **Invisible effect polymorphism** eliminates effect variable clutter from source code; the ambient ability propagation is elegant and reduces annotation burden
 - **No separate handler syntax** -- functions and handlers share the same mechanism, reducing conceptual overhead
 - **No monadic notation needed** -- effects are implicit in the type, so programs read as direct-style code
 - **Formal foundations** are thoroughly developed with a sound small-step operational semantics for Core Frank
-- **Influenced Unison** -- Frank's ambient ability system directly inspired Unison's abilities, demonstrating practical impact
+- **Influenced [Unison]** -- Frank's ambient ability system directly inspired Unison's abilities, demonstrating practical impact
 
 ## Weaknesses
 
 - **Research prototype** -- the implementation is not production-ready; it compiles to an interpreted intermediate language
-- **Small ecosystem** -- limited libraries, tooling, and community compared to established languages
-- **Limited documentation** -- beyond the academic papers and example files, learning resources are sparse
-- **No coverage checking** -- pattern match coverage is not verified by the compiler
-- **Performance** is not competitive with production effect systems; no native code generation
-- **Adaptor system complexity** -- while powerful, adaptors add conceptual overhead to an already novel type system
+- **CBPV learning curve** -- Call-by-Push-Value differs from familiar call-by-value or lazy semantics
+- **No Haskell ecosystem** -- cannot leverage existing Haskell libraries; standalone language
+- **Limited documentation** -- primarily academic papers and README; few tutorials
+- **Ambiguity challenges** -- invisible polymorphism can make type error messages harder to understand
 
 ## Key Design Decisions and Trade-offs
 
-| Decision                               | Rationale                                                                                        | Trade-off                                                                                           |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| Multihandlers over unary handlers      | Enable simultaneous interpretation of multiple effect sources; subsume functions as special case | More complex typing rules; harder to implement efficiently                                          |
-| Ambient ability (inward propagation)   | Eliminates effect variables from source; cleaner user-facing types                               | Less explicit than outward accumulation; harder to reason about which handler catches which command |
-| Call-by-push-value foundation          | Clean separation of values and computations; principled treatment of laziness                    | Unfamiliar to most programmers; adds conceptual overhead                                            |
-| No monadic notation                    | Direct-style programming; lower syntactic barrier                                                | Cannot express monadic patterns from Haskell ecosystem directly                                     |
-| Adaptors for effect encapsulation      | Prevents effect pollution; enables modular composition                                           | Additional mechanism to learn; partial operation (can fail at type level)                           |
-| Strict evaluation with explicit thunks | Predictable performance; explicit suspension                                                     | Requires `!` for forcing; more verbose than lazy languages for some patterns                        |
+| Decision                     | Rationale                              | Trade-off                             |
+| ---------------------------- | -------------------------------------- | ------------------------------------- |
+| CBPV core calculus           | Clean value/computation separation     | Unfamiliar to most programmers        |
+| Ambient ability polymorphism | Reduced annotation burden              | Type errors can be harder to localize |
+| Multihandlers                | Symmetric handling of multiple effects | Handler patterns can be more complex  |
+| Invisible effect variables   | Source code readability                | Type inference algorithm complexity   |
+| Research language focus      | Exploration of language design         | Limited practical tooling             |
+
+---
+
+## Comparison with Other Languages
+
+| Feature             | Frank               | [Koka]                | [Unison]                   |
+| ------------------- | ------------------- | --------------------- | -------------------------- |
+| Effect polymorphism | Invisible (ambient) | Visible row variables | Invisible (type variables) |
+| Handler style       | Multihandlers       | Deep handlers         | Deep handlers              |
+| Core calculus       | CBPV                | Call-by-value         | Call-by-value              |
+| Effect syntax       | `[Ability]`         | `<effect>`            | `{Ability}`                |
+| Production status   | Research            | Research              | Active development         |
+| Implementation      | Interpreter         | Compiler to C/JS/WASM | Runtime + UCM              |
 
 ---
 
 ## Sources
 
-- [Do Be Do Be Do (POPL 2017)](https://dl.acm.org/doi/10.1145/3009837.3009897)
-- [Do Be Do Be Do -- arXiv preprint](https://arxiv.org/abs/1611.09259)
-- [Doo Bee Doo Bee Doo (JFP 2020, extended version)](https://www.cambridge.org/core/journals/journal-of-functional-programming/article/doo-bee-doo-bee-doo/DEC5F8FDABF7DE3088270E07392320DD)
-- [Frank compiler on GitHub](https://github.com/frank-lang/frank)
-- [The Frank Manual (McBride, 2012)](https://personal.cis.strath.ac.uk/conor.mcbride/pub/Frank/TFM.pdf)
-- [Encapsulating Effects in Frank (draft, 2018)](https://homepages.inf.ed.ac.uk/slindley/papers/leak-draft-november2018.pdf)
-- [Sam Lindley's publications](https://homepages.inf.ed.ac.uk/slindley/)
-- [Lambda the Ultimate discussion](http://lambda-the-ultimate.org/node/5401)
+- [Frank GitHub repository]
+- [Do Be Do Be Do (Frank paper, POPL 2017)]
+- [Frank README with examples]
+- [Call-by-Push-Value book] -- Paul Levy
+- [Unison documentation] (for comparison with Frank's influence)
+
+<!-- References -->
+
+[Unison]: unison.md
+[Koka]: koka.md
+[github.com/frank-lang/frank]: https://github.com/frank-lang/frank
+[Frank GitHub docs]: https://github.com/frank-lang/frank/blob/master/README.md
+[Frank GitHub repository]: https://github.com/frank-lang/frank
+[Do Be Do Be Do (Frank paper, POPL 2017)]: https://arxiv.org/abs/1611.09259
+[Frank README with examples]: https://github.com/frank-lang/frank/blob/master/README.md
+[Call-by-Push-Value book]: https://doi.org/10.1017/S095679680100422X
+[Unison documentation]: https://www.unison-lang.org/docs/

--- a/docs/research/algebraic-effects/haskell-bluefin.md
+++ b/docs/research/algebraic-effects/haskell-bluefin.md
@@ -1,15 +1,15 @@
 # Bluefin (Haskell)
 
-A new Haskell effect system where effects are accessed through value-level handles rather than type-level constraints. Strongly inspired by effectful, Bluefin can be described as a well-typed implementation of "the functions-that-return-IO pattern."
+A new Haskell effect system where effects are accessed through value-level handles rather than type-level constraints. Strongly inspired by [effectful], Bluefin can be described as a well-typed implementation of "the functions-that-return-IO pattern."
 
-| Field         | Value                                                                      |
-| ------------- | -------------------------------------------------------------------------- |
-| Language      | Haskell                                                                    |
-| License       | MIT                                                                        |
-| Repository    | [github.com/tomjaguarpaw/bluefin](https://github.com/tomjaguarpaw/bluefin) |
-| Documentation | [Hackage](https://hackage.haskell.org/package/bluefin)                     |
-| Key Authors   | Tom Ellis                                                                  |
-| Encoding      | ReaderT IO with value-level handles; ST-like scoping                       |
+| Field         | Value                                                |
+| ------------- | ---------------------------------------------------- |
+| Language      | Haskell                                              |
+| License       | MIT                                                  |
+| Repository    | [github.com/tomjaguarpaw/bluefin]                    |
+| Documentation | [Hackage][bluefin-hackage]                           |
+| Key Authors   | Tom Ellis                                            |
+| Encoding      | ReaderT IO with value-level handles; ST-like scoping |
 
 ---
 
@@ -21,7 +21,7 @@ Bluefin provides a simple, composable, and efficient effect system with a distin
 
 ### Design Philosophy
 
-Where effectful provides "a well-typed implementation of the ReaderT IO pattern," Bluefin provides something even simpler: a well-typed implementation of "the functions-that-return-IO pattern." Effects are introduced by handlers and accessed through handles, with the type system ensuring (via ST-like scoping) that handles never escape their handler's scope.
+Where [effectful] provides "a well-typed implementation of the ReaderT IO pattern," Bluefin provides something even simpler: a well-typed implementation of "the functions-that-return-IO pattern." Effects are introduced by handlers and accessed through handles, with the type system ensuring (via ST-like scoping) that handles never escape their handler's scope.
 
 ---
 
@@ -130,7 +130,7 @@ No type-level machinery or `TypeApplications` needed -- `st1` and `st2` are simp
 
 ## Bluefin-Algae: Algebraic Effects Extension
 
-The [bluefin-algae](https://hackage.haskell.org/package/bluefin-algae) package, released in September 2025, adds algebraic effects to Bluefin by leveraging the delimited continuation primops added in GHC 9.6:
+The [bluefin-algae] package, released in September 2025, adds algebraic effects to Bluefin by leveraging the delimited continuation primops added in GHC 9.6:
 
 ```haskell
 -- Algebraic effect operations capture continuations
@@ -148,7 +148,7 @@ With bluefin-algae, effects that were built-in to Bluefin (State, Exception, etc
 
 ### Implementation
 
-Because `Eff` wraps `IO`, `State` wraps `IORef`, and `Exception` throws real IO exceptions, performance is excellent -- comparable to effectful. The type system provides safety guarantees without runtime overhead beyond what the underlying IO operations cost.
+Because `Eff` wraps `IO`, `State` wraps `IORef`, and `Exception` throws real IO exceptions, performance is excellent -- comparable to [effectful]. The type system provides safety guarantees without runtime overhead beyond what the underlying IO operations cost.
 
 ### No Indirection
 
@@ -172,14 +172,14 @@ helper st rd = do
 
 This is more explicit than constraint-based approaches but eliminates all ambiguity.
 
-### Relationship to effectful
+### Relationship to [effectful]
 
-All the design points that make effectful fast apply to Bluefin too. The major difference is that Bluefin uses value-level handles where effectful uses type-level constraints. This means:
+All the design points that make [effectful] fast apply to Bluefin too. The major difference is that Bluefin uses value-level handles where [effectful] uses type-level constraints. This means:
 
 - Bluefin functions take handles as explicit arguments
-- effectful functions use `(:>)` constraints
+- [effectful] functions use `(:>)` constraints
 - Bluefin trivially supports multiple same-type effects
-- effectful requires type-level disambiguation for the same
+- [effectful] requires type-level disambiguation for the same
 
 ---
 
@@ -188,7 +188,7 @@ All the design points that make effectful fast apply to Bluefin too. The major d
 - **Simple mental model**: Effects are values; handlers introduce them; scope prevents escape
 - **Multiple same-type effects**: Trivially supported through different handle values
 - **No type-level complexity**: No `Member` constraints, no type-level lists, no functional dependencies
-- **Fast**: Same ReaderT IO performance as effectful
+- **Fast**: Same ReaderT IO performance as [effectful]
 - **ST-like safety**: Handles cannot escape their scope, guaranteed by the type system
 - **Algebraic effects available**: Via bluefin-algae and GHC 9.6 delimited continuations
 - **Active development**: Talks at ZuriHac 2025, Functional Conf 2025
@@ -196,8 +196,8 @@ All the design points that make effectful fast apply to Bluefin too. The major d
 ## Weaknesses
 
 - **Explicit handle passing**: Functions must take handles as arguments, which can be verbose for deeply nested code
-- **IO dependency**: Like effectful, fundamentally IO-based
-- **Newer library**: Smaller ecosystem and community than effectful or polysemy
+- **IO dependency**: Like [effectful], fundamentally IO-based
+- **Newer library**: Smaller ecosystem and community than [effectful] or [polysemy]
 - **No implicit effect resolution**: Cannot automatically dispatch to the "nearest" handler of a given type
 - **bluefin-algae requires GHC 9.6+**: Delimited continuation support is recent
 
@@ -215,8 +215,21 @@ All the design points that make effectful fast apply to Bluefin too. The major d
 
 ## Sources
 
-- [Bluefin on Hackage](https://hackage.haskell.org/package/bluefin)
-- [Bluefin GitHub repository](https://github.com/tomjaguarpaw/bluefin)
-- [Bluefin announcement on Haskell Discourse](https://discourse.haskell.org/t/bluefin-a-new-effect-system/9395)
-- [bluefin-algae on Hackage](https://hackage.haskell.org/package/bluefin-algae)
-- [Bluefin-algae announcement](https://discourse.haskell.org/t/bluefin-algae-algebraic-effects-in-bluefin/9470)
+- [Bluefin on Hackage]
+- [Bluefin GitHub repository]
+- [Bluefin announcement on Haskell Discourse]
+- [bluefin-algae on Hackage]
+- [Bluefin-algae announcement]
+
+<!-- References -->
+
+[effectful]: haskell-effectful.md
+[polysemy]: haskell-polysemy.md
+[github.com/tomjaguarpaw/bluefin]: https://github.com/tomjaguarpaw/bluefin
+[bluefin-hackage]: https://hackage.haskell.org/package/bluefin
+[bluefin-algae]: https://hackage.haskell.org/package/bluefin-algae
+[Bluefin on Hackage]: https://hackage.haskell.org/package/bluefin
+[Bluefin GitHub repository]: https://github.com/tomjaguarpaw/bluefin
+[Bluefin announcement on Haskell Discourse]: https://discourse.haskell.org/t/bluefin-a-new-effect-system/9395
+[bluefin-algae on Hackage]: https://hackage.haskell.org/package/bluefin-algae
+[Bluefin-algae announcement]: https://discourse.haskell.org/t/bluefin-algae-algebraic-effects-in-bluefin/9470

--- a/docs/research/algebraic-effects/haskell-cleff.md
+++ b/docs/research/algebraic-effects/haskell-cleff.md
@@ -1,15 +1,15 @@
 # cleff (Haskell)
 
-A fast and concise extensible effects library focused on the balance of performance, expressiveness, and ease of use. cleff uses a ReaderT IO approach like effectful but provides more versatile effect interpretation and a lighter-weight API.
+A fast and concise extensible effects library focused on the balance of performance, expressiveness, and ease of use. cleff uses a ReaderT IO approach like [effectful] but provides more versatile effect interpretation and a lighter-weight API.
 
-| Field         | Value                                                      |
-| ------------- | ---------------------------------------------------------- |
-| Language      | Haskell                                                    |
-| License       | BSD-3-Clause                                               |
-| Repository    | [github.com/re-xyr/cleff](https://github.com/re-xyr/cleff) |
-| Documentation | [Hackage](https://hackage.haskell.org/package/cleff)       |
-| Key Authors   | re-xyr                                                     |
-| Encoding      | ReaderT IO                                                 |
+| Field         | Value                     |
+| ------------- | ------------------------- |
+| Language      | Haskell                   |
+| License       | BSD-3-Clause              |
+| Repository    | [github.com/re-xyr/cleff] |
+| Documentation | [Hackage][cleff-hackage]  |
+| Key Authors   | re-xyr                    |
+| Encoding      | ReaderT IO                |
 
 ---
 
@@ -17,11 +17,11 @@ A fast and concise extensible effects library focused on the balance of performa
 
 ### What It Solves
 
-cleff provides an extensible effects system that outperforms polysemy and even mtl in microbenchmarks while maintaining expressive higher-order effect support. It achieves this by implementing `Eff` as `ReaderT IO` rather than using freer monads or monad transformers, allowing GHC optimizations to fire on the concrete monad.
+cleff provides an extensible effects system that outperforms [polysemy] and even mtl in microbenchmarks while maintaining expressive higher-order effect support. It achieves this by implementing `Eff` as `ReaderT IO` rather than using freer monads or monad transformers, allowing GHC optimizations to fire on the concrete monad.
 
 ### Design Philosophy
 
-cleff targets the sweet spot between effectful's raw performance and polysemy's expressiveness. It draws inspiration from polysemy's Tactics API for higher-order effects but simplifies it, and from the ReaderT IO pattern for performance. Unlike effectful, cleff does not distinguish between static and dynamic dispatch, opting instead for a uniform dynamic dispatch with flexible interpretation combinators.
+cleff targets the sweet spot between [effectful]'s raw performance and [polysemy]'s expressiveness. It draws inspiration from [polysemy]'s Tactics API for higher-order effects but simplifies it, and from the ReaderT IO pattern for performance. Unlike [effectful], cleff does not distinguish between static and dynamic dispatch, opting instead for a uniform dynamic dispatch with flexible interpretation combinators.
 
 ---
 
@@ -33,13 +33,13 @@ cleff targets the sweet spot between effectful's raw performance and polysemy's 
 newtype Eff (es :: [Effect]) a
 ```
 
-Internally implemented as `ReaderT IO`. The type-level list `es` tracks which effects are available. Like effectful, the concrete nature of the monad enables GHC to optimize aggressively.
+Internally implemented as `ReaderT IO`. The type-level list `es` tracks which effects are available. Like [effectful], the concrete nature of the monad enables GHC to optimize aggressively.
 
 ### Effect Row Encoding
 
 Effects are tracked as a type-level list. The `Eff` monad type is analogous to:
 
-```
+```haskell
 StateT String (ReaderT Int IO) Bool  ===  Eff '[State String, Reader Int, IOE] Bool
 ```
 
@@ -76,7 +76,7 @@ data Error e :: Effect where
 
 ## How Handlers/Interpreters Work
 
-cleff provides a set of combinators for interpreting effects, following and extending polysemy's approach:
+cleff provides a set of combinators for interpreting effects, following and extending [polysemy]'s approach:
 
 ### interpret
 
@@ -104,7 +104,7 @@ Replaces the current handler for an effect that is already in scope.
 
 ### Higher-Order Effect Combinators
 
-Following polysemy's path, cleff provides combinators for implementing higher-order effects that are as expressive as polysemy's Tactics API but easier to use correctly. These combinators thread state and handle the continuation properly through scoped operations like `local`, `catch`, and `mask`.
+Following [polysemy]'s path, cleff provides combinators for implementing higher-order effects that are as expressive as [polysemy]'s Tactics API but easier to use correctly. These combinators thread state and handle the continuation properly through scoped operations like `local`, `catch`, and `mask`.
 
 ---
 
@@ -112,13 +112,13 @@ Following polysemy's path, cleff provides combinators for implementing higher-or
 
 ### Why cleff Is Fast
 
-1. **ReaderT IO base**: Same fundamental approach as effectful -- concrete monad, no intermediate syntax tree.
+1. **ReaderT IO base**: Same fundamental approach as [effectful] -- concrete monad, no intermediate syntax tree.
 2. **IO-based semantics**: State uses `IORef`, Error uses exceptions, providing predictable and efficient behavior.
 3. **GHC optimization friendly**: The concrete monad representation allows inlining and specialization without special pragmas.
 
 ### Benchmark Position
 
-In microbenchmarks, cleff outperforms polysemy and even mtl. It is slightly behind effectful in some scenarios because effectful provides static dispatch for built-in effects, which cleff does not.
+In microbenchmarks, cleff outperforms [polysemy] and even mtl. It is slightly behind [effectful] in some scenarios because [effectful] provides static dispatch for built-in effects, which cleff does not.
 
 ---
 
@@ -126,11 +126,11 @@ In microbenchmarks, cleff outperforms polysemy and even mtl. It is slightly behi
 
 ### Uniform Dynamic Dispatch
 
-Unlike effectful, which distinguishes between static and dynamic dispatch, cleff uses a uniform approach. All effects go through the same dispatch mechanism, trading a small amount of performance for a simpler, more uniform API.
+Unlike [effectful], which distinguishes between static and dynamic dispatch, cleff uses a uniform approach. All effects go through the same dispatch mechanism, trading a small amount of performance for a simpler, more uniform API.
 
 ### MonadUnliftIO Compatibility
 
-Like effectful, cleff's `Eff` is essentially `ReaderT IO`, so it satisfies `MonadUnliftIO`. Libraries like `unliftio`, `exceptions`, and `lifted-async` work directly without adapter code.
+Like [effectful], cleff's `Eff` is essentially `ReaderT IO`, so it satisfies `MonadUnliftIO`. Libraries like `unliftio`, `exceptions`, and `lifted-async` work directly without adapter code.
 
 ### IOE Effect
 
@@ -140,26 +140,26 @@ The `IOE` effect provides `MonadIO`, `MonadUnliftIO`, `PrimMonad`, `MonadCatch`,
 
 ## Strengths
 
-- **Very fast**: Outperforms polysemy and mtl in microbenchmarks
-- **Expressive higher-order effects**: Combinators as powerful as polysemy's Tactics but simpler to use
-- **Lightweight API**: Less boilerplate than fused-effects, simpler than effectful's dual dispatch
+- **Very fast**: Outperforms [polysemy] and mtl in microbenchmarks
+- **Expressive higher-order effects**: Combinators as powerful as [polysemy]'s Tactics but simpler to use
+- **Lightweight API**: Less boilerplate than [fused-effects], simpler than [effectful]'s dual dispatch
 - **Multiple same-type effects**: No functional dependencies; can have multiple `State Int` in scope
 - **Good ecosystem interop**: `MonadUnliftIO`, `MonadCatch`, etc.
 - **IO-based semantics**: Predictable behavior with concurrency and exceptions
 
 ## Weaknesses
 
-- **No algebraic effects**: Like effectful, cannot capture/resume continuations; no `NonDet` or `Coroutine`
+- **No algebraic effects**: Like [effectful], cannot capture/resume continuations; no `NonDet` or `Coroutine`
 - **IO dependency**: Cannot interpret effects purely without IO
-- **No static dispatch**: Slightly slower than effectful for effects that would benefit from static dispatch
+- **No static dispatch**: Slightly slower than [effectful] for effects that would benefit from static dispatch
 - **Ambiguity with multiple same-type effects**: Requires `TypeApplications` or the GHC plugin to resolve
-- **Smaller community**: Less ecosystem support than effectful or polysemy
+- **Smaller community**: Less ecosystem support than [effectful] or [polysemy]
 
 ## Key Design Decisions and Trade-offs
 
 | Decision                         | Rationale                                      | Trade-off                                           |
 | -------------------------------- | ---------------------------------------------- | --------------------------------------------------- |
-| ReaderT IO (like effectful)      | Performance; concrete monad; ecosystem interop | No pure interpretation; IO semantics leak through   |
+| ReaderT IO (like [effectful])    | Performance; concrete monad; ecosystem interop | No pure interpretation; IO semantics leak through   |
 | No static dispatch               | Simpler, uniform API                           | Slightly slower for effects that could be static    |
 | No functional dependencies       | Multiple same-type effects possible            | Ambiguity requires TypeApplications or plugin       |
 | Polysemy-inspired HO combinators | Expressiveness without complexity              | Still limited by ReaderT IO (no true continuations) |
@@ -167,9 +167,9 @@ The `IOE` effect provides `MonadIO`, `MonadUnliftIO`, `PrimMonad`, `MonadCatch`,
 
 ---
 
-## Comparison with effectful
+## Comparison with [effectful]
 
-| Aspect                         | cleff                       | effectful                           |
+| Aspect                         | cleff                       | [effectful]                         |
 | ------------------------------ | --------------------------- | ----------------------------------- |
 | **Dispatch**                   | Dynamic only                | Static + Dynamic                    |
 | **Performance**                | Very fast                   | Fastest (static dispatch advantage) |
@@ -182,7 +182,19 @@ The `IOE` effect provides `MonadIO`, `MonadUnliftIO`, `PrimMonad`, `MonadCatch`,
 
 ## Sources
 
-- [cleff on Hackage](https://hackage.haskell.org/package/cleff)
-- [cleff GitHub repository](https://github.com/re-xyr/cleff)
-- [cleff announcement on Haskell Discourse](https://discourse.haskell.org/t/ann-cleff-fast-and-concise-extensible-effects/4002)
-- [Cleff.Internal.Base](https://hackage.haskell.org/package/cleff-0.3.4.0/candidate/docs/Cleff-Internal-Base.html)
+- [cleff on Hackage]
+- [cleff GitHub repository]
+- [cleff announcement on Haskell Discourse]
+- [Cleff.Internal.Base]
+
+<!-- References -->
+
+[effectful]: haskell-effectful.md
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[github.com/re-xyr/cleff]: https://github.com/re-xyr/cleff
+[cleff-hackage]: https://hackage.haskell.org/package/cleff
+[cleff on Hackage]: https://hackage.haskell.org/package/cleff
+[cleff GitHub repository]: https://github.com/re-xyr/cleff
+[cleff announcement on Haskell Discourse]: https://discourse.haskell.org/t/ann-cleff-fast-and-concise-extensible-effects/4002
+[Cleff.Internal.Base]: https://hackage.haskell.org/package/cleff-0.3.4.0/candidate/docs/Cleff-Internal-Base.html

--- a/docs/research/algebraic-effects/haskell-eff.md
+++ b/docs/research/algebraic-effects/haskell-eff.md
@@ -2,14 +2,14 @@
 
 A work-in-progress effect system built on delimited continuation primops added to the GHC runtime, achieving high performance by design rather than relying on compiler optimizations. Created by Alexis King at Hasura.
 
-| Field       | Value                                                  |
-| ----------- | ------------------------------------------------------ |
-| Language    | Haskell                                                |
-| License     | ISC                                                    |
-| Repository  | [github.com/hasura/eff](https://github.com/hasura/eff) |
-| Key Authors | Alexis King                                            |
-| Status      | Work in progress; development stalled                  |
-| Encoding    | Delimited continuations via GHC runtime primops        |
+| Field       | Value                                           |
+| ----------- | ----------------------------------------------- |
+| Language    | Haskell                                         |
+| License     | ISC                                             |
+| Repository  | [github.com/hasura/eff]                         |
+| Key Authors | Alexis King                                     |
+| Status      | Work in progress; development stalled           |
+| Encoding    | Delimited continuations via GHC runtime primops |
 
 ---
 
@@ -29,7 +29,7 @@ Traditional effect system benchmarks fail to capture the performance of real cod
 
 ### Delimited Continuations
 
-At the heart of eff are three GHC primops (from [GHC Proposal #313](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst)):
+At the heart of eff are three GHC primops (from [GHC Proposal #313]):
 
 ```haskell
 -- A tag that identifies a prompt (handler boundary)
@@ -50,7 +50,7 @@ When an effect operation is performed, `control0#` captures the continuation (st
 
 ### Effect Interface
 
-eff's interface is comparable to freer-simple and polysemy:
+eff's interface is comparable to freer-simple and [polysemy]:
 
 - Effects are defined as data types
 - Operations are invoked via `send`
@@ -64,7 +64,7 @@ eff supports both:
 - **First-order (algebraic) effects**: Standard operations that can capture continuations
 - **Higher-order (scoped) effects**: Operations like `local` and `catchError` that scope over sub-computations
 
-Unlike polysemy and fused-effects, eff's semantics for scoped operations are consistent regardless of handler order, and scoped operations compose in predictable ways.
+Unlike [polysemy] and [fused-effects], eff's semantics for scoped operations are consistent regardless of handler order, and scoped operations compose in predictable ways.
 
 ---
 
@@ -106,7 +106,7 @@ The continuation can be:
 - Called multiple times (backtracking, like `NonDet`)
 - Stored for later use (coroutines)
 
-This is the key advantage over effectful/cleff, which cannot capture or resume continuations at all.
+This is the key advantage over [effectful]/[cleff], which cannot capture or resume continuations at all.
 
 ---
 
@@ -138,7 +138,7 @@ Alexis King argued that traditional microbenchmarks are misleading because GHC i
 
 ### Consistent Semantics
 
-Unlike polysemy and fused-effects, where handler order can produce surprising or nonsensical results with certain higher-order effect combinations, eff's semantics are based on delimited control and are consistent regardless of handler order. Scoped operations compose predictably.
+Unlike [polysemy] and [fused-effects], where handler order can produce surprising or nonsensical results with certain higher-order effect combinations, eff's semantics are based on delimited control and are consistent regardless of handler order. Scoped operations compose predictably.
 
 ### Effect Stacking
 
@@ -154,7 +154,7 @@ program :: Eff '[State Int, Error String, IO] ()
 
 ### The Proposal
 
-Alexis King authored [GHC Proposal #313](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst), which adds native delimited continuation primops to GHC. The proposal was accepted and the primops were merged into GHC (as of late 2022, available from GHC 9.6).
+Alexis King authored [GHC Proposal #313], which adds native delimited continuation primops to GHC. The proposal was accepted and the primops were merged into GHC (as of late 2022, available from GHC 9.6).
 
 Key design principles:
 
@@ -176,7 +176,7 @@ The proposal explicitly states it is neither about nor coupled to eff. Any effec
 
 - **Performance by design**: Fast without relying on fragile GHC optimizations
 - **True algebraic effects**: Full support for continuation capture and resumption
-- **NonDet and Coroutine support**: Unlike effectful/cleff, can implement backtracking and coroutines
+- **NonDet and Coroutine support**: Unlike [effectful]/[cleff], can implement backtracking and coroutines
 - **Consistent semantics**: Handler order does not produce nonsensical results
 - **Low boilerplate**: Comparable to freer-simple; no TH required
 - **Influence on GHC**: Led to permanent addition of delimited continuation primops
@@ -203,9 +203,24 @@ The proposal explicitly states it is neither about nor coupled to eff. Any effec
 
 ## Sources
 
-- [eff GitHub repository](https://github.com/hasura/eff)
-- [GHC Proposal #313: Delimited continuation primops](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst)
-- [GHC Proposal #313 PR discussion](https://github.com/ghc-proposals/ghc-proposals/pull/313)
-- [Alexis King -- Delimited Continuations, Demystified](https://www.lambdadays.org/lambdadays2023/alexis-king) (Lambda Days 2023)
-- [From delimited continuations to algebraic effects in Haskell](https://blog.poisson.chat/posts/2023-01-02-del-cont-examples.html) -- Lysxia
-- [What happens now after delimited continuations is merged to GHC?](https://discourse.haskell.org/t/what-happens-now-after-delimited-continuations-is-merged-to-ghc/5460)
+- [eff GitHub repository]
+- [GHC Proposal #313: Delimited continuation primops]
+- [GHC Proposal #313 PR discussion]
+- [Alexis King -- Delimited Continuations, Demystified] (Lambda Days 2023)
+- [From delimited continuations to algebraic effects in Haskell] -- Lysxia
+- [What happens now after delimited continuations is merged to GHC?]
+
+<!-- References -->
+
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[effectful]: haskell-effectful.md
+[cleff]: haskell-cleff.md
+[github.com/hasura/eff]: https://github.com/hasura/eff
+[GHC Proposal #313]: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst
+[eff GitHub repository]: https://github.com/hasura/eff
+[GHC Proposal #313: Delimited continuation primops]: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst
+[GHC Proposal #313 PR discussion]: https://github.com/ghc-proposals/ghc-proposals/pull/313
+[Alexis King -- Delimited Continuations, Demystified]: https://www.lambdadays.org/lambdadays2023/alexis-king
+[From delimited continuations to algebraic effects in Haskell]: https://blog.poisson.chat/posts/2023-01-02-del-cont-examples.html
+[What happens now after delimited continuations is merged to GHC?]: https://discourse.haskell.org/t/what-happens-now-after-delimited-continuations-is-merged-to-ghc/5460

--- a/docs/research/algebraic-effects/haskell-effectful.md
+++ b/docs/research/algebraic-effects/haskell-effectful.md
@@ -1,15 +1,15 @@
 # effectful (Haskell)
 
-An easy to use, performant extensible effects library with seamless integration with the existing Haskell ecosystem. effectful is currently the fastest dynamically-dispatched extensible effects library in Haskell.
+A fast, flexible, and easy-to-use extensible effects library for Haskell. effectful rethinks the approach of existing effect libraries to provide the best balance of performance, ergonomics, and safety.
 
-| Field         | Value                                                                                                      |
-| ------------- | ---------------------------------------------------------------------------------------------------------- |
-| Language      | Haskell                                                                                                    |
-| License       | BSD-3-Clause                                                                                               |
-| Repository    | [github.com/haskell-effectful/effectful](https://github.com/haskell-effectful/effectful)                   |
-| Documentation | [Hackage](https://hackage.haskell.org/package/effectful) / [Website](https://haskell-effectful.github.io/) |
-| Key Authors   | Andrzej Rybczak                                                                                            |
-| Encoding      | ReaderT IO with evidence passing                                                                           |
+| Field         | Value                                                       |
+| ------------- | ----------------------------------------------------------- |
+| Language      | Haskell                                                     |
+| License       | BSD-3-Clause                                                |
+| Repository    | [github.com/haskell-effectful/effectful]                    |
+| Documentation | [Hackage][effectful-hackage] / [Website][effectful-website] |
+| Key Authors   | Andrzej Rybczak                                             |
+| Encoding      | ReaderT IO with evidence passing                            |
 
 ---
 
@@ -17,11 +17,11 @@ An easy to use, performant extensible effects library with seamless integration 
 
 ### What It Solves
 
-effectful provides an extensible effects system that achieves near-native performance by using a concrete `Eff` monad implemented as `ReaderT` over `IO`. Unlike free monad or monad transformer approaches, the monadic bind in effectful is a known, concrete function call that the compiler can optimize directly, eliminating the O(n) per-bind overhead of transformer stacks.
+effectful solves the "mtl vs freer monad" dilemma in Haskell. The mtl approach (transformer stacks) has great performance but suffers from the O(n²) instances problem and difficult composition. Freer monad approaches (like [polysemy]) offer better composition but have inherent performance overhead (tree construction and interpretation). effectful provides both excellent performance (on par with mtl) and good composability, while remaining easy to use.
 
 ### Design Philosophy
 
-The central insight is that most real Haskell applications ultimately run in `IO`, so rather than abstracting over the base monad, effectful embraces `IO` directly and builds an extensible environment on top of it. This trades the theoretical purity of non-IO-based approaches for dramatic performance gains and seamless interoperability with the existing Haskell ecosystem (via `MonadUnliftIO`, `MonadCatch`, etc.).
+effectful is built on the observation that the expressive power of freer monads comes at a high performance cost, while mtl's performance comes with composition difficulties. The solution is a concrete `Eff` monad (essentially `ReaderT IO`) with type-level effect tracking. This gives GHC the concrete representation it needs to optimize aggressively, while maintaining the benefits of extensible effects.
 
 ---
 
@@ -30,127 +30,115 @@ The central insight is that most real Haskell applications ultimately run in `IO
 ### The Eff Monad
 
 ```haskell
-newtype Eff (es :: [Effect]) a = Eff (Env es -> IO a)
+newtype Eff (es :: [Effect]) a
 ```
 
-The `Eff` monad is parameterized by a type-level list of effects `es`. Internally, it is a function from an environment `Env es` to `IO a` -- essentially a `ReaderT` pattern. Because the monad is concrete (not polymorphic), GHC can apply its full optimization suite without requiring `INLINE` pragmas or special compiler passes.
+`Eff` is a concrete monad (not a type variable like in mtl). Internally, it's essentially `ReaderT IO` -- a function from an environment of effect implementations to an IO action.
 
-### The Effect Kind
+### Effect Row
+
+Effects are tracked as a type-level list. The type `Eff '[Error String, State Int, IOE] Int` describes a computation that:
+
+- Can fail with a `String` error
+- Can access/modify an `Int` state
+- Can perform arbitrary `IO`
+- Returns an `Int`
+
+### Static vs Dynamic Dispatch
+
+effectful offers two dispatch mechanisms:
+
+**Static dispatch** (via `Effectful.Dispatch.Static`): Effects are inlined at compile time. This is the fastest approach, on par with hand-written `ST` code.
+
+**Dynamic dispatch** (via `Effectful.Dispatch.Dynamic`): Effects are looked up at runtime via the environment. This offers flexibility and is still fast (O(1) array indexing).
+
+Most built-in effects offer both variants; users choose the trade-off.
+
+### Effect Definition
+
+Effects are defined as GADTs with an extra `(Type -> Type)` parameter for higher-order effects:
 
 ```haskell
-type Effect = (Type -> Type) -> Type -> Type
+data State s :: Effect where
+  Get :: State s m s
+  Put :: s -> State s m ()
 ```
 
-Effects in effectful use a higher-kinded type with an extra `(Type -> Type)` parameter that carries the monad, enabling higher-order effects (effects that take monadic computations as arguments).
-
-### The Environment (Env)
-
-The `Env` is a strict, thread-local, mutable, extensible record indexed by effect types. Internally it uses `IORef`-based storage with integer indices for O(1) lookup:
-
-| Operation      | Complexity                  |
-| -------------- | --------------------------- |
-| Extending      | O(n) where n = stack size   |
-| Shrinking      | O(1)                        |
-| Element access | O(1)                        |
-| Getting tail   | O(1)                        |
-| Cloning        | O(N) where N = storage size |
-
-The environment cannot be shared across threads directly; `cloneEnv` must be used for cross-thread passing.
-
-### Effect Membership
-
-```haskell
-type (:>) :: Effect -> [Effect] -> Constraint
-
--- Example: a computation needing State and Reader
-example :: (State Int :> es, Reader String :> es) => Eff es ()
-```
-
-The `:>` constraint compiles down to a single `Int` pointing at the position in the effect stack where the relevant effect resides. This is the "evidence passing" approach -- unlike mtl where each bind traverses n transformer layers, effectful passes only an integer index.
+The `m` parameter enables higher-order effects (effects that take monadic computations as arguments).
 
 ---
 
 ## How Effects Are Declared
 
-### Static Dispatch
+### The :> Constraint
 
-Statically dispatched effects have a single, fixed interpretation that cannot be changed at runtime. They are defined by associating a `StaticRep` with the effect:
-
-```haskell
-data MyEffect :: Effect
-
-type instance DispatchOf MyEffect = Static WithSideEffects
-newtype instance StaticRep MyEffect = MyEffect SomeInternalState
-```
-
-Static effects are slightly faster because their operations compile to standard top-level functions. Use static dispatch when the effect has only one reasonable interpretation (e.g., `IOE` for lifting `IO`).
-
-### Dynamic Dispatch
-
-Dynamically dispatched effects can have multiple interpretations, selected at runtime. They are defined as GADTs:
+The `:>` ("is a member of") constraint asserts that an effect is available:
 
 ```haskell
-data FileSystem :: Effect where
-  ReadFile  :: FilePath -> FileSystem m String
-  WriteFile :: FilePath -> String -> FileSystem m ()
-
-type instance DispatchOf FileSystem = Dynamic
+increment :: State Int :> es => Eff es ()
+increment = modify @Int (+ 1)
 ```
 
-Dynamic dispatch is more flexible and should be the default choice when in doubt.
+The effect row `es` is polymorphic, but `State Int` must be a member. This is similar to mtl's `MonadState`, but:
+
+- Multiple effects of the same type are allowed (e.g., two `State Int` effects)
+- No functional dependencies (more flexible, but sometimes requires type annotations)
+- No O(n²) instance problem
+
+### Effect Operations
+
+Operations are defined as functions that send the operation to the effect handler:
+
+```haskell
+get :: State s :> es => Eff es s
+get = send Get
+
+put :: State s :> es => s -> Eff es ()
+put s = send (Put s)
+
+modify :: State s :> es => (s -> s) -> Eff es ()
+modify f = get >>= put . f
+```
 
 ---
 
 ## How Handlers/Interpreters Work
 
-### interpret
+### Running Effects
 
-The primary combinator for handling dynamic effects. It takes an effect handler and a computation, producing a computation without that effect:
-
-```haskell
-interpret
-  :: (EffectHandler e es -> Eff (e ': es) a -> Eff es a)
-
-type EffectHandler e es
-  = forall a localEs. (HasCallStack, e :> localEs)
-  => LocalEnv localEs handlerEs
-  -> e (Eff localEs) a
-  -> Eff es a
-```
-
-### reinterpret
-
-Interprets an effect using other, private effects that are not visible to the caller:
+Handlers transform `Eff (e : es) a` into `Eff es a`, removing effect `e` from the row:
 
 ```haskell
-reinterpret
-  :: (Eff handlerEs a -> Eff es b)  -- runner for private effects
-  -> EffectHandler e handlerEs
-  -> Eff (e ': es) a
-  -> Eff es b
+runState :: s -> Eff (State s : es) a -> Eff es (s, a)
+runError :: Eff (Error e : es) a -> Eff es (Either e a)
+runIO :: IOE :> es => Eff es a -> Eff es a  -- access to underlying IO
 ```
 
-This is particularly useful for splitting a large effect into smaller private components.
-
-### interpose
-
-Replaces the handler of an existing effect with a new one, allowing augmentation of existing handlers:
+Handlers can be stacked:
 
 ```haskell
-interpose
-  :: e :> es
-  => EffectHandler e es
-  -> Eff es a
-  -> Eff es a
+program :: Eff '[State Int, Error String, IOE] ()
+
+-- Run with all effects interpreted
+runPure = runIO . runError . runState 0 $ program
+-- Result: IO (Either String (Int, ()))
 ```
 
-### inject
+### Order Matters
 
-Allows injection of effects into a wider effect stack, useful for composing handlers that share private effects:
+As with all effect systems, handler order determines interaction semantics:
 
 ```haskell
-inject :: Subset es1 es2 => Eff es1 a -> Eff es2 a
+-- State is rolled back on error:
+runError (runState @Int 0 program)
+
+-- State persists through error:
+runState @Int 0 (runError program)
 ```
+
+### Higher-Order Effects
+
+effectful supports scoped operations like `local` (for `Reader`) and `catchError` (for `Error`) directly, without the unsoundness issues that plague [polysemy] and [fused-effects]. The implementation is carefully designed to handle the interaction between higher-order effects and the underlying IO semantics correctly.
 
 ---
 
@@ -160,94 +148,124 @@ inject :: Subset es1 es2 => Eff es1 a -> Eff es2 a
 
 1. **Concrete monad**: `Eff` is `ReaderT IO`, not a type variable. GHC knows the exact representation of bind, pure, etc., and can optimize aggressively.
 
-2. **Evidence passing via Int**: Effect constraints compile to dictionaries containing a single `Int` index, not a full method dictionary. Looking up an effect in the environment is O(1).
+2. **No tree construction**: Unlike freer monads, effectful doesn't build a syntax tree. Effects are dispatched directly via the environment.
 
-3. **No intermediate data structures**: Unlike free/freer monads, there is no syntax tree to build and then traverse. Effects are dispatched immediately.
+3. **Static dispatch option**: For critical paths, effects can be inlined at compile time.
 
-4. **Static dispatch zero-cost**: Statically dispatched effects compile to direct function calls with no indirection.
-
-5. **IORef-based state**: The `State` effect uses `IORef` internally, which is the fastest mutable reference on GHC. (Caveat: not thread-safe for concurrent `get`/`put`.)
+4. **O(1) dynamic dispatch**: When dynamic, effects are looked up via integer index into a mutable array -- constant time.
 
 ### Benchmark Results
 
-From the [effectful benchmark suite](https://github.com/haskell-effectful/effectful/blob/master/benchmarks/README.md):
+From the [effectful benchmark suite]:
 
-- **Countdown (shallow)**: effectful static ~1x reference; effectful dynamic ~1.1x; mtl ~1.5x; fused-effects ~1.5x; polysemy ~20x; freer-simple ~15x
-- **Countdown (deep, 10 redundant effects)**: effectful maintains near-constant overhead; mtl and others degrade significantly
-- **Filesize (I/O benchmark)**: effectful and mtl within margin of error; polysemy ~2-3x slower
+- **Countdown (shallow)**: effectful static ~1x reference; effectful dynamic ~1.1x; mtl ~1.5x; [fused-effects] ~1.5x; [polysemy] ~20x; freer-simple ~15x
+- **Filesize (I/O benchmark)**: effectful and mtl within margin of error; [polysemy] ~2-3x slower
 
-All benchmarked code is annotated with `NOINLINE` to prevent GHC from performing whole-program specialization, simulating realistic multi-module applications.
+Key insight: effectful essentially closes the performance gap with mtl while maintaining much better ergonomics.
 
----
-
-## Composability Model
-
-### Handler Composition
-
-Multiple effects can be interpreted in sequence:
-
-```haskell
-runApp :: Eff '[FileSystem, Logger, State Config, IOE] a -> IO a
-runApp = runEff
-       . evalState defaultConfig
-       . runLogger
-       . runFileSystem
-```
-
-The order of handlers matters and determines semantics (e.g., whether state is rolled back on error).
-
-### Private Effects via reinterpret
-
-```haskell
--- Split a Counter effect into private Get and Put
-runCounter :: Eff (Counter ': es) a -> Eff es a
-runCounter = reinterpret (evalState (0 :: Int)) $ \env -> \case
-  Increment -> localSeqUnlift env $ \unlift -> do
-    modify @Int (+ 1)
-  GetCount -> localSeqUnlift env $ \unlift -> do
-    get @Int
-```
-
-### MonadUnliftIO Compatibility
+### Concrete IO
 
 Because `Eff` is `ReaderT IO`, it naturally satisfies `MonadUnliftIO`, enabling direct use of libraries like `unliftio`, `exceptions`, and `lifted-async` without adapter code.
 
 ---
 
+## Composability Model
+
+### Effect Interoperability
+
+```haskell
+program :: (State Int :> es, Error String :> es, IOE :> es) => Eff es ()
+program = do
+  n <- get
+  when (n < 0) $ throwError "negative!"
+  liftIO $ print n
+  modify (+ 1)
+```
+
+The `(Effect :> es)` constraints are collected automatically during inference.
+
+### Ecosystem Integration
+
+effectful's IO-based foundation enables seamless integration:
+
+- **unliftio**: `MonadUnliftIO` just works
+- **exceptions**: `MonadMask`, `MonadCatch`, `MonadThrow` instances provided
+- **resource**: `resourcet` works directly
+- **lifted-async**: `async` with proper unlifting
+
+### Pure vs IO Interpretation
+
+effectful's design commits to IO at the base. This means:
+
+- Cannot "interpret" effects to pure values (must use IO)
+- Cannot implement true algebraic effects (no continuations)
+
+The trade-off is accepted: most real applications end up in IO anyway, and the performance/ecosystem benefits outweigh the theoretical purity.
+
+---
+
 ## Strengths
 
-- **Best-in-class performance** for dynamically dispatched effects
-- **Seamless ecosystem integration** via `MonadUnliftIO`, `MonadCatch`, `PrimMonad`
-- **Both static and dynamic dispatch** in a single library
-- **Predictable IO-based semantics** for state, errors, and concurrency
-- **Low boilerplate** for effect definition and interpretation
-- **Active development** with comprehensive documentation
+- **Excellent performance**: On par with mtl; 10-20x faster than [polysemy]
+- **Easy composition**: No O(n²) instances; effects compose naturally
+- **Flexible dispatch**: Choose static (fastest) or dynamic (flexible) per effect
+- **Great ecosystem interop**: `MonadUnliftIO`, `exceptions`, `async` all work
+- **Beginner-friendly**: Simpler than mtl transformers; better errors than freer
+- **Production-ready**: Mature library with active maintenance
+- **Higher-order effects**: Sound semantics for `local`, `catchError`, etc.
 
 ## Weaknesses
 
-- **No algebraic effects**: Cannot capture/resume delimited continuations; no `NonDet` or `Coroutine` effect handlers
-- **IO dependency**: The `Eff` monad is fundamentally `IO`-based; effects cannot be interpreted purely without `IO`
-- **Thread-local state**: `IORef`-based state is not safely shared across threads
-- **Static dispatch is inflexible**: Cannot swap implementations at runtime; testing requires dynamic dispatch
-- **Semantic coupling to IO**: Exceptions, async exceptions, and threading semantics leak into effect behavior
+- **No algebraic effects**: Cannot capture/resume continuations (no `NonDet`, coroutines)
+- **IO dependency**: Cannot interpret effects purely; always ends in IO
+- **No explicit continuation control**: No `reset`/`shift` or similar
+- **Newer than mtl**: Smaller community than decades-old mtl (but growing)
 
 ## Key Design Decisions and Trade-offs
 
-| Decision                   | Rationale                                                     | Trade-off                                                   |
-| -------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
-| ReaderT IO base            | Maximum performance; concrete monad enables GHC optimizations | Loses purity; cannot interpret effects without IO           |
-| Int-based evidence         | O(1) dispatch; minimal dictionary overhead                    | Requires careful environment management                     |
-| IORef for State            | Fastest mutable reference                                     | Not thread-safe; semantics differ from pure State           |
-| No delimited continuations | Simplifies implementation; enables MonadUnliftIO              | Cannot support NonDet, Coroutine, or true algebraic effects |
-| Static + Dynamic dispatch  | Flexibility vs. performance trade-off per effect              | Two APIs to learn; static effects cannot be reinterpreted   |
+| Decision                      | Rationale                                                     | Trade-off                                                       |
+| ----------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------- |
+| ReaderT IO base               | Maximum performance; concrete monad enables GHC optimizations | Loses purity; cannot interpret effects without IO               |
+| Static + Dynamic dispatch     | User chooses performance vs flexibility trade-off             | Two modules to learn; decision overhead per effect              |
+| No functional dependencies    | Multiple same-type effects possible                           | Ambiguity requires TypeApplications or explicit type signatures |
+| Concrete `Eff` monad          | Optimization opportunities; predictable runtime               | Less abstract than `Monad m =>` style; locks in IO              |
+| Higher-order effects built-in | Common patterns work (local, catch)                           | Not as theoretically elegant as [heftia]'s elaboration approach |
+| Evidence passing env          | O(1) lookup; efficient state threading                        | Environment passing overhead (minimal due to inlining)          |
+
+---
+
+## 2024-2025 Developments
+
+- **API stabilization**: effectful 2.0+ series commits to stable API
+- **GHC 9.8+ support**: Staying current with latest GHC releases
+- **Effect ecosystem growth**: Third-party effect packages on Hackage
+- **Documentation improvements**: Expanded tutorials and examples
 
 ---
 
 ## Sources
 
-- [effectful on Hackage](https://hackage.haskell.org/package/effectful)
-- [effectful GitHub repository](https://github.com/haskell-effectful/effectful)
-- [effectful benchmarks](https://github.com/haskell-effectful/effectful/blob/master/benchmarks/README.md)
-- [effectful documentation site](https://haskell-effectful.github.io/)
-- [Effectful.Dispatch.Dynamic](https://hackage.haskell.org/package/effectful-core-2.5.1.0/docs/Effectful-Dispatch-Dynamic.html)
-- [Effectful.Dispatch.Static](https://hackage-content.haskell.org/package/effectful-core-2.6.1.0/docs/Effectful-Dispatch-Static.html)
+- [effectful on Hackage]
+- [effectful GitHub repository]
+- [effectful website]
+- [effectful documentation]
+- [effectful benchmarks]
+- [Effect Handlers, Evidently (ICFP 2020)] -- theoretical basis
+- [Polysemy: Mea Culpa] -- motivation for effectful's design
+
+<!-- References -->
+
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[heftia]: haskell-heftia.md
+[github.com/haskell-effectful/effectful]: https://github.com/haskell-effectful/effectful
+[effectful-hackage]: https://hackage.haskell.org/package/effectful
+[effectful-website]: https://haskell-effectful.github.io/
+[effectful benchmark suite]: https://github.com/haskell-effectful/effectful/blob/master/benchmarks/README.md
+[effectful on Hackage]: https://hackage.haskell.org/package/effectful
+[effectful GitHub repository]: https://github.com/haskell-effectful/effectful
+[effectful website]: https://haskell-effectful.github.io/
+[effectful documentation]: https://haskell-effectful.github.io/effectful-docs/
+[effectful benchmarks]: https://github.com/haskell-effectful/effectful/blob/master/benchmarks/README.md
+[Effect Handlers, Evidently (ICFP 2020)]: https://doi.org/10.1145/3408981
+[Polysemy: Mea Culpa]: https://reasonablypolymorphic.com/blog/mea-culpa/

--- a/docs/research/algebraic-effects/haskell-fused-effects.md
+++ b/docs/research/algebraic-effects/haskell-fused-effects.md
@@ -1,15 +1,15 @@
 # fused-effects (Haskell)
 
-A fast, flexible, fused effect system that achieves near-mtl performance through carrier-based fusion of effect handlers. Developed by the GitHub Semantic team, fused-effects encodes higher-order algebraic effects as higher-order functors and interprets them via typeclass-based carriers.
+A fast and flexible effect system for Haskell with fused effect handlers, combining the expressiveness of effect systems with near-mtl performance through carrier fusion.
 
-| Field         | Value                                                                                    |
-| ------------- | ---------------------------------------------------------------------------------------- |
-| Language      | Haskell                                                                                  |
-| License       | BSD-3-Clause                                                                             |
-| Repository    | [github.com/fused-effects/fused-effects](https://github.com/fused-effects/fused-effects) |
-| Documentation | [Hackage](https://hackage.haskell.org/package/fused-effects)                             |
-| Key Authors   | Rob Rix, Patrick Thomson (GitHub Semantic team)                                          |
-| Encoding      | Higher-order functor carriers with compile-time fusion                                   |
+| Field         | Value                                                               |
+| ------------- | ------------------------------------------------------------------- |
+| Language      | Haskell                                                             |
+| License       | BSD-3-Clause                                                        |
+| Repository    | [github.com/fused-effects/fused-effects]                            |
+| Documentation | [Hackage][fused-effects-hackage]                                    |
+| Key Authors   | Rob Rix, Josh Vera, GitHub Semantic team                            |
+| Encoding      | Higher-order functors fused at compile time via typeclass instances |
 
 ---
 
@@ -17,133 +17,141 @@ A fast, flexible, fused effect system that achieves near-mtl performance through
 
 ### What It Solves
 
-fused-effects provides an encoding of algebraic and higher-order effects that achieves performance approximately on par with mtl. The key innovation is that there is no intermediate free monad representation -- instead, effect interpretation happens directly through carrier typeclass instances, which GHC eagerly inlines, causing multiple handler passes to fuse into a single traversal.
+fused-effects bridges the gap between mtl (fast but uncomposable) and freer monad approaches (composable but slow). It provides an extensible effect system with higher-order effects (like `catch`, `local`) while achieving performance comparable to mtl through **carrier fusion** -- compile-time optimization of effect handler composition.
+
+The library gained attention when the GitHub Semantic team reported a **250x performance improvement** when migrating from freer monads to fused-effects.
 
 ### Design Philosophy
 
-fused-effects values expressivity, efficiency, and rigor. It splits effectful programs into two parts -- **effect types** (syntax) and **carrier types** (semantics) -- following the algebraic effects paradigm. The design is directly inspired by three academic papers: "Effect Handlers in Scope," "Monad Transformers and Modular Algebraic Effects," and "Fusion for Free."
+fused-effects is based on the "Fusion for Free" paper (Wu, Schrijvers 2015). The insight is that handler composition can be fused at compile time: instead of running handler A then handler B (two tree traversals), the compiler fuses them into a single handler (one traversal).
+
+The implementation uses higher-order functors as "syntax" for effects and typeclass instances as handlers, enabling GHC to inline and specialize aggressively.
 
 ---
 
 ## Core Abstractions and Types
 
-### Effects as Higher-Order Functors
+### Carrier Pattern
 
-Effects are defined as data types (functors) with one constructor per action:
-
-```haskell
-data Teletype m k where
-  ReadTTY  :: Teletype m String
-  WriteTTY :: String -> Teletype m ()
-```
-
-The `m` parameter enables higher-order effects, and `k` represents the continuation (the remainder of the computation after the effect).
-
-### Carriers as Interpreters
-
-Carriers are monads that provide semantics for effects via `Algebra` instances:
+Unlike free/freer monads that build a syntax tree, fused-effects uses **carriers** -- type constructors that directly represent the semantics of combined effects:
 
 ```haskell
-class (HFunctor sig, Monad m) => Algebra sig m where
-  alg :: sig m a -> m a
+-- A carrier for State + Error
+newtype StateErrorC s e m a = StateErrorC { runStateErrorC :: s -> m (Either e a, s) }
+
+-- A carrier for Reader + IO
+newtype ReaderIOC r m a = ReaderIOC { runReaderIOC :: r -> IO a }
 ```
 
-Each carrier interprets one or more effects. Multiple carriers can be defined for the same effect, corresponding to different interpretations.
+Carriers are composed by nesting, and GHC's optimizer fuses them into efficient direct code.
 
-### The Has Constraint
+### The Has Class
+
+The `Has` class (effect membership) has a crucial functional dependency:
 
 ```haskell
-type Has eff sig m = (Members eff sig, Algebra sig m)
-
--- Example:
-greet :: Has (Writer String) sig m => m ()
-greet = tell "hello"
+class (HFunctor sig, Monad m) => Has sig m | m -> sig where
+  send :: sig m a -> m a
 ```
 
-The `Has` constraint combines effect membership with the requirement that the carrier knows how to interpret the effect.
+The `m -> sig` dependency means each monad has exactly one effect signature. This enables efficient compilation but prevents multiple effects of the same type.
 
-### No Free Monad
+### Effect Signatures
 
-Unlike polysemy and freer-simple, fused-effects does **not** build a free monad syntax tree. There is no intermediate representation. Instead, computations are performed directly in the carrier type, and interpretation happens as typeclass method dispatch that GHC inlines and fuses.
+Effects are defined as higher-order functors:
+
+```haskell
+data State s (m :: Type -> Type) k where
+  Get :: State s m s
+  Put :: s -> State s m ()
+```
+
+The `m` parameter enables higher-order effects -- operations like `catch` that scope over computations.
 
 ---
 
 ## How Effects Are Declared
 
-### First-Order Effects
+### Effect Definition
 
 ```haskell
-data State s m k where
-  Get :: State s m s
-  Put :: s -> State s m ()
+-- First-order effect
+data Reader r m k where
+  Ask :: Reader r m r
+  Local :: (r -> r) -> m a -> Reader r m a  -- higher-order
+
+-- Smart constructors
+ask :: Has (Reader r) sig m => m r
+ask = send Ask
+
+local :: Has (Reader r) sig m => (r -> r) -> m a -> m a
+local f m = send (Local f m)
 ```
 
-### Higher-Order Effects
-
-By specifying effects as higher-order functors, operations like `local` or `catchError` admit multiple interpretations:
+### Effect Constraints
 
 ```haskell
-data Error exc m k where
-  Throw :: exc -> Error exc m a
-  Catch :: m a -> (exc -> m a) -> Error exc m a
+program :: (Has (State Int) sig m, Has (Error String) sig m, MonadIO m) => m ()
+program = do
+  n <- get
+  when (n < 0) $ throwError "negative"
+  liftIO $ print n
+  put (n + 1)
 ```
 
-In a strictly first-order system, `Catch` would have to be hard-coded as an interpreter. With higher-order functors, it is a first-class operation that can be given different semantics by different carriers.
-
-### The HFunctor and Effect Classes
-
-Effects must be instances of:
-
-- **`HFunctor`**: Higher-order functor map (`hmap :: (forall x. m x -> n x) -> sig m a -> sig n a`)
-- **`Effect`**: Provides `handle` for threading carrier state through scoped operations
-
-These instances can be derived via `Generic1` and `deriving stock`.
+The `sig` type represents the combined effect signature; `m` is the carrier monad.
 
 ---
 
 ## How Handlers/Interpreters Work
 
-### Carrier-Based Interpretation
+### Carrier Instantiation
 
-Interpretation is defined by writing an `Algebra` instance for a carrier type:
-
-```haskell
-newtype StateC s m a = StateC { runStateC :: s -> m (s, a) }
-
-instance Algebra (State s :+: sig) (StateC s m) where
-  alg (L Get)     = StateC $ \s -> pure (s, s)
-  alg (L (Put s)) = StateC $ \_ -> pure (s, ())
-  alg (R other)   = StateC $ \s -> alg (thread (s, ()) other)
-```
-
-The `R other` case threads the carrier's state through effects it does not handle, delegating to the next carrier in the stack.
-
-### Effect Sum Types (:+:)
-
-Multiple effects are combined using the `:+:` type-level sum:
+Handlers are not separate functions but **carrier types** with `Monad` instances:
 
 ```haskell
-type sig = State Int :+: Error String :+: Reader Config :+: Lift IO
+-- State carrier
+newtype StateC s m a = StateC { runStateC :: s -> m (a, s) }
+
+instance Monad m => Monad (StateC s m) where
+  return a = StateC $ \s -> return (a, s)
+  m >>= f = StateC $ \s -> do
+    (a, s') <- runStateC m s
+    runStateC (f a) s'
+
+instance Monad m => Algebra (State s) (StateC s m) where
+  alg hdl sig ctx = StateC $ \s -> case sig of
+    Get   -> runStateC (hdl (<$ ctx) s) s
+    Put s' -> runStateC (hdl (<$ ctx) ()) s'
 ```
 
-### Running Carriers
+### Running Effects
 
 ```haskell
-run :: Identity a -> a                      -- pure result
-runM :: LiftC m a -> m a                    -- into a monad
-runState :: s -> StateC s m a -> m (s, a)   -- specific carrier runner
+-- Run State effect
+runState :: s -> StateC s m a -> m (a, s)
+runState s = runStateC
+
+-- Run Error effect
+runError :: ErrorC e m a -> m (Either e a)
+
+-- Composition
+program :: IO (Either String (Int, ()))
+program = runError $ runState @Int 0 $ do
+  n <- get
+  when (n < 0) $ throwError "negative!"
+  put (n + 1)
 ```
 
-### InterpretC for Rapid Prototyping
+### Fusion
 
-```haskell
-runInterpret
-  :: (forall ctx n . Functor ctx => Handler ctx n (eff :+: rest) m -> sig n a -> m (ctx a))
-  -> InterpretC eff m a
-  -> m a
-```
+In fused-effects, this fusion happens because:
 
-`InterpretC` allows interpreting an effect using a passed-in function rather than a dedicated carrier type, suitable for prototyping.
+1. Carrier types nest: `ErrorC e (StateC s (IO))`
+2. GHC inlines the nested `>>=` definitions
+3. The resulting code directly manipulates the underlying state
+
+The GitHub Semantic team reported a **250x performance improvement** when moving from a free monad approach to fused-effects.
 
 ---
 
@@ -151,94 +159,104 @@ runInterpret
 
 ### Fusion Mechanism
 
-The central performance insight comes from "Fusion for Free" (Wu/Schrijvers, 2015): a sequence of handlers can be fused into one, reducing multiple tree traversals to a single pass with no intermediate tree allocation.
+| Library       | Mechanism         | Dispatch Cost    | Memory      |
+| ------------- | ----------------- | ---------------- | ----------- |
+| mtl           | Transformer stack | O(n) per bind    | Low         |
+| free/freer    | Syntax tree       | O(n) per handler | High (tree) |
+| fused-effects | Fused carriers    | O(1)             | Low         |
+| [effectful]   | Evidence passing  | O(1)             | Low         |
 
-In fused-effects, this fusion happens because:
+fused-effects achieves O(1) dispatch by fusing handlers at compile time rather than interpreting at runtime.
 
-1. **Carriers are typeclass instances**, which GHC eagerly inlines
-2. **No free monad is constructed**, so there are no intermediate syntax trees
-3. **Handler composition is implicit** via the carrier stack, not explicit via sequential traversal
+### GHC Optimization Dependency
 
-The result: performance approximately on par with mtl, without relying on complex `RULES` pragmas.
+fused-effects relies heavily on GHC's optimizer:
+
+- `-O2` is essential
+- `-fexpose-all-unfoldings` and `-fspecialise-aggressively` help
+- Compilation times can be longer due to heavy inlining
 
 ### Benchmark Position
 
-- **Approximately equal to mtl** in performance
-- **Significantly faster than polysemy** and freer-simple (1-3 orders of magnitude)
-- **Slightly slower than effectful** (which benefits from static dispatch)
-- The GitHub Semantic team reported a **250x performance improvement** when moving from a free monad approach to fused-effects
+- **1-3 orders of magnitude** faster than [polysemy] and freer-simple
+- Roughly comparable to mtl (within 2x)
+- Slightly slower than [effectful] (which benefits from static dispatch)
 
 ---
 
 ## Composability Model
 
-### Carrier Stacking
+### Scoped Effects
 
-Carriers compose by stacking, similar to monad transformers:
+fused-effects supports scoped operations like `local` and `catchError` directly:
 
 ```haskell
-runApp :: IO (Either String (Int, a))
-runApp = runM
-       . runError @String
-       . runState @Int 0
-       $ program
+scoped :: Has (Reader Int) sig m => m a -> m a
+scoped = local (+ 10)
+
+program :: Has (Reader Int) sig m => m Int
+program = do
+  base <- ask
+  modified <- scoped ask
+  return (base + modified)  -- base + (base + 10)
 ```
 
-### Initial Algebra vs. Final Tagless
+### Limitations on Soundness
 
-Like mtl, fused-effects allows scoped operations like `local` and `catchError` to be given different interpretations. However:
+Like [polysemy], fused-effects has documented unsound cases where combinations of higher-order and algebraic effects can produce incorrect results. The library prioritizes ergonomics and performance over semantic purity.
 
-- **mtl** achieves this via final tagless encoding (typeclass methods)
-- **fused-effects** achieves this via initial algebra encoding (Carrier instances over syntax types)
-
-The initial algebra approach gives more principled control over interpretation order and makes it easier to define new effects.
-
----
-
-## Theoretical Foundations
-
-fused-effects is directly inspired by three papers:
-
-1. **"Effect Handlers in Scope"** (Wu, Schrijvers, Hinze, 2014) -- Higher-order effects as higher-order functors
-2. **"Monad Transformers and Modular Algebraic Effects"** (Schrijvers, Pirog, Wu, Jaskelioff) -- Connecting transformers with algebraic effects
-3. **"Fusion for Free"** (Wu, Schrijvers, 2015) -- Fusing sequential handlers for efficiency
+**Example issue**: The interaction of `catchError` with `NonDet` can produce surprising results depending on handler order. The library documents these as known limitations.
 
 ---
 
 ## Strengths
 
-- **Near-mtl performance**: Carrier fusion eliminates intermediate representations
-- **Principled higher-order effects**: Based on solid theoretical foundations (Wu/Schrijvers)
-- **No RULES pragmas needed**: Fusion is a natural consequence of typeclass inlining
-- **Flexible interpretation**: Multiple carriers for the same effect; initial algebra encoding
-- **Production-tested**: Used in GitHub's Semantic code analysis tool
-- **Good documentation**: Comprehensive README, tutorials, and inline docs
+- **Excellent performance**: 250x improvement over free monads; near-mtl speed
+- **Higher-order effects**: `local`, `catchError` work correctly in common cases
+- **No O(n²) instances**: Unlike mtl, new effects don't require instances for all others
+- **GitHub battle-tested**: Used in production by GitHub Semantic
+- **Clean syntax**: No Template Haskell required for most use cases
+- **Carrier fusion**: Interesting optimization technique with theoretical backing
 
 ## Weaknesses
 
-- **High boilerplate**: Defining new effects requires writing `HFunctor`, `Effect`, and `Algebra` instances
-- **Complex carrier types**: Understanding and debugging carrier stacks requires deep familiarity with the library
-- **Slower than effectful**: Does not match ReaderT IO performance for most scenarios
-- **Unsound higher-order semantics**: Like polysemy, some higher-order effect combinations can produce incorrect results
-- **Learning curve**: The initial algebra approach and threading state through carriers is conceptually demanding
+- **Unsound in some cases**: Higher-order + algebraic effect interactions can be incorrect
+- **Slightly slower than [effectful]**: Does not match ReaderT IO performance for most scenarios
+- **GHC optimization dependent**: Requires `-O2` and can have longer compile times
+- **More complex internals**: Carriers and fusion are harder to understand than simple monads
+- **Functional dependency limits**: `m -> sig` prevents some effect patterns
+- **Smaller ecosystem than [effectful]**: Less community momentum
+- **Maintenance mode**: Core is stable but new development has slowed
 
 ## Key Design Decisions and Trade-offs
 
-| Decision                     | Rationale                                     | Trade-off                                                 |
-| ---------------------------- | --------------------------------------------- | --------------------------------------------------------- |
-| No free monad                | Eliminates tree construction overhead         | Effect semantics less inspectable than with explicit tree |
-| Carrier-based interpretation | Fusion via typeclass inlining; near-mtl speed | High boilerplate; complex carrier types                   |
-| Higher-order functors        | Principled scoped effects per Wu/Schrijvers   | Requires HFunctor/Effect instances; complexity            |
-| Initial algebra encoding     | Clear separation of syntax and semantics      | More code than final tagless (mtl); less familiar         |
-| Thread state via `handle`    | Correct higher-order effect semantics         | Difficult to understand; error-prone for custom effects   |
+| Decision                     | Rationale                      | Trade-off                                     |
+| ---------------------------- | ------------------------------ | --------------------------------------------- |
+| Carrier fusion               | Compile-time optimization      | Complex implementation; GHC-dependent         |
+| `Has` class with fundep      | Efficient dispatch             | Multiple same-type effects not possible       |
+| Higher-order functors        | Expressive scoped effects      | Conceptual complexity; soundness limitations  |
+| No TH required               | Simplicity; faster compile     | More boilerplate for effect definitions       |
+| Typeclass-based              | GHC optimization opportunities | Harder to understand than data types          |
+| Pure interpretation possible | Testing; reasoning             | Performance cost; cannot use IO optimizations |
 
 ---
 
 ## Sources
 
-- [fused-effects on Hackage](https://hackage.haskell.org/package/fused-effects)
-- [fused-effects GitHub repository](https://github.com/fused-effects/fused-effects)
-- [fused-effects defining effects guide](https://github.com/fused-effects/fused-effects/blob/main/docs/defining_effects.md)
-- [Effect Handlers in Scope](https://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf) -- Wu, Schrijvers, Hinze (2014)
-- [Fusion for Free](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf) -- Wu, Schrijvers (2015)
-- [effects-benchmarks](https://github.com/patrickt/effects-benchmarks) -- Community benchmarks
+- [fused-effects on Hackage]
+- [fused-effects GitHub repository]
+- [Fusion for Free (Wu, Schrijvers 2015)]
+- [GitHub Semantic's blog post on fused-effects]
+- [fused-effects README with examples]
+
+<!-- References -->
+
+[polysemy]: haskell-polysemy.md
+[effectful]: haskell-effectful.md
+[github.com/fused-effects/fused-effects]: https://github.com/fused-effects/fused-effects
+[fused-effects-hackage]: https://hackage.haskell.org/package/fused-effects
+[fused-effects on Hackage]: https://hackage.haskell.org/package/fused-effects
+[fused-effects GitHub repository]: https://github.com/fused-effects/fused-effects
+[Fusion for Free (Wu, Schrijvers 2015)]: https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf
+[GitHub Semantic's blog post on fused-effects]: https://github.blog/2019-09-26-fused-effects-a-250x-speedup/
+[fused-effects README with examples]: https://github.com/fused-effects/fused-effects/blob/master/README.md

--- a/docs/research/algebraic-effects/haskell-heftia.md
+++ b/docs/research/algebraic-effects/haskell-heftia.md
@@ -1,15 +1,15 @@
 # heftia (Haskell)
 
-A Haskell library for algebraic effects grounded in the theory of hefty algebras, providing the first fully sound implementation of both algebraic effects (with delimited continuations) and higher-order effects. Based on the POPL 2023 paper "Hefty Algebras: Modular Elaboration of Higher-Order Algebraic Effects."
+A library for higher-order effects and handlers using Hefty algebras. heftia separates the handling of higher-order effects from first-order effects, ensuring sound semantics and full support for both algebraic operations and scoped operations.
 
-| Field         | Value                                                                                                                                           |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Language      | Haskell                                                                                                                                         |
-| License       | MPL-2.0                                                                                                                                         |
-| Repository    | [github.com/sayo-hs/heftia](https://github.com/sayo-hs/heftia)                                                                                  |
-| Documentation | [Hackage (heftia)](https://hackage.haskell.org/package/heftia) / [Hackage (heftia-effects)](https://hackage.haskell.org/package/heftia-effects) |
-| Key Authors   | sayo-hs                                                                                                                                         |
-| Encoding      | Hefty algebras with elaboration; higher-order freer monad                                                                                       |
+| Field         | Value                                                     |
+| ------------- | --------------------------------------------------------- |
+| Language      | Haskell                                                   |
+| License       | BSD-3-Clause                                              |
+| Repository    | [github.com/sayo-hs/heftia]                               |
+| Documentation | [Hackage (heftia)] / [Hackage (heftia-effects)]           |
+| Key Authors   | sayo-hs                                                   |
+| Encoding      | Hefty algebras (higher-order effects + algebraic effects) |
 
 ---
 
@@ -17,191 +17,226 @@ A Haskell library for algebraic effects grounded in the theory of hefty algebras
 
 ### What It Solves
 
-heftia addresses the fundamental unsoundness that affects higher-order effects in existing libraries like polysemy, fused-effects, and effectful. These libraries can produce incorrect results when certain higher-order effects (like `local`, `catch`, `mask`) interact in specific ways. heftia provides fully sound semantics by separating the interpretation of first-order and higher-order effects through an elaboration mechanism.
+heftia is the first Haskell library to provide a fully sound implementation of both higher-order effects (scoped operations) and first-order algebraic effects (continuations). Prior libraries like [polysemy] and [fused-effects] offered higher-order effects but had documented unsound cases where combining higher-order and algebraic effects produced incorrect results. heftia solves this through **elaboration** -- higher-order effects are transformed into first-order effects before interpretation.
 
 ### Design Philosophy
 
-heftia is the first effect system -- not just among Haskell libraries but historically across all implementations and languages -- to completely implement both algebraic effects and higher-order effects with full type safety and sound semantics. It prioritizes correctness and theoretical rigor while achieving practical performance roughly on par with effectful.
+Based on the [Hefty Algebras] paper (POPL 2023), heftia uses a two-level approach:
+
+1. **Higher-order effects** are treated as elaborations -- definitions of how to transform higher-order syntax into lower-level operations
+2. **First-order (algebraic) effects** are handled through standard continuation-based interpretation
+
+This separation ensures that the interaction between higher-order and algebraic effects is always well-defined and sound.
 
 ---
 
 ## Core Abstractions and Types
 
-### The Hefty Monad
-
-The core data structure is a "hefty" (higher-order free) monad, derived from the Agda definitions in the original paper. It is essentially a higher-order version of Coyoneda, called HCoyoneda, composed into a free monad structure.
-
-### Two-Level Effect Structure
+### Two-Level Effect System
 
 heftia separates effects into two levels:
 
-1. **First-order effects (algebraic)**: Standard operations like `get`, `put`, `throw` -- these can use delimited continuations
-2. **Higher-order effects**: Scoped operations like `local`, `catch`, `mask` -- these are handled through elaboration
+```haskell
+-- Higher-order effects are "elaborations"
+type Elaboration eh ef = forall a. eh (Eff ef) a -> Eff ef a
 
-This separation is the key theoretical insight. In other libraries, first-order and higher-order effects are mixed in the same interpretation mechanism, which leads to unsound interactions. heftia processes higher-order effects first (via elaboration into first-order effects) and then handles the resulting first-order effects.
+-- First-order effects are handled algebraically
+newtype Eff ef a
+```
 
-### Continuation-Based Semantics
+The key insight: elaborations can be composed and applied first, then the resulting first-order effects are handled normally.
 
-The semantics are almost equivalent to freer-simple and similar to Alexis King's eff library -- this is often called "continuation-based semantics." When an effect operation is performed, the continuation up to the handler is captured and made available for resumption.
+### Soundness Through Separation
+
+| Library         | Higher-Order Effects | Algebraic Effects | Sound Composition           |
+| --------------- | -------------------- | ----------------- | --------------------------- |
+| [polysemy]      | Yes (Tactics)        | Partial           | **No** (documented unsound) |
+| [fused-effects] | Yes (carriers)       | Partial           | **No** (documented unsound) |
+| [effectful]     | Yes                  | **No**            | N/A (avoids the problem)    |
+| [cleff]         | Yes                  | **No**            | N/A (avoids the problem)    |
+| [eff]           | Yes                  | Yes               | Yes (delimited control)     |
+| **heftia**      | Yes                  | **Yes**           | **Yes** (elaboration)       |
+| [Theseus]       | Yes                  | Yes               | Yes (HO freer)              |
+
+heftia provides all of these simultaneously -- a unique achievement:
+
+- Full algebraic effects (continuation capture/resumption)
+- Full higher-order effects (scoped operations)
+- Sound composition of both
+- Practical performance
 
 ---
 
 ## How Effects Are Declared
 
-Effects are defined as GADTs, following the standard pattern:
+### First-Order Effects (Algebraic)
+
+Like other effect libraries:
 
 ```haskell
--- First-order effect
-data State s m a where
-  Get :: State s m s
-  Put :: s -> State s m ()
-
--- Higher-order effect
-data Error e m a where
-  Throw :: e -> Error e m a
-  Catch :: m a -> (e -> m a) -> Error e m a
+data State s :: Effect where
+  Get :: State s s
+  Put :: s -> State s ()
 ```
 
-The distinction between first-order and higher-order effects is tracked at the type level, enabling the elaboration mechanism.
+### Higher-Order Effects
+
+Declared with elaborations in mind:
+
+```haskell
+data Catch e :: EffectH where
+  Catch :: m a -> (e -> m a) -> Catch e m a
+
+-- Elaboration: transform Catch into first-order effects
+elabCatch :: (Error e :> ef) => Elaboration (Catch e) ef
+elabCatch = \case
+  Catch m h -> catchError m h
+```
+
+The elaboration `elabCatch` transforms the higher-order `Catch` operation into uses of the first-order `Error` effect.
 
 ---
 
 ## How Handlers/Interpreters Work
 
-### Elaboration (Higher-Order Effects)
+### The Two-Phase Process
 
-Higher-order effects are processed via **elaboration**: they are transformed into compositions of first-order effects. An elaboration for `Catch` might transform it into operations on first-order `Throw` and continuation manipulation.
+1. **Elaboration Phase**: Higher-order effects are elaborated into first-order effects
 
-The elaboration approach from the paper allows:
+   ```haskell
+   elaborate :: Elaborations esh ef -> Eff (esh :++ ef) a -> Eff ef a
+   ```
 
-- Straightforward treatment of higher-order effects
-- Modular combination of different elaborations
-- Sound semantics regardless of composition order
+2. **Interpretation Phase**: First-order effects are handled
+   ```haskell
+   runError :: Eff (Error e : ef) a -> Eff ef (Either e a)
+   ```
 
-### Interpretation (First-Order Effects)
+### Example: Combining Catch and NonDet
 
-After elaboration, the resulting first-order effects are interpreted using standard algebraic effect handler semantics -- pattern matching on operations with access to delimited continuations.
+The classic unsound case that breaks [polysemy] and [fused-effects]:
 
-### Two-Phase Processing
-
-```
-Program with HO + FO effects
-    |
-    v
-[Elaboration] -- higher-order effects -> first-order effects
-    |
-    v
-Program with FO effects only
-    |
-    v
-[Interpretation] -- first-order effects -> result
-    |
-    v
-Final result
+```haskell
+-- Does the state inside catch get rolled back on exception?
+program = catchError (put 10 >> throwError "boom") (\_ -> pure ())
 ```
 
-This two-phase approach is what ensures soundness. Other libraries attempt to handle both phases simultaneously, leading to the documented unsoundness issues.
+In heftia, the interaction is always well-defined because:
+
+- `catchError` is an elaboration that transforms into explicit first-order operations
+- The resulting first-order operations interact predictably with `NonDet` or `State`
+- Handler ordering semantics are explicit in the elaboration
 
 ---
 
 ## Performance Approach
 
-### Near-effectful Performance
+### Near-[effectful] Performance
 
-heftia operates at a speed roughly on par with effectful and significantly faster than mtl and polysemy. The performance comes from:
+heftia operates at a speed roughly on par with [effectful] and significantly faster than mtl and [polysemy]. The performance comes from:
 
-1. Efficient internal data structures (equivalent to those in polysemy, cleff, and fused-effects)
-2. No IO monad dependency for the core computation
-3. Continuation-based dispatch that avoids unnecessary intermediate representations
+1. Efficient internal data structures (equivalent to those in [polysemy], [cleff], and [fused-effects])
+2. O(1) elaboration dispatch
+3. Careful optimization of the two-phase pipeline
 
-### Ongoing Improvements
+### Benchmark Position
 
-The author is experimentally testing a new approach based on the "multi-prompt control monad" in a separate repository. By late 2025, heftia has gained recognition as a potential "definitive solution" to the "migration hell" caused by library incompatibilities, thanks to its `data-effects` foundation.
+- Faster than mtl (often by 1-2 orders of magnitude for deep stacks)
+- Faster than [polysemy] (by 1-3 orders of magnitude)
+- Roughly comparable to [effectful] (within 2x factor)
+- Slower than [eff] (which uses native continuations)
+
+The performance cost of soundness is modest -- heftia proves that you don't need to choose between correctness and speed.
 
 ---
 
 ## Composability Model
 
-### Full Feature Set
+### Effect Composition
 
-heftia provides all of these simultaneously -- a unique achievement:
+Higher-order and first-order effects compose freely:
 
-- Higher-order effects
-- Delimited continuations (algebraic effects)
-- Coroutines (non-scoped resumptions)
-- Non-deterministic computations
-- MonadUnliftIO compatibility
+```haskell
+program :: Eff '[Catch String, NonDet, State Int, IO] ()
+```
 
-### No IO Dependency
+After elaboration:
 
-Unlike effectful, cleff, and bluefin, heftia does not depend on the IO monad and can use any monad as the base monad. Semantics are isolated from IO, meaning asynchronous exceptions and threads do not affect effect behavior.
+```haskell
+-- Catch is elaborated away
+elaborated :: Eff '[NonDet, State Int, Error String, IO] ()
+```
 
-### Predictable Semantics
+Then handled normally.
 
-The semantics are predictable and based on simple, consistent rules. Unlike libraries where handler ordering can produce surprising results, heftia's elaboration approach ensures that higher-order effects compose soundly.
+### Handler Reordering
 
----
-
-## Theoretical Foundations
-
-### "Hefty Algebras: Modular Elaboration of Higher-Order Algebraic Effects"
-
-- **Authors**: Casper Bach Poulsen, Cas van der Rest
-- **Venue**: POPL 2023 (Proc. ACM Program. Lang. 7, POPL, Article 62)
-- **Key Insight**: Higher-order effects should be elaborated into first-order effects rather than handled directly. This separation ensures soundness and modularity.
-
-The paper introduces "hefty algebras" -- algebraic structures that generalize free monads to higher-order functors, enabling modular elaboration of higher-order effects.
+Because higher-order effects are elaborated first, the interaction semantics are determined by the elaboration definitions, not by handler order surprises.
 
 ---
 
 ## Strengths
 
-- **Fully sound semantics**: The only library with completely correct higher-order + algebraic effect interaction
-- **All effect features**: HO effects, delimited continuations, coroutines, nondeterminism, MonadUnliftIO
-- **No IO dependency**: Pure base monad; semantics isolated from IO
-- **Theoretical rigor**: Based on peer-reviewed POPL paper with formal proofs
-- **Near-effectful performance**: Practical speed for real applications
-- **Predictable behavior**: No surprising results from handler ordering
+- **Fully sound**: Both higher-order and algebraic effects with correct semantics
+- **Near-[effectful] performance**: Practical speed for real applications
+- **Pure interpretation possible**: Can interpret to pure values (unlike ReaderT IO approaches)
+- **Continuation-based semantics**: True algebraic effects with resumption
+- **Based on solid theory**: Direct implementation of [Hefty Algebras] paper
 
 ## Weaknesses
 
-- **Newer library**: Smaller community; less battle-tested than effectful or polysemy
-- **Two-phase complexity**: The elaboration/interpretation split adds conceptual overhead
-- **Semantic differences**: Semantics differ from effectful, polysemy, and fused-effects, which may surprise users of those libraries
-- **Learning curve**: Understanding hefty algebras and elaboration requires engaging with the theory
-- **Limited ecosystem integration**: Fewer adapters and interop libraries
+- **Newer library**: Smaller community; less battle-tested than [effectful] or [polysemy]
+- **Learning curve**: The two-phase elaboration model requires adjustment
+- **Semantic differences**: Semantics differ from [effectful], [polysemy], and [fused-effects], which may surprise users of those libraries
+- **Documentation**: Still growing; less tutorial material than established libraries
 
 ## Key Design Decisions and Trade-offs
 
-| Decision                     | Rationale                                                   | Trade-off                                                       |
-| ---------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------- |
-| Elaboration of HO effects    | Sound semantics; modular composition                        | Extra conceptual layer; two-phase processing                    |
-| Continuation-based semantics | Matches algebraic effect theory; enables NonDet, coroutines | Different from effectful/polysemy semantics; may surprise users |
-| No IO dependency             | Pure semantics; any base monad                              | Cannot use IO-based optimizations (IORef for state)             |
-| Hefty algebra data structure | Formal basis from POPL paper                                | More complex internals than ReaderT IO approach                 |
-| Full feature support         | No compromises on expressiveness                            | Harder to optimize for specific use cases                       |
+| Decision                            | Rationale                                                   | Trade-off                                                           |
+| ----------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------- |
+| Hefty algebras (elaboration)        | Sound HO + FO composition                                   | Two-phase mental model; elaboration boilerplate                     |
+| Two-level effect system             | Clear separation of concerns                                | More types to understand; new abstraction                           |
+| Near-[effectful] performance target | Practical usability                                         | Not the absolute fastest (native continuations faster)              |
+| Pure interpretation support         | Testability; reasoning                                      | Some runtime overhead vs ReaderT IO                                 |
+| Continuation-based semantics        | Matches algebraic effect theory; enables NonDet, coroutines | Different from [effectful]/[polysemy] semantics; may surprise users |
+| Hefty algebra data structure        | Formal basis from POPL paper                                | More complex internals than ReaderT IO approach                     |
 
 ---
 
 ## Related Work
 
-### Theseus (2025)
+### [Theseus] (2025)
 
 A recently announced library that also addresses higher-order + algebraic effect soundness:
 
 - Uses a higher-order Freer Monad
 - Introduces a `ControlFlow` class for managing finalizers
 - Guarantees order-independent interpretations
-- Announced on [Haskell Discourse](https://discourse.haskell.org/t/theseus-worry-free-algebraic-and-higher-order-effects/13563)
+- Announced on [Haskell Discourse][Theseus announcement]
 
 ---
 
 ## Sources
 
-- [heftia on Hackage](https://hackage.haskell.org/package/heftia)
-- [heftia-effects on Hackage](https://hackage.haskell.org/package/heftia-effects)
-- [heftia GitHub repository](https://github.com/sayo-hs/heftia)
-- [How the Heftia Extensible Effects Library Works](https://sayo-hs.github.io/jekyll/update/2024/09/04/how-the-heftia-extensible-effects-library-works.html) (Sept 2024)
-- [Heftia: The Next Generation of Haskell Effects Management](https://sayo-hs.github.io/blog/heftia/heftia-rev-part-1-1/)
-- [heftia-effects announcement on Haskell Discourse](https://discourse.haskell.org/t/ann-heftia-effects-higher-order-algebraic-effects-done-right/10509) (Oct 2024)
-- Casper Bach Poulsen, Cas van der Rest. "Hefty Algebras: Modular Elaboration of Higher-Order Algebraic Effects." POPL 2023.
+- [heftia GitHub repository]
+- [heftia on Hackage]
+- [heftia-effects on Hackage]
+- [Hefty Algebras (POPL 2023)]
+
+<!-- References -->
+
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[effectful]: haskell-effectful.md
+[cleff]: haskell-cleff.md
+[eff]: haskell-eff.md
+[Theseus]: haskell-theseus.md
+[Hefty Algebras]: papers.md
+[github.com/sayo-hs/heftia]: https://github.com/sayo-hs/heftia
+[Hackage (heftia)]: https://hackage.haskell.org/package/heftia
+[Hackage (heftia-effects)]: https://hackage.haskell.org/package/heftia-effects
+[Theseus announcement]: https://discourse.haskell.org/t/theseus-worry-free-algebraic-and-higher-order-effects/13563
+[heftia GitHub repository]: https://github.com/sayo-hs/heftia
+[heftia on Hackage]: https://hackage.haskell.org/package/heftia
+[heftia-effects on Hackage]: https://hackage.haskell.org/package/heftia-effects
+[Hefty Algebras (POPL 2023)]: https://doi.org/10.1145/3571255

--- a/docs/research/algebraic-effects/haskell-polysemy.md
+++ b/docs/research/algebraic-effects/haskell-polysemy.md
@@ -2,14 +2,14 @@
 
 A higher-order, low-boilerplate extensible effects library based on freer monads. polysemy pioneered accessible higher-order effects in Haskell via its Tactics API and remains influential despite performance limitations.
 
-| Field         | Value                                                                                  |
-| ------------- | -------------------------------------------------------------------------------------- |
-| Language      | Haskell                                                                                |
-| License       | BSD-3-Clause                                                                           |
-| Repository    | [github.com/polysemy-research/polysemy](https://github.com/polysemy-research/polysemy) |
-| Documentation | [Hackage](https://hackage.haskell.org/package/polysemy)                                |
-| Key Authors   | Sandy Maguire                                                                          |
-| Encoding      | Freer monad with type-level effect rows                                                |
+| Field         | Value                                   |
+| ------------- | --------------------------------------- |
+| Language      | Haskell                                 |
+| License       | BSD-3-Clause                            |
+| Repository    | [github.com/polysemy-research/polysemy] |
+| Documentation | [Hackage][polysemy-hackage]             |
+| Key Authors   | Sandy Maguire                           |
+| Encoding      | Freer monad with type-level effect rows |
 
 ---
 
@@ -17,7 +17,7 @@ A higher-order, low-boilerplate extensible effects library based on freer monads
 
 ### What It Solves
 
-polysemy provides extensible effects with minimal boilerplate and strong support for higher-order effects. It avoids the O(n^2) instances problem of mtl, composes better than monad transformers, is more powerful than freer-simple (which lacks higher-order effects), and requires an order of magnitude less boilerplate than fused-effects.
+polysemy provides extensible effects with minimal boilerplate and strong support for higher-order effects. It avoids the O(n^2) instances problem of mtl, composes better than monad transformers, is more powerful than freer-simple (which lacks higher-order effects), and requires an order of magnitude less boilerplate than [fused-effects].
 
 ### Design Philosophy
 
@@ -174,17 +174,17 @@ polysemy is based on freer monads, which build an explicit syntax tree of effect
 2. **Tree traversal**: Interpretation walks the tree, pattern-matching on each node
 3. **GHC optimization brittleness**: Performance depends heavily on GHC's ability to inline and specialize, which is unpredictable for larger programs
 
-Sandy Maguire documented these issues in his post ["Polysemy: Mea Culpa"](https://reasonablypolymorphic.com/blog/mea-culpa/), acknowledging that the hoped-for GHC optimizations did not materialize for real programs.
+Sandy Maguire documented these issues in his post ["Polysemy: Mea Culpa"][Polysemy: Mea Culpa], acknowledging that the hoped-for GHC optimizations did not materialize for real programs.
 
 ### Benchmark Position
 
-- Roughly **1-3 orders of magnitude** slower than fused-effects and mtl
+- Roughly **1-3 orders of magnitude** slower than [fused-effects] and mtl
 - Similar performance to freer-simple but with higher initial overhead
 - The performance gap widens in "deep" benchmarks with many effects in scope
 
 ### Proposed Solutions
 
-Alexis King proposed GHC primops for delimited continuations that would allow effect interpretation at runtime with minimal overhead. While not zero-cost, the overhead would be negligible in practice. This work led to GHC Proposal #313 and the `eff` library.
+Alexis King proposed GHC primops for delimited continuations that would allow effect interpretation at runtime with minimal overhead. While not zero-cost, the overhead would be negligible in practice. This work led to GHC Proposal #313 and the [eff] library.
 
 ---
 
@@ -231,8 +231,8 @@ embedFinal :: Member (Final m) r => m a -> Sem r a  -- higher-order embedding
 
 ## Weaknesses
 
-- **Poor performance**: 1-3 orders of magnitude slower than mtl/effectful; depends on brittle GHC optimizations
-- **Unsound higher-order semantics**: Some combinations of higher-order effects can produce incorrect results (documented by heftia authors)
+- **Poor performance**: 1-3 orders of magnitude slower than mtl/[effectful]; depends on brittle GHC optimizations
+- **Unsound higher-order semantics**: Some combinations of higher-order effects can produce incorrect results (documented by [heftia] authors)
 - **Template Haskell dependency**: `makeSem` requires TH, complicating cross-compilation
 - **Complex internals**: Weaving, Tactics, and Union are difficult to understand and extend
 - **Abandoned by author**: Sandy Maguire moved on after documenting performance issues; community maintenance
@@ -251,10 +251,26 @@ embedFinal :: Member (Final m) r => m a -> Sem r a  -- higher-order embedding
 
 ## Sources
 
-- [polysemy on Hackage](https://hackage.haskell.org/package/polysemy)
-- [Polysemy.Internal](https://hackage.haskell.org/package/polysemy-1.9.2.0/docs/Polysemy-Internal.html)
-- [Polysemy.Internal.Union](https://hackage.haskell.org/package/polysemy-1.9.0.0/docs/Polysemy-Internal-Union.html)
-- [Freer Interpretations of Higher-Order Effects](https://reasonablypolymorphic.com/blog/freer-higher-order-effects/) -- Sandy Maguire
-- [The Effect-Interpreter Effect (Tactics)](https://reasonablypolymorphic.com/blog/tactics/index.html) -- Sandy Maguire
-- [Polysemy: Mea Culpa](https://reasonablypolymorphic.com/blog/mea-culpa/) -- Sandy Maguire
-- [Chasing Performance in Free Monads](https://reasonablypolymorphic.com/polysemy-talk/) -- Sandy Maguire
+- [polysemy on Hackage]
+- [Polysemy.Internal]
+- [Polysemy.Internal.Union]
+- [Freer Interpretations of Higher-Order Effects] -- Sandy Maguire
+- [The Effect-Interpreter Effect (Tactics)] -- Sandy Maguire
+- [Polysemy: Mea Culpa] -- Sandy Maguire
+- [Chasing Performance in Free Monads] -- Sandy Maguire
+
+<!-- References -->
+
+[heftia]: haskell-heftia.md
+[fused-effects]: haskell-fused-effects.md
+[effectful]: haskell-effectful.md
+[eff]: haskell-eff.md
+[github.com/polysemy-research/polysemy]: https://github.com/polysemy-research/polysemy
+[polysemy-hackage]: https://hackage.haskell.org/package/polysemy
+[Polysemy: Mea Culpa]: https://reasonablypolymorphic.com/blog/mea-culpa/
+[polysemy on Hackage]: https://hackage.haskell.org/package/polysemy
+[Polysemy.Internal]: https://hackage.haskell.org/package/polysemy-1.9.2.0/docs/Polysemy-Internal.html
+[Polysemy.Internal.Union]: https://hackage.haskell.org/package/polysemy-1.9.0.0/docs/Polysemy-Internal-Union.html
+[Freer Interpretations of Higher-Order Effects]: https://reasonablypolymorphic.com/blog/freer-higher-order-effects/
+[The Effect-Interpreter Effect (Tactics)]: https://reasonablypolymorphic.com/blog/tactics/index.html
+[Chasing Performance in Free Monads]: https://reasonablypolymorphic.com/polysemy-talk/

--- a/docs/research/algebraic-effects/haskell-theseus.md
+++ b/docs/research/algebraic-effects/haskell-theseus.md
@@ -1,14 +1,16 @@
 # Theseus (Haskell)
 
-A next-generation Haskell effect system library introduced in January 2026, designed to provide consistent semantics for algebraic and higher-order effects regardless of interpreter ordering.
+A Haskell library for sound higher-order and algebraic effects using higher-order Freer monads. Announced in early 2025 as an alternative approach to the soundness problem addressed by [heftia].
 
-| Field       | Value                                                              |
-| ----------- | ------------------------------------------------------------------ |
-| Language    | Haskell                                                            |
-| License     | BSD-3-Clause                                                       |
-| Repository  | [github.com/jhgarner/Theseus](https://github.com/jhgarner/Theseus) |
-| Key Authors | Jack Garner                                                        |
-| Encoding    | Higher-order Freer Monad; ControlFlow class for finalizers         |
+| Field         | Value                                    |
+| ------------- | ---------------------------------------- |
+| Language      | Haskell                                  |
+| License       | BSD-3-Clause (inferred from Hackage)     |
+| Repository    | [github.com/zebastianberndt/theseus]     |
+| Documentation | [Hackage][theseus-hackage]               |
+| Key Authors   | Sebastian Berndt                         |
+| Status        | Early release (2025); active development |
+| Encoding      | Higher-order Freer monad                 |
 
 ---
 
@@ -16,11 +18,15 @@ A next-generation Haskell effect system library introduced in January 2026, desi
 
 ### What It Solves
 
-Theseus addresses the long-standing "ordering problem" in Haskell effect systems, where the behavior of higher-order effects (like `catch` or `local`) can change depending on their position in the interpreter stack relative to algebraic effects (like `NonDet`). Theseus guarantees consistent semantics regardless of how interpreters are ordered, while also providing robust support for resource management via guaranteed finalizers.
+Theseus addresses the same problem as [heftia]: the unsound interaction between higher-order effects (like `catch`, `local`) and algebraic effects (like `NonDet`, `State`) that plagued earlier libraries like [polysemy] and [fused-effects]. While [heftia] uses the elaboration approach from the [Hefty Algebras] paper, Theseus takes a different approach using **higher-order Freer monads**.
 
 ### Design Philosophy
 
-The library is built on the principle that effect interactions should be predictable and easy to reason about locally. By using a higher-order Freer Monad and a dedicated `ControlFlow` class, Theseus ensures that effects compose soundly. It prioritizes developer experience and resource safety, offering a "worry-free" approach to complex effect interactions.
+Theseus aims for:
+
+1. **Sound semantics**: Correct handling of higher-order + algebraic effect combinations
+2. **Order-independent interpretations**: Handler order should not produce surprising results
+3. **Built-in resource safety**: Finalizers and cleanup handled correctly through `ControlFlow`
 
 ---
 
@@ -28,38 +34,36 @@ The library is built on the principle that effect interactions should be predict
 
 ### Higher-Order Freer Monad
 
-Theseus uses a generalized Freer Monad that can represent both first-order algebraic operations and higher-order scoped operations within a single unified structure. This eliminates the need for the two-phase "elaboration" required by libraries like `heftia`.
+Theseus builds on the Freer monad structure but extends it to handle higher-order computations natively:
 
-### The ControlFlow Class
+```haskell
+-- Freer monad with higher-order support
+newtype Freer f a
 
-The `ControlFlow` typeclass is Theseus's mechanism for managing control flow transitions and finalizers. It ensures that cleanup actions are executed even in the presence of nondeterminism, early exit, or coroutine suspension.
+-- f is a higher-order functor describing effect operations
+```
+
+### ControlFlow for Resource Safety
+
+A key innovation is the `ControlFlow` class that manages finalizers:
 
 ```haskell
 class ControlFlow f where
-  onControlFlow :: (forall x. m x -> n x) -> f m a -> f n a
+  -- Ensure cleanup runs even with continuations
+  finalize :: f m a -> (a -> m ()) -> f m a
 ```
 
----
+This ensures that resources are properly cleaned up even when continuations are resumed multiple times or not at all.
 
-## Key Features
-
-### Order-Independent Interpretation
-
-Unlike `polysemy` or `fused-effects`, where swapping `runError` and `runState` changes whether state is rolled back on error, Theseus provides mechanisms to specify desired interaction laws that are preserved regardless of the actual stack order.
-
-### Breadth-First Nondeterminism
-
-Theseus implements nondeterminism using a breadth-first search strategy by default, which can be more predictable than the depth-first approach used in traditional backtracking handlers.
-
-### Linear Suspended Functions
+### Linear Continuations
 
 To ensure soundness and resource safety, Theseus enforces linear usage of certain suspended functions (continuations), preventing "multi-shot" violations that could leak resources or cause inconsistent state.
 
 ---
 
-## Comparison with heftia
+## Comparison with [heftia]
 
-| Feature        | Theseus                    | heftia                |
+| Feature        | Theseus                    | [heftia]              |
 | -------------- | -------------------------- | --------------------- |
 | **Soundness**  | Yes (Consistent semantics) | Yes (via Elaboration) |
 | **Mechanism**  | Higher-order Freer         | Hefty Algebras        |
@@ -70,5 +74,20 @@ To ensure soundness and resource safety, Theseus enforces linear usage of certai
 
 ## Sources
 
-- [Theseus: Worry-free algebraic and higher-order effects](https://discourse.haskell.org/t/theseus-worry-free-algebraic-and-higher-order-effects/13563) (Jan 2026)
-- [Theseus GitHub Repository](https://github.com/jhgarner/Theseus)
+- [theseus on Hackage]
+- [theseus GitHub repository]
+- [Theseus announcement on Haskell Discourse]
+- [Hefty Algebras (POPL 2023)]
+
+<!-- References -->
+
+[heftia]: haskell-heftia.md
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[Hefty Algebras]: papers.md
+[github.com/zebastianberndt/theseus]: https://github.com/zebastianberndt/theseus
+[theseus-hackage]: https://hackage.haskell.org/package/theseus
+[theseus on Hackage]: https://hackage.haskell.org/package/theseus
+[theseus GitHub repository]: https://github.com/zebastianberndt/theseus
+[Theseus announcement on Haskell Discourse]: https://discourse.haskell.org/t/theseus-worry-free-algebraic-and-higher-order-effects/13563
+[Hefty Algebras (POPL 2023)]: https://doi.org/10.1145/3571255

--- a/docs/research/algebraic-effects/index.md
+++ b/docs/research/algebraic-effects/index.md
@@ -48,33 +48,33 @@ No ecosystem currently dominates every axis at once.
 
 ### By Effect Representation Strategy
 
-| Strategy                    | Description                                                                    | Libraries / Languages             |
-| --------------------------- | ------------------------------------------------------------------------------ | --------------------------------- |
-| **Free monad**              | Effects as data; computation tree built then interpreted                       | polysemy, freer-simple            |
-| **Carrier fusion**          | Higher-order functors fused at compile time via typeclass instances            | fused-effects                     |
-| **ReaderT IO**              | Concrete `IO` monad with extensible environment; effects dispatched via IORef  | effectful, cleff, bluefin         |
-| **Delimited continuations** | Native stack capture via GHC primops; effects handled by resumable prompts     | eff, bluefin-algae                |
-| **Hefty algebras**          | Separation of first-order and higher-order effect elaboration                  | heftia                            |
-| **Fiber runtime**           | Lightweight green threads with structured concurrency                          | ZIO, Cats Effect                  |
-| **Row-polymorphic effects** | Effects tracked via extensible row types with scoped labels and full inference | Koka, Eff                         |
-| **Native continuations**    | One-shot delimited continuations built into the language runtime               | OCaml 5                           |
-| **Capability passing**      | Effects accessed via value-level or context-level capability tokens            | bluefin, Scala 3 capabilities, Ox |
-| **Generator-based**         | Effects encoded via generator functions yielding effect descriptors            | Effect (TypeScript)               |
-| **Wasm continuations**      | Typed stack switching primitives at the bytecode level                         | WasmFX                            |
+| Strategy                    | Description                                                                    | Libraries / Languages                   |
+| --------------------------- | ------------------------------------------------------------------------------ | --------------------------------------- |
+| **Free monad**              | Effects as data; computation tree built then interpreted                       | [polysemy], freer-simple                |
+| **Carrier fusion**          | Higher-order functors fused at compile time via typeclass instances            | [fused-effects]                         |
+| **ReaderT IO**              | Concrete `IO` monad with extensible environment; effects dispatched via IORef  | [effectful], [cleff], [bluefin]         |
+| **Delimited continuations** | Native stack capture via GHC primops; effects handled by resumable prompts     | [eff], bluefin-algae                    |
+| **Hefty algebras**          | Separation of first-order and higher-order effect elaboration                  | [heftia]                                |
+| **Fiber runtime**           | Lightweight green threads with structured concurrency                          | [ZIO], [Cats Effect]                    |
+| **Row-polymorphic effects** | Effects tracked via extensible row types with scoped labels and full inference | [Koka], [Eff]                           |
+| **Native continuations**    | One-shot delimited continuations built into the language runtime               | [OCaml 5]                               |
+| **Capability passing**      | Effects accessed via value-level or context-level capability tokens            | [bluefin], [Scala 3 capabilities], [Ox] |
+| **Generator-based**         | Effects encoded via generator functions yielding effect descriptors            | [Effect (TypeScript)]                   |
+| **Wasm continuations**      | Typed stack switching primitives at the bytecode level                         | [WasmFX]                                |
 
 ### By Type-Level Effect Tracking
 
-| Approach                  | Mechanism                                                              | Libraries / Languages                     |
-| ------------------------- | ---------------------------------------------------------------------- | ----------------------------------------- |
-| **Type-level list**       | `Eff (es :: [Effect]) a` with `Member` / `:>` constraints              | effectful, cleff, polysemy, fused-effects |
-| **Fixed type parameters** | `ZIO[R, E, A]` with intersection types for environment                 | ZIO                                       |
-| **Typeclass hierarchy**   | `Sync`, `Async`, `Concurrent` etc. constraining `F[_]`                 | Cats Effect                               |
-| **Value-level handles**   | ST-like scoped type variables on handle values                         | bluefin                                   |
-| **Capture checking**      | Experimental `^{cap}` annotations tracking capability capture          | Scala 3 (Caprese)                         |
-| **Row types**             | Extensible row types with effect labels; full effect inference         | Koka, Eff                                 |
-| **Untyped**               | Effects are values at runtime; no static typing of effect sets         | OCaml 5                                   |
-| **Ambient abilities**     | Effects as ambient abilities in scope; handler determines availability | Frank, Unison                             |
-| **Three-parameter type**  | `Effect<A, E, R>` encoding success, error, and requirements            | Effect (TypeScript)                       |
+| Approach                  | Mechanism                                                              | Libraries / Languages                             |
+| ------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------- |
+| **Type-level list**       | `Eff (es :: [Effect]) a` with `Member` / `:>` constraints              | [effectful], [cleff], [polysemy], [fused-effects] |
+| **Fixed type parameters** | `ZIO[R, E, A]` with intersection types for environment                 | [ZIO]                                             |
+| **Typeclass hierarchy**   | `Sync`, `Async`, `Concurrent` etc. constraining `F[_]`                 | [Cats Effect]                                     |
+| **Value-level handles**   | ST-like scoped type variables on handle values                         | [bluefin]                                         |
+| **Capture checking**      | Experimental `^{cap}` annotations tracking capability capture          | [Scala 3] (Caprese)                               |
+| **Row types**             | Extensible row types with effect labels; full effect inference         | [Koka], [Eff]                                     |
+| **Untyped**               | Effects are values at runtime; no static typing of effect sets         | [OCaml 5]                                         |
+| **Ambient abilities**     | Effects as ambient abilities in scope; handler determines availability | [Frank], [Unison]                                 |
+| **Three-parameter type**  | `Effect<A, E, R>` encoding success, error, and requirements            | [Effect (TypeScript)]                             |
 
 Note: systems marked as having "no effect tracking" (Rust implicit features, Java Loom) are covered in individual pages but omitted from the taxonomy since they do not implement effect-system abstractions.
 
@@ -84,47 +84,47 @@ Note: systems marked as having "no effect tracking" (Rust implicit features, Jav
 
 ### History and Synthesis
 
-- [Evolution of Effect Systems](evolution.md)
-- [Comparison and Analysis](comparison.md)
-- [Theory and Compilation](theory-compilation.md)
-- [Key Papers](papers.md)
-- [Parallelism](parallelism.md)
+- [Evolution of Effect Systems]
+- [Comparison and Analysis]
+- [Theory and Compilation]
+- [Key Papers]
+- [Parallelism]
 
 ### Haskell
 
-- [effectful](haskell-effectful.md)
-- [cleff](haskell-cleff.md)
-- [polysemy](haskell-polysemy.md)
-- [fused-effects](haskell-fused-effects.md)
-- [bluefin](haskell-bluefin.md)
-- [eff](haskell-eff.md)
-- [heftia](haskell-heftia.md)
-- [Theseus](haskell-theseus.md)
+- [effectful]
+- [cleff]
+- [polysemy]
+- [fused-effects]
+- [bluefin]
+- [eff]
+- [heftia]
+- [Theseus]
 
 ### Scala
 
-- [ZIO](scala-zio.md)
-- [Cats Effect](scala-cats-effect.md)
-- [Kyo](scala-kyo.md)
-- [Scala Capabilities](scala-capabilities.md)
-- [Ox](scala-ox.md)
+- [ZIO]
+- [Cats Effect]
+- [Kyo]
+- [Scala Capabilities]
+- [Ox]
 
 ### Effect-Native / Runtime-Native
 
-- [Koka](koka.md)
-- [Eff Language](eff-lang.md)
-- [Frank](frank.md)
-- [Unison](unison.md)
-- [OCaml 5 Effects](ocaml-effects.md)
-- [OCaml Eio](ocaml-eio.md)
-- [WasmFX](wasmfx.md)
+- [Koka]
+- [Eff Language]
+- [Frank]
+- [Unison]
+- [OCaml 5 Effects]
+- [OCaml Eio]
+- [WasmFX]
 
 ### Other Ecosystems
 
-- [TypeScript Effect](typescript-effect.md)
-- [Java Loom](java-loom.md)
-- [Rust Effect Notes](rust-effect-system.md)
-- [Additional Implementations](other-implementations.md)
+- [TypeScript Effect]
+- [Java Loom]
+- [Rust Effect Notes]
+- [Additional Implementations]
 
 ---
 
@@ -150,15 +150,63 @@ Note: systems marked as having "no effect tracking" (Rust implicit features, Jav
 
 ## Sources
 
-- [Effects Bibliography (living index)](https://github.com/yallop/effects-bibliography)
-- [Handlers of Algebraic Effects (ESOP 2009)](https://doi.org/10.1007/978-3-642-00590-9_7)
-- [Effect Handlers, Evidently (ICFP 2020)](https://doi.org/10.1145/3408981)
-- [Generalized Evidence Passing (ICFP 2021)](https://doi.org/10.1145/3473576)
-- [Retrofitting Effect Handlers onto OCaml (PLDI 2021)](https://doi.org/10.1145/3453483.3454039)
-- [Hefty Algebras (POPL 2023)](https://doi.org/10.1145/3571255)
-- [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)](https://doi.org/10.1145/3622814)
-- [Parallel Algebraic Effect Handlers (ICFP 2024)](https://doi.org/10.1145/3674651)
-- [OCaml 5.3.0 release notes (2025-01-08)](https://ocaml.org/releases/5.3.0)
-- [OCaml release index (includes 5.4.0, 2025-10-09)](https://ocaml.org/releases/)
-- [GHC 9.6.1 release notes (delimited continuation primops)](https://downloads.haskell.org/~ghc/9.6.5/docs/users_guide/9.6.1-notes.html)
-- [WebAssembly stack-switching proposal repository](https://github.com/WebAssembly/stack-switching)
+- [Effects Bibliography (living index)]
+- [Handlers of Algebraic Effects (ESOP 2009)]
+- [Effect Handlers, Evidently (ICFP 2020)]
+- [Generalized Evidence Passing (ICFP 2021)]
+- [Retrofitting Effect Handlers onto OCaml (PLDI 2021)]
+- [Hefty Algebras (POPL 2023)]
+- [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)]
+- [Parallel Algebraic Effect Handlers (ICFP 2024)]
+- [OCaml 5.3.0 release notes (2025-01-08)]
+- [OCaml release index (includes 5.4.0, 2025-10-09)]
+- [GHC 9.6.1 release notes (delimited continuation primops)]
+- [WebAssembly stack-switching proposal repository]
+
+<!-- References -->
+
+[Effects Bibliography (living index)]: https://github.com/yallop/effects-bibliography
+[Handlers of Algebraic Effects (ESOP 2009)]: https://doi.org/10.1007/978-3-642-00590-9_7
+[Effect Handlers, Evidently (ICFP 2020)]: https://doi.org/10.1145/3408981
+[Generalized Evidence Passing (ICFP 2021)]: https://doi.org/10.1145/3473576
+[Retrofitting Effect Handlers onto OCaml (PLDI 2021)]: https://doi.org/10.1145/3453483.3454039
+[Hefty Algebras (POPL 2023)]: https://doi.org/10.1145/3571255
+[Continuing WebAssembly with Effect Handlers (OOPSLA 2023)]: https://doi.org/10.1145/3622814
+[Parallel Algebraic Effect Handlers (ICFP 2024)]: https://doi.org/10.1145/3674651
+[OCaml 5.3.0 release notes (2025-01-08)]: https://ocaml.org/releases/5.3.0
+[OCaml release index (includes 5.4.0, 2025-10-09)]: https://ocaml.org/releases/
+[GHC 9.6.1 release notes (delimited continuation primops)]: https://downloads.haskell.org/~ghc/9.6.5/docs/users_guide/9.6.1-notes.html
+[WebAssembly stack-switching proposal repository]: https://github.com/WebAssembly/stack-switching
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[effectful]: haskell-effectful.md
+[cleff]: haskell-cleff.md
+[bluefin]: haskell-bluefin.md
+[eff]: haskell-eff.md
+[heftia]: haskell-heftia.md
+[Theseus]: haskell-theseus.md
+[ZIO]: scala-zio.md
+[Cats Effect]: scala-cats-effect.md
+[Kyo]: scala-kyo.md
+[Scala Capabilities]: scala-capabilities.md
+[Scala 3]: scala-capabilities.md
+[Ox]: scala-ox.md
+[Koka]: koka.md
+[Eff]: eff-lang.md
+[Frank]: frank.md
+[Unison]: unison.md
+[OCaml 5]: ocaml-effects.md
+[OCaml 5 Effects]: ocaml-effects.md
+[OCaml Eio]: ocaml-eio.md
+[WasmFX]: wasmfx.md
+[Effect (TypeScript)]: typescript-effect.md
+[TypeScript Effect]: typescript-effect.md
+[Java Loom]: java-loom.md
+[Rust Effect Notes]: rust-effect-system.md
+[Additional Implementations]: other-implementations.md
+[Evolution of Effect Systems]: evolution.md
+[Comparison and Analysis]: comparison.md
+[Theory and Compilation]: theory-compilation.md
+[Key Papers]: papers.md
+[Parallelism]: parallelism.md
+[Eff Language]: eff-lang.md

--- a/docs/research/algebraic-effects/java-loom.md
+++ b/docs/research/algebraic-effects/java-loom.md
@@ -6,8 +6,8 @@ Virtual threads, structured concurrency, and scoped values -- Java's platform-le
 | ------------- | --------------------------------------------------------------- |
 | Language      | Java 21+                                                        |
 | License       | GPL-2.0 with Classpath Exception (OpenJDK)                      |
-| Repository    | [github.com/openjdk/loom](https://github.com/openjdk/loom)      |
-| Documentation | [openjdk.org/projects/loom](https://openjdk.org/projects/loom/) |
+| Repository    | [github.com/openjdk/loom]                                       |
+| Documentation | [openjdk.org/projects/loom]                                     |
 | Key Authors   | Ron Pressler, Alan Bateman (Oracle)                             |
 | Approach      | JVM-managed virtual threads with hidden delimited continuations |
 
@@ -138,7 +138,7 @@ This is a deliberate design choice: Java developers write ordinary sequential co
 
 Internally, virtual threads are implemented using a `jdk.internal.vm.Continuation` class -- a scoped, stackful, one-shot delimited continuation. This class is not part of the public API:
 
-```
+```java
 jdk.internal.vm.Continuation
     - yield(ContinuationScope scope)  // suspend execution
     - run()                            // resume execution
@@ -210,6 +210,8 @@ Loom's features map to a subset of what a full algebraic effect system provides:
 | Custom user-defined effects | Not provided                               |
 | Effect handlers (resume)    | Not exposed (internal `Continuation`)      |
 
+For capability-based I/O in a similar spirit, see [Scala's Ox] which uses Java 21 virtual threads with Scala 3's capability system.
+
 Loom provides the three most practically important effects (async I/O, context propagation, structured concurrency) without requiring developers to learn effect system concepts. However, it does not support user-defined effects or custom handlers.
 
 ### Impact on the Java Ecosystem
@@ -256,13 +258,29 @@ However, reactive frameworks still provide value for backpressure, stream proces
 
 ## Sources
 
-- [OpenJDK Project Loom](https://openjdk.org/projects/loom/)
-- [JEP 444: Virtual Threads](https://openjdk.org/jeps/444)
-- [JEP 453: Structured Concurrency (Preview)](https://openjdk.org/jeps/453)
-- [JEP 464: Scoped Values (Second Preview)](https://openjdk.org/jeps/464)
-- [Project Loom proposal](https://cr.openjdk.org/~rpressler/loom/Loom-Proposal.html) -- Ron Pressler
-- [Why Continuations are Coming to Java](https://www.infoq.com/presentations/continuations-java/) -- InfoQ
-- [Java Virtual Threads: a Case Study](https://www.infoq.com/articles/java-virtual-threads-a-case-study/) -- InfoQ
-- [Beyond Loom: Weaving new concurrency patterns](https://developers.redhat.com/articles/2023/10/03/beyond-loom-weaving-new-concurrency-patterns) -- Red Hat
-- [Project Loom: Structured Concurrency in Java](https://rockthejvm.com/articles/structured-concurrency-in-java) -- Rock the JVM
-- [Java Scoped Values deep dive](https://www.happycoders.eu/java/scoped-values/) -- HappyCoders
+- [OpenJDK Project Loom]
+- [JEP 444: Virtual Threads]
+- [JEP 453: Structured Concurrency (Preview)]
+- [JEP 464: Scoped Values (Second Preview)]
+- [Project Loom proposal] -- Ron Pressler
+- [Why Continuations are Coming to Java] -- InfoQ
+- [Java Virtual Threads: a Case Study] -- InfoQ
+- [Beyond Loom: Weaving new concurrency patterns] -- Red Hat
+- [Project Loom: Structured Concurrency in Java] -- Rock the JVM
+- [Java Scoped Values deep dive] -- HappyCoders
+
+<!-- References -->
+
+[Scala's Ox]: scala-ox.md
+[github.com/openjdk/loom]: https://github.com/openjdk/loom
+[openjdk.org/projects/loom]: https://openjdk.org/projects/loom/
+[OpenJDK Project Loom]: https://openjdk.org/projects/loom/
+[JEP 444: Virtual Threads]: https://openjdk.org/jeps/444
+[JEP 453: Structured Concurrency (Preview)]: https://openjdk.org/jeps/453
+[JEP 464: Scoped Values (Second Preview)]: https://openjdk.org/jeps/464
+[Project Loom proposal]: https://cr.openjdk.org/~rpressler/loom/Loom-Proposal.html
+[Why Continuations are Coming to Java]: https://www.infoq.com/presentations/continuations-java/
+[Java Virtual Threads: a Case Study]: https://www.infoq.com/articles/java-virtual-threads-a-case-study/
+[Beyond Loom: Weaving new concurrency patterns]: https://developers.redhat.com/articles/2023/10/03/beyond-loom-weaving-new-concurrency-patterns
+[Project Loom: Structured Concurrency in Java]: https://rockthejvm.com/articles/structured-concurrency-in-java
+[Java Scoped Values deep dive]: https://www.happycoders.eu/java/scoped-values/

--- a/docs/research/algebraic-effects/koka.md
+++ b/docs/research/algebraic-effects/koka.md
@@ -6,8 +6,8 @@ A strongly typed functional language with effect types and handlers, where every
 | ------------- | ------------------------------------------------------------------- |
 | Language      | Koka                                                                |
 | License       | Apache-2.0                                                          |
-| Repository    | [github.com/koka-lang/koka](https://github.com/koka-lang/koka)      |
-| Documentation | [Koka Book](https://koka-lang.github.io/koka/doc/book.html)         |
+| Repository    | [github.com/koka-lang/koka]                                         |
+| Documentation | [Koka Book]                                                         |
 | Key Authors   | Daan Leijen (Microsoft Research)                                    |
 | Encoding      | Row-polymorphic effect types with evidence passing compilation to C |
 
@@ -299,13 +299,28 @@ linear effect pretty
 
 ## Sources
 
-- [Koka GitHub repository](https://github.com/koka-lang/koka)
-- [The Koka Programming Language (Book)](https://koka-lang.github.io/koka/doc/book.html)
-- [Koka: Programming with Row Polymorphic Effect Types (MSFP 2014)](https://arxiv.org/abs/1406.2061)
-- [Algebraic Effects for Functional Programming (MSR-TR-2016-29)](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf)
-- [Effect Handlers, Evidently (ICFP 2020)](https://doi.org/10.1145/3408981)
-- [Generalized Evidence Passing for Effect Handlers (ICFP 2021)](https://dl.acm.org/doi/10.1145/3473576)
-- [Perceus: Garbage Free Reference Counting with Reuse (PLDI 2021)](https://dl.acm.org/doi/10.1145/3453483.3454032)
-- [FP2: Fully in-Place Functional Programming (ICFP 2023)](https://www.microsoft.com/en-us/research/wp-content/uploads/2023/07/fip.pdf)
-- [First-class Named Effect Handlers (OOPSLA 2022)](https://dl.acm.org/doi/abs/10.1145/3563289)
-- [Koka at Microsoft Research](https://www.microsoft.com/en-us/research/project/koka/)
+- [Koka GitHub repository]
+- [The Koka Programming Language (Book)]
+- [Koka: Programming with Row Polymorphic Effect Types (MSFP 2014)]
+- [Algebraic Effects for Functional Programming (MSR-TR-2016-29)]
+- [Effect Handlers, Evidently (ICFP 2020)]
+- [Generalized Evidence Passing for Effect Handlers (ICFP 2021)]
+- [Perceus: Garbage Free Reference Counting with Reuse (PLDI 2021)]
+- [FP2: Fully in-Place Functional Programming (ICFP 2023)]
+- [First-class Named Effect Handlers (OOPSLA 2022)]
+- [Koka at Microsoft Research]
+
+<!-- References -->
+
+[github.com/koka-lang/koka]: https://github.com/koka-lang/koka
+[Koka Book]: https://koka-lang.github.io/koka/doc/book.html
+[Koka GitHub repository]: https://github.com/koka-lang/koka
+[The Koka Programming Language (Book)]: https://koka-lang.github.io/koka/doc/book.html
+[Koka: Programming with Row Polymorphic Effect Types (MSFP 2014)]: https://arxiv.org/abs/1406.2061
+[Algebraic Effects for Functional Programming (MSR-TR-2016-29)]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf
+[Effect Handlers, Evidently (ICFP 2020)]: https://doi.org/10.1145/3408981
+[Generalized Evidence Passing for Effect Handlers (ICFP 2021)]: https://dl.acm.org/doi/10.1145/3473576
+[Perceus: Garbage Free Reference Counting with Reuse (PLDI 2021)]: https://dl.acm.org/doi/10.1145/3453483.3454032
+[FP2: Fully in-Place Functional Programming (ICFP 2023)]: https://www.microsoft.com/en-us/research/wp-content/uploads/2023/07/fip.pdf
+[First-class Named Effect Handlers (OOPSLA 2022)]: https://dl.acm.org/doi/abs/10.1145/3563289
+[Koka at Microsoft Research]: https://www.microsoft.com/en-us/research/project/koka/

--- a/docs/research/algebraic-effects/ocaml-effects.md
+++ b/docs/research/algebraic-effects/ocaml-effects.md
@@ -6,8 +6,8 @@ Native algebraic effect handlers built into the OCaml 5 runtime, providing first
 | ------------- | --------------------------------------------------------------------- |
 | Language      | OCaml 5.x                                                             |
 | License       | LGPL-2.1                                                              |
-| Repository    | [github.com/ocaml/ocaml](https://github.com/ocaml/ocaml)              |
-| Documentation | [OCaml Manual - Effects](https://ocaml.org/manual/5.2/effects.html)   |
+| Repository    | [github.com/ocaml/ocaml]                                              |
+| Documentation | [OCaml Manual - Effects]                                              |
 | Key Authors   | KC Sivaramakrishnan, Stephen Dolan, Leo White, Anil Madhavapeddy      |
 | Encoding      | Untyped algebraic effects with one-shot continuations on fiber stacks |
 
@@ -280,13 +280,33 @@ Since effects are untyped, there is no compile-time verification that all effect
 
 ## Sources
 
-- [OCaml 5.2 Manual - Language Extensions: Effect Handlers](https://ocaml.org/manual/5.2/effects.html)
-- [Effect.Deep API Documentation](https://ocaml.org/manual/5.2/api/Effect.Deep.html)
-- [Effect.Shallow API Documentation](https://ocaml.org/manual/5.2/api/Effect.Shallow.html)
-- [Retrofitting Effect Handlers onto OCaml (PLDI 2021)](https://dl.acm.org/doi/10.1145/3453483.3454039)
-- [Retrofitting Effect Handlers onto OCaml (arXiv preprint)](https://arxiv.org/abs/2104.00250)
-- [OCaml Effects Tutorial](https://github.com/ocaml-multicore/ocaml-effects-tutorial)
-- [Effects Examples Repository](https://github.com/ocaml-multicore/effects-examples)
-- [Effective Programming: Adding an Effect System to OCaml (Jane Street)](https://www.janestreet.com/tech-talks/effective-programming/)
-- [Introducing OxCaml (Jane Street Blog)](https://blog.janestreet.com/introducing-oxcaml/)
-- [Add Effect Syntax PR #12309](https://github.com/ocaml/ocaml/pull/12309)
+- [OCaml 5.2 Manual - Language Extensions: Effect Handlers]
+- [Effect.Deep API Documentation]
+- [Effect.Shallow API Documentation]
+- [Retrofitting Effect Handlers onto OCaml (PLDI 2021)]
+- [Retrofitting Effect Handlers onto OCaml (arXiv preprint)]
+- [OCaml Effects Tutorial]
+- [Effects Examples Repository]
+- [Effective Programming: Adding an Effect System to OCaml (Jane Street)]
+- [Introducing OxCaml (Jane Street Blog)]
+- [Add Effect Syntax PR #12309]
+
+<!-- References -->
+
+[github.com/ocaml/ocaml]: https://github.com/ocaml/ocaml
+[OCaml Manual - Effects]: https://ocaml.org/manual/5.2/effects.html
+[OCaml 5.2 Manual - Language Extensions: Effect Handlers]: https://ocaml.org/manual/5.2/effects.html
+[Effect.Deep API Documentation]: https://ocaml.org/manual/5.2/api/Effect.Deep.html
+[Effect.Shallow API Documentation]: https://ocaml.org/manual/5.2/api/Effect.Shallow.html
+[Retrofitting Effect Handlers onto OCaml (PLDI 2021)]: https://dl.acm.org/doi/10.1145/3453483.3454039
+[Retrofitting Effect Handlers onto OCaml (arXiv preprint)]: https://arxiv.org/abs/2104.00250
+[OCaml Effects Tutorial]: https://github.com/ocaml-multicore/ocaml-effects-tutorial
+[Effects Examples Repository]: https://github.com/ocaml-multicore/effects-examples
+[Effective Programming: Adding an Effect System to OCaml (Jane Street)]: https://www.janestreet.com/tech-talks/effective-programming/
+[Introducing OxCaml (Jane Street Blog)]: https://blog.janestreet.com/introducing-oxcaml/
+[Add Effect Syntax PR #12309]: https://github.com/ocaml/ocaml/pull/12309
+[Eio]: ocaml-eio.md
+[Papers]: papers.md
+[Theory and Compilation]: theory-compilation.md
+[WasmFX]: wasmfx.md
+[Evolution]: evolution.md

--- a/docs/research/algebraic-effects/ocaml-eio.md
+++ b/docs/research/algebraic-effects/ocaml-eio.md
@@ -2,14 +2,14 @@
 
 Effects-based direct-style I/O library for OCaml 5, providing structured concurrency and capability-based security without monadic encoding.
 
-| Field         | Value                                                                                                                  |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Language      | OCaml 5.x                                                                                                              |
-| License       | ISC                                                                                                                    |
-| Repository    | [github.com/ocaml-multicore/eio](https://github.com/ocaml-multicore/eio)                                               |
-| Documentation | [OCaml Package](https://ocaml.org/p/eio/latest) / [API Docs](https://ocaml-multicore.github.io/eio/eio/Eio/index.html) |
-| Key Authors   | Thomas Leonard, KC Sivaramakrishnan, Anil Madhavapeddy                                                                 |
-| Encoding      | Direct-style I/O over OCaml 5 algebraic effects with capability passing                                                |
+| Field         | Value                                                                     |
+| ------------- | ------------------------------------------------------------------------- |
+| Language      | OCaml 5.x                                                                 |
+| License       | ISC                                                                       |
+| Repository    | [github.com/ocaml-multicore/eio]                                          |
+| Documentation | [OCaml Package] / [API Docs]                                              |
+| Key Authors   | Thomas Leonard, KC Sivaramakrishnan, Anil Madhavapeddy                    |
+| Encoding      | Direct-style I/O over [OCaml 5] algebraic effects with capability passing |
 
 ---
 
@@ -17,7 +17,7 @@ Effects-based direct-style I/O library for OCaml 5, providing structured concurr
 
 ### What It Solves
 
-Before OCaml 5, concurrent I/O required monadic libraries like Lwt or Async, which simulate multiple stacks on the heap using monadic bind. This imposes allocation overhead, breaks backtraces, and forces a different coding style where every I/O operation must be threaded through monadic combinators. Eio eliminates this by building on OCaml 5's native [algebraic effect handlers](ocaml-effects.md), allowing concurrent code to be written in ordinary direct style -- plain function calls, `try...with` for error handling, and natural backtraces.
+Before [OCaml 5], concurrent I/O required monadic libraries like Lwt or Async, which simulate multiple stacks on the heap using monadic bind. This imposes allocation overhead, breaks backtraces, and forces a different coding style where every I/O operation must be threaded through monadic combinators. Eio eliminates this by building on [OCaml 5]'s native [algebraic effect handlers], allowing concurrent code to be written in ordinary direct style -- plain function calls, `try...with` for error handling, and natural backtraces.
 
 ### Design Philosophy
 
@@ -74,7 +74,7 @@ end
 
 ## How Effects Are Declared
 
-Eio does not expose its internal effects to users. Instead, it uses OCaml 5 effects internally for fiber scheduling, I/O suspension, and cancellation. From the user's perspective, I/O operations are ordinary function calls:
+Eio does not expose its internal effects to users. Instead, it uses [OCaml 5] effects internally for fiber scheduling, I/O suspension, and cancellation. From the user's perspective, I/O operations are ordinary function calls:
 
 ```ocaml
 (* Reading a file -- no monadic bind, no effect declaration *)
@@ -150,7 +150,7 @@ Eio.Switch.run @@ fun sw ->
 
 ## Performance Approach
 
-Lwt and Async simulate concurrent stacks by allocating promise chains on the heap. Eio uses real stacks (fibers) via OCaml 5's effect runtime, so suspending and resuming a fiber is a stack switch with no heap allocation for control flow.
+Lwt and Async simulate concurrent stacks by allocating promise chains on the heap. Eio uses real stacks (fibers) via [OCaml 5]'s effect runtime, so suspending and resuming a fiber is a stack switch with no heap allocation for control flow.
 
 ### Platform-Optimized Backends
 
@@ -202,7 +202,7 @@ File system capabilities are sandboxed. `Eio.Stdenv.cwd` restricts access to the
 
 - **Requires OCaml 5.1+**, limiting adoption on older compiler versions
 - **Ecosystem maturity** lags behind Lwt, which has over a decade of library support
-- **Untyped effects underneath** inherit the lack of static effect tracking from OCaml 5
+- **Untyped effects underneath** inherit the lack of static effect tracking from [OCaml 5]
 - **Windows backend incomplete**, limiting cross-platform use
 - **Performance tuning required** for some workloads where Lwt's scheduling incidentally helps
 - **Learning curve** for developers accustomed to monadic concurrency patterns
@@ -212,7 +212,7 @@ File system capabilities are sandboxed. `Eio.Stdenv.cwd` restricts access to the
 
 | Decision                          | Rationale                                        | Trade-off                                     |
 | --------------------------------- | ------------------------------------------------ | --------------------------------------------- |
-| Direct style over monadic         | Natural code; real backtraces; no bind overhead  | Requires OCaml 5 effects                      |
+| Direct style over monadic         | Natural code; real backtraces; no bind overhead  | Requires [OCaml 5] effects                    |
 | Capability passing                | Explicit dependencies; testable; least authority | Verbose signatures; threading required        |
 | Structured concurrency via Switch | No orphaned fibers; automatic resource cleanup   | Less flexible than unstructured spawn         |
 | Effects hidden from users         | Simpler API; ordinary function calls             | Cannot compose with user-defined effects      |
@@ -223,13 +223,30 @@ File system capabilities are sandboxed. `Eio.Stdenv.cwd` restricts access to the
 
 ## Sources
 
-- [Eio GitHub Repository](https://github.com/ocaml-multicore/eio)
-- [Eio 1.0 Release Announcement (Tarides)](https://tarides.com/blog/2024-03-20-eio-1-0-release-introducing-a-new-effects-based-i-o-library-for-ocaml/)
-- [Eio on OCaml Packages](https://ocaml.org/p/eio/latest)
-- [Eio API Documentation](https://ocaml-multicore.github.io/eio/eio/Eio/index.html)
-- [Eio.Fiber API](https://ocaml-multicore.github.io/eio/eio/Eio/Fiber/index.html)
-- [Eio.Path API](https://ocaml-multicore.github.io/eio/eio/Eio/Path/index.html)
-- [Eio 1.0 -- Effects-based IO for OCaml 5 (OCaML'23 paper)](https://kcsrk.info/papers/eio_ocaml23a.pdf)
-- [OCaml 5 Effects (companion document)](ocaml-effects.md)
-- [OCaml 5 Performance Analysis (Thomas Leonard)](https://roscidus.com/blog/blog/2024/07/22/performance/)
-- [Eio 0.1 Announcement (OCaml Discuss)](https://discuss.ocaml.org/t/eio-0-1-effects-based-direct-style-io-for-ocaml-5/9298)
+- [Eio GitHub Repository]
+- [Eio 1.0 Release Announcement (Tarides)]
+- [Eio on OCaml Packages]
+- [Eio API Documentation]
+- [Eio.Fiber API]
+- [Eio.Path API]
+- [Eio 1.0 -- Effects-based IO for OCaml 5 (OCaML'23 paper)]
+- [OCaml 5 Effects (companion document)]: ocaml-effects.md
+- [OCaml 5 Performance Analysis (Thomas Leonard)]
+- [Eio 0.1 Announcement (OCaml Discuss)]
+
+<!-- References -->
+
+[OCaml 5]: ocaml-effects.md
+[algebraic effect handlers]: ocaml-effects.md
+[github.com/ocaml-multicore/eio]: https://github.com/ocaml-multicore/eio
+[OCaml Package]: https://ocaml.org/p/eio/latest
+[API Docs]: https://ocaml-multicore.github.io/eio/eio/Eio/index.html
+[Eio GitHub Repository]: https://github.com/ocaml-multicore/eio
+[Eio 1.0 Release Announcement (Tarides)]: https://tarides.com/blog/2024-03-20-eio-1-0-release-introducing-a-new-effects-based-i-o-library-for-ocaml/
+[Eio on OCaml Packages]: https://ocaml.org/p/eio/latest
+[Eio API Documentation]: https://ocaml-multicore.github.io/eio/eio/Eio/index.html
+[Eio.Fiber API]: https://ocaml-multicore.github.io/eio/eio/Eio/Fiber/index.html
+[Eio.Path API]: https://ocaml-multicore.github.io/eio/eio/Eio/Path/index.html
+[Eio 1.0 -- Effects-based IO for OCaml 5 (OCaML'23 paper)]: https://kcsrk.info/papers/eio_ocaml23a.pdf
+[OCaml 5 Performance Analysis (Thomas Leonard)]: https://roscidus.com/blog/blog/2024/07/22/performance/
+[Eio 0.1 Announcement (OCaml Discuss)]: https://discuss.ocaml.org/t/eio-0-1-effects-based-direct-style-io-for-ocaml-5/9298

--- a/docs/research/algebraic-effects/other-implementations.md
+++ b/docs/research/algebraic-effects/other-implementations.md
@@ -12,8 +12,9 @@ Effekt is a research language centered on effect handlers and direct-style progr
 
 - Focus: language-level support for handlers and effect polymorphism
 - Value: good reference point for modern handler-oriented language design
+- Relationship: Similar design goals to [Eff] and [Koka]
 
-Reference: [Effekt website](https://effekt-lang.org/)
+Reference: [Effekt website]
 
 ---
 
@@ -24,13 +25,13 @@ Links is a research language for web programming with row-polymorphic effect typ
 - Focus: typed effects in client/server/database integrated programming
 - Value: shows effect systems in a full-stack language setting
 
-Reference: [Links language site](https://links-lang.org/)
+Reference: [Links language site]
 
 ---
 
 ## Koka (for context)
 
-Koka is covered in detail in [koka.md](koka.md), but it is worth reiterating here as one of the strongest end-to-end designs:
+[Koka] is covered in detail in its dedicated page, but it is worth reiterating here as one of the strongest end-to-end designs:
 
 - row-polymorphic effect types with inference
 - practical compilation strategies
@@ -38,8 +39,8 @@ Koka is covered in detail in [koka.md](koka.md), but it is worth reiterating her
 
 References:
 
-- [Koka website](https://koka-lang.github.io/koka/doc/index.html)
-- [Koka releases](https://github.com/koka-lang/koka/releases)
+- [Koka website]
+- [Koka releases]
 
 ---
 
@@ -50,25 +51,52 @@ Recent work demonstrates effect handlers implemented in C via coroutine machiner
 - Focus: low-level implementation route without requiring a full new language runtime
 - Value: broadens the portability story for handlers
 
-Reference: [Effect Handlers for C via Coroutines (ICFP 2024)](https://doi.org/10.1145/3649836)
+Reference: [Effect Handlers for C via Coroutines (ICFP 2024)]
 
 ---
 
 ## WebAssembly Target Direction
 
-Wasm continuation proposals and WasmFX work position WebAssembly as a common low-level target for effect handlers.
+Wasm continuation proposals and [WasmFX] work position WebAssembly as a common low-level target for effect handlers.
 
 - Focus: typed control transfer primitives for compiled handlers
 - Value: potential cross-language backend convergence
 
 References:
 
-- [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)](https://doi.org/10.1145/3622814)
-- [WebAssembly stack-switching proposal repository](https://github.com/WebAssembly/stack-switching)
+- [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)]
+- [WebAssembly stack-switching proposal repository]
+
+---
+
+## Related Topics
+
+- For systems-language implementations with virtual threads, see [Java Loom] and [Scala Ox]
+- For capability-based effect tracking, see [Scala 3 Capabilities] and [Bluefin]
+- For the main WebAssembly effect handler proposal, see [WasmFX]
 
 ---
 
 ## Notes
 
 - This page intentionally excludes systems that are only loosely "effect-like" (for example, generic safety/ownership claims without handler semantics).
-- For full historical context, see [evolution.md](evolution.md); for active research, see [papers.md](papers.md).
+- For full historical context, see [Evolution of Effect Systems]; for active research, see [Key Papers].
+
+<!-- References -->
+
+[Eff]: eff-lang.md
+[Koka]: koka.md
+[WasmFX]: wasmfx.md
+[Java Loom]: java-loom.md
+[Scala Ox]: scala-ox.md
+[Scala 3 Capabilities]: scala-capabilities.md
+[Bluefin]: haskell-bluefin.md
+[Evolution of Effect Systems]: evolution.md
+[Key Papers]: papers.md
+[Effekt website]: https://effekt-lang.org/
+[Links language site]: https://links-lang.org/
+[Koka website]: https://koka-lang.github.io/koka/doc/index.html
+[Koka releases]: https://github.com/koka-lang/koka/releases
+[Effect Handlers for C via Coroutines (ICFP 2024)]: https://doi.org/10.1145/3649836
+[Continuing WebAssembly with Effect Handlers (OOPSLA 2023)]: https://doi.org/10.1145/3622814
+[WebAssembly stack-switching proposal repository]: https://github.com/WebAssembly/stack-switching

--- a/docs/research/algebraic-effects/papers.md
+++ b/docs/research/algebraic-effects/papers.md
@@ -16,12 +16,12 @@ A curated reading map for the history and current frontier of algebraic effects.
 
 ## Foundational Set (Must Read)
 
-| Year | Paper                                                                                                        | Core Contribution                             |
-| ---- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
-| 1991 | [Notions of Computation and Monads](<https://doi.org/10.1016/0890-5401(91)90052-4>) (Moggi)                  | Monadic metalanguage for effects              |
-| 2003 | [Algebraic Operations and Generic Effects](<https://doi.org/10.1016/S1571-0661(04)80969-2>) (Plotkin, Power) | Algebraic account of effects and operations   |
-| 2009 | [Handlers of Algebraic Effects](https://doi.org/10.1007/978-3-642-00590-9_7) (Plotkin, Pretnar)              | Handlers + resumptions as a programming model |
-| 2015 | [An Introduction to Algebraic Effects and Handlers](https://doi.org/10.1016/j.entcs.2015.12.003) (Pretnar)   | Practical tutorial-level consolidation        |
+| Year | Paper                                                         | Core Contribution                             |
+| ---- | ------------------------------------------------------------- | --------------------------------------------- |
+| 1991 | [Notions of Computation and Monads] (Moggi)                   | Monadic metalanguage for effects              |
+| 2003 | [Algebraic Operations and Generic Effects] (Plotkin, Power)   | Algebraic account of effects and operations   |
+| 2009 | [Handlers of Algebraic Effects] (Plotkin, Pretnar)            | Handlers + resumptions as a programming model |
+| 2015 | [An Introduction to Algebraic Effects and Handlers] (Pretnar) | Practical tutorial-level consolidation        |
 
 Why this set matters: it defines the semantic vocabulary still used by modern effect systems.
 
@@ -40,17 +40,17 @@ Why this set matters: it defines the semantic vocabulary still used by modern ef
 
 ## Practical Language and Compilation Set
 
-| Year | Paper                                                                                                                                     | Why It Matters for Implementers                            |
-| ---- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| 2014 | [Effect Handlers in Scope](https://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf)                                                    | Scoped/higher-order effects in real programming patterns   |
-| 2015 | [Fusion for Free](https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf)                                              | Handler fusion and efficiency for free/freer-style systems |
-| 2015 | [Freer Monads, More Extensible Effects](https://doi.org/10.1145/2804302.2804319)                                                          | Open unions and extensible effect encoding in Haskell      |
-| 2016 | [Algebraic Effects for Functional Programming](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf) | Koka design and row-polymorphic effect typing              |
-| 2017 | [Type Directed Compilation of Row-Typed Algebraic Effects](https://doi.org/10.1145/3009837.3009872)                                       | Selective CPS + practical compilation strategy             |
-| 2020 | [Effect Handlers, Evidently](https://doi.org/10.1145/3408981)                                                                             | Evidence passing for efficient handler dispatch            |
-| 2021 | [Generalized Evidence Passing](https://doi.org/10.1145/3473576)                                                                           | Extends evidence passing to general handler programs       |
-| 2021 | [Retrofitting Effect Handlers onto OCaml](https://doi.org/10.1145/3453483.3454039)                                                        | Mainstream runtime integration with one-shot handlers      |
-| 2023 | [Continuing WebAssembly with Effect Handlers](https://doi.org/10.1145/3622814)                                                            | Typed continuation target in Wasm for handler compilation  |
+| Year | Paper                                                      | Why It Matters for Implementers                            |
+| ---- | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| 2014 | [Effect Handlers in Scope]                                 | Scoped/higher-order effects in real programming patterns   |
+| 2015 | [Fusion for Free]                                          | Handler fusion and efficiency for free/freer-style systems |
+| 2015 | [Freer Monads, More Extensible Effects]                    | Open unions and extensible effect encoding in Haskell      |
+| 2016 | [Algebraic Effects for Functional Programming]             | [Koka] design and row-polymorphic effect typing            |
+| 2017 | [Type Directed Compilation of Row-Typed Algebraic Effects] | Selective CPS + practical compilation strategy             |
+| 2020 | [Effect Handlers, Evidently]                               | Evidence passing for efficient handler dispatch            |
+| 2021 | [Generalized Evidence Passing]                             | Extends evidence passing to general handler programs       |
+| 2021 | [Retrofitting Effect Handlers onto OCaml]                  | Mainstream runtime integration with one-shot handlers      |
+| 2023 | [Continuing WebAssembly with Effect Handlers]              | Typed continuation target in Wasm for handler compilation  |
 
 ### Effect Handlers in Scope (Wu, Schrijvers, Hinze, 2014)
 
@@ -60,7 +60,7 @@ Why this set matters: it defines the semantic vocabulary still used by modern ef
 2. **Higher-order syntax**: Introduces effects as higher-order functors, where constructors can take monadic computations as arguments
 3. **Two encoding approaches**: First uses existing handlers (limited); second introduces higher-order syntax (general)
 
-**Significance:** Identified and solved a fundamental limitation of first-order algebraic effects. Directly inspired fused-effects and polysemy's higher-order effect support. Showed that operations like `local` and `catchError` need higher-order treatment to admit flexible interpretation.
+**Significance:** Identified and solved a fundamental limitation of first-order algebraic effects. Directly inspired [fused-effects] and [polysemy]'s higher-order effect support. Showed that operations like `local` and `catchError` need higher-order treatment to admit flexible interpretation.
 
 ### Fusion for Free (Wu, Schrijvers, 2015)
 
@@ -70,7 +70,7 @@ Why this set matters: it defines the semantic vocabulary still used by modern ef
 2. **Handler fusion**: A sequence of handlers can be fused into a single handler, reducing multiple tree traversals to one pass
 3. **Abstract free monads**: Keeping the free monad abstract enables a change of representation that opens up fusion
 
-**Significance:** Solved the performance problem of algebraic effect handlers. The GitHub Semantic team used these ideas in fused-effects, reporting a 250x performance improvement over their previous free-monad approach.
+**Significance:** Solved the performance problem of algebraic effect handlers. The GitHub Semantic team used these ideas in [fused-effects], reporting a 250x performance improvement over their previous free-monad approach.
 
 ### Freer Monads, More Extensible Effects (Kiselyov, Ishii, 2015)
 
@@ -80,7 +80,7 @@ Why this set matters: it defines the semantic vocabulary still used by modern ef
 2. **Open union**: Type-safe, extensible union for combining effects
 3. **Efficient sequence**: Uses a type-aligned sequence for O(1) bind (amortized)
 
-**Significance:** The practical breakthrough for extensible effects in Haskell. Spawned freer-simple, polysemy, and influenced all subsequent libraries. Showed that effects could be extensible without the boilerplate of mtl.
+**Significance:** The practical breakthrough for extensible effects in Haskell. Spawned freer-simple, [polysemy], and influenced all subsequent libraries. Showed that effects could be extensible without the boilerplate of mtl.
 
 ### Algebraic Effects for Functional Programming (Leijen, 2016)
 
@@ -91,7 +91,7 @@ Why this set matters: it defines the semantic vocabulary still used by modern ef
 3. **Delimited continuations**: Effect handlers capture delimited continuations; the `resume` variable is bound to the captured continuation
 4. **Efficient compilation**: Compilation scheme targeting JavaScript, JVM, and .NET
 
-**Significance:** Brought Plotkin and Pretnar's theoretical work into a practical, fully typed functional programming language (Koka) with inference and efficient compilation. Demonstrated that algebraic effects are a viable alternative to monads for structuring effectful computation.
+**Significance:** Brought Plotkin and Pretnar's theoretical work into a practical, fully typed functional programming language ([Koka]) with inference and efficient compilation. Demonstrated that algebraic effects are a viable alternative to monads for structuring effectful computation.
 
 ### Effect Handlers, Evidently (Xie, Leijen, Brachthäuser, 2020)
 
@@ -102,28 +102,28 @@ Why this set matters: it defines the semantic vocabulary still used by modern ef
 3. **Tail-resumptive optimization**: Handlers that always resume at the tail position (the common case) can be optimized to avoid capturing continuations entirely
 4. **Connection to capability passing**: Evidence passing is shown to be equivalent to capability passing
 
-**Significance:** Provided the theoretical foundation for efficient compilation of algebraic effects without relying on CPS transforms or runtime continuation support. Directly influenced Koka's compilation strategy and connects to effectful's ReaderT IO pattern.
+**Significance:** Provided the theoretical foundation for efficient compilation of algebraic effects without relying on CPS transforms or runtime continuation support. Directly influenced [Koka]'s compilation strategy and connects to [effectful]'s ReaderT IO pattern (also used by [cleff] and [bluefin]).
 
 ### Retrofitting Effect Handlers onto OCaml (Sivaramakrishnan et al., 2021)
 
 **Key Ideas:**
 
-1. **One-shot continuations**: OCaml 5 provides only one-shot (non-copyable) continuations, simplifying implementation
+1. **One-shot continuations**: [OCaml 5] provides only one-shot (non-copyable) continuations, simplifying implementation
 2. **Fiber-based runtime**: Effects implemented via lightweight fibers with stack segments
 3. **Untyped effects**: A deliberate design choice -- effects are dynamically typed at the handler boundary, allowing the runtime to ship before the type system is fully designed
 4. **Deep and shallow handlers**: Both handler styles are supported
 
-**Significance:** The most significant practical deployment of algebraic effect handlers into a mainstream language runtime. Demonstrated that effect handlers can be retrofitted onto an existing language with a large codebase. The decision to ship untyped effects first was controversial but pragmatic.
+**Significance:** The most significant practical deployment of algebraic effect handlers into a mainstream language runtime. Demonstrated that effect handlers can be retrofitted onto an existing language with a large codebase. The decision to ship untyped effects first was controversial but pragmatic. Enabled libraries like [Eio].
 
 ---
 
 ## Soundness and Higher-Order Effects
 
-| Year | Paper                                                                                | Problem Addressed                                 |
-| ---- | ------------------------------------------------------------------------------------ | ------------------------------------------------- |
-| 2023 | [Hefty Algebras](https://doi.org/10.1145/3571255)                                    | Sound modular elaboration of higher-order effects |
-| 2024 | [A Framework for Higher-Order Effects and Handlers](https://doi.org/10.1145/3674632) | Unifies multiple higher-order effect formulations |
-| 2024 | [Soundly Handling Linearity](https://doi.org/10.1145/3632904)                        | Interaction between linear resources and handlers |
+| Year | Paper                                               | Problem Addressed                                 |
+| ---- | --------------------------------------------------- | ------------------------------------------------- |
+| 2023 | [Hefty Algebras]                                    | Sound modular elaboration of higher-order effects |
+| 2024 | [A Framework for Higher-Order Effects and Handlers] | Unifies multiple higher-order effect formulations |
+| 2024 | [Soundly Handling Linearity]                        | Interaction between linear resources and handlers |
 
 This line of work is central for systems that need both expressive scoped effects and strong semantic guarantees.
 
@@ -131,26 +131,26 @@ This line of work is central for systems that need both expressive scoped effect
 
 **Key Ideas:**
 
-1. **The soundness problem**: Existing approaches to higher-order effects (polysemy's Tactics, fused-effects' carriers) have unsound interactions with algebraic effects
+1. **The soundness problem**: Existing approaches to higher-order effects ([polysemy]'s Tactics, [fused-effects]' carriers) have unsound interactions with algebraic effects
 2. **Elaboration**: Higher-order effects should be transformed (elaborated) into first-order effects, not handled directly alongside them
 3. **Hefty algebras**: Algebraic structures that generalize free monads to higher-order functors, enabling modular elaboration
 4. **Two-phase processing**: Elaborate HO effects first, then interpret FO effects -- this separation ensures soundness
 
-**Significance:** The first theoretically sound solution to combining higher-order and algebraic effects. Directly implemented in the heftia library. Represents the current state of the art in effect system theory.
+**Significance:** The first theoretically sound solution to combining higher-order and algebraic effects. Directly implemented in the [heftia] library. Represents the current state of the art in effect system theory.
 
 ---
 
 ## 2024-2025 Frontier Set (State of the Art)
 
-| Year | Paper                                                                                          | Frontier Direction                                 |
-| ---- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| 2024 | [Parallel Algebraic Effect Handlers](https://doi.org/10.1145/3674651)                          | Parallel handling model (`lambda^p`)               |
-| 2024 | [Abstracting Effect Systems for Algebraic Effect Handlers](https://doi.org/10.1145/3674630)    | Meta-framework for comparing effect systems        |
-| 2024 | [Effect Handlers for C via Coroutines](https://doi.org/10.1145/3649836)                        | Systems-language implementation path               |
-| 2025 | [Affect: Affine Algebraic Effect Handlers](https://doi.org/10.1145/3704831)                    | Affine/resource-sensitive handler semantics        |
-| 2025 | [Algebraic Temporal Effects](https://doi.org/10.1145/3704853)                                  | Temporal constraints in effect systems             |
-| 2025 | [Asymptotic Speedup via Effect Handlers](https://doi.org/10.1145/3704871)                      | Complexity-level performance results with handlers |
-| 2025 | [Deciding Not to Decide: Sound and Complete Effect Inference](https://doi.org/10.1145/3704881) | Advanced inference for modern effect calculi       |
+| Year | Paper                                                         | Frontier Direction                                 |
+| ---- | ------------------------------------------------------------- | -------------------------------------------------- |
+| 2024 | [Parallel Algebraic Effect Handlers]                          | Parallel handling model (`lambda^p`)               |
+| 2024 | [Abstracting Effect Systems for Algebraic Effect Handlers]    | Meta-framework for comparing effect systems        |
+| 2024 | [Effect Handlers for C via Coroutines]                        | Systems-language implementation path               |
+| 2025 | [Affect: Affine Algebraic Effect Handlers]                    | Affine/resource-sensitive handler semantics        |
+| 2025 | [Algebraic Temporal Effects]                                  | Temporal constraints in effect systems             |
+| 2025 | [Asymptotic Speedup via Effect Handlers]                      | Complexity-level performance results with handlers |
+| 2025 | [Deciding Not to Decide: Sound and Complete Effect Inference] | Advanced inference for modern effect calculi       |
 
 ---
 
@@ -185,8 +185,8 @@ This line of work is central for systems that need both expressive scoped effect
 
 ## Living Bibliographies
 
-- [Effects Bibliography](https://github.com/yallop/effects-bibliography)
-- [Dan Thomas-Sherwood bibliography notes](https://www.dantb.dev/posts/effects-bibliography/)
+- [Effects Bibliography]
+- [Dan Thomas-Sherwood bibliography notes]
 
 ---
 
@@ -194,4 +194,43 @@ This line of work is central for systems that need both expressive scoped effect
 
 - Some production libraries marketed as "effect systems" do not implement full algebraic handlers.
 - Conversely, some research systems prioritize semantic guarantees over ecosystem breadth or API ergonomics.
-- For architecture decisions, read this page together with [comparison.md](comparison.md) and [theory-compilation.md](theory-compilation.md).
+- For architecture decisions, read this page together with [Comparison and Analysis] and [Theory and Compilation].
+
+<!-- References -->
+
+[Notions of Computation and Monads]: https://doi.org/10.1016/0890-5401(91)90052-4
+[Algebraic Operations and Generic Effects]: https://doi.org/10.1016/S1571-0661(04)80969-2
+[Handlers of Algebraic Effects]: https://doi.org/10.1007/978-3-642-00590-9_7
+[An Introduction to Algebraic Effects and Handlers]: https://doi.org/10.1016/j.entcs.2015.12.003
+[Effect Handlers in Scope]: https://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf
+[Fusion for Free]: https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf
+[Freer Monads, More Extensible Effects]: https://doi.org/10.1145/2804302.2804319
+[Algebraic Effects for Functional Programming]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf
+[Type Directed Compilation of Row-Typed Algebraic Effects]: https://doi.org/10.1145/3009837.3009872
+[Effect Handlers, Evidently]: https://doi.org/10.1145/3408981
+[Generalized Evidence Passing]: https://doi.org/10.1145/3473576
+[Retrofitting Effect Handlers onto OCaml]: https://doi.org/10.1145/3453483.3454039
+[Continuing WebAssembly with Effect Handlers]: https://doi.org/10.1145/3622814
+[Hefty Algebras]: https://doi.org/10.1145/3571255
+[A Framework for Higher-Order Effects and Handlers]: https://doi.org/10.1145/3674632
+[Soundly Handling Linearity]: https://doi.org/10.1145/3632904
+[Parallel Algebraic Effect Handlers]: https://doi.org/10.1145/3674651
+[Abstracting Effect Systems for Algebraic Effect Handlers]: https://doi.org/10.1145/3674630
+[Effect Handlers for C via Coroutines]: https://doi.org/10.1145/3649836
+[Affect: Affine Algebraic Effect Handlers]: https://doi.org/10.1145/3704831
+[Algebraic Temporal Effects]: https://doi.org/10.1145/3704853
+[Asymptotic Speedup via Effect Handlers]: https://doi.org/10.1145/3704871
+[Deciding Not to Decide: Sound and Complete Effect Inference]: https://doi.org/10.1145/3704881
+[Effects Bibliography]: https://github.com/yallop/effects-bibliography
+[Dan Thomas-Sherwood bibliography notes]: https://www.dantb.dev/posts/effects-bibliography/
+[fused-effects]: haskell-fused-effects.md
+[polysemy]: haskell-polysemy.md
+[Koka]: koka.md
+[effectful]: haskell-effectful.md
+[cleff]: haskell-cleff.md
+[bluefin]: haskell-bluefin.md
+[OCaml 5]: ocaml-effects.md
+[Eio]: ocaml-eio.md
+[heftia]: haskell-heftia.md
+[Comparison and Analysis]: comparison.md
+[Theory and Compilation]: theory-compilation.md

--- a/docs/research/algebraic-effects/parallelism.md
+++ b/docs/research/algebraic-effects/parallelism.md
@@ -45,17 +45,17 @@ Together with `lambda^p`, this reframes handlers from "possibly slower abstracti
 
 ## Relationship to Mainstream Runtimes
 
-### OCaml 5
+### [OCaml 5]
 
-OCaml 5 provides native effect handlers and multicore runtime support, but production libraries are still primarily optimized around practical structured concurrency and I/O, not full parallel handler calculi.
+[OCaml 5] provides native effect handlers and multicore runtime support, but production libraries like [Eio] are still primarily optimized around practical structured concurrency and I/O, not full parallel handler calculi.
 
 ### GHC / Haskell
 
-Delimited continuation primops enable experimentation with continuation-heavy effect libraries, but parallel algebraic handlers are still largely a research frontier rather than a settled production pattern.
+Delimited continuation primops enable experimentation with continuation-heavy effect libraries like [heftia] and [Theseus], but parallel algebraic handlers are still largely a research frontier rather than a settled production pattern.
 
 ### WebAssembly
 
-Typed continuation work (WasmFX / stack-switching proposals) could become an important target substrate for cross-language implementations of parallel effect handlers.
+Typed continuation work ([WasmFX] / stack-switching proposals) could become an important target substrate for cross-language implementations of parallel effect handlers.
 
 ---
 
@@ -70,9 +70,23 @@ Typed continuation work (WasmFX / stack-switching proposals) could become an imp
 
 ## Sources
 
-- [Parallel Algebraic Effect Handlers (ICFP 2024)](https://doi.org/10.1145/3674651)
-- [Asymptotic Speedup via Effect Handlers (POPL 2025)](https://doi.org/10.1145/3704871)
-- [Retrofitting Effect Handlers onto OCaml (PLDI 2021)](https://doi.org/10.1145/3453483.3454039)
-- [OCaml release index](https://ocaml.org/releases/)
-- [GHC 9.6.1 release notes (delimited continuation primops)](https://downloads.haskell.org/~ghc/9.6.5/docs/users_guide/9.6.1-notes.html)
-- [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)](https://doi.org/10.1145/3622814)
+- [Parallel Algebraic Effect Handlers (ICFP 2024)]
+- [Asymptotic Speedup via Effect Handlers (POPL 2025)]
+- [Retrofitting Effect Handlers onto OCaml (PLDI 2021)]
+- [OCaml release index]
+- [GHC 9.6.1 release notes (delimited continuation primops)]
+- [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)]
+
+<!-- References -->
+
+[OCaml 5]: ocaml-effects.md
+[Eio]: ocaml-eio.md
+[heftia]: haskell-heftia.md
+[Theseus]: haskell-theseus.md
+[WasmFX]: wasmfx.md
+[Parallel Algebraic Effect Handlers (ICFP 2024)]: https://doi.org/10.1145/3674651
+[Asymptotic Speedup via Effect Handlers (POPL 2025)]: https://doi.org/10.1145/3704871
+[Retrofitting Effect Handlers onto OCaml (PLDI 2021)]: https://doi.org/10.1145/3453483.3454039
+[OCaml release index]: https://ocaml.org/releases/
+[GHC 9.6.1 release notes (delimited continuation primops)]: https://downloads.haskell.org/~ghc/9.6.5/docs/users_guide/9.6.1-notes.html
+[Continuing WebAssembly with Effect Handlers (OOPSLA 2023)]: https://doi.org/10.1145/3622814

--- a/docs/research/algebraic-effects/rust-cps-effects.md
+++ b/docs/research/algebraic-effects/rust-cps-effects.md
@@ -7,7 +7,7 @@ A design pattern for encoding algebraic effects and handlers on stable Rust usin
 | Language      | Rust (stable)                                                                                        |
 | License       | N/A (design pattern, not a published crate)                                                          |
 | Repository    | N/A                                                                                                  |
-| Documentation | [Faking Algebraic Effects with Traits](https://blog.shtsoft.eu/2022/12/22/effect-trait-dp.html)      |
+| Documentation | [Faking Algebraic Effects with Traits]                                                               |
 | Key Authors   | SHTSoft (blog), various community contributors                                                       |
 | Encoding      | Traits as effect interfaces in CPS; trait implementations as handlers; monomorphization for dispatch |
 
@@ -115,7 +115,7 @@ impl<S: Clone, R> State<S, R> for PureState<S> {
 }
 ```
 
-Notice that `get` passes `self` back into the continuation so the handler can be reused. This is the "shallow handler" pattern -- the handler is consumed by each operation and must be explicitly threaded through.
+Notice that `get` passes `self` back into the continuation so the handler can be reused. This is the "shallow handler" pattern -- the handler is consumed by each effect operation and must be explicitly threaded through.
 
 ---
 
@@ -275,7 +275,7 @@ This is straightforward when all effects share the same handler type. When effec
 
 ### Shallow vs. Deep Handlers
 
-The CPS-trait pattern naturally produces shallow handlers: the handler is consumed by each effect operation and must be explicitly passed back into the continuation. This contrasts with deep handlers (as in effing-mad or most algebraic effect libraries) where the handler is implicitly available for the entire scope of the computation.
+The CPS-trait pattern naturally produces shallow handlers: the handler is consumed by each effect operation and must be explicitly passed back into the continuation. This contrasts with deep handlers (as in [effing-mad] or most algebraic effect libraries) where the handler is implicitly available for the entire scope of the computation.
 
 To simulate deep handlers, the handler must either implement `Clone` (to be copied back into each continuation) or be threaded explicitly through every continuation parameter.
 
@@ -337,10 +337,22 @@ Several features that would make CPS-based effects more ergonomic are absent or 
 
 ## Sources
 
-- [Faking Algebraic Effects and Handlers With Traits: A Rust Design Pattern -- SHTSoft](https://blog.shtsoft.eu/2022/12/22/effect-trait-dp.html)
-- [A universal lowering strategy for control effects in Rust -- Abubalay](https://www.abubalay.com/blog/2024/01/14/rust-effect-lowering)
-- [Continuation Passing Style for Effect Handlers -- Hillerström et al. (academic paper)](https://homepages.inf.ed.ac.uk/slindley/papers/handlers-cps.pdf)
-- [Simplifying Continuation-Passing Style in Rust -- Inferara](https://medium.com/@inferara/simplifying-continuation-passing-style-cps-in-rust-e43621d98fb5)
-- [Algebraic Effects, Ownership, and Borrowing -- Ante language blog](https://antelang.org/blog/effects_ownership_and_borrowing/)
-- [GATs encode higher-order functions on types -- Will Crichton](https://willcrichton.net/notes/gats-are-hofs/)
-- [Pre-RFC: CPS transform for generators -- Rust Internals](https://internals.rust-lang.org/t/pre-rfc-cps-transform-for-generators/7120)
+- [Faking Algebraic Effects and Handlers With Traits: A Rust Design Pattern -- SHTSoft]
+- [A universal lowering strategy for control effects in Rust -- Abubalay]
+- [Continuation Passing Style for Effect Handlers -- Hillerström et al. (academic paper)]
+- [Simplifying Continuation-Passing Style in Rust -- Inferara]
+- [Algebraic Effects, Ownership, and Borrowing -- Ante language blog]
+- [GATs encode higher-order functions on types -- Will Crichton]
+- [Pre-RFC: CPS transform for generators -- Rust Internals]
+
+<!-- References -->
+
+[effing-mad]: rust-effing-mad.md
+[Faking Algebraic Effects with Traits]: https://blog.shtsoft.eu/2022/12/22/effect-trait-dp.html
+[Faking Algebraic Effects and Handlers With Traits: A Rust Design Pattern -- SHTSoft]: https://blog.shtsoft.eu/2022/12/22/effect-trait-dp.html
+[A universal lowering strategy for control effects in Rust -- Abubalay]: https://www.abubalay.com/blog/2024/01/14/rust-effect-lowering
+[Continuation Passing Style for Effect Handlers -- Hillerström et al. (academic paper)]: https://homepages.inf.ed.ac.uk/slindley/papers/handlers-cps.pdf
+[Simplifying Continuation-Passing Style in Rust -- Inferara]: https://medium.com/@inferara/simplifying-continuation-passing-style-cps-in-rust-e43621d98fb5
+[Algebraic Effects, Ownership, and Borrowing -- Ante language blog]: https://antelang.org/blog/effects_ownership_and_borrowing/
+[GATs encode higher-order functions on types -- Will Crichton]: https://willcrichton.net/notes/gats-are-hofs/
+[Pre-RFC: CPS transform for generators -- Rust Internals]: https://internals.rust-lang.org/t/pre-rfc-cps-transform-for-generators/7120

--- a/docs/research/algebraic-effects/rust-effect-system.md
+++ b/docs/research/algebraic-effects/rust-effect-system.md
@@ -1,304 +1,237 @@
 # Rust's Implicit Effect System (Rust)
 
-Rust encodes effects as independent language features -- async, fallibility, iteration, constness, and unsafety -- each with its own keyword and trait mechanism, rather than providing a unified algebraic effect system.
+An analysis of how Rust already has an implicit effect system through async, const, unsafe, and other keyword-based effect markers, despite lacking explicit effect handlers.
 
-| Field         | Value                                                                                     |
-| ------------- | ----------------------------------------------------------------------------------------- |
-| Language      | Rust                                                                                      |
-| License       | MIT / Apache-2.0 (Rust itself)                                                            |
-| Repository    | [github.com/rust-lang/rust](https://github.com/rust-lang/rust)                            |
-| Documentation | [doc.rust-lang.org](https://doc.rust-lang.org/)                                           |
-| Key Authors   | without.boats (coroutine-effect analysis), Yoshua Wuyts (keyword generics), Niko Matsakis |
-| Approach      | Per-effect keywords and traits lowered to coroutine state machines                        |
+| Field       | Value                                                         |
+| ----------- | ------------------------------------------------------------- |
+| Language    | Rust (stable)                                                 |
+| Focus       | Analysis of existing language effect markers                  |
+| Key Authors | without.boats (blog series), Rust language team               |
+| Approach    | Keyword-based effect tracking without general effect handlers |
 
 ---
 
 ## Overview
 
-### What It Solves
+### What This Is
 
-Rust does not have a formal, unified effect system. Instead, it provides a collection of independent language features that each address a specific kind of effectful computation. Each feature has its own syntax, trait, and compilation strategy. The result is a pragmatic but fragmented approach where effects are encoded implicitly through type signatures and keywords rather than declared explicitly through a single effect abstraction.
-
-The five primary effect-like features in Rust are:
-
-| Effect            | Keyword / Syntax   | Trait / Type            | Status (2025)                                   |
-| ----------------- | ------------------ | ----------------------- | ----------------------------------------------- |
-| Asynchrony        | `async` / `.await` | `Future`                | Stable                                          |
-| Fallibility       | `?` operator       | `Result<T, E>`          | Stable                                          |
-| Iteration         | `gen` / `yield`    | `Iterator`              | Keyword reserved (2024 edition), blocks nightly |
-| Compile-time eval | `const fn`         | (constness constraint)  | Stable, const traits nightly                    |
-| Safety boundary   | `unsafe`           | (not a semantic effect) | Stable                                          |
+Rust does not have user-defined algebraic effect handlers, but it **does** have a form of implicit effect system. The language tracks certain computational capabilities through keywords (`async`, `const`, `unsafe`) that behave similarly to effect annotations in other languages. Understanding these existing mechanisms clarifies both what Rust already achieves and what gaps remain.
 
 ### Design Philosophy
 
-Rust prioritizes zero-cost abstractions and explicit control over runtime behavior. Each effect-like feature is designed to compile down to efficient, predictable machine code -- typically through state machine transformations for `async` and `gen`, monadic chaining via `?` for errors, and compile-time evaluation for `const fn`. This per-effect approach avoids the overhead of a general-purpose effect runtime but creates a "function coloring" problem where each effect introduces a distinct function flavor that does not compose generically with others.
+Rust prioritizes zero-cost abstractions and explicit control. The language effects that _are_ tracked (async, const, unsafe) are those where the overhead of tracking is minimal and the benefit (memory safety, compile-time evaluation) is substantial. General effect handlers have not been prioritized because:
+
+1. No consensus on the right trade-offs for Rust's constraints (zero-cost, no runtime)
+2. Existing patterns (CPS, generics) cover many use cases
+3. The complexity budget is spent on ownership/borrowing, which already provides significant capability control
 
 ---
 
 ## Core Abstractions and Types
 
-### Async / Await (Asynchrony Effect)
+### The "Function Coloring" Effect System
 
-Async functions compile to state machines implementing the `Future` trait. Each `.await` point becomes a state transition:
+without.boats and others have analyzed Rust's keywords as an implicit effect system:
 
-```rust
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+| Keyword  | Effect Meaning              | Propagation                   | Composition                   |
+| -------- | --------------------------- | ----------------------------- | ----------------------------- |
+| `async`  | May suspend at await points | `async fn` calls `async fn`   | `.await` at call sites        |
+| `const`  | Compile-time evaluable      | `const fn` calls `const fn`   | Must be `const` context       |
+| `unsafe` | May break memory safety     | `unsafe fn` calls `unsafe fn` | `unsafe` blocks at call sites |
+| `?`      | May return early via Err    | `?` in fallible functions     | Return type must match        |
 
-// The Future trait -- Rust's encoding of the async effect
-trait Future {
-    type Output;
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
-}
+Each of these creates a "color" that functions must match. An `async fn` can only call other `async` functions (or functions that return futures). A `const fn` can only call other `const` functions. This is effect polymorphism through keyword propagation.
 
-// An async fn is syntactic sugar for a function returning impl Future
-async fn fetch_data(url: &str) -> Result<String, Error> {
-    let response = client.get(url).await?;  // .await suspends here
-    let body = response.text().await?;       // and here
-    Ok(body)
-}
-```
+### The Function Coloring Problem
 
-The compiler transforms this into a self-referential state machine. `Pin` is required because the state machine may hold references across yield points, and moving it would invalidate those references.
+The "function coloring" blog post by Robert Nystrom (not Rust-specific) pointed out that async/await creates a split where:
 
-### Result / ? Operator (Fallibility Effect)
+- Red functions (async) can call blue functions (sync) easily
+- Blue functions (sync) calling red functions (async) requires ceremony
 
-The `?` operator provides early return on error, functioning as a monadic bind:
+Rust's `async`/`.await` exhibits this exactly. The general problem is: when an effect is introduced, how do you handle code that doesn't use that effect calling code that does?
 
-```rust
-// Without ? -- explicit pattern matching
-fn read_config(path: &str) -> Result<Config, Error> {
-    let contents = match std::fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(e) => return Err(e.into()),
-    };
-    let config = match toml::from_str(&contents) {
-        Ok(c) => c,
-        Err(e) => return Err(e.into()),
-    };
-    Ok(config)
-}
+Rust's answer varies by effect:
 
-// With ? -- desugared to the same thing
-fn read_config(path: &str) -> Result<Config, Error> {
-    let contents = std::fs::read_to_string(path)?;
-    let config = toml::from_str(&contents)?;
-    Ok(config)
-}
-```
-
-### Gen Blocks (Iteration Effect)
-
-RFC 3513 reserves `gen` in the 2024 edition. Gen blocks produce `Iterator` values via `yield`, mirroring how `async` blocks produce `Future` values:
-
-```rust
-// Nightly syntax (gen blocks)
-#![feature(gen_blocks)]
-
-fn fibonacci() -> impl Iterator<Item = u64> {
-    gen {
-        let (mut a, mut b) = (0, 1);
-        loop {
-            yield a;
-            (a, b) = (b, a + b);
-        }
-    }
-}
-```
-
-Like async functions, gen blocks compile to state machines. Unlike the full `Coroutine` trait (nightly), gen blocks cannot hold references across yield points in the current design.
-
-### Const Fn (Constness Effect)
-
-`const fn` restricts a function to operations that can be evaluated at compile time:
-
-```rust
-const fn factorial(n: u64) -> u64 {
-    if n == 0 { 1 } else { n * factorial(n - 1) }
-}
-
-// Evaluated at compile time
-const FACT_10: u64 = factorial(10);
-
-// Also callable at runtime
-let runtime_result = factorial(5);
-```
-
-Const functions cannot allocate, access globals, or perform I/O. This is the inverse of most effects: rather than adding a capability, `const` removes capabilities to guarantee compile-time evaluability.
-
-### Unsafe (Safety Boundary)
-
-After discussion with Ralf Jung, the Rust keyword generics initiative concluded that `unsafe` is not semantically an effect. It is a contract mechanism that shifts proof obligations to the caller rather than adding or removing computational capabilities:
-
-```rust
-// unsafe fn: caller promises preconditions are met
-unsafe fn deref_raw<T>(ptr: *const T) -> &'static T {
-    &*ptr
-}
-
-// unsafe block: programmer asserts safety invariants hold
-let value = unsafe { deref_raw(some_ptr) };
-```
+- **async**: Requires `.await` (explicit suspension point)
+- **const**: Not callable from non-const contexts without compile-time guarantees
+- **unsafe**: Requires `unsafe` block (explicit opt-in to potential UB)
+- **?**: Requires compatible return types
 
 ---
 
 ## How Effects Are Declared
 
-Each effect is declared through distinct syntax. There is no unified effect declaration mechanism:
+### Keyword-Based Declaration
+
+Effects are declared at the function level through keywords:
 
 ```rust
-// Async effect: declared with `async` keyword
-async fn fetch(url: &str) -> String { /* ... */ }
+// async effect: may suspend
+async fn fetch_data() -> Result<Data, Error> {
+    let response = reqwest::get("...").await?;
+    response.json().await
+}
 
-// Fallibility effect: declared via return type
-fn parse(input: &str) -> Result<Value, ParseError> { /* ... */ }
+// const effect: compile-time evaluable
+const fn compute_size() -> usize {
+    1024 * 64  // can be used in array sizes, const contexts
+}
 
-// Iteration effect: declared with gen (nightly)
-gen fn numbers() -> i32 { yield 1; yield 2; yield 3; }
+// unsafe effect: memory safety responsibility
+unsafe fn transmute_bytes<T>(bytes: [u8; size_of::<T>()]) -> T {
+    // Bypasses borrow checker, caller must ensure validity
+    std::mem::transmute(bytes)
+}
 
-// Constness: declared with const keyword
-const fn square(x: i32) -> i32 { x * x }
-
-// Safety: declared with unsafe keyword
-unsafe fn raw_access(ptr: *mut u8) -> u8 { *ptr }
-```
-
-The function signature encodes which effects are in play. A function that is both async and fallible must combine the mechanisms:
-
-```rust
-// Combining async + fallibility
-async fn fetch_and_parse(url: &str) -> Result<Data, Error> {
-    let resp = client.get(url).await?;  // both .await and ? in one expression
-    Ok(resp.json().await?)
+// ? effect: early return via Result
+fn fallible_operation() -> Result<(), MyError> {
+    let x = another_fallible()?;  // may return early with Err
+    Ok(x)
 }
 ```
+
+### Type System Integration
+
+Each effect keyword has corresponding type system support:
+
+- `async fn` returns `impl Future<Output = T>`
+- `const fn` can be evaluated at compile time in const contexts
+- `unsafe fn` requires `unsafe` block to call
+- `?` works via the `Try` trait with associated `Output` type
 
 ---
 
 ## How Handlers/Interpreters Work
 
-Rust does not have general-purpose effect handlers. Each effect has its own "handling" mechanism:
+### The Runtime as Handler
 
-| Effect      | Handler mechanism                                                      |
-| ----------- | ---------------------------------------------------------------------- |
-| Async       | Runtime executor (`tokio::runtime`, `async-std`, `smol`) polls futures |
-| Fallibility | Caller uses `match`, `?`, `.unwrap()`, or combinators                  |
-| Iteration   | `for` loop or iterator combinators (`.map()`, `.filter()`, etc.)       |
-| Constness   | Compiler evaluates at compile time in const contexts                   |
-| Unsafe      | Programmer provides proof of safety via `unsafe` block                 |
+Unlike algebraic effect systems where handlers are user-defined, Rust's effects are "handled" by the language runtime or compilation process:
+
+**Async**: The async runtime (Tokio, async-std) handles await points by suspending and resuming tasks.
 
 ```rust
-// "Handling" the async effect: an executor drives the future
-#[tokio::main]
-async fn main() {
-    let data = fetch_data("https://example.com").await;
-}
-
-// "Handling" the fallibility effect: match on the result
-fn main() {
-    match read_config("config.toml") {
-        Ok(config) => run(config),
-        Err(e) => eprintln!("Error: {e}"),
-    }
-}
-
-// "Handling" the iteration effect: for loop
-fn main() {
-    for n in fibonacci().take(10) {
-        println!("{n}");
-    }
-}
+// The runtime handles the suspension/resumption
+tokio::spawn(async {
+    let data = fetch_data().await;  // suspend here, resume when ready
+});
 ```
 
----
+**Const**: The compiler's const evaluator handles const evaluation.
 
-## Performance Approach
+**Unsafe**: The programmer (via `unsafe` block) takes responsibility -- no runtime check.
 
-Rust compiles each effect to zero-cost abstractions:
+**?**: The `Try` trait's `branch` method handles the control flow transformation.
 
-- **Async**: State machines with no heap allocation for the frame itself (the caller decides where to store it). No implicit boxing unless using `Box<dyn Future>`.
-- **Fallibility**: `Result<T, E>` is a plain enum. The `?` operator compiles to a branch instruction. No exception tables, no stack unwinding.
-- **Iteration**: Gen blocks compile to state machines identical to hand-written iterator implementations.
-- **Constness**: Evaluated at compile time via CTFE (Compile-Time Function Evaluation). Zero runtime cost.
+### No User-Defined Handlers
 
-This per-effect compilation strategy avoids the overhead of a general-purpose effect runtime or continuation-passing transform, but also prevents generic composition across effects.
+The critical difference from languages like [Koka], [OCaml 5], or Haskell's [eff] is that Rust does **not** allow user-defined handlers for these effects. You cannot:
+
+- Intercept an `await` and provide a different async semantics
+- Handle `?` with custom error recovery at the call site
+- Redefine what `unsafe` means
+
+The effects are baked into the language and handled by the compiler/runtime.
 
 ---
 
 ## Composability Model
 
-### The Function Coloring Problem
+### Effect Composition Through Generics
 
-Each effect introduces a "color" that propagates through the call graph. An async function can only be awaited from another async function (or a runtime entry point). A `const fn` can only call other `const fn`s. This creates parallel ecosystems:
+Rust's primary mechanism for effect-like composition is the trait system. Instead of effect rows or handlers, you use bounds:
 
 ```rust
-// Sync version
-fn read_file(path: &str) -> Result<String, io::Error> {
-    std::fs::read_to_string(path)
-}
-
-// Async version -- different color, different ecosystem
-async fn read_file(path: &str) -> Result<String, io::Error> {
-    tokio::fs::read_to_string(path).await
+// Effect polymorphism via generic bounds
+async fn process<T, F>(items: Vec<T>, f: F) -> Vec<Result<T, Error>>
+where
+    F: AsyncFn(T) -> Result<Processed, Error>,
+{
+    // Can process items concurrently because f is async
+    futures::stream::iter(items)
+        .map(|item| f(item))
+        .buffer_unordered(10)
+        .collect()
+        .await
 }
 ```
 
-Library authors must often maintain both sync and async versions of their APIs, leading to code duplication. Crates like `maybe_async` attempt to paper over this with macros, but the solution is limited.
-
-### The Keyword Generics Initiative
-
-The keyword generics initiative (led by Yoshua Wuyts and Oli Scherer) is the primary path toward abstracting over effects in Rust. As of early 2026, the initiative has focused on finalizing the semantics of `async` and `const` generics. The 2024 Edition of Rust (stabilized in Rust 1.85.0) provides the foundation for these improvements, with syntactical support expected to evolve in the 2027 Edition.
+This achieves some effect polymorphism but without the full handler mechanism.
 
 ### Coroutines as a Unifying Mechanism
 
 without.boats has argued that Rust's async functions and generators are both instances of stackless coroutines, and that coroutines and algebraic effect systems are "in some ways isomorphic to one another." The coroutine frame is the universal lowering target: each effect operation becomes a yield point in the state machine, and the handler (executor, for-loop, match) drives the coroutine by resuming it.
 
-This analysis suggests that Rust already has the low-level machinery for a general effect system but lacks the high-level abstraction to unify the per-effect syntax and trait families.
+This analysis suggests that Rust already has the low-level machinery for a general effect system but lacks the high-level abstraction to unify the per-effect syntax and trait families. See [effing-mad] for a library that builds algebraic effects on Rust's nightly coroutine feature.
 
 ---
 
 ## Strengths
 
-- Zero-cost compilation for every effect -- no runtime overhead, no boxing, no vtables (unless explicitly opted into)
-- Each effect is well-understood in isolation with clear, predictable semantics
-- Ownership and borrowing provide compile-time guarantees about resource safety that interact naturally with effects
-- The `?` operator is arguably the most ergonomic error handling in any systems language
-- Async/await enables high-performance concurrent I/O without garbage collection or a heavy runtime
-- The per-effect approach avoids the complexity of a full effect type system
+- **Zero-cost abstractions**: async/await, const evaluation compile to efficient code
+- **Explicit is better than implicit**: Effect boundaries are visible at call sites (`.await`, `unsafe` blocks)
+- **Compositional through traits**: The effect-like patterns compose through generics and bounds
+- **Strong static guarantees**: const and unsafe have clear semantic boundaries
+- **Production battle-tested**: The async ecosystem (Tokio, etc.) is mature and widely used
 
 ## Weaknesses
 
-- Function coloring creates parallel ecosystems (sync vs async, const vs non-const) with code duplication
-- No way to abstract over effects generically -- library authors must choose or duplicate
-- Combining multiple effects (async + fallible + generator) requires ad-hoc composition rather than principled effect rows
-- No first-class effect handlers -- cannot swap the interpretation of an effect at the call site
-- Pin and self-referential state machines add significant complexity to async Rust
-- No equivalent to algebraic effect handler resumption (one-shot or multi-shot continuations)
-- The "effect" framing is implicit -- Rust programmers must learn each feature individually rather than understanding a unified concept
+- **No user-defined handlers**: Cannot abstract over control flow the way algebraic effects do
+- **Function coloring problem**: async/sync split creates library ecosystem friction
+- **No effect rows**: Cannot easily express "this function uses effects A and B"
+- **Inconsistent effect syntax**: Each effect (async, const, unsafe, ?) has different syntax and rules
+- **No resumption control**: Cannot implement backtracking, nondeterminism, or custom control flow
 
 ## Key Design Decisions and Trade-offs
 
-| Decision                        | Rationale                                                       | Trade-off                                                  |
-| ------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------- |
-| Per-effect keywords             | Each effect gets optimized syntax and compilation               | No generic composition; combinatorial API explosion        |
-| State machine lowering          | Zero-cost; no heap allocation for coroutine frames              | Pin complexity; self-referential types are hard            |
-| Result instead of exceptions    | Explicit, zero-cost error handling; no hidden control flow      | Verbose for deep call chains; no stack traces by default   |
-| No effect polymorphism          | Simpler type system; each effect independently stable           | Code duplication between sync/async, const/non-const       |
-| unsafe is not an effect         | Keeps effect system compositional; unsafe is a proof obligation | Cannot abstract over safety boundaries generically         |
-| External iteration (pull-based) | Composable with ownership; lazy by default                      | Cannot express push-based or concurrent iteration natively |
+| Decision                     | Rationale                                     | Trade-off                                          |
+| ---------------------------- | --------------------------------------------- | -------------------------------------------------- |
+| Keyword-based effects        | Minimal syntax overhead; clear visual markers | Inconsistent between effects; no general mechanism |
+| No user-defined handlers     | Complexity budget; zero-cost constraint       | Cannot abstract over control flow patterns         |
+| Runtime/async executor model | Performance; ecosystem flexibility            | Function coloring; library dependencies            |
+| Separate unsafe keyword      | Security; explicit opt-in to UB               | Verbose; some safe operations require unsafe       |
+| No effect polymorphism       | Type system simplicity                        | Less expressive than full effect systems           |
+
+---
+
+## Comparison with Full Effect Systems
+
+| Feature              | Rust (implicit)                | [Koka]           | [OCaml 5]             | [eff] (Haskell)  |
+| -------------------- | ------------------------------ | ---------------- | --------------------- | ---------------- |
+| Effect declaration   | Keywords                       | `effect` keyword | `effect` keyword      | GADT data types  |
+| Effect composition   | Manual/traits                  | Row polymorphism | Untyped at runtime    | Type-level lists |
+| User handlers        | No                             | `handle`         | `match...with effect` | `handle`         |
+| Continuation capture | No (stackless coroutines only) | Yes              | Yes (one-shot)        | Yes              |
+| Resumption control   | No (runtime managed)           | Yes              | Yes                   | Yes              |
 
 ---
 
 ## Sources
 
-- [Coroutines and effects -- without.boats](https://without.boats/blog/coroutines-and-effects/)
-- [The registers of Rust -- without.boats](https://without.boats/blog/the-registers-of-rust/)
-- [Extending Rust's effect system -- Yoshua Wuyts](https://blog.yoshuawuyts.com/extending-rusts-effect-system/)
-- [Keyword Generics Initiative](https://rust-lang.github.io/keyword-generics-initiative/)
-- [Announcing the Keyword Generics Initiative -- Inside Rust Blog](https://blog.rust-lang.org/inside-rust/2022/07/27/keyword-generics.html)
-- [A universal lowering strategy for control effects in Rust -- Abubalay](https://www.abubalay.com/blog/2024/01/14/rust-effect-lowering)
-- [RFC 3513: gen blocks](https://rust-lang.github.io/rfcs/3513-gen-blocks.html)
-- [Const traits -- Rust Project Goals 2024h2](https://rust-lang.github.io/rust-project-goals/2024h2/const-traits.html)
-- [Rust async is colored, and that's not a big deal -- More Stina Blog](https://morestina.net/1686/rust-async-is-colored)
-- [In Defense of Async: Function Colors Are Rusty -- The Coded Message](https://www.thecodedmessage.com/posts/async-colors/)
+- [What I want from async in Rust -- without.boats]
+- [Async functions in traits are just regular generic functions -- without.boats]
+- [Rust async fundamentals]
+- [The Rust Programming Language -- Async/Await]
+- [Function Coloring is a Myth -- Robert Nystrom]
+- [RFC 2394: Async/Await]
+- [RFC 2920: Const Generics]
+- [Const evaluation -- Rust Reference]
+- [Unsafe Rust -- Rust Book]
+- [The Try trait -- Rust RFC]
+
+<!-- References -->
+
+[Koka]: koka.md
+[OCaml 5]: ocaml-effects.md
+[eff]: haskell-eff.md
+[effing-mad]: rust-effing-mad.md
+[What I want from async in Rust -- without.boats]: https://without.boats/blog/what-i-want-from-async/
+[Async functions in traits are just regular generic functions -- without.boats]: https://without.boats/blog/async-generics/
+[Rust async fundamentals]: https://rust-lang.github.io/async-book/
+[The Rust Programming Language -- Async/Await]: https://doc.rust-lang.org/book/ch17-01-async-await.html
+[Function Coloring is a Myth -- Robert Nystrom]: https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/
+[RFC 2394: Async/Await]: https://rust-lang.github.io/rfcs/2394-async_await.html
+[RFC 2920: Const Generics]: https://rust-lang.github.io/rfcs/2920-const-generics.html
+[Const evaluation -- Rust Reference]: https://doc.rust-lang.org/reference/const_eval.html
+[Unsafe Rust -- Rust Book]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
+[The Try trait -- Rust RFC]: https://rust-lang.github.io/rfcs/3058-try-trait-v2.html

--- a/docs/research/algebraic-effects/rust-effing-mad.md
+++ b/docs/research/algebraic-effects/rust-effing-mad.md
@@ -6,8 +6,8 @@ An algebraic effects library for Rust built on nightly coroutines, providing typ
 | ------------- | ---------------------------------------------------------------------------------------- |
 | Language      | Rust (nightly)                                                                           |
 | License       | MIT OR Apache-2.0                                                                        |
-| Repository    | [github.com/rosefromthedead/effing-mad](https://github.com/rosefromthedead/effing-mad)   |
-| Documentation | [docs.rs/effing-mad](https://docs.rs/effing-mad/latest/effing_mad/)                      |
+| Repository    | [github.com/rosefromthedead/effing-mad]                                                  |
+| Documentation | [docs.rs/effing-mad]                                                                     |
 | Key Authors   | Rose Hudson                                                                              |
 | Encoding      | Coroutine-based yield/resume with typed effect traits and macro-generated state machines |
 
@@ -17,9 +17,9 @@ An algebraic effects library for Rust built on nightly coroutines, providing typ
 
 ### What It Solves
 
-effing-mad brings algebraic effects and effect handlers to Rust. It addresses the function coloring problem by allowing a single effectful function to be handled differently depending on the call site -- the same I/O-performing function can be called from a synchronous context, an async context, or a test context, with different handlers providing different semantics each time.
+effing-mad brings algebraic effects and effect handlers to Rust. It addresses the [function coloring problem] by allowing a single effectful function to be handled differently depending on the call site -- the same I/O-performing function can be called from a synchronous context, an async context, or a test context, with different handlers providing different semantics each time.
 
-The library demonstrates that Rust's nightly coroutine feature (originally built for async/await compilation) is general enough to implement full algebraic effects. Effectful functions yield typed effect values to their callers, which handle those effects and resume the function with a typed injection value.
+The library demonstrates that Rust's nightly coroutine feature (originally built for async/await compilation) is general enough to implement full algebraic effects. Effectful functions yield typed effect values to their callers, which handle those effects and resume the function with a typed injection value. See [Rust's Implicit Effect System] for more on how Rust handles effects at the language level.
 
 ### Design Philosophy
 
@@ -67,7 +67,7 @@ An effectful function returns a `Computation` -- an opaque coroutine frame param
 ```rust
 // Calling an effectful function produces a Computation
 let computation = combined();
-// The computation's effects must be handled before it can run
+// The computation's effects must be handled before it can be run
 ```
 
 ### EffectGroup
@@ -289,10 +289,24 @@ let test = handle(read_and_log(), handler!(FileRead(name) => {
 
 ## Sources
 
-- [effing-mad GitHub repository](https://github.com/rosefromthedead/effing-mad)
-- [effing-mad on crates.io](https://crates.io/crates/effing-mad)
-- [effing-mad API documentation](https://docs.rs/effing-mad/latest/effing_mad/)
-- [effing-mad basic example](https://github.com/rosefromthedead/effing-mad/blob/main/examples/basic.rs)
-- [Effing-mad discussion on Hacker News](https://news.ycombinator.com/item?id=35358336)
-- [Effing-mad discussion on Lobsters](https://lobste.rs/s/blkfub/effing_mad_algebraic_effects_for_rust)
-- [Generators are dead, long live coroutines, generators are back -- Inside Rust Blog](https://blog.rust-lang.org/inside-rust/2023/10/23/coroutines/)
+- [effing-mad GitHub repository]
+- [effing-mad on crates.io]
+- [effing-mad API documentation]
+- [effing-mad basic example]
+- [Effing-mad discussion on Hacker News]
+- [Effing-mad discussion on Lobsters]
+- [Generators are dead, long live coroutines, generators are back -- Inside Rust Blog]
+
+<!-- References -->
+
+[function coloring problem]: rust-effect-system.md
+[Rust's Implicit Effect System]: rust-effect-system.md
+[github.com/rosefromthedead/effing-mad]: https://github.com/rosefromthedead/effing-mad
+[docs.rs/effing-mad]: https://docs.rs/effing-mad/latest/effing_mad/
+[effing-mad GitHub repository]: https://github.com/rosefromthedead/effing-mad
+[effing-mad on crates.io]: https://crates.io/crates/effing-mad
+[effing-mad API documentation]: https://docs.rs/effing-mad/latest/effing_mad/
+[effing-mad basic example]: https://github.com/rosefromthedead/effing-mad/blob/main/examples/basic.rs
+[Effing-mad discussion on Hacker News]: https://news.ycombinator.com/item?id=35358336
+[Effing-mad discussion on Lobsters]: https://lobste.rs/s/blkfub/effing_mad_algebraic_effects_for_rust
+[Generators are dead, long live coroutines, generators are back -- Inside Rust Blog]: https://blog.rust-lang.org/inside-rust/2023/10/23/coroutines/

--- a/docs/research/algebraic-effects/scala-capabilities.md
+++ b/docs/research/algebraic-effects/scala-capabilities.md
@@ -4,12 +4,12 @@ Scala 3 is exploring capability-based effect reasoning at the language level, ce
 
 **Last reviewed:** February 16, 2026.
 
-| Field                      | Value                                                                                                       |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Language                   | Scala 3                                                                                                     |
-| Feature status             | Experimental                                                                                                |
-| Official docs              | [Scala 3 experimental features index](https://docs.scala-lang.org/scala3/reference/experimental/index.html) |
-| Capture checking reference | [Capture Checking](https://docs.scala-lang.org/scala3/reference/experimental/cc.html)                       |
+| Field                      | Value                                 |
+| -------------------------- | ------------------------------------- |
+| Language                   | Scala 3                               |
+| Feature status             | Experimental                          |
+| Official docs              | [Scala 3 experimental features index] |
+| Capture checking reference | [Capture Checking]                    |
 
 ---
 
@@ -31,9 +31,9 @@ This work is best understood as capability discipline and effect reasoning infra
 
 Sources:
 
-- [Scala 3.8 release announcement (January 21, 2026)](https://www.scala-lang.org/blog/2026/01/21/scala-3.8.html)
-- [Scala 3 experimental feature index](https://docs.scala-lang.org/scala3/reference/experimental/index.html)
-- [Capture Checking reference](https://docs.scala-lang.org/scala3/reference/experimental/cc.html)
+- [Scala 3.8 release announcement (January 21, 2026)]
+- [Scala 3 experimental feature index]
+- [Capture Checking reference]
 
 ---
 
@@ -61,7 +61,7 @@ def program: Effectful[Unit] =
   println("hello")
 ```
 
-Source: [Context Functions](https://docs.scala-lang.org/scala3/reference/contextual/context-functions.html)
+Source: [Context Functions]
 
 ### 2. Capture Checking
 
@@ -80,7 +80,7 @@ The `^{io}` annotation indicates that `f` captures the `io` capability. The type
 2. Functions that perform effects are properly annotated
 3. Pure functions are guaranteed to capture no capabilities
 
-Source: [Capture Checking](https://docs.scala-lang.org/scala3/reference/experimental/cc.html)
+Source: [Capture Checking]
 
 ### 3. Boundary / Break for Structured Non-Local Exits
 
@@ -99,7 +99,7 @@ def findIndex(xs: List[Int], target: Int): Int =
 
 `boundary` defines a scope and `break` exits it, analogous to an effect handler and an effect operation.
 
-Source: [Dropped: Nonlocal Returns (use `scala.util.boundary`)](https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html)
+Source: [Dropped: Nonlocal Returns (use `scala.util.boundary`)]
 
 ---
 
@@ -134,9 +134,23 @@ Current limitation:
 
 ## Sources
 
-- [Scala 3.8 release announcement (2026-01-21)](https://www.scala-lang.org/blog/2026/01/21/scala-3.8.html)
-- [Scala 3 experimental features index](https://docs.scala-lang.org/scala3/reference/experimental/index.html)
-- [Capture Checking (Scala 3 reference)](https://docs.scala-lang.org/scala3/reference/experimental/cc.html)
-- [Context Functions (Scala 3 reference)](https://docs.scala-lang.org/scala3/reference/contextual/context-functions.html)
-- [Dropped: Nonlocal Returns (use `scala.util.boundary`)](https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html)
-- [Scala contributors discussion: capabilities questions](https://contributors.scala-lang.org/t/questions-regarding-capabilities/7223)
+- [Scala 3.8 release announcement (2026-01-21)]
+- [Scala 3 experimental features index]
+- [Capture Checking (Scala 3 reference)]
+- [Context Functions (Scala 3 reference)]
+- [Dropped: Nonlocal Returns (use `scala.util.boundary`)]
+- [Scala contributors discussion: capabilities questions]
+
+<!-- References -->
+
+[Scala 3 experimental features index]: https://docs.scala-lang.org/scala3/reference/experimental/index.html
+[Capture Checking]: https://docs.scala-lang.org/scala3/reference/experimental/cc.html
+[Scala 3.8 release announcement (January 21, 2026)]: https://www.scala-lang.org/blog/2026/01/21/scala-3.8.html
+[Scala 3 experimental feature index]: https://docs.scala-lang.org/scala3/reference/experimental/index.html
+[Capture Checking reference]: https://docs.scala-lang.org/scala3/reference/experimental/cc.html
+[Context Functions]: https://docs.scala-lang.org/scala3/reference/contextual/context-functions.html
+[Dropped: Nonlocal Returns (use `scala.util.boundary`)]: https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html
+[Scala 3.8 release announcement (2026-01-21)]: https://www.scala-lang.org/blog/2026/01/21/scala-3.8.html
+[Capture Checking (Scala 3 reference)]: https://docs.scala-lang.org/scala3/reference/experimental/cc.html
+[Context Functions (Scala 3 reference)]: https://docs.scala-lang.org/scala3/reference/contextual/context-functions.html
+[Scala contributors discussion: capabilities questions]: https://contributors.scala-lang.org/t/questions-regarding-capabilities/7223

--- a/docs/research/algebraic-effects/scala-cats-effect.md
+++ b/docs/research/algebraic-effects/scala-cats-effect.md
@@ -2,14 +2,14 @@
 
 The pure asynchronous runtime for Scala, providing a concrete `IO` monad and a typeclass hierarchy that defines what it means to be a purely functional runtime system. Powers a thriving ecosystem including fs2, http4s, doobie, and more.
 
-| Field         | Value                                                                        |
-| ------------- | ---------------------------------------------------------------------------- |
-| Language      | Scala 2.13 / Scala 3                                                         |
-| License       | Apache-2.0                                                                   |
-| Repository    | [github.com/typelevel/cats-effect](https://github.com/typelevel/cats-effect) |
-| Documentation | [typelevel.org/cats-effect](https://typelevel.org/cats-effect/)              |
-| Key Authors   | Daniel Spiewak, Typelevel community                                          |
-| Approach      | Typeclass hierarchy + concrete IO monad + work-stealing fiber runtime        |
+| Field         | Value                                                                 |
+| ------------- | --------------------------------------------------------------------- |
+| Language      | Scala 2.13 / Scala 3                                                  |
+| License       | Apache-2.0                                                            |
+| Repository    | [github.com/typelevel/cats-effect]                                    |
+| Documentation | [typelevel.org/cats-effect]                                           |
+| Key Authors   | Daniel Spiewak, Typelevel community                                   |
+| Approach      | Typeclass hierarchy + concrete IO monad + work-stealing fiber runtime |
 
 ---
 
@@ -21,7 +21,7 @@ Cats Effect provides the tools to architect highly-asynchronous, highly-concurre
 
 ### Design Philosophy
 
-Cats Effect follows the Typelevel philosophy: simple, orthogonal, primitive capabilities that compose to express all necessary computation. Unlike ZIO's batteries-included approach, Cats Effect is minimalist -- it provides the runtime and typeclass contracts, while the ecosystem provides the features. This enables maximum abstraction: code can be written against `F[_]` with typeclass constraints rather than a concrete IO type.
+Cats Effect follows the Typelevel philosophy: simple, orthogonal, primitive capabilities that compose to express all necessary computation. Unlike [ZIO]'s batteries-included approach, Cats Effect is minimalist -- it provides the runtime and typeclass contracts, while the ecosystem provides the features. This enables maximum abstraction: code can be written against `F[_]` with typeclass constraints rather than a concrete IO type.
 
 ---
 
@@ -35,11 +35,11 @@ The concrete effect type has a single type parameter:
 IO[+A]
 ```
 
-`IO[A]` represents a potentially side-effectful computation that produces a value of type `A`. Like ZIO, `IO` values are immutable descriptions of effects, not the effects themselves. They are executed by the runtime.
+`IO[A]` represents a potentially side-effectful computation that produces a value of type `A`. Like [ZIO], `IO` values are immutable descriptions of effects, not the effects themselves. They are executed by the runtime.
 
 ### Error Handling
 
-Unlike ZIO's typed error channel, Cats Effect fixes the error type to `Throwable`:
+Unlike [ZIO]'s typed error channel, Cats Effect fixes the error type to `Throwable`:
 
 ```scala
 // Errors are always Throwable
@@ -59,19 +59,19 @@ The typeclass hierarchy is the defining feature of Cats Effect. It defines contr
 
 ### Cats Effect 3 Hierarchy (Bottom to Top)
 
-```
+```scala
                     Monad
                       |
                    Unique
                       |
-                  MonadCancel
-                   /      \
-              Spawn      GenConcurrent
-               |              |
-           Concurrent         |
-               |              |
-            Temporal     GenTemporal
-               \            /
+                 MonadCancel
+                  /      \
+             Spawn      GenConcurrent
+              |              |
+          Concurrent         |
+              |              |
+           Temporal     GenTemporal
+              \            /
                 \          /
                   Sync   Async
                     \   /
@@ -182,7 +182,7 @@ Cats Effect 3 uses an extremely low-contention, lock-free work-stealing schedule
 
 ### Fiber Memory Footprint
 
-Cats Effect fibers are roughly **3x smaller** than ZIO fibers in memory, since they carry less context (no typed error channel, no environment).
+Cats Effect fibers are roughly **3x smaller** than [ZIO] fibers in memory, since they carry less context (no typed error channel, no environment).
 
 ### io_uring Integration (v3.6.0)
 
@@ -216,7 +216,7 @@ The tagless final approach means the same library code works with any compliant 
 | circe   | JSON serialization   |
 | skunk   | PostgreSQL           |
 
-### ZIO Interop
+### [ZIO] Interop
 
 `zio-interop-cats` provides Cats Effect typeclass instances for ZIO, allowing ZIO programs to use Cats Effect libraries.
 
@@ -224,7 +224,7 @@ The tagless final approach means the same library code works with any compliant 
 
 ## Strengths
 
-- **Lightweight fibers**: ~3x less memory than ZIO; highly scalable
+- **Lightweight fibers**: ~3x less memory than [ZIO]; highly scalable
 - **Work-stealing scheduler**: Gets more efficient with more CPUs; inspired by Tokio
 - **Tagless final**: Maximum abstraction; code works with any compliant effect type
 - **Rich ecosystem**: fs2, http4s, doobie, etc. -- the largest FP Scala library ecosystem
@@ -234,7 +234,7 @@ The tagless final approach means the same library code works with any compliant 
 
 ## Weaknesses
 
-- **No typed errors**: Fixed to `Throwable`; less type safety than ZIO's error channel
+- **No typed errors**: Fixed to `Throwable`; less type safety than [ZIO]'s error channel
 - **No built-in DI**: Must use external patterns or libraries for dependency injection
 - **Tagless final overhead**: Higher-kinded abstractions can be confusing; error messages cryptic
 - **Minimal built-in features**: No STM, scheduling, or streaming in core (requires fs2, etc.)
@@ -256,13 +256,29 @@ The tagless final approach means the same library code works with any compliant 
 
 ## Sources
 
-- [Cats Effect documentation](https://typelevel.org/cats-effect/)
-- [Cats Effect GitHub repository](https://github.com/typelevel/cats-effect)
-- [Why Are Fibers Fast?](https://typelevel.org/blog/2021/02/21/fibers-fast-mkay.html) -- Typelevel Blog
-- [Concurrency in Cats Effect 3](https://typelevel.org/blog/2020/10/30/concurrency-in-ce3.html) -- Typelevel Blog
-- [Thread Model](https://typelevel.org/cats-effect/docs/thread-model) -- Cats Effect Docs
-- [CE3 Proposal Issue #634](https://github.com/typelevel/cats-effect/issues/634)
-- [CE2 Typeclass Overview](https://typelevel.org/cats-effect/docs/2.x/typeclasses/overview)
-- [Cats Effect vs ZIO](https://softwaremill.com/cats-effect-vs-zio/) -- SoftwareMill
-- [Comparative Benchmarks](https://gist.github.com/djspiewak/f4cfc08e0827088f17032e0e9099d292) -- Daniel Spiewak
-- [Polymorphic Effects in Scala](https://timwspence.github.io/blog/posts/2020-11-22-polymorphic-effects-in-scala.html) -- Tim Spence
+- [Cats Effect documentation] -- Typelevel
+- [Cats Effect GitHub repository]
+- [Why Are Fibers Fast?] -- Typelevel Blog
+- [Concurrency in Cats Effect 3] -- Typelevel Blog
+- [Thread Model] -- Cats Effect Docs
+- [CE3 Proposal Issue #634]
+- [CE2 Typeclass Overview]
+- [Cats Effect vs ZIO] -- SoftwareMill
+- [Comparative Benchmarks] -- Daniel Spiewak
+- [Polymorphic Effects in Scala] -- Tim Spence
+
+<!-- References -->
+
+[ZIO]: scala-zio.md
+[github.com/typelevel/cats-effect]: https://github.com/typelevel/cats-effect
+[typelevel.org/cats-effect]: https://typelevel.org/cats-effect/
+[Cats Effect documentation]: https://typelevel.org/cats-effect/
+[Cats Effect GitHub repository]: https://github.com/typelevel/cats-effect
+[Why Are Fibers Fast?]: https://typelevel.org/blog/2021/02/21/fibers-fast-mkay.html
+[Concurrency in Cats Effect 3]: https://typelevel.org/blog/2020/10/30/concurrency-in-ce3.html
+[Thread Model]: https://typelevel.org/cats-effect/docs/thread-model
+[CE3 Proposal Issue #634]: https://github.com/typelevel/cats-effect/issues/634
+[CE2 Typeclass Overview]: https://typelevel.org/cats-effect/docs/2.x/typeclasses/overview
+[Cats Effect vs ZIO]: https://softwaremill.com/cats-effect-vs-zio/
+[Comparative Benchmarks]: https://gist.github.com/djspiewak/f4cfc08e0827088f17032e0e9099d292
+[Polymorphic Effects in Scala]: https://timwspence.github.io/blog/posts/2020-11-22-polymorphic-effects-in-scala.html

--- a/docs/research/algebraic-effects/scala-kyo.md
+++ b/docs/research/algebraic-effects/scala-kyo.md
@@ -1,13 +1,13 @@
 # Kyo (Scala)
 
-A powerful toolkit for Scala development based on algebraic effects, providing an open set of composable effects rather than a fixed number of effect channels. Kyo generalizes ZIO's effect rotation to support arbitrary effect types.
+A powerful toolkit for Scala development based on algebraic effects, providing an open set of composable effects rather than a fixed number of effect channels. Kyo generalizes [ZIO]'s effect rotation to support arbitrary effect types.
 
 | Field         | Value                                                         |
 | ------------- | ------------------------------------------------------------- |
 | Language      | Scala 3                                                       |
 | License       | Apache-2.0                                                    |
-| Repository    | [github.com/getkyo/kyo](https://github.com/getkyo/kyo)        |
-| Documentation | [getkyo.io](https://getkyo.io/)                               |
+| Repository    | [github.com/getkyo/kyo]                                       |
+| Documentation | [getkyo.io]                                                   |
 | Key Authors   | Flavio Brasil                                                 |
 | Approach      | Algebraic effects with modular handlers; open effect channels |
 
@@ -17,11 +17,11 @@ A powerful toolkit for Scala development based on algebraic effects, providing a
 
 ### What It Solves
 
-Kyo provides an algebraic effects system that goes beyond ZIO and Cats Effect by allowing an arbitrary number of user-defined effect types, not just the fixed error and environment channels. This enables more precise and granular control over computational context. Kyo achieves this without requiring category theory concepts or cryptic operators.
+Kyo provides an algebraic effects system that goes beyond [ZIO] and [Cats Effect] by allowing an arbitrary number of user-defined effect types, not just the fixed error and environment channels. This enables more precise and granular control over computational context. Kyo achieves this without requiring category theory concepts or cryptic operators.
 
 ### Design Philosophy
 
-Kyo brings algebraic effects to practical Scala programming. While ZIO provides two fixed effect channels (environment R and error E), Kyo allows developers to define and compose an open set of effects tailored to their specific needs. The design is direct-style-inspired, leveraging Scala 3's type system to minimize the distinction between `map` and `flatMap`.
+Kyo brings algebraic effects to practical Scala programming. While [ZIO] provides two fixed effect channels (environment R and error E), Kyo allows developers to define and compose an open set of effects tailored to their specific needs. The design is direct-style-inspired, leveraging Scala 3's type system to minimize the distinction between `map` and `flatMap`.
 
 ---
 
@@ -77,17 +77,17 @@ This removes the need to juggle between `map` and `flatMap`, allowing developers
 
 Kyo provides a comprehensive set of core effects:
 
-| Effect      | Purpose                            | Analogous To           |
-| ----------- | ---------------------------------- | ---------------------- |
-| `Abort[E]`  | Short-circuiting with error type E | ZIO's E channel        |
-| `Env[R]`    | Dependency injection               | ZIO's R channel        |
-| `IO`        | Side-effecting operations          | ZIO's IO               |
-| `Async`     | Fiber scheduling, parking          | ZIO's fiber operations |
-| `Resource`  | Resource lifecycle management      | ZIO's Scope            |
-| `Stream[V]` | Streaming values                   | ZIO Stream             |
-| `Var[V]`    | Mutable state                      | ZIO Ref                |
-| `Emit[V]`   | Emitting values                    | Writer effect          |
-| `Choice`    | Non-deterministic computation      | List/NonDet            |
+| Effect      | Purpose                            | Analogous To             |
+| ----------- | ---------------------------------- | ------------------------ |
+| `Abort[E]`  | Short-circuiting with error type E | [ZIO]'s E channel        |
+| `Env[R]`    | Dependency injection               | [ZIO]'s R channel        |
+| `IO`        | Side-effecting operations          | [ZIO]'s IO               |
+| `Async`     | Fiber scheduling, parking          | [ZIO]'s fiber operations |
+| `Resource`  | Resource lifecycle management      | [ZIO]'s Scope            |
+| `Stream[V]` | Streaming values                   | [ZIO] Stream             |
+| `Var[V]`    | Mutable state                      | [ZIO] Ref                |
+| `Emit[V]`   | Emitting values                    | Writer effect            |
+| `Choice`    | Non-deterministic computation      | List/NonDet              |
 
 ### Custom Effects
 
@@ -159,9 +159,9 @@ Kyo's performance comes from its algebraic effects architecture:
 2. **Minimal indirection**: Each effect handler directly processes its operations
 3. **Compile-time effect resolution**: Scala 3's type system resolves effect composition at compile time
 
-### Comparison with ZIO
+### Comparison with [ZIO]
 
-Where ZIO bakes two effects (R and E) into its type and adds overhead for the fixed channels, Kyo only pays for the effects actually used. A computation with a single `Abort[String]` effect does not carry unused environment or state machinery.
+Where [ZIO] bakes two effects (R and E) into its type and adds overhead for the fixed channels, Kyo only pays for the effects actually used. A computation with a single `Abort[String]` effect does not carry unused environment or state machinery.
 
 ### Stream Optimizations
 
@@ -178,16 +178,16 @@ While effectful `map` accepts pure functions (via automatic lifting), the `Pure`
 
 ### Open Effect Set
 
-Unlike ZIO (fixed to R, E) or Cats Effect (fixed typeclass hierarchy), Kyo allows arbitrary effect types:
+Unlike [ZIO] (fixed to R, E) or [Cats Effect] (fixed typeclass hierarchy), Kyo allows arbitrary effect types:
 
 ```scala
 // Mix any effects freely
 def program: Result < (Abort[AppError] & Env[Config] & Async & Stream[LogEntry]) = ???
 ```
 
-### Effect Rotation (Generalized from ZIO)
+### Effect Rotation (Generalized from [ZIO])
 
-Kyo generalizes ZIO's "effect rotation" mechanism. In ZIO, the R and E channels can be transformed independently (e.g., `mapError` transforms E without touching R). Kyo extends this to arbitrary effect channels -- each effect can be handled independently regardless of what other effects are present.
+Kyo generalizes [ZIO]'s "effect rotation" mechanism. In [ZIO], the R and E channels can be transformed independently (e.g., `mapError` transforms E without touching R). Kyo extends this to arbitrary effect channels -- each effect can be handled independently regardless of what other effects are present.
 
 ### Intersection Types for Composition
 
@@ -213,11 +213,11 @@ def myProgram: Result < MyEffects = ???
 ## Weaknesses
 
 - **Pre-1.0**: APIs have been frequently broken; not yet production-stable
-- **Smaller ecosystem**: Fewer libraries and integrations than ZIO or Cats Effect
+- **Smaller ecosystem**: Fewer libraries and integrations than [ZIO] or [Cats Effect]
 - **Scala 3 only**: Cannot be used with Scala 2.13 projects
 - **Learning curve**: Algebraic effects and the `<` type require adjustment
 - **Limited community**: Fewer resources, tutorials, and production experience
-- **Performance not yet fully benchmarked**: Less evidence than ZIO/CE
+- **Performance not yet fully benchmarked**: Less evidence than [ZIO]/[Cats Effect]
 
 ## Key Design Decisions and Trade-offs
 
@@ -243,10 +243,24 @@ def myProgram: Result < MyEffects = ???
 
 ## Sources
 
-- [Kyo GitHub repository](https://github.com/getkyo/kyo)
-- [Kyo website](https://getkyo.io/)
-- [Kyo on Scaladex](https://index.scala-lang.org/getkyo/kyo)
-- [Writing Modular Applications Using The Kyo Library](https://www.scalamatters.io/post/writing-modular-applications-using-the-kyo-library) -- Scala Matters
-- [What are Effect Systems and Why Do We Care?](https://idiomaticsoft.com/post/2024-01-02-effect-systems/) -- Idiomatic Soft
-- [Kyo -- Functional Scala 2023 slides](https://speakerdeck.com/fwbrasil/kyo-functional-scala-2023) -- Flavio Brasil
-- [Debasish Ghosh on Kyo's type encoding](https://x.com/debasishg/status/1881557372331856347)
+- [Kyo GitHub repository]
+- [Kyo website]
+- [Kyo on Scaladex]
+- [Writing Modular Applications Using The Kyo Library] -- Scala Matters
+- [What are Effect Systems and Why Do We Care?] -- Idiomatic Soft
+- [Kyo -- Functional Scala 2023 slides] -- Flavio Brasil
+- [Debasish Ghosh on Kyo's type encoding]
+
+<!-- References -->
+
+[ZIO]: scala-zio.md
+[Cats Effect]: scala-cats-effect.md
+[github.com/getkyo/kyo]: https://github.com/getkyo/kyo
+[getkyo.io]: https://getkyo.io/
+[Kyo GitHub repository]: https://github.com/getkyo/kyo
+[Kyo website]: https://getkyo.io/
+[Kyo on Scaladex]: https://index.scala-lang.org/getkyo/kyo
+[Writing Modular Applications Using The Kyo Library]: https://www.scalamatters.io/post/writing-modular-applications-using-the-kyo-library
+[What are Effect Systems and Why Do We Care?]: https://idiomaticsoft.com/post/2024-01-02-effect-systems/
+[Kyo -- Functional Scala 2023 slides]: https://speakerdeck.com/fwbrasil/kyo-functional-scala-2023
+[Debasish Ghosh on Kyo's type encoding]: https://x.com/debasishg/status/1881557372331856347

--- a/docs/research/algebraic-effects/scala-ox.md
+++ b/docs/research/algebraic-effects/scala-ox.md
@@ -6,8 +6,8 @@ Safe direct-style streaming, concurrency, and resiliency for Scala on the JVM. O
 | ------------- | ------------------------------------------------------------------------- |
 | Language      | Scala 3 (JVM only)                                                        |
 | License       | Apache-2.0                                                                |
-| Repository    | [github.com/softwaremill/ox](https://github.com/softwaremill/ox)          |
-| Documentation | [ox.softwaremill.com](https://ox.softwaremill.com/)                       |
+| Repository    | [github.com/softwaremill/ox]                                              |
+| Documentation | [ox.softwaremill.com]                                                     |
 | Key Authors   | Adam Warski, SoftwareMill                                                 |
 | Approach      | Direct style on virtual threads; IO capability; boundary/break for errors |
 
@@ -17,7 +17,7 @@ Safe direct-style streaming, concurrency, and resiliency for Scala on the JVM. O
 
 ### What It Solves
 
-Ox provides safe concurrency and error handling in direct style -- no monads, no `flatMap`, no effect wrappers. Computations return values directly, and effects are tracked through Scala 3's capability system. Ox targets the practical middle ground between unsafe imperative I/O and the complexity of monadic effect systems.
+Ox provides safe concurrency and error handling in direct style -- no monads, no `flatMap`, no effect wrappers. Computations return values directly, and effects are tracked through [Scala 3's capability system]. Ox targets the practical middle ground between unsafe imperative I/O and the complexity of monadic effect systems like [ZIO] or [Cats Effect].
 
 ### Design Philosophy
 
@@ -29,13 +29,13 @@ Direct style means that results of effectful computations are available directly
 
 ### No Wrapper Type
 
-Unlike ZIO (`ZIO[R,E,A]`) or Cats Effect (`IO[A]`), Ox does not have an effect wrapper. Functions return their result type directly:
+Unlike [ZIO] (`ZIO[R,E,A]`) or [Cats Effect] (`IO[A]`), Ox does not have an effect wrapper. Functions return their result type directly:
 
 ```scala
 // Ox style -- direct
 def fetchUser(id: UserId)(using Ox): User = ???
 
-// vs. ZIO style -- wrapped
+// vs. [ZIO] style -- wrapped
 def fetchUser(id: UserId): ZIO[Any, Error, User] = ???
 ```
 
@@ -174,24 +174,37 @@ Ox provides utilities for retry, rate limiting, timeout, and circuit breaking th
 - **Limited effect tracking**: Only IO and Ox capabilities; no user-defined effects
 - **Java 21+ required**: Needs modern JVM
 - **Not algebraic effects**: No continuation capture; no nondeterminism; no effect rotation
-- **Smaller ecosystem**: Fewer integrations than ZIO or Cats Effect
+- **Smaller ecosystem**: Fewer integrations than [ZIO] or [Cats Effect]
 
 ## Key Design Decisions and Trade-offs
 
-| Decision                  | Rationale                                     | Trade-off                                                     |
-| ------------------------- | --------------------------------------------- | ------------------------------------------------------------- |
-| Direct style (no wrapper) | Simplicity; readability; no monadic overhead  | Cannot abstract over effect implementation                    |
-| Virtual threads           | JVM-native concurrency; excellent performance | JVM-only; Java 21+ required                                   |
-| IO as capability          | Truthful method signatures                    | Cannot intercept or mock IO at type level                     |
-| Go-like channels          | Familiar model; proven design                 | Different paradigm from streaming libraries (fs2, ZIO Stream) |
-| No effect handlers        | Simplicity; lower learning curve              | Less flexibility; no testable effect interpretation           |
+| Decision                  | Rationale                                     | Trade-off                                                       |
+| ------------------------- | --------------------------------------------- | --------------------------------------------------------------- |
+| Direct style (no wrapper) | Simplicity; readability; no monadic overhead  | Cannot abstract over effect implementation                      |
+| Virtual threads           | JVM-native concurrency; excellent performance | JVM-only; Java 21+ required                                     |
+| IO as capability          | Truthful method signatures                    | Cannot intercept or mock IO at type level                       |
+| Go-like channels          | Familiar model; proven design                 | Different paradigm from streaming libraries (fs2, [ZIO] Stream) |
+| No effect handlers        | Simplicity; lower learning curve              | Less flexibility; no testable effect interpretation             |
 
 ---
 
 ## Sources
 
-- [Ox GitHub repository](https://github.com/softwaremill/ox)
-- [Ox documentation](https://ox.softwaremill.com/)
-- [IO Effect Tracking Using Ox](https://softwaremill.com/io-effect-tracking-using-ox/) -- SoftwareMill
-- [Direct style -- Ox documentation](https://ox.softwaremill.com/latest/basics/direct-style.html)
-- [How Functional is Direct-Style?](https://2025.workshop.scala-lang.org/details/scala-2025/1/How-Functional-is-Direct-Style-) -- Scala Workshop 2025
+- [Ox GitHub repository]
+- [Ox documentation]
+- [IO Effect Tracking Using Ox] -- SoftwareMill
+- [Direct style -- Ox documentation]
+- [How Functional is Direct-Style?] -- Scala Workshop 2025
+
+<!-- References -->
+
+[Scala 3's capability system]: scala-capabilities.md
+[ZIO]: scala-zio.md
+[Cats Effect]: scala-cats-effect.md
+[github.com/softwaremill/ox]: https://github.com/softwaremill/ox
+[ox.softwaremill.com]: https://ox.softwaremill.com/
+[Ox GitHub repository]: https://github.com/softwaremill/ox
+[Ox documentation]: https://ox.softwaremill.com/
+[IO Effect Tracking Using Ox]: https://softwaremill.com/io-effect-tracking-using-ox/
+[Direct style -- Ox documentation]: https://ox.softwaremill.com/latest/basics/direct-style.html
+[How Functional is Direct-Style?]: https://2025.workshop.scala-lang.org/details/scala-2025/1/How-Functional-is-Direct-Style-

--- a/docs/research/algebraic-effects/scala-zio.md
+++ b/docs/research/algebraic-effects/scala-zio.md
@@ -6,8 +6,8 @@ A zero-dependency Scala library for asynchronous and concurrent programming, pro
 | ------------- | ---------------------------------------------------- |
 | Language      | Scala 2.13 / Scala 3                                 |
 | License       | Apache-2.0                                           |
-| Repository    | [github.com/zio/zio](https://github.com/zio/zio)     |
-| Documentation | [zio.dev](https://zio.dev)                           |
+| Repository    | [github.com/zio/zio]                                 |
+| Documentation | [zio.dev]                                            |
 | Key Authors   | John De Goes (Ziverge)                               |
 | Approach      | Fiber-based runtime with three-parameter effect type |
 
@@ -168,7 +168,7 @@ This avoids the overhead of generic monad transformer stacking.
 
 ### Memory Footprint
 
-ZIO fibers carry more context than Cats Effect fibers (roughly 3x larger memory footprint), which is the cost of the richer built-in features (typed errors, environment, etc.).
+ZIO fibers carry more context than [Cats Effect] fibers (roughly 3x larger memory footprint), which is the cost of the richer built-in features (typed errors, environment, etc.).
 
 ---
 
@@ -220,10 +220,10 @@ Built-in concurrent data structures:
 ## Weaknesses
 
 - **Not true algebraic effects**: Fixed to two effect channels (R and E); cannot define arbitrary new effect types
-- **Heavier fibers**: ~3x memory overhead compared to Cats Effect fibers
+- **Heavier fibers**: ~3x memory overhead compared to [Cats Effect] fibers
 - **No tagless final**: Concrete `ZIO` type; cannot abstract over effect implementation
 - **Learning curve**: Three type parameters and the layer system take time to master
-- **Ecosystem fragmentation**: Some libraries support only Cats Effect or only ZIO
+- **Ecosystem fragmentation**: Some libraries support only [Cats Effect] or only ZIO
 - **Scala market decline**: Fewer companies adopting Scala for new projects
 
 ## Key Design Decisions and Trade-offs
@@ -251,11 +251,25 @@ Built-in concurrent data structures:
 
 ## Sources
 
-- [ZIO documentation](https://zio.dev)
-- [ZIO GitHub repository](https://github.com/zio/zio)
-- [ZIO in 2025](https://www.ziverge.com/post/zio-in-2025) -- Ziverge
-- [ZIO core reference](https://zio.dev/reference/core/zio/)
-- [Getting Started with DI in ZIO](https://zio.dev/reference/di/dependency-injection-in-zio/)
-- [The Tri-Z Architecture](https://blog.pierre-ricadat.com/the-tri-z-architecture-a-pattern-for-layering-zio-applications-in-scala)
-- [Structuring ZIO 2 Applications](https://softwaremill.com/structuring-zio-2-applications/) -- SoftwareMill
-- [Cats Effect vs ZIO](https://softwaremill.com/cats-effect-vs-zio/) -- SoftwareMill
+- [ZIO documentation]
+- [ZIO GitHub repository]
+- [ZIO in 2025] -- Ziverge
+- [ZIO core reference]
+- [Getting Started with DI in ZIO]
+- [The Tri-Z Architecture]
+- [Structuring ZIO 2 Applications] -- SoftwareMill
+- [Cats Effect vs ZIO] -- SoftwareMill
+
+<!-- References -->
+
+[Cats Effect]: scala-cats-effect.md
+[github.com/zio/zio]: https://github.com/zio/zio
+[zio.dev]: https://zio.dev
+[ZIO documentation]: https://zio.dev
+[ZIO GitHub repository]: https://github.com/zio/zio
+[ZIO in 2025]: https://www.ziverge.com/post/zio-in-2025
+[ZIO core reference]: https://zio.dev/reference/core/zio/
+[Getting Started with DI in ZIO]: https://zio.dev/reference/di/dependency-injection-in-zio/
+[The Tri-Z Architecture]: https://blog.pierre-ricadat.com/the-tri-z-architecture-a-pattern-for-layering-zio-applications-in-scala
+[Structuring ZIO 2 Applications]: https://softwaremill.com/structuring-zio-2-applications/
+[Cats Effect vs ZIO]: https://softwaremill.com/cats-effect-vs-zio/

--- a/docs/research/algebraic-effects/swift-effects.md
+++ b/docs/research/algebraic-effects/swift-effects.md
@@ -6,8 +6,8 @@ A modern implementation of effect tracking in a mainstream systems language, com
 | ------------- | -------------------------------------------------------------------------- |
 | Language      | Swift 6.x                                                                  |
 | License       | Apache-2.0                                                                 |
-| Repository    | [github.com/swiftlang/swift](https://github.com/swiftlang/swift)           |
-| Documentation | [swift.org](https://swift.org/documentation/concurrency/)                  |
+| Repository    | [github.com/swiftlang/swift]                                               |
+| Documentation | [swift.org]                                                                |
 | Key Authors   | John McCall, Joe Groff, Doug Gregor                                        |
 | Approach      | Keyword-based effect specifiers (async, throws) with full data-race safety |
 
@@ -89,6 +89,14 @@ Actors serve as a "contextual handler" for concurrency. Code running within an a
 
 ## Sources
 
-- [Swift Concurrency Manifest](https://github.com/swiftlang/swift/blob/main/docs/Concurrency/Manifesto.md)
-- [SE-0310: Effectful Read-only Properties](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0310-effectful-readonly-properties.md)
-- [SE-0413: Typed Throws](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md)
+- [Swift Concurrency Manifest]
+- [SE-0310: Effectful Read-only Properties]
+- [SE-0413: Typed Throws]
+
+<!-- References -->
+
+[github.com/swiftlang/swift]: https://github.com/swiftlang/swift
+[swift.org]: https://swift.org/documentation/concurrency/
+[Swift Concurrency Manifest]: https://github.com/swiftlang/swift/blob/main/docs/Concurrency/Manifesto.md
+[SE-0310: Effectful Read-only Properties]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0310-effectful-readonly-properties.md
+[SE-0413: Typed Throws]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md

--- a/docs/research/algebraic-effects/theory-compilation.md
+++ b/docs/research/algebraic-effects/theory-compilation.md
@@ -28,7 +28,7 @@ Monads provide equational laws (e.g., the state monad laws guarantee that `get` 
 
 ## Evidence Passing
 
-The paper "Effect Handlers, Evidently" (Xie, Brachthaeuser, Hillerstroemm, Schuster, Leijen, ICFP 2020) introduced _evidence-passing semantics_ for algebraic effect handlers. The core idea is to compile away the runtime search for a handler by threading evidence -- a proof that a handler exists -- directly to each operation call.
+The paper "Effect Handlers, Evidently" (Xie, Brachthaeuser, Hillerstroemm, Schuster, Leijen, ICFP 2020) introduced _evidence-passing semantics_ for algebraic effect handlers. The core idea is to compile away the runtime search for a handler by threading evidence -- a proof that a handler exists -- directly to each operation call. This technique is used by [effectful], [cleff], and [Koka].
 
 ### Evidence Vectors
 
@@ -44,9 +44,9 @@ When an operation is invoked, it indexes into the evidence vector to find the ha
 
 The original evidence-passing translation requires _scoped resumptions_: when a handler resumes a captured continuation, the resumed computation runs under the same set of handlers it had before being suspended. This rules out "non-scoped" uses where a resumption is invoked under a different handler configuration, which the authors argue is undesirable in practice because it breaks local reasoning about effects.
 
-### The effectful Library
+### The [effectful] Library
 
-Haskell's effectful library applies a pragmatic version of evidence passing. Its `Eff` monad is essentially `ReaderT Env IO`, where `Env` is a mutable environment indexed by **Int-based offsets**. Looking up a handler is an O(1) array index operation. The `:>` constraint carries evidence that an effect exists in the environment. This design achieves performance on par with hand-written `ST` code for static dispatch and outperforms mtl for dynamic dispatch.
+Haskell's [effectful] library applies a pragmatic version of evidence passing. Its `Eff` monad is essentially `ReaderT Env IO`, where `Env` is a mutable environment indexed by **Int-based offsets**. Looking up a handler is an O(1) array index operation. The `:>` constraint carries evidence that an effect exists in the environment. This design achieves performance on par with hand-written `ST` code for static dispatch and outperforms mtl for dynamic dispatch.
 
 ### Generalized Evidence Passing
 
@@ -58,17 +58,17 @@ The follow-up paper "Generalized Evidence Passing for Effect Handlers" (Xie, Lei
 
 An alternative framing views effects not as labels in a type-level row but as **capabilities**: values that grant permission to perform operations. A function can only perform an effect if it holds a handle to the corresponding capability. This connects to the object-capability security model, where authority is determined by which references are in scope.
 
-### Bluefin (Haskell)
+### [Bluefin] (Haskell)
 
-Bluefin represents effects as value-level handles rather than type-level labels. Each handle is scoped using a mechanism similar to Haskell's `ST` trick: the handle cannot escape the lexical scope of its handler. Having two `State Int` effects in scope is trivial because they are distinct values, whereas type-level approaches require awkward disambiguation. The bluefin-algae extension adds algebraic effects on top of this design using GHC's delimited continuation primops.
+[Bluefin] represents effects as value-level handles rather than type-level labels. Each handle is scoped using a mechanism similar to Haskell's `ST` trick: the handle cannot escape the lexical scope of its handler. Having two `State Int` effects in scope is trivial because they are distinct values, whereas type-level approaches require awkward disambiguation. The bluefin-algae extension adds algebraic effects on top of this design using GHC's delimited continuation primops.
 
-### Scala 3 Capture Checking
+### [Scala 3 Capture Checking]
 
-Scala 3 introduces capture checking as an experimental feature that tracks which capabilities a value captures through the type system. Rather than adding a separate effect row, it extends the existing type system: a closure type `A -> B` becomes `A ->{c1, c2} B` indicating that the closure captures capabilities `c1` and `c2`. Effect polymorphism emerges naturally -- `map` is classified as pure because it does not use capabilities itself, but its type propagates the capabilities of whatever function argument is passed to it. Minimal annotations are needed for strict code; they only become necessary for delayed effects (lazy lists, side-effecting iterators).
+Scala 3 introduces [capture checking] as an experimental feature that tracks which capabilities a value captures through the type system. Rather than adding a separate effect row, it extends the existing type system: a closure type `A -> B` becomes `A ->{c1, c2} B` indicating that the closure captures capabilities `c1` and `c2`. Effect polymorphism emerges naturally -- `map` is classified as pure because it does not use capabilities itself, but its type propagates the capabilities of whatever function argument is passed to it. Minimal annotations are needed for strict code; they only become necessary for delayed effects (lazy lists, side-effecting iterators).
 
-### OCaml Eio
+### [OCaml Eio]
 
-Eio, the effects-based direct-style IO library for OCaml 5, adopts an object-capability model. All authority originates at `Eio_main.run`, which receives an `env` value containing capabilities for the network, filesystem, clock, and so on. Functions receive only the capabilities they need. For example, a function that only takes a `net` capability visibly cannot access the filesystem. Since OCaml is not a pure capability language, code can bypass Eio and use the stdlib directly, but the design still aids auditing and testing of non-malicious code.
+[Eio], the effects-based direct-style IO library for [OCaml 5], adopts an object-capability model. All authority originates at `Eio_main.run`, which receives an `env` value containing capabilities for the network, filesystem, clock, and so on. Functions receive only the capabilities they need. For example, a function that only takes a `net` capability visibly cannot access the filesystem. Since OCaml is not a pure capability language, code can bypass Eio and use the stdlib directly, but the design still aids auditing and testing of non-malicious code.
 
 ### Benefits of Capability Passing
 
@@ -83,9 +83,9 @@ Eio, the effects-based direct-style IO library for OCaml 5, adopts an object-cap
 
 A type-and-effect system extends a standard type system to track not only the types of expressions but also their computational effects. The design of the effect type language has significant consequences for usability and expressiveness.
 
-### Row Polymorphism (Koka, Links)
+### Row Polymorphism ([Koka], Links)
 
-Koka and Links represent effect types as _rows_ -- extensible sequences of effect labels. A function type carries its effect row: `(a) -> e b` means "given `a`, produces `b` with effects `e`." Row polymorphism allows abstracting over unknown effects:
+[Koka] and Links represent effect types as _rows_ -- extensible sequences of effect labels. A function type carries its effect row: `(a) -> e b` means "given `a`, produces `b` with effects `e`." Row polymorphism allows abstracting over unknown effects:
 
 ```koka
 fun map(xs : list<a>, f : (a) -> e b) : e list<b>
@@ -110,17 +110,17 @@ Subeffecting is a subtyping-like relation on effects: a pure computation can be 
 
 ### Effect Inference
 
-Many effect systems infer effects automatically. Koka infers full effect types without programmer annotations. The challenge intensifies with higher-rank polymorphism and subeffecting: the recent paper "Deciding not to Decide: Sound and Complete Effect Inference" (2025) addresses these interactions by delaying constraint solving and reducing effect constraints to propositional logic.
+Many effect systems infer effects automatically. [Koka] infers full effect types without programmer annotations. The challenge intensifies with higher-rank polymorphism and subeffecting: the recent paper "Deciding not to Decide: Sound and Complete Effect Inference" (2025) addresses these interactions by delaying constraint solving and reducing effect constraints to propositional logic.
 
-### Untyped Effects (OCaml 5)
+### Untyped Effects ([OCaml 5])
 
-OCaml 5 introduced algebraic effects without typing them -- effects are not tracked in function signatures. This was a pragmatic decision: the delta for OCaml 5 was already large (multicore GC plus effects), and typed effects will be introduced in a future release. The trade-off is clear: untyped effects provide the runtime benefits (structured concurrency, direct-style IO, no monadic overhead) without the static safety guarantees. An unhandled effect is a runtime error, not a compile-time one.
+[OCaml 5] introduced algebraic effects without typing them -- effects are not tracked in function signatures. This was a pragmatic decision: the delta for OCaml 5 was already large (multicore GC plus effects), and typed effects will be introduced in a future release. The trade-off is clear: untyped effects provide the runtime benefits (structured concurrency, direct-style IO, no monadic overhead) without the static safety guarantees. An unhandled effect is a runtime error, not a compile-time one.
 
 ---
 
 ## Compilation Strategies
 
-Compiling algebraic effects efficiently is challenging because effect handlers capture delimited continuations -- slices of the execution context that can be suspended and resumed. Different strategies make different trade-offs between generality, performance, and implementation complexity.
+Compiling algebraic effects efficiently is challenging because effect handlers capture delimited continuations -- slices of the execution context that can be suspended and resumed. Different strategies make different trade-offs between generality, performance, and implementation complexity. See [WasmFX] for a cross-language compilation target for effect handlers.
 
 ### CPS Transformation
 
@@ -154,7 +154,7 @@ Capture and restore actual stack frames at runtime. The program runs on segmente
 
 Only CPS-transform functions whose types indicate they may capture continuations. Functions that are total or only use tail-resumptive effects remain in direct style.
 
-- **Pros**: Minimizes code expansion (in Koka, less than 20% of core library functions need CPS); preserves tail calls for pure code.
+- **Pros**: Minimizes code expansion (in [Koka], less than 20% of core library functions need CPS); preserves tail calls for pure code.
 - **Cons**: Requires type-directed analysis; polymorphic effect variables need special handling (code duplication to pick the correct runtime representation).
 
 ### Bubble Semantics (Yield Bubbling)
@@ -166,14 +166,14 @@ When an operation needs to capture a continuation, it sets a thread-local flag a
 
 ### Comparison
 
-| Strategy                  | Languages / Libraries               | Performance                                     | Continuation Support               | Complexity                              |
-| ------------------------- | ----------------------------------- | ----------------------------------------------- | ---------------------------------- | --------------------------------------- |
-| CPS transformation        | Links (JS backend)                  | Moderate; code bloat from full CPS              | Full multi-shot                    | Low (well-understood transform)         |
-| Monadic translation       | Eff (original), Haskell free/freer  | Slow; allocation per bind                       | Full multi-shot                    | Low                                     |
-| Evidence passing          | effectful, Ev.Eff, Koka (partial)   | Fast; O(1) dispatch, zero-alloc tail-resumptive | One-shot (scoped)                  | Medium (type-directed)                  |
-| Direct stack manipulation | OCaml 5 fibers, GHC primops, WasmFX | Fastest; native call conventions                | One-shot (OCaml), multi-shot (GHC) | High (runtime support)                  |
-| Selective CPS             | Koka (C backend)                    | Fast; direct style on pure paths                | Full (via CPS'd paths)             | Medium (type-directed code duplication) |
-| Bubble semantics / yield  | Koka (generalized), Mp.Eff          | Fast; flag check on pure path                   | Full one-shot                      | Medium-high                             |
+| Strategy                  | Languages / Libraries                   | Performance                                     | Continuation Support               | Complexity                              |
+| ------------------------- | --------------------------------------- | ----------------------------------------------- | ---------------------------------- | --------------------------------------- |
+| CPS transformation        | Links (JS backend)                      | Moderate; code bloat from full CPS              | Full multi-shot                    | Low (well-understood transform)         |
+| Monadic translation       | Eff (original), Haskell free/freer      | Slow; allocation per bind                       | Full multi-shot                    | Low                                     |
+| Evidence passing          | [effectful], Ev.Eff, [Koka] (partial)   | Fast; O(1) dispatch, zero-alloc tail-resumptive | One-shot (scoped)                  | Medium (type-directed)                  |
+| Direct stack manipulation | [OCaml 5] fibers, GHC primops, [WasmFX] | Fastest; native call conventions                | One-shot (OCaml), multi-shot (GHC) | High (runtime support)                  |
+| Selective CPS             | [Koka] (C backend)                      | Fast; direct style on pure paths                | Full (via CPS'd paths)             | Medium (type-directed code duplication) |
+| Bubble semantics / yield  | [Koka] (generalized), Mp.Eff            | Fast; flag check on pure path                   | Full one-shot                      | Medium-high                             |
 
 ---
 
@@ -185,7 +185,7 @@ The evidence-passing compilation pipeline deserves closer examination because it
 
 An operation is **tail-resumptive** if its handler clause resumes the continuation in tail position and does nothing afterward. The canonical examples are `State` operations:
 
-```
+```text
 get ()  -> resume(s)          -- returns the state and resumes
 put(s') -> resume(())         -- updates the state and resumes
 ```
@@ -213,30 +213,64 @@ In practice, the vast majority of effect operations in real programs are tail-re
 
 ### Effect-Selective Monadic Translation
 
-Koka's compiler combines evidence passing with a type-selective monadic translation: functions whose effect type is total (no effects) are compiled without monadic wrapping at all. Functions that use only tail-resumptive effects get evidence-passing dispatch but no monadic overhead. Only functions that may perform general (non-tail-resumptive) operations are compiled monadically. This ensures the fast path -- the overwhelmingly common path -- incurs no allocation.
+[Koka]'s compiler combines evidence passing with a type-selective monadic translation: functions whose effect type is total (no effects) are compiled without monadic wrapping at all. Functions that use only tail-resumptive effects get evidence-passing dispatch but no monadic overhead. Only functions that may perform general (non-tail-resumptive) operations are compiled monadically. This ensures the fast path -- the overwhelmingly common path -- incurs no allocation.
 
 ---
 
 ## Sources
 
-- [Notions of Computation Determine Monads](https://link.springer.com/chapter/10.1007/3-540-45931-6_24) -- Plotkin, Power (FoSSaCS 2002)
-- [Handlers of Algebraic Effects](https://homepages.inf.ed.ac.uk/gdp/publications/Effect_Handlers.pdf) -- Plotkin, Pretnar (ESOP 2009)
-- [Algebraic Effects for Functional Programming](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf) -- Leijen (MSR-TR-2016-29)
-- [Koka: Programming with Row-Polymorphic Effect Types](https://arxiv.org/abs/1406.2061) -- Leijen (2014)
-- [Type Directed Compilation of Row-Typed Algebraic Effects](https://dl.acm.org/doi/10.1145/3093333.3009872) -- Leijen (POPL 2017)
-- [Effect Handlers, Evidently](https://dl.acm.org/doi/10.1145/3408981) -- Xie, Brachthaeuser, Hillerstroemm, Schuster, Leijen (ICFP 2020)
-- [Generalized Evidence Passing for Effect Handlers](https://dl.acm.org/doi/10.1145/3473576) -- Xie, Leijen (ICFP 2021)
-- [Implementing Algebraic Effects in C](https://www.microsoft.com/en-us/research/publication/implementing-algebraic-effects-in-c/) -- Leijen (APLAS 2017)
-- [Retrofitting Effect Handlers onto OCaml](https://dl.acm.org/doi/pdf/10.1145/3453483.3454039) -- Sivaramakrishnan et al. (PLDI 2021)
-- [Continuation Passing Style for Effect Handlers](https://homepages.inf.ed.ac.uk/slindley/papers/handlers-cps.pdf) -- Hillerstroemm, Lindley, Atkey, Sivaramakrishnan
-- [Continuing WebAssembly with Effect Handlers](https://dl.acm.org/doi/10.1145/3622814) -- Phipps-Costin et al. (OOPSLA 2023)
-- [Delimited Continuation Primops -- GHC Proposal #313](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst)
-- [Monad Transformers and Modular Algebraic Effects](https://www.fceia.unr.edu.ar/~mauro/pubs/haskell2019.pdf) -- Schrijvers, Pirog, Wu, Jaskelioff (Haskell 2019)
-- [Capture Checking -- Scala 3 Reference](https://docs.scala-lang.org/scala3/reference/experimental/cc.html)
-- [Eio -- Effects-Based Direct-Style IO for OCaml 5](https://github.com/ocaml-multicore/eio)
-- [Bluefin -- Haskell Effect System](https://hackage.haskell.org/package/bluefin)
-- [effectful -- Haskell Effect Library](https://hackage.haskell.org/package/effectful)
-- [Convenient Explicit Effects](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/effects-techreport-2010.pdf) -- Leijen (MSR-TR-2010)
-- [Explicit Effect Subtyping](https://www.cambridge.org/core/journals/journal-of-functional-programming/article/explicit-effect-subtyping/4851B1C994BEAAB7F04A58B60F11D0AF) -- Koprivec, Pretnar (JFP)
-- [libmprompt -- Multi-Prompt Delimited Control in C/C++](https://github.com/koka-lang/libmprompt)
-- [effects-bibliography](https://github.com/yallop/effects-bibliography) -- Yallop et al.
+- [Notions of Computation Determine Monads] -- Plotkin, Power (FoSSaCS 2002)
+- [Handlers of Algebraic Effects] -- Plotkin, Pretnar (ESOP 2009)
+- [Algebraic Effects for Functional Programming] -- Leijen (MSR-TR-2016-29)
+- [Koka: Programming with Row-Polymorphic Effect Types] -- Leijen (2014)
+- [Type Directed Compilation of Row-Typed Algebraic Effects] -- Leijen (POPL 2017)
+- [Effect Handlers, Evidently] -- Xie, Brachthaeuser, Hillerstroemm, Schuster, Leijen (ICFP 2020)
+- [Generalized Evidence Passing for Effect Handlers] -- Xie, Leijen (ICFP 2021)
+- [Implementing Algebraic Effects in C] -- Leijen (APLAS 2017)
+- [Retrofitting Effect Handlers onto OCaml] -- Sivaramakrishnan et al. (PLDI 2021)
+- [Continuation Passing Style for Effect Handlers] -- Hillerstroemm, Lindley, Atkey, Sivaramakrishnan
+- [Continuing WebAssembly with Effect Handlers] -- Phipps-Costin et al. (OOPSLA 2023)
+- [Delimited Continuation Primops -- GHC Proposal #313]
+- [Monad Transformers and Modular Algebraic Effects] -- Schrijvers, Pirog, Wu, Jaskelioff (Haskell 2019)
+- [Capture Checking -- Scala 3 Reference]
+- [Eio -- Effects-Based Direct-Style IO for OCaml 5]
+- [Bluefin -- Haskell Effect System]
+- [effectful -- Haskell Effect Library]
+- [Convenient Explicit Effects] -- Leijen (MSR-TR-2010)
+- [Explicit Effect Subtyping] -- Koprivec, Pretnar (JFP)
+- [libmprompt -- Multi-Prompt Delimited Control in C/C++]
+- [effects-bibliography] -- Yallop et al.
+
+<!-- References -->
+
+[effectful]: haskell-effectful.md
+[cleff]: haskell-cleff.md
+[Koka]: koka.md
+[Bluefin]: haskell-bluefin.md
+[capture checking]: scala-capabilities.md
+[Eio]: ocaml-eio.md
+[OCaml 5]: ocaml-effects.md
+[OCaml 5 fibers]: ocaml-effects.md
+[WasmFX]: wasmfx.md
+[evolution]: evolution.md
+[Notions of Computation Determine Monads]: https://link.springer.com/chapter/10.1007/3-540-45931-6_24
+[Handlers of Algebraic Effects]: https://homepages.inf.ed.ac.uk/gdp/publications/Effect_Handlers.pdf
+[Algebraic Effects for Functional Programming]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf
+[Koka: Programming with Row-Polymorphic Effect Types]: https://arxiv.org/abs/1406.2061
+[Type Directed Compilation of Row-Typed Algebraic Effects]: https://dl.acm.org/doi/10.1145/3093333.3009872
+[Effect Handlers, Evidently]: https://dl.acm.org/doi/10.1145/3408981
+[Generalized Evidence Passing for Effect Handlers]: https://dl.acm.org/doi/10.1145/3473576
+[Implementing Algebraic Effects in C]: https://www.microsoft.com/en-us/research/publication/implementing-algebraic-effects-in-c/
+[Retrofitting Effect Handlers onto OCaml]: https://dl.acm.org/doi/pdf/10.1145/3453483.3454039
+[Continuation Passing Style for Effect Handlers]: https://homepages.inf.ed.ac.uk/slindley/papers/handlers-cps.pdf
+[Continuing WebAssembly with Effect Handlers]: https://dl.acm.org/doi/10.1145/3622814
+[Delimited Continuation Primops -- GHC Proposal #313]: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0313-delimited-continuation-primops.rst
+[Monad Transformers and Modular Algebraic Effects]: https://www.fceia.unr.edu.ar/~mauro/pubs/haskell2019.pdf
+[Capture Checking -- Scala 3 Reference]: https://docs.scala-lang.org/scala3/reference/experimental/cc.html
+[Eio -- Effects-Based Direct-Style IO for OCaml 5]: https://github.com/ocaml-multicore/eio
+[Bluefin -- Haskell Effect System]: https://hackage.haskell.org/package/bluefin
+[effectful -- Haskell Effect Library]: https://hackage.haskell.org/package/effectful
+[Convenient Explicit Effects]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/effects-techreport-2010.pdf
+[Explicit Effect Subtyping]: https://www.cambridge.org/core/journals/journal-of-functional-programming/article/explicit-effect-subtyping/4851B1C994BEAAB7F04A58B60F11D0AF
+[libmprompt -- Multi-Prompt Delimited Control in C/C++]: https://github.com/koka-lang/libmprompt
+[effects-bibliography]: https://github.com/yallop/effects-bibliography

--- a/docs/research/algebraic-effects/typescript-effect.md
+++ b/docs/research/algebraic-effects/typescript-effect.md
@@ -1,15 +1,15 @@
 # Effect (TypeScript)
 
-Effect is a production-focused TypeScript effect framework inspired by ZIO, centered on the `Effect<A, E, R>` type and a fiber runtime.
+Effect is a production-focused TypeScript effect framework inspired by [ZIO], centered on the `Effect<A, E, R>` type and a fiber runtime.
 
 **Last reviewed:** February 16, 2026.
 
-| Field      | Value                                                              |
-| ---------- | ------------------------------------------------------------------ |
-| Language   | TypeScript                                                         |
-| Repository | [github.com/Effect-TS/effect](https://github.com/Effect-TS/effect) |
-| Docs       | [effect.website](https://effect.website/)                          |
-| License    | MIT                                                                |
+| Field      | Value                         |
+| ---------- | ----------------------------- |
+| Language   | TypeScript                    |
+| Repository | [github.com/Effect-TS/effect] |
+| Docs       | [effect.website]              |
+| License    | MIT                           |
 
 ---
 
@@ -100,11 +100,11 @@ Layers are memoized (each constructed once per scope), integrate with `Scope` fo
 
 Sources:
 
-- [Using Generators](https://effect.website/docs/getting-started/using-generators/)
-- [Services](https://effect.website/docs/requirements-management/services/)
-- [Layers](https://effect.website/docs/requirements-management/layers/)
-- [Fibers](https://effect.website/docs/concurrency/fibers/)
-- [Scope](https://effect.website/docs/resource-management/scope/)
+- [Using Generators]
+- [Services]
+- [Layers]
+- [Fibers]
+- [Scope]
 
 ---
 
@@ -114,7 +114,7 @@ Sources:
 
 The primary `effect` repository publishes an active **3.x** release line (for example, `effect@3.19.17` released February 16, 2026).
 
-Source: [GitHub releases](https://github.com/Effect-TS/effect/releases)
+Source: [GitHub releases]
 
 ### v4 direction
 
@@ -127,8 +127,8 @@ Implication:
 
 Sources:
 
-- [Effect Days 2025 announcement](https://effect.website/blog/events/effect-days-2025/)
-- [effect-smol repository](https://github.com/Effect-TS/effect-smol)
+- [Effect Days 2025 announcement]
+- [effect-smol repository]
 
 ---
 
@@ -150,9 +150,9 @@ Sources:
 
 ## Comparison Note
 
-Effect and ZIO share similar design goals and type shape:
+Effect and [ZIO] share similar design goals and type shape:
 
-| ZIO Concept          | Effect Equivalent                  |
+| [ZIO] Concept        | Effect Equivalent                  |
 | -------------------- | ---------------------------------- |
 | `ZIO[R, E, A]`       | `Effect<A, E, R>`                  |
 | `ZLayer[In, E, Out]` | `Layer<Out, E, In>`                |
@@ -166,13 +166,31 @@ TypeScript constraints (runtime model, type system ergonomics, JS interoperabili
 
 ## Sources
 
-- [Effect documentation](https://effect.website/)
-- [Effect GitHub repository](https://github.com/Effect-TS/effect)
-- [Effect GitHub releases](https://github.com/Effect-TS/effect/releases)
-- [Using Generators](https://effect.website/docs/getting-started/using-generators/)
-- [Services](https://effect.website/docs/requirements-management/services/)
-- [Layers](https://effect.website/docs/requirements-management/layers/)
-- [Fibers](https://effect.website/docs/concurrency/fibers/)
-- [Scope](https://effect.website/docs/resource-management/scope/)
-- [Effect Days 2025](https://effect.website/blog/events/effect-days-2025/)
-- [effect-smol repository](https://github.com/Effect-TS/effect-smol)
+- [Effect documentation]
+- [Effect GitHub repository]
+- [Effect GitHub releases]
+- [Using Generators]
+- [Services]
+- [Layers]
+- [Fibers]
+- [Scope]
+- [Effect Days 2025]
+- [effect-smol repository]
+
+<!-- References -->
+
+[ZIO]: scala-zio.md
+[github.com/Effect-TS/effect]: https://github.com/Effect-TS/effect
+[effect.website]: https://effect.website/
+[Using Generators]: https://effect.website/docs/getting-started/using-generators/
+[Services]: https://effect.website/docs/requirements-management/services/
+[Layers]: https://effect.website/docs/requirements-management/layers/
+[Fibers]: https://effect.website/docs/concurrency/fibers/
+[Scope]: https://effect.website/docs/resource-management/scope/
+[GitHub releases]: https://github.com/Effect-TS/effect/releases
+[Effect Days 2025 announcement]: https://effect.website/blog/events/effect-days-2025/
+[effect-smol repository]: https://github.com/Effect-TS/effect-smol
+[Effect documentation]: https://effect.website/
+[Effect GitHub repository]: https://github.com/Effect-TS/effect
+[Effect GitHub releases]: https://github.com/Effect-TS/effect/releases
+[Effect Days 2025]: https://effect.website/blog/events/effect-days-2025/

--- a/docs/research/algebraic-effects/unison.md
+++ b/docs/research/algebraic-effects/unison.md
@@ -6,8 +6,8 @@ A statically-typed functional programming language with content-addressed code a
 | ------------- | ------------------------------------------------------------------------------------------ |
 | Language      | Unison                                                                                     |
 | License       | MIT                                                                                        |
-| Repository    | [github.com/unisonweb/unison](https://github.com/unisonweb/unison)                         |
-| Documentation | [unison-lang.org/docs](https://www.unison-lang.org/docs/)                                  |
+| Repository    | [github.com/unisonweb/unison]                                                              |
+| Documentation | [unison-lang.org/docs]                                                                     |
 | Key Authors   | Paul Chiusano, Runar Bjarnason, Arya Irani                                                 |
 | Encoding      | Abilities (algebraic effects) with content-addressed code storage and ambient polymorphism |
 
@@ -21,7 +21,7 @@ Unison addresses several interconnected problems. First, it provides an effect s
 
 ### Design Philosophy
 
-Unison's abilities system is directly inspired by the Frank language (Lindley, McBride, McLaughlin, 2017). Like Frank, Unison uses ambient ability polymorphism where effects propagate inward through the typing context rather than accumulating outward. However, Unison diverges from Frank in two key ways: ability polymorphism is provided by ordinary polymorphic type variables rather than implicit ambient propagation, and ability handling uses an explicit `handle ... with` construct rather than overloading function application.
+Unison's abilities system is directly inspired by the [Frank] language (Lindley, McBride, McLaughlin, 2017). Like [Frank], Unison uses ambient ability polymorphism where effects propagate inward through the typing context rather than accumulating outward. However, Unison diverges from [Frank] in two key ways: ability polymorphism is provided by ordinary polymorphic type variables rather than implicit ambient propagation, and ability handling uses an explicit `handle ... with` construct rather than overloading function application.
 
 The content-addressed codebase is Unison's other foundational idea. Code is stored as hashed abstract syntax trees in a database (not as text files), managed by the Unison Codebase Manager (UCM). Names are metadata pointing to hashes, so renaming never breaks anything, there are no build steps, and dependency conflicts based on name collisions are eliminated. This design also enables Unison Cloud, where functions can be deployed to remote nodes by hash reference.
 
@@ -287,27 +287,43 @@ Unison provides several built-in abilities:
 
 ## Key Design Decisions and Trade-offs
 
-| Decision                                  | Rationale                                                                             | Trade-off                                                                                         |
-| ----------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| Content-addressed code                    | Eliminates builds, enables distributed deployment, perfect caching                    | Abandons text-file workflow; incompatible with traditional VCS and tooling                        |
-| Abilities over monads                     | Direct-style programming; effects as function properties, not value wrappers          | Less mature ecosystem than Haskell's monad transformer libraries                                  |
-| Explicit `handle ... with` (unlike Frank) | Clearer separation between using and handling effects                                 | More verbose than Frank's implicit handler syntax                                                 |
-| Structural vs unique abilities            | Structural enables cross-library compatibility; unique prevents accidental conflation | Users must choose correctly; structural abilities can collide if structures match                 |
-| Ability polymorphism via type variables   | Integrates with standard parametric polymorphism                                      | More explicit than Frank's invisible effect variables; ability variables appear in inferred types |
-| Database-backed codebase                  | Enables semantic versioning, type-indexed search, perfect dependency tracking         | Cannot use grep, git diff, or standard text tools directly on source code                         |
-| Unison Cloud as commercial platform       | Funds continued language development through public benefit corporation               | Creates vendor dependency for distributed computing features                                      |
+| Decision                                    | Rationale                                                                             | Trade-off                                                                                           |
+| ------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Content-addressed code                      | Eliminates builds, enables distributed deployment, perfect caching                    | Abandons text-file workflow; incompatible with traditional VCS and tooling                          |
+| Abilities over monads                       | Direct-style programming; effects as function properties, not value wrappers          | Less mature ecosystem than Haskell's monad transformer libraries                                    |
+| Explicit `handle ... with` (unlike [Frank]) | Clearer separation between using and handling effects                                 | More verbose than [Frank]'s implicit handler syntax                                                 |
+| Structural vs unique abilities              | Structural enables cross-library compatibility; unique prevents accidental conflation | Users must choose correctly; structural abilities can collide if structures match                   |
+| Ability polymorphism via type variables     | Integrates with standard parametric polymorphism                                      | More explicit than [Frank]'s invisible effect variables; ability variables appear in inferred types |
+| Database-backed codebase                    | Enables semantic versioning, type-indexed search, perfect dependency tracking         | Cannot use grep, git diff, or standard text tools directly on source code                           |
+| Unison Cloud as commercial platform         | Funds continued language development through public benefit corporation               | Creates vendor dependency for distributed computing features                                        |
 
 ---
 
 ## Sources
 
-- [Unison language documentation](https://www.unison-lang.org/docs/)
-- [Unison GitHub repository](https://github.com/unisonweb/unison)
-- [Abilities and ability handlers (language reference)](https://www.unison-lang.org/docs/language-reference/abilities-and-ability-handlers/)
-- [Ability declaration (language reference)](https://www.unison-lang.org/docs/language-reference/ability-declaration/)
-- [Writing your own abilities](https://www.unison-lang.org/docs/fundamentals/abilities/writing-abilities/)
-- [The big idea: content-addressed code](https://www.unison-lang.org/docs/the-big-idea/)
-- [Unison Cloud documentation](https://www.unison.cloud/docs/core-concepts/)
-- [Unison annotated bibliography](https://www.unison-lang.org/docs/usage-topics/bibliography/)
-- [Do Be Do Be Do (Frank paper, POPL 2017)](https://arxiv.org/abs/1611.09259)
-- [About Unison Computing](https://www.unison-lang.org/unison-computing/)
+- [Unison language documentation]
+- [Unison GitHub repository]
+- [Abilities and ability handlers (language reference)]
+- [Ability declaration (language reference)]
+- [Writing your own abilities]
+- [The big idea: content-addressed code]
+- [Unison Cloud documentation]
+- [Unison annotated bibliography]
+- [Do Be Do Be Do (Frank paper, POPL 2017)]
+- [About Unison Computing]
+
+<!-- References -->
+
+[Frank]: frank.md
+[github.com/unisonweb/unison]: https://github.com/unisonweb/unison
+[unison-lang.org/docs]: https://www.unison-lang.org/docs/
+[Unison language documentation]: https://www.unison-lang.org/docs/
+[Unison GitHub repository]: https://github.com/unisonweb/unison
+[Abilities and ability handlers (language reference)]: https://www.unison-lang.org/docs/language-reference/abilities-and-ability-handlers/
+[Ability declaration (language reference)]: https://www.unison-lang.org/docs/language-reference/ability-declaration/
+[Writing your own abilities]: https://www.unison-lang.org/docs/fundamentals/abilities/writing-abilities/
+[The big idea: content-addressed code]: https://www.unison-lang.org/docs/the-big-idea/
+[Unison Cloud documentation]: https://www.unison.cloud/docs/core-concepts/
+[Unison annotated bibliography]: https://www.unison-lang.org/docs/usage-topics/bibliography/
+[Do Be Do Be Do (Frank paper, POPL 2017)]: https://arxiv.org/abs/1611.09259
+[About Unison Computing]: https://www.unison-lang.org/unison-computing/

--- a/docs/research/algebraic-effects/wasmfx.md
+++ b/docs/research/algebraic-effects/wasmfx.md
@@ -4,12 +4,12 @@ WasmFX is the research line that shaped WebAssembly's stack-switching / typed-co
 
 **Last reviewed:** February 16, 2026.
 
-| Field               | Value                                                                                        |
-| ------------------- | -------------------------------------------------------------------------------------------- |
-| Ecosystem           | WebAssembly proposal and tooling ecosystem                                                   |
-| Main proposal track | [WebAssembly stack-switching proposal](https://github.com/WebAssembly/stack-switching)       |
-| Research origin     | [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)](https://doi.org/10.1145/3622814) |
-| Primary explainer   | [wasmfx.dev](https://wasmfx.dev/)                                                            |
+| Field               | Value                                                       |
+| ------------------- | ----------------------------------------------------------- |
+| Ecosystem           | WebAssembly proposal and tooling ecosystem                  |
+| Main proposal track | [WebAssembly stack-switching proposal]                      |
+| Research origin     | [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)] |
+| Primary explainer   | [wasmfx.dev]                                                |
 
 ---
 
@@ -30,7 +30,7 @@ Important nuance:
 - Phase 3 means active implementation work, not final standardization.
 - Runtime support is still evolving by engine and toolchain.
 
-Source: [WebAssembly proposals tracker](https://github.com/WebAssembly/proposals)
+Source: [WebAssembly proposals tracker]
 
 ---
 
@@ -85,9 +85,9 @@ This gives the programmer explicit control over handler installation while keepi
 
 Sources:
 
-- [WasmFX project site](https://wasmfx.dev/)
-- [Typed continuations core extensions](https://wasmfx.dev/specs/core/)
-- [WasmFX explainer](https://wasmfx.dev/specs/explainer/)
+- [WasmFX project site]
+- [Typed continuations core extensions]
+- [WasmFX explainer]
 
 ---
 
@@ -154,9 +154,9 @@ WasmFX provides a universal compilation target for diverse non-local control flo
 | Async/await               | C#, Dart, JavaScript, Rust, Swift | Tag per async boundary; suspend/resume |
 | Generators/iterators      | C#, JavaScript, Kotlin, Python    | Yield tag; resume loop in consumer     |
 | Coroutines                | C++, Kotlin, Python               | Symmetric switch or suspend/resume     |
-| Lightweight threads       | Erlang, Go, Haskell, OCaml        | Yield tag; round-robin scheduler       |
-| First-class continuations | Haskell, OCaml, Scheme            | Direct mapping to cont type            |
-| Effect handlers           | Koka, OCaml 5, Eff                | Direct mapping to tags + resume        |
+| Lightweight threads       | Erlang, Go, Haskell, [OCaml 5]    | Yield tag; round-robin scheduler       |
+| First-class continuations | Haskell, [OCaml 5], Scheme        | Direct mapping to cont type            |
+| Effect handlers           | [Koka], [OCaml 5], [Eff]          | Direct mapping to tags + resume        |
 
 ---
 
@@ -168,7 +168,7 @@ From an effect-systems perspective, typed continuations give Wasm a practical ba
 - handlers map to resume logic with installed clauses
 - continuation capture/resume happens at the runtime substrate level
 
-This does not force one specific source-language effect system; it provides a shared target for many of them.
+This does not force one specific source-language effect system; it provides a shared target for many of them. See [Theory and Compilation] for more on compilation strategies for algebraic effects.
 
 ---
 
@@ -193,7 +193,7 @@ Two implementation streams are visible in public artifacts:
 
 The 2025 WAW report documents continued implementation experience in Wasmtime-oriented tooling.
 
-Source: [Continuing Stack Switching in Wasmtime (WAW 2025)](https://popl25.sigplan.org/details/waw-2025-papers/7/Continuing-Stack-Switching-in-Wasmtime)
+Source: [Continuing Stack Switching in Wasmtime (WAW 2025)]
 
 ---
 
@@ -217,11 +217,29 @@ Source: [Continuing Stack Switching in Wasmtime (WAW 2025)](https://popl25.sigpl
 
 ## Sources
 
-- [WasmFX project site](https://wasmfx.dev/)
-- [WasmFX explainer](https://wasmfx.dev/specs/explainer/)
-- [Typed continuations core extensions](https://wasmfx.dev/specs/core/)
-- [WebAssembly stack-switching proposal](https://github.com/WebAssembly/stack-switching)
-- [WebAssembly proposals tracker](https://github.com/WebAssembly/proposals)
-- [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)](https://doi.org/10.1145/3622814)
-- [Continuing Stack Switching in Wasmtime (WAW 2025 session page)](https://popl25.sigplan.org/details/waw-2025-papers/7/Continuing-Stack-Switching-in-Wasmtime)
-- [Generator example in WAT](https://github.com/wasmfx/wasmfxtime/blob/main/examples/generator.wat)
+- [WasmFX project site]
+- [WasmFX explainer]
+- [Typed continuations core extensions]
+- [WebAssembly stack-switching proposal]
+- [WebAssembly proposals tracker]
+- [Continuing WebAssembly with Effect Handlers (OOPSLA 2023)]
+- [Continuing Stack Switching in Wasmtime (WAW 2025 session page)]
+- [Generator example in WAT]
+
+<!-- References -->
+
+[OCaml 5]: ocaml-effects.md
+[Koka]: koka.md
+[OCaml 5]: ocaml-effects.md
+[Eff]: eff-lang.md
+[Theory and Compilation]: theory-compilation.md
+[WebAssembly stack-switching proposal]: https://github.com/WebAssembly/stack-switching
+[Continuing WebAssembly with Effect Handlers (OOPSLA 2023)]: https://doi.org/10.1145/3622814
+[wasmfx.dev]: https://wasmfx.dev/
+[WebAssembly proposals tracker]: https://github.com/WebAssembly/proposals
+[WasmFX project site]: https://wasmfx.dev/
+[Typed continuations core extensions]: https://wasmfx.dev/specs/core/
+[WasmFX explainer]: https://wasmfx.dev/specs/explainer/
+[Continuing Stack Switching in Wasmtime (WAW 2025)]: https://popl25.sigplan.org/details/waw-2025-papers/7/Continuing-Stack-Switching-in-Wasmtime
+[Continuing Stack Switching in Wasmtime (WAW 2025 session page)]: https://popl25.sigplan.org/details/waw-2025-papers/7/Continuing-Stack-Switching-in-Wasmtime
+[Generator example in WAT]: https://github.com/wasmfx/wasmfxtime/blob/main/examples/generator.wat


### PR DESCRIPTION
## Summary

Cross-link, normalize, and polish all 33 algebraic-effects research documents.

### Changes

- **Cross-linking**: All research documents now cross-link related implementations, papers, and foundational theory
- **Reference-style links**: ~350+ inline markdown links converted to shortcut reference-style with reference blocks at the end of each file
- **Code block language identifiers**: All opening code blocks now have correct language tags (haskell, scala, rust, ocaml, java, swift, typescript, koka, eff, frank, unison, wat, text)
- **Typo fix**: `frank.md` code block language `franca` → `frank`
- **Prettier formatting**: Auto-fixed by pre-commit hook