### PR TITLE
docs(guidelines): add mtl, freer-simple, and TurboLift effect-system research pages

### DIFF
--- a/docs/research/algebraic-effects/comparison.md
+++ b/docs/research/algebraic-effects/comparison.md
@@ -38,7 +38,7 @@ Every effect system navigates tension between several competing concerns. No sys
 | **Haskell continuation-backed libraries ([eff], [bluefin-algae])** | Library-specific                                   | Closer to full handlers                 | GHC delimited continuation primops            | Runtime-backed control effects in Haskell                             | API/maintenance maturity varies across libraries               |
 | **Haskell hefty-style line ([heftia], [Theseus])**                 | Algebraic + higher-order structure                 | Yes                                     | Elaborate HO effects before FO interpretation | Strong soundness story for HO interactions                            | Newer ecosystem; higher conceptual load                        |
 | **[Scala ZIO] / [Cats Effect]**                                    | Typed channels/typeclasses                         | No (not algebraic handlers)             | Fiber runtime on JVM                          | Production-grade concurrency/runtime tooling                          | Different abstraction goal than algebraic handlers             |
-| **[Scala Kyo]**                                                    | Open effect channels                               | Handler-inspired algebraic model        | Runtime/library-specific                      | Direct-style ergonomics with effect tracking                          | Rapidly evolving API/model compared with mature stacks         |
+| **[Scala Kyo] / [TurboLift]**                                      | Open effect channels                               | Handler-inspired algebraic model        | Runtime/library-specific                      | Direct-style ergonomics with effect tracking                          | Rapidly evolving API/model compared with mature stacks         |
 | **[Scala 3 capabilities] / capture checking**                      | Capability/capture types                           | N/A (language capability system)        | Language-level type discipline                | Promising static reasoning for authority/effects                      | Experimental status in Scala 3.8                               |
 | **[Effect (TypeScript)]**                                          | `Effect<A, E, R>` style channels                   | Handler-inspired library model          | Generator/runtime encoding                    | Strong industrial ergonomics in JS/TS ecosystem                       | Runtime overhead model differs from native runtimes            |
 | **[WasmFX] / stack-switching targets**                             | Low-level typed continuation substrate             | Target-level primitives                 | Runtime/VM continuation support               | Cross-language compilation path for handlers                          | Proposal/toolchain maturity still evolving                     |
@@ -51,9 +51,9 @@ Every effect system navigates tension between several competing concerns. No sys
 
 | Encoding                             | Bind Cost      | Dispatch Cost            | Memory         | GHC Optimization Dependency |
 | ------------------------------------ | -------------- | ------------------------ | -------------- | --------------------------- |
-| **mtl (transformers)**               | O(n) per layer | O(1)                     | Low            | Moderate                    |
+| **[mtl] (transformers)**             | O(n) per layer | O(1)                     | Low            | Moderate                    |
 | **Free monad**                       | O(1) amortized | O(n) per handler         | High (tree)    | Low                         |
-| **Freer monad**                      | O(1) amortized | O(n) per handler         | High (tree)    | Low                         |
+| **Freer monad** ([freer-simple])     | O(1) amortized | O(n) per handler         | High (tree)    | Low                         |
 | **Carrier fusion**                   | O(1)           | O(1) (fused)             | Low            | High (inlining critical)    |
 | **ReaderT IO**                       | O(1)           | O(1)                     | Low            | Low (concrete monad)        |
 | **Delimited continuations**          | O(1)           | O(1)                     | Low-Medium     | None (by design)            |
@@ -67,9 +67,9 @@ Every effect system navigates tension between several competing concerns. No sys
 
 | Encoding                         | Captures Continuations | Sound HO Effects        | Pure Interpretation  | Multiple Same-Type Effects |
 | -------------------------------- | ---------------------- | ----------------------- | -------------------- | -------------------------- |
-| **mtl**                          | No                     | N/A (no HO as data)     | Yes                  | No (fundeps)               |
+| **[mtl]**                        | No                     | N/A (no HO as data)     | Yes                  | No (fundeps)               |
 | **Free monad**                   | Via tree inspection    | No HO effects           | Yes                  | Yes                        |
-| **Freer monad**                  | Via tree inspection    | No HO effects           | Yes                  | Yes                        |
+| **Freer monad** ([freer-simple]) | Via tree inspection    | No HO effects           | Yes                  | Yes                        |
 | **Carrier fusion**               | Limited                | Partial (unsound cases) | Yes                  | Yes                        |
 | **ReaderT IO**                   | No                     | Partial (unsound cases) | No                   | Yes                        |
 | **Delimited continuations**      | Yes (native)           | Yes (eff)               | No (IO-based)        | Yes                        |
@@ -135,7 +135,7 @@ OCaml and GHC runtime support, plus Wasm target work, suggest long-term success 
 ### If your primary goal is production reliability today
 
 - Haskell: [effectful]/[cleff] when continuation-heavy algebraic semantics are not required
-- Scala: [ZIO] or [Cats Effect] for mature runtime ecosystems
+- Scala: [ZIO] or [Cats Effect] for mature runtime ecosystems; [TurboLift] for handler-centric typed effects
 - OCaml: [Eio] on [OCaml 5] for direct-style concurrent systems
 
 ### If your primary goal is semantic expressiveness of handlers
@@ -196,6 +196,8 @@ OCaml and GHC runtime support, plus Wasm target work, suggest long-term success 
 [WebAssembly stack-switching proposal repo]: https://github.com/WebAssembly/stack-switching
 [effects-bibliography]: https://github.com/yallop/effects-bibliography
 [effectful]: haskell-effectful.md
+[mtl]: haskell-mtl.md
+[freer-simple]: haskell-freer-simple.md
 [eff]: haskell-eff.md
 [Koka]: koka.md
 [OCaml 5]: ocaml-effects.md
@@ -214,6 +216,7 @@ OCaml and GHC runtime support, plus Wasm target work, suggest long-term success 
 [ZIO]: scala-zio.md
 [Cats Effect]: scala-cats-effect.md
 [Scala Kyo]: scala-kyo.md
+[TurboLift]: scala-turbolift.md
 [Scala 3 capabilities]: scala-capabilities.md
 [WasmFX]: wasmfx.md
 [Parallel handlers]: parallelism.md

--- a/docs/research/algebraic-effects/evolution.md
+++ b/docs/research/algebraic-effects/evolution.md
@@ -121,9 +121,9 @@ Recent work shifts from "can handlers work?" to "which guarantees and performanc
 
 The Haskell ecosystem provides the clearest case study of how effect encodings evolved in a single language, because each generation directly addressed limitations of its predecessor.
 
-### Generation 1: Monad Transformers (mtl, ~1995+)
+### Generation 1: Monad Transformers ([mtl], ~1995+)
 
-Monad transformers compose effects by stacking transformer layers. The `mtl` library provides typeclasses (`MonadState`, `MonadReader`, `MonadError`) that abstract over the concrete stack.
+Monad transformers compose effects by stacking transformer layers. The [mtl] library provides typeclasses (`MonadState`, `MonadReader`, `MonadError`) that abstract over the concrete stack.
 
 **Strengths:** Well-understood; decades of use; good GHC optimization.
 
@@ -131,11 +131,11 @@ Monad transformers compose effects by stacking transformer layers. The `mtl` lib
 
 ### Generation 2: Free and Freer Monads (~2008-2015)
 
-Free monads represent effects as data, building a syntax tree interpreted by handlers. The freer monad (Kiselyov, Ishii 2015) removed the Functor constraint and introduced open unions for extensible effects.
+Free monads represent effects as data, building a syntax tree interpreted by handlers. The freer monad (Kiselyov, Ishii 2015) removed the Functor constraint and introduced open unions for extensible effects, later popularized in libraries like [freer-simple].
 
 **Strengths:** Effects as inspectable data; clean syntax/semantics separation; no O(n²) instance problem.
 
-**Limitations:** ~30x slower than mtl for short stacks in benchmarks; no support for higher-order effects (scoped operations).
+**Limitations:** ~30x slower than [mtl] for short stacks in benchmarks; no support for higher-order effects (scoped operations).
 
 ### Generation 3: Fused Effects and Higher-Order Effects (~2018-2019)
 
@@ -242,6 +242,8 @@ Different ecosystems currently optimize different subsets of these properties.
 [Parallel Algebraic Effect Handlers]: parallelism.md
 [fused-effects]: haskell-fused-effects.md
 [polysemy]: haskell-polysemy.md
+[mtl]: haskell-mtl.md
+[freer-simple]: haskell-freer-simple.md
 [effectful]: haskell-effectful.md
 [cleff]: haskell-cleff.md
 [eff]: haskell-eff.md

--- a/docs/research/algebraic-effects/haskell-freer-simple.md
+++ b/docs/research/algebraic-effects/haskell-freer-simple.md
@@ -1,0 +1,196 @@
+# freer-simple (Haskell)
+
+A friendly extensible-effects library built on freer monads, open unions, and fast type-aligned queues. `freer-simple` was a major step in making extensible effects practical in Haskell before the newer ReaderT-IO and continuation-primop generations.
+
+| Field         | Value                                     |
+| ------------- | ----------------------------------------- |
+| Language      | Haskell                                   |
+| License       | BSD-3-Clause                              |
+| Repository    | [freer-simple GitHub repository]          |
+| Documentation | [Hackage][freer-simple on Hackage]        |
+| Key Authors   | Alexis King, Oleg Kiselyov (foundational) |
+| Encoding      | Freer monad + open union + FTCQueue       |
+
+---
+
+## Overview
+
+### What It Solves
+
+`freer-simple` solves two long-standing pain points of classic transformer stacks:
+
+1. Boilerplate from stacking and lifting monad transformers.
+2. Limited modularity when introducing new effect capabilities.
+
+It gives a single `Eff` monad with a type-level effect list, plus interpreters that can be composed to remove effects one by one.
+
+### Design Philosophy
+
+The library emphasizes ergonomics and accessibility for extensible effects: represent effects as ordinary GADTs, send operations with `send`, and interpret with combinators like `interpret`/`reinterpret`. Compared to [polysemy], it is lower-level and smaller in scope; compared to [mtl], it is more modular in effect declaration and interpretation.
+
+---
+
+## Core Abstractions and Types
+
+### The Eff Monad
+
+The core type is:
+
+```haskell
+data Eff effs a
+```
+
+where `effs` is a type-level list of available effects.
+
+Internally, the representation uses:
+
+- **Open unions** (`Data.OpenUnion`) for effect requests.
+- **Fast type-aligned queue** (`Data.FTCQueue`) for continuations.
+
+This structure avoids the classic free-monad Functor constraint and supports efficient continuation composition.
+
+### Membership Constraints
+
+`Member`/`Members` constraints declare required capabilities:
+
+```haskell
+Member (State Int) effs => Eff effs Int
+```
+
+The concrete list stays polymorphic, which enables interpreters to be reordered and combined more flexibly than fixed transformer stacks.
+
+### Core Primitives
+
+Key primitives include:
+
+- `send` to emit an effect request.
+- `run` for pure programs (`Eff '[] a -> a`).
+- `runM` for programs ending in one monadic effect (`Eff '[m] a -> m a`).
+- Handler constructors like `handleRelay` / `handleRelayS`.
+
+---
+
+## How Effects Are Declared
+
+Effects are defined as GADTs with one constructor per operation:
+
+```haskell
+data Teletype r where
+  ReadTTY  :: Teletype String
+  WriteTTY :: String -> Teletype ()
+```
+
+Operations are then exposed as smart constructors using `send`, manually or via Template Haskell (`makeEffect`):
+
+```haskell
+readTTY :: Member Teletype effs => Eff effs String
+readTTY = send ReadTTY
+```
+
+Built-in modules provide common effects (`Reader`, `State`, `Writer`, `Error`, etc.) as reusable GADTs plus handlers.
+
+---
+
+## How Handlers/Interpreters Work
+
+Interpreters eliminate effects from the row.
+
+### First-Order Interpretation
+
+`interpret` maps each operation to the remaining `Eff` stack:
+
+```haskell
+interpret
+  :: (forall v. e v -> Eff effs v)
+  -> Eff (e ': effs) a
+  -> Eff effs a
+```
+
+### Reinterpretation
+
+`reinterpret` converts one effect into another (or several), enabling layered implementation without exposing private internal effects in external signatures.
+
+### Running
+
+Programs typically compose several handlers then finish with `run` or `runM`.
+
+This gives a clear "build syntax first, interpret later" workflow similar to other extensible-effect systems.
+
+---
+
+## Performance Approach
+
+### Why It Was a Breakthrough
+
+`freer-simple` improved significantly over older free encodings by using freer representation plus open-union dispatch and FTCQueue continuations. For many teams, it made extensible effects viable without custom compiler support.
+
+### Current Performance Position
+
+Relative to newer libraries, `freer-simple` is generally slower in deep effect-heavy workloads because it still builds/interprets effect requests at runtime. Benchmarks in later ecosystem discussions (and in [effectful benchmark suite] comparisons) consistently place it behind [effectful], [cleff], and usually [fused-effects].
+
+The key takeaway: historically important and still expressive, but no longer state-of-the-art on throughput/latency-sensitive hot paths.
+
+---
+
+## Composability Model
+
+### Strength of the Model
+
+- Effects are declared as independent algebras.
+- Programs can stay polymorphic over `effs`.
+- Interpreters can be swapped for pure tests or IO-backed execution.
+
+### Limits
+
+- Compared to [polysemy], higher-order/scoped effects are less ergonomic and less central to the core design.
+- Compared to ReaderT-IO systems ([effectful], [cleff]), interoperability with mainstream `MonadUnliftIO`-style ecosystems is less direct.
+
+---
+
+## Strengths
+
+- **Historically foundational**: key bridge from transformers to modern extensible effects.
+- **Good ergonomics for first-order effects**: concise GADT + `send` + interpreter workflow.
+- **Pure interpretation support**: easy to test and reason about interpreter logic.
+- **Modular effect rows**: avoids many stack-coupling issues of monad transformers.
+- **Template Haskell helpers**: `makeEffect` reduces operation boilerplate.
+
+## Weaknesses
+
+- **Performance lag vs newer systems**: usually behind [effectful]/[cleff]/[fused-effects] on demanding benchmarks.
+- **Aging ecosystem momentum**: fewer recent releases and less active expansion than newer libraries.
+- **Higher-order effect ergonomics**: weaker than later designs centered around HO effects.
+- **Complex internals**: open-union + continuation machinery is non-trivial for contributors.
+
+## Key Design Decisions and Trade-offs
+
+| Decision                     | Rationale                                        | Trade-off                                  |
+| ---------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| Freer-monad core             | Extensible effects as data, modular interpreters | Runtime interpretation overhead            |
+| Open union dispatch          | Type-safe membership of many effects             | Internal complexity                        |
+| FTCQueue continuations       | Better asymptotic continuation composition       | Harder internals than plain transformers   |
+| Library-level implementation | No compiler patching required                    | Limited runtime optimization opportunities |
+| TH (`makeEffect`) support    | Lower user boilerplate                           | TH dependency and generated-code opacity   |
+
+---
+
+## Sources
+
+- [freer-simple on Hackage]
+- [freer-simple GitHub repository]
+- [Control.Monad.Freer.Internal docs]
+- [Freer Monads, More Extensible Effects (2015)]
+- [effectful benchmark suite]
+
+<!-- References -->
+
+[mtl]: haskell-mtl.md
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[effectful]: haskell-effectful.md
+[cleff]: haskell-cleff.md
+[freer-simple on Hackage]: https://hackage.haskell.org/package/freer-simple
+[freer-simple GitHub repository]: https://github.com/lexi-lambda/freer-simple
+[Control.Monad.Freer.Internal docs]: https://hackage.haskell.org/package/freer-simple/docs/Control-Monad-Freer-Internal.html
+[Freer Monads, More Extensible Effects (2015)]: https://doi.org/10.1145/2804302.2804319
+[effectful benchmark suite]: https://github.com/haskell-effectful/effectful/blob/master/benchmarks/README.md

--- a/docs/research/algebraic-effects/haskell-mtl.md
+++ b/docs/research/algebraic-effects/haskell-mtl.md
@@ -1,0 +1,187 @@
+# mtl (Haskell)
+
+The classic monad-transformer class stack for Haskell. `mtl` provides a stable, ubiquitous abstraction layer over `transformers`, and remains a baseline for performance and ecosystem interoperability in Haskell effectful programming.
+
+| Field         | Value                                      |
+| ------------- | ------------------------------------------ |
+| Language      | Haskell                                    |
+| License       | BSD-3-Clause                               |
+| Repository    | [mtl GitHub repository]                    |
+| Documentation | [Hackage][mtl on Hackage]                  |
+| Key Authors   | Andy Gill, Mark P. Jones (foundational)    |
+| Encoding      | Monad transformers + typeclasses (fundeps) |
+
+---
+
+## Overview
+
+### What It Solves
+
+`mtl` solves practical modularity for effectful programs by giving a common interface (`MonadReader`, `MonadState`, `MonadError`, etc.) over concrete transformer stacks. Instead of writing directly against `ReaderT r (StateT s (ExceptT e IO))`, code can be polymorphic in `m` and constrained by capabilities.
+
+### Design Philosophy
+
+`mtl` is pragmatic and conservative: keep semantics explicit, keep runtime representation close to transformer stacks, and provide broad compatibility with the rest of Haskell. It predates modern algebraic-effect libraries and is not trying to model handlers/resumptions as first-class constructs.
+
+---
+
+## Core Abstractions and Types
+
+### Capability Classes
+
+The central abstraction is a set of multi-parameter typeclasses with functional dependencies:
+
+```haskell
+class Monad m => MonadState s m | m -> s where
+  get :: m s
+  put :: s -> m ()
+```
+
+The dependency `m -> s` says that a given monad `m` determines a single state type `s`.
+
+### Transformer-Based Runtime Representation
+
+`mtl` reuses concrete transformers from [transformers on Hackage], such as:
+
+- `ReaderT r m a`
+- `StateT s m a`
+- `ExceptT e m a`
+- `WriterT w m a`
+
+This gives predictable runtime behavior: each effect layer is explicit in the type and represented as a concrete wrapper.
+
+### Typical Stack
+
+```haskell
+type AppM = ReaderT Env (StateT AppState (ExceptT AppError IO))
+```
+
+`mtl` class instances let this stack satisfy constraints like `MonadReader Env`, `MonadState AppState`, and `MonadError AppError`.
+
+---
+
+## How Effects Are Declared
+
+Effects are not declared as GADTs (as in [polysemy], [fused-effects], or [effectful]). They are introduced by choosing transformer layers and by requiring matching typeclass constraints:
+
+```haskell
+program
+  :: (MonadReader Env m, MonadState Int m, MonadError String m)
+  => m ()
+program = do
+  env <- ask
+  n <- get
+  when (n < 0) (throwError "negative")
+  put (n + env.delta)
+```
+
+This style keeps code generic in `m`, while concretely choosing interpretation via the final transformer stack.
+
+---
+
+## How Handlers/Interpreters Work
+
+`mtl` uses runner/unwrapper functions from transformers rather than algebraic handlers:
+
+```haskell
+runReaderT :: ReaderT r m a -> r -> m a
+runStateT  :: StateT s m a  -> s -> m (a, s)
+runExceptT :: ExceptT e m a -> m (Either e a)
+```
+
+Composition order determines semantics:
+
+```haskell
+-- Error outside state: state can be discarded with failure
+runExceptT (runStateT program s0)
+
+-- State outside error: state is preserved around error layer
+runStateT (runExceptT program) s0
+```
+
+This is a key strength and limitation: semantics are explicit and well-understood, but behavior depends on stack ordering and lifting patterns.
+
+---
+
+## Performance Approach
+
+### Why mtl Is Often Fast
+
+`mtl` is usually efficient because it compiles to concrete transformer code with familiar inlining/specialization behavior. It avoids constructing free/freer syntax trees and interpreting them at runtime.
+
+### Typical Costs
+
+1. Each bind traverses the transformer structure in the chosen stack order.
+2. Repeated `lift` operations add boilerplate and can obscure hot paths.
+3. Large capability surfaces increase instance complexity (the classic "instance boilerplate" issue that motivated extensible-effect libraries).
+
+In practice, modern benchmarks frequently show `mtl` as a strong baseline that is competitive with optimized ReaderT-IO effect libraries for many workloads, while being much faster than classic freer encodings in deep interpreter-heavy pipelines.
+
+---
+
+## Composability Model
+
+`mtl` composes effects via transformer stacking plus typeclass constraints.
+
+### Advantages
+
+- Very mature ecosystem support.
+- Predictable interaction with existing libraries via `MonadIO`, `MonadUnliftIO`, etc.
+- Straightforward local reasoning once the stack is fixed.
+
+### Frictions
+
+- Order-sensitive semantics are sometimes surprising.
+- Functional dependencies restrict multiple same-type effects (for example, two independent `State Int` capabilities in one `m`).
+- Deep stacks accumulate lifting and instance complexity.
+
+---
+
+## Strengths
+
+- **Battle-tested standard**: decades of production and ecosystem use.
+- **Excellent interoperability**: most Haskell libraries expose `mtl`-friendly APIs.
+- **Predictable semantics**: explicit stack and explicit runners.
+- **Strong baseline performance**: often close to optimized hand-written transformer code.
+- **Low conceptual surprise**: no advanced handler machinery required.
+
+## Weaknesses
+
+- **No algebraic handlers**: no first-class operation/handler/resumption model.
+- **Order-sensitive behavior**: changing stack order can change semantics significantly.
+- **Multiple same-effect limitations**: fundeps constrain some composition patterns.
+- **Boilerplate/lifting burden**: grows with stack depth.
+- **Instance surface complexity**: extensibility overhead motivated newer effect systems.
+
+## Key Design Decisions and Trade-offs
+
+| Decision                          | Rationale                                               | Trade-off                                         |
+| --------------------------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| Typeclasses + fundeps             | Ergonomic capability constraints (`MonadState s m`)     | Restricts multiple same-type effects in one monad |
+| Reuse of `transformers` datatypes | Shared ecosystem and predictable runtime representation | Explicit stack management and lift-heavy code     |
+| Runner-based interpretation       | Transparent semantics and easy debugging                | No modular algebraic handler composition          |
+| Concrete stack ordering           | Direct control over semantics                           | Subtle behavior changes when reordering layers    |
+| Conservative evolution            | Stability for huge downstream ecosystem                 | Slower adoption of newer effect abstractions      |
+
+---
+
+## Sources
+
+- [mtl on Hackage]
+- [mtl GitHub repository]
+- [Control.Monad.State docs]
+- [transformers on Hackage]
+- [Functional Programming with Overloading and Higher-Order Polymorphism (1995)]
+- [Evolution of Algebraic Effect Systems]
+
+<!-- References -->
+
+[polysemy]: haskell-polysemy.md
+[fused-effects]: haskell-fused-effects.md
+[effectful]: haskell-effectful.md
+[Evolution of Algebraic Effect Systems]: evolution.md
+[mtl on Hackage]: https://hackage.haskell.org/package/mtl
+[mtl GitHub repository]: https://github.com/haskell/mtl
+[Control.Monad.State docs]: https://hackage.haskell.org/package/mtl/docs/Control-Monad-State.html
+[transformers on Hackage]: https://hackage.haskell.org/package/transformers
+[Functional Programming with Overloading and Higher-Order Polymorphism (1995)]: http://web.cecs.pdx.edu/~mpj/pubs/springschool.html

--- a/docs/research/algebraic-effects/index.md
+++ b/docs/research/algebraic-effects/index.md
@@ -92,6 +92,8 @@ Note: systems marked as having "no effect tracking" (Rust implicit features, Jav
 
 ### Haskell
 
+- [mtl]
+- [freer-simple]
 - [effectful]
 - [cleff]
 - [polysemy]
@@ -106,6 +108,7 @@ Note: systems marked as having "no effect tracking" (Rust implicit features, Jav
 - [ZIO]
 - [Cats Effect]
 - [Kyo]
+- [TurboLift]
 - [Scala Capabilities]
 - [Ox]
 
@@ -199,11 +202,14 @@ Note: systems marked as having "no effect tracking" (Rust implicit features, Jav
 [OCaml 5 Effects]: ocaml-effects.md
 [OCaml Eio]: ocaml-eio.md
 [WasmFX]: wasmfx.md
+[mtl]: haskell-mtl.md
+[freer-simple]: haskell-freer-simple.md
 [Effect (TypeScript)]: typescript-effect.md
 [TypeScript Effect]: typescript-effect.md
 [Java Loom]: java-loom.md
 [Rust Effect Notes]: rust-effect-system.md
 [Additional Implementations]: other-implementations.md
+[TurboLift]: scala-turbolift.md
 [Evolution of Effect Systems]: evolution.md
 [Comparison and Analysis]: comparison.md
 [Theory and Compilation]: theory-compilation.md

--- a/docs/research/algebraic-effects/scala-turbolift.md
+++ b/docs/research/algebraic-effects/scala-turbolift.md
@@ -1,0 +1,217 @@
+# TurboLift (Scala)
+
+A Scala 3 algebraic-effects library centered on typed effect sets, first-class handlers, and uniquely labelled effect instances. TurboLift explores advanced effect features (labelled effects, higher-order effects, applicative parallel composition, bidirectional effects) within idiomatic Scala syntax.
+
+| Field         | Value                                                                    |
+| ------------- | ------------------------------------------------------------------------ |
+| Language      | Scala 3                                                                  |
+| License       | MIT                                                                      |
+| Repository    | [TurboLift GitHub repository]                                            |
+| Documentation | [TurboLift microsite][TurboLift microsite]                               |
+| Key Authors   | Marcin Zajączkowski                                                      |
+| Encoding      | `Computation[A, U]` + typed handlers over intersection-typed effect sets |
+
+---
+
+## Overview
+
+### What It Solves
+
+TurboLift provides a strongly typed algebraic-effects model for Scala that is more open-ended than fixed-channel runtimes like [ZIO] and less typeclass-centric than [Cats Effect]. It targets modular effect composition while preserving direct and readable syntax.
+
+### Design Philosophy
+
+TurboLift aims to make advanced handler-based programming practical in Scala 3 using:
+
+- Effect sets represented at the type level with intersection types.
+- Explicit, reusable handlers as first-class values.
+- Mandatory effect labelling to preserve modularity and avoid ambiguity.
+
+The project is explicit about exploring features that are often absent or restricted in mainstream production effect libraries.
+
+---
+
+## Core Abstractions and Types
+
+### Computation
+
+The central type is:
+
+```scala
+Computation[+A, -U]
+```
+
+with infix alias:
+
+```scala
+A !! U
+```
+
+`A` is the produced value type, while `U` is the set of required effects.
+
+### Effect Sets via Intersection Types
+
+TurboLift models required effects as intersections:
+
+- `Any` means no required effects.
+- `X & Y` means both effects are required.
+
+This allows inferred capability sets to remain visible in inferred types and compositional across modules.
+
+### Effect, Signature, Interpreter, Handler
+
+The official architecture describes five roles:
+
+1. `Signature` (effect algebra/service interface).
+2. `Effect` (operation-invocation surface).
+3. `Interpreter` (semantic implementation).
+4. `Handler` (scope-delimiting eliminator/transformer).
+5. `Computation` (program description).
+
+Handlers are polymorphic transformers over computations and can both eliminate requested effects and introduce dependencies.
+
+---
+
+## How Effects Are Declared
+
+Effects are defined as signatures plus effect objects that perform operations:
+
+```scala
+trait FileSystemSignature extends Signature:
+  def readFile(path: String): String !! ThisEffect
+  def writeFile(path: String, contents: String): Unit !! ThisEffect
+
+case object FileSystem extends Effect[FileSystemSignature] with FileSystemSignature:
+  final override def readFile(path: String) = perform(_.readFile(path))
+  final override def writeFile(path: String, contents: String) =
+    perform(_.writeFile(path, contents))
+```
+
+TurboLift also supports predefined effects (for example, `Reader`, `State`, `Error`, `Choice`, etc.) and optional bindless syntax extensions.
+
+---
+
+## How Handlers/Interpreters Work
+
+### Handler Application
+
+Handlers delimit effect scopes and transform computation types:
+
+```scala
+val result =
+  program
+    .handleWith(State.handler(100))
+    .handleWith(Reader.handler(3))
+    .handleWith(Error.handler)
+    .run
+```
+
+As effects are eliminated, the required effect set shrinks. Once no required effects remain (or only `IO`, depending on API path), execution can be finalized.
+
+### Composition of Handlers
+
+Handlers are composable values and can be transformed/combined with dedicated combinators (for example, independent composition operators documented in the handler API).
+
+### Higher-Order and Scoped Operations
+
+TurboLift explicitly supports higher-order/scoped operations and documents ordering-sensitive pitfalls from transformer ecosystems. Its examples emphasize consistent behavior under different handler orders for representative state/error scoped programs.
+
+---
+
+## Performance Approach
+
+### Parallel/Applicative Composition
+
+TurboLift includes parallel-friendly composition (`*!` / `zipPar`) where handlers permit it. If every active handler is parallelizable, branches can execute concurrently (implicit fiber fork/join); otherwise, composition falls back to sequential behavior.
+
+### Handler-Dependent Parallelizability
+
+The docs distinguish handlers that are parallelizable from those that are not (for example, linear local-state handlers vs aggregating/shared variants). This makes parallel behavior explicit in interpretation strategy rather than implicit in syntax alone.
+
+### Benchmark Positioning
+
+TurboLift’s official performance positioning points to [Effect Zoo] benchmarks and related benchmark suites rather than a single canonical chart in the core docs. The project narrative is "high performance with advanced feature support," with concrete numbers published in external benchmark repos.
+
+---
+
+## Composability Model
+
+### Labelled Effects as Default
+
+A defining trait is **always-labelled effects** (via singleton-typed effect instances). Multiple instances of the same effect family can safely coexist:
+
+```scala
+case object Foo extends State[Int]
+case object Bar extends State[Int]
+```
+
+This directly addresses ambiguity and modularity challenges that appear in many effect systems.
+
+### Bidirectional Effects
+
+TurboLift supports operations that request both `ThisEffect` and additional effects, enabling explicit public dependencies in effect signatures. This separates interface-level dependencies from private interpreter dependencies and supports more structured modularity.
+
+### Ecosystem Interop
+
+The wider ecosystem includes companion projects (for example, [Spot] for Cats-Effect instances over TurboLift `IO`, [Beam], [Enterprise], [DaaE]). This indicates a growing but still niche integration story compared to [ZIO] and [Cats Effect].
+
+---
+
+## Strengths
+
+- **Advanced feature set**: labelled, higher-order, bidirectional, and applicative/parallel patterns in one system.
+- **First-class handler model**: explicit, composable effect elimination.
+- **Strong type-level modularity**: intersection-typed effect sets stay visible in signatures.
+- **Multiple same-family effects**: unique labels avoid common ambiguity pitfalls.
+- **Modern Scala 3 ergonomics**: expressive syntax, optional bindless extension.
+
+## Weaknesses
+
+- **Smaller ecosystem/community**: far less industrial adoption than [ZIO] or [Cats Effect].
+- **Evolving platform surface**: docs and APIs are ambitious and still maturing.
+- **Conceptual complexity**: advanced handler semantics require deeper effect-system fluency.
+- **Benchmark interpretation overhead**: performance understanding often requires consulting external benchmark repositories.
+- **Scala 3 + Java baseline constraints**: requires modern toolchain (Java 11+).
+
+## Key Design Decisions and Trade-offs
+
+| Decision                                                     | Rationale                                                    | Trade-off                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------- |
+| Intersection-typed effect sets (`U`)                         | Direct, compositional type-level effect tracking             | Verbose types for complex programs                |
+| Always-labelled effect instances                             | True modularity; multiple same-family effects safely coexist | Slightly more declaration boilerplate             |
+| First-class handlers                                         | Explicit semantics, reusable interpretation logic            | Higher conceptual load than single-runtime models |
+| Built-in advanced features (HOE, applicative, bidirectional) | Rich expressiveness uncommon in mainstream stacks            | Larger semantic surface to learn and maintain     |
+| Optional bindless DSL                                        | More direct-style ergonomics                                 | Extra module/dependency and tooling complexity    |
+
+---
+
+## Sources
+
+- [TurboLift microsite]
+- [TurboLift GitHub repository]
+- [TurboLift overview]
+- [TurboLift labelled effects]
+- [TurboLift higher-order effects]
+- [TurboLift bidirectional effects]
+- [TurboLift applicative effects]
+- [TurboLift on Scaladex]
+- [Effect Zoo]
+
+<!-- References -->
+
+[ZIO]: scala-zio.md
+[Cats Effect]: scala-cats-effect.md
+[Kyo]: scala-kyo.md
+[TurboLift microsite]: https://marcinzh.github.io/turbolift/
+[TurboLift GitHub repository]: https://github.com/marcinzh/turbolift
+[TurboLift overview]: https://marcinzh.github.io/turbolift/overview.html
+[TurboLift labelled effects]: https://marcinzh.github.io/turbolift/advanced/labelled.html
+[TurboLift higher-order effects]: https://marcinzh.github.io/turbolift/advanced/higher.html
+[TurboLift bidirectional effects]: https://marcinzh.github.io/turbolift/advanced/bidir.html
+[TurboLift applicative effects]: https://marcinzh.github.io/turbolift/advanced/applicative.html
+[TurboLift on Scaladex]: https://index.scala-lang.org/marcinzh/turbolift
+[Effect Zoo]: https://github.com/marcinzh/effect-zoo
+[Spot]: https://github.com/marcinzh/spot
+[Beam]: https://github.com/marcinzh/beam
+[Enterprise]: https://github.com/marcinzh/enterprise
+[DaaE]: https://github.com/marcinzh/daae


### PR DESCRIPTION
## Summary
- add new algebraic-effects deep-dive docs for `mtl`, `freer-simple`, and `TurboLift`
- update research index navigation and references to include the three new pages
- add cross-links in comparison and evolution docs so the new pages are connected from existing analysis

## Files Added
- `docs/research/algebraic-effects/haskell-mtl.md`
- `docs/research/algebraic-effects/haskell-freer-simple.md`
- `docs/research/algebraic-effects/scala-turbolift.md`

## Files Updated
- `docs/research/algebraic-effects/index.md`
- `docs/research/algebraic-effects/comparison.md`
- `docs/research/algebraic-effects/evolution.md`

## Verification
- pre-commit hooks pass locally (including markdown formatting, link checks, and markdown example verification).
