### PR TITLE
docs(guidelines): add forced named arguments idiom

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,16 @@ export default defineConfig({
               { text: 'Appendix: Official DStyle', link: '/guidelines/dstyle' },
             ],
           },
+          {
+            text: 'Idioms',
+            collapsed: true,
+            items: [
+              {
+                text: 'Forcing Named Arguments',
+                link: '/guidelines/idioms/forced-named-arguments/',
+              },
+            ],
+          },
         ],
       },
       {

--- a/docs/guidelines/code-style.md
+++ b/docs/guidelines/code-style.md
@@ -173,6 +173,32 @@ auto result = createWidget(
 );
 ```
 
+### Forcing Named Arguments
+
+Force external callers to use named arguments by adding a `private`-typed
+sentinel with a default value as the first parameter. Callers outside the
+module cannot construct the private type, so positional calls fail at compile
+time while named calls skip past the sentinel via its default:
+
+```d
+private struct NamedOnly {}
+
+void draw(NamedOnly _ = NamedOnly.init, int x = 0, int y = 0, int width = 0, int height = 0)
+{
+    // ...
+}
+
+// From another module:
+draw(x: 10, y: 20, width: 100, height: 200); // ✅
+draw(10, 20, 100, 200);                       // ❌ compile error
+```
+
+The same technique applies to struct fields. For the function-parameter
+variant the sentinel is zero-cost — it produces identical assembly to a plain
+function. See [Forcing Named Arguments](idioms/forced-named-arguments/) for
+the full write-up including ABI analysis, struct caveats, and alternative
+techniques that were evaluated.
+
 ## Interpolated Expression Sequences ([DIP1036](https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1036.md))
 
 Use IES (`i"..."`) when interspersing string literals with expressions. Preference order:

--- a/docs/guidelines/idioms/forced-named-arguments/abi_comparison.d
+++ b/docs/guidelines/idioms/forced-named-arguments/abi_comparison.d
@@ -1,0 +1,51 @@
+// Compare ABI codegen: normal vs NamedOnly sentinel
+// Compile with: ldc2 -O2 -release -output-s abi_comparison.d
+//
+// Finding: free-function sentinel is zero-overhead (identical asm).
+// Struct-field sentinel adds sizeof/alignment overhead (1 byte + padding).
+
+private struct NamedOnly {}
+
+struct Rect
+{
+    int x, y, width, height;
+}
+
+// NamedOnly is 1 byte => 4 bytes with alignment padding before the first int.
+// RectNamed.sizeof == 20, Rect.sizeof == 16.
+struct RectNamed
+{
+    NamedOnly _ = NamedOnly.init;
+    int x, y, width, height;
+}
+
+pragma(msg, "NamedOnly.sizeof = ", NamedOnly.sizeof);
+pragma(msg, "Rect.sizeof      = ", Rect.sizeof);
+pragma(msg, "RectNamed.sizeof = ", RectNamed.sizeof);
+
+// --- Free functions: zero overhead ---
+
+export Rect withSentinel(
+    NamedOnly _ = NamedOnly.init,
+    int x = 0, int y = 0, int width = 0, int height = 0, int margin = 0,
+)
+{
+    return Rect(x - margin, y - margin, width + 2 * margin, height + 2 * margin);
+}
+
+export Rect withoutSentinel(int x, int y, int width, int height, int margin)
+{
+    return Rect(x - margin, y - margin, width + 2 * margin, height + 2 * margin);
+}
+
+// --- Call sites ---
+
+export Rect callSentinel(int x, int y, int w, int h, int m)
+{
+    return withSentinel(x: x, y: y, width: w, height: h, margin: m);
+}
+
+export Rect callPlain(int x, int y, int w, int h, int m)
+{
+    return withoutSentinel(x, y, w, h, m);
+}

--- a/docs/guidelines/idioms/forced-named-arguments/alternatives.d
+++ b/docs/guidelines/idioms/forced-named-arguments/alternatives.d
@@ -1,0 +1,109 @@
+/// Alternative techniques for forcing named arguments — none of them work.
+/// Each section demonstrates one approach and why it fails.
+///
+/// This file is for reference only; it is NOT expected to compile as-is
+/// (the failing lines are left uncommented to show the errors).
+
+module alternatives;
+
+import std.stdio : writefln;
+
+// ---------------------------------------------------------------------------
+// 1. @disable this(int, int, …) — blocks BOTH positional AND named
+// ---------------------------------------------------------------------------
+
+struct Opts1
+{
+    int x, y, width, height;
+    @disable this(int, int, int, int);
+}
+
+void test1()
+{
+    // auto a = Opts1(10, 20, 100, 200);                    // ❌ blocked
+    // auto b = Opts1(x: 10, y: 20, width: 100, height: 200); // ❌ also blocked!
+}
+
+// ---------------------------------------------------------------------------
+// 2. Distinct wrapper types — type-safe, but doesn't force naming
+// ---------------------------------------------------------------------------
+
+struct X { int v; }
+struct Y { int v; }
+struct W { int v; }
+struct H { int v; }
+
+void draw2(X x, Y y, W w, H h)
+{
+    writefln("draw2(%d, %d, %d, %d)", x.v, y.v, w.v, h.v);
+}
+
+void test2()
+{
+    draw2(X(1), Y(2), W(3), H(4));             // compiles — positional
+    draw2(x: X(1), y: Y(2), w: W(3), h: H(4)); // compiles — named
+    // Both work — naming is not enforced.
+}
+
+// ---------------------------------------------------------------------------
+// 3. All-default parameters — positional still works
+// ---------------------------------------------------------------------------
+
+void draw3(int x = 0, int y = 0, int width = 0, int height = 0)
+{
+    writefln("draw3(%d, %d, %d, %d)", x, y, width, height);
+}
+
+void test3()
+{
+    draw3(10, 20, 100, 200);                                  // ✅ positional
+    draw3(x: 10, y: 20, width: 100, height: 200);             // ✅ named
+    // Both work — naming is not enforced.
+}
+
+// ---------------------------------------------------------------------------
+// 4. Struct parameter wrapper — positional struct literal still works
+// ---------------------------------------------------------------------------
+
+struct DrawOpts
+{
+    int x, y, width, height;
+}
+
+void draw4(DrawOpts o)
+{
+    writefln("draw4(%d, %d, %d, %d)", o.x, o.y, o.width, o.height);
+}
+
+void test4()
+{
+    draw4(DrawOpts(10, 20, 100, 200));                                  // ✅ positional
+    draw4(DrawOpts(x: 10, y: 20, width: 100, height: 200));            // ✅ named
+    // Both work — naming is not enforced.
+}
+
+// ---------------------------------------------------------------------------
+// 5. static opCall with @disable this() — opCall is unreachable
+// ---------------------------------------------------------------------------
+
+struct Opts5
+{
+    private int _x, _y;
+
+    @disable this();
+
+    static Opts5 opCall(int x, int y)
+    {
+        Opts5 o = void;
+        o._x = x;
+        o._y = y;
+        return o;
+    }
+}
+
+void test5()
+{
+    // auto o = Opts5(x: 1, y: 2);  // ❌ Error: constructor is not callable
+    // auto p = Opts5(1, 2);         // ❌ Error: expected 0 arguments, not 2
+    // @disable this() blocks everything — opCall is never reached.
+}

--- a/docs/guidelines/idioms/forced-named-arguments/index.md
+++ b/docs/guidelines/idioms/forced-named-arguments/index.md
@@ -1,0 +1,206 @@
+# Forcing Named Arguments in D
+
+## Problem
+
+D's [named arguments (DIP1030)](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1030.md) are convenient but **optional** — callers can always fall back to positional arguments. For APIs with multiple parameters of the same type (e.g., `int x, int y, int width, int height`), positional calls are error-prone because swapping arguments compiles silently.
+
+There is no built-in keyword-only parameter mechanism (unlike Python's `*` separator).
+
+## Solution: Private Sentinel Type
+
+Place a `private`-typed parameter with a default value as the **first** parameter. External callers cannot construct or match the private type positionally, so they must use named arguments for the remaining parameters.
+
+### Functions
+
+::: code-group
+
+```d [mylib/drawing.d — definition]
+module mylib.drawing;
+
+/// Sentinel type — private to this module, impossible to name or
+/// construct from the outside.
+private struct NamedOnly {}
+
+/// Draws a rectangle. External callers must use named arguments:
+///     draw(x: 10, y: 20, width: 100, height: 200);
+void draw(NamedOnly _ = NamedOnly.init, int x = 0, int y = 0, int width = 0, int height = 0)
+{
+    // ...
+}
+```
+
+```d [caller.d — usage]
+import mylib.drawing;
+
+draw(x: 10, y: 20, width: 100, height: 200);  // ✅ compiles
+draw(width: 50, height: 50);                    // ✅ partial — rest get defaults
+draw(10, 20, 100, 200);                         // ❌ Error: cannot pass `int` to parameter `NamedOnly`
+```
+
+:::
+
+### Structs
+
+The same trick works for struct initialization — place the sentinel as the first field:
+
+::: code-group
+
+```d [mylib/config.d — definition]
+module mylib.config;
+
+struct ServerConfig
+{
+    private struct NamedOnly {}
+
+    NamedOnly _ = NamedOnly.init;
+    string host;
+    ushort port;
+    uint maxConnections = 100;
+}
+```
+
+```d [caller.d — usage]
+import mylib.config;
+
+auto cfg = ServerConfig(host: "localhost", port: 8080);  // ✅ compiles
+auto bad = ServerConfig("localhost", 8080);               // ❌ Error: cannot convert `string` to `NamedOnly`
+```
+
+:::
+
+## Guidelines
+
+- Name the sentinel `_` so it is clearly not a real parameter
+- Always give it `= NamedOnly.init` so callers never need to mention it
+- All real parameters should also have defaults when the sentinel is used, since
+  named arguments allow skipping parameters (e.g., `draw(width: 50, height: 50)`)
+- Use this idiom for APIs where positional argument confusion would be a source
+  of bugs (e.g., multiple parameters of the same type like coordinates)
+- **Prefer the function-parameter variant** over the struct-field variant for
+  zero-overhead guarantees (see [ABI Impact](#abi-impact) below)
+
+## ABI Impact
+
+The sentinel is a zero-sized struct. Its impact depends on where it is used:
+
+| Variant            | Overhead    | Why                                                                          |
+| ------------------ | ----------- | ---------------------------------------------------------------------------- |
+| Function parameter | **None**    | Zero-sized struct occupies no register and no stack slot — identical codegen |
+| Struct field       | **4 bytes** | D structs have minimum `sizeof == 1`; alignment padding inflates the struct  |
+
+### Compiler Output
+
+With LDC at `-O2 -release`, the function-parameter variant produces **byte-identical** assembly to a plain function (full source: [`abi_comparison.d`](abi_comparison.d)):
+
+::: code-group
+
+```d [sentinel version]
+export Rect withSentinel(
+    NamedOnly _ = NamedOnly.init,
+    int x = 0, int y = 0, int width = 0, int height = 0, int margin = 0,
+)
+{
+    return Rect(x - margin, y - margin, width + 2 * margin, height + 2 * margin);
+}
+```
+
+```d [baseline — no sentinel]
+export Rect withoutSentinel(int x, int y, int width, int height, int margin)
+{
+    return Rect(x - margin, y - margin, width + 2 * margin, height + 2 * margin);
+}
+```
+
+```asm [generated assembly (identical for both)]
+subl    %r8d, %edi
+subl    %r8d, %esi
+leal    (%rdx,%r8,2), %edx
+leal    (%rcx,%r8,2), %ecx
+shlq    $32, %rsi
+leaq    (%rdi,%rsi), %rax
+shlq    $32, %rcx
+orq     %rcx, %rdx
+retq
+```
+
+:::
+
+## Alternative Techniques Considered
+
+None of the following enforce named-only arguments:
+
+| Technique                                      | Idea                                                          | Why it doesn't work                                                                                                 |
+| ---------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `@disable this(int, int, …)`                   | Disable the positional constructor on a struct                | Named args resolve to the **same** constructor signature, so `@disable` blocks both positional and named calls      |
+| Distinct wrapper types (`struct X { int v; }`) | Each parameter gets its own type, preventing accidental swaps | Provides **type safety** but doesn't force naming — callers can still write `draw(X(10), Y(20))` positionally       |
+| All-default parameters                         | Give every parameter a default so callers can skip freely     | Positional calls still compile — `draw(10, 20, 100, 200)` is accepted without names                                 |
+| Struct parameter wrapper                       | `void draw(DrawOpts opts)`                                    | Encourages naming at the struct literal site, but `DrawOpts(10, 20, 100, 200)` still compiles positionally          |
+| `static opCall` with `@disable this()`         | Disable default constructor and route through `static opCall` | `@disable this()` interferes with `opCall` — the compiler tries the disabled constructor first and rejects the call |
+
+The experiments for each technique are in this directory — [`alternatives.d`](alternatives.d) collects all failing approaches, and [`abi_comparison.d`](abi_comparison.d) is the ABI snippet shown above. The multi-module enforcement test:
+
+::: code-group
+
+```d [lib.d — module with sentinel]
+module lib;
+
+private struct NamedOnly {}
+
+struct Rect
+{
+    int x, y, width, height;
+}
+
+Rect inflateRect(NamedOnly _ = NamedOnly.init, int x = 0, int y = 0, int width = 0, int height = 0, int margin = 0)
+{
+    return Rect(x - margin, y - margin, width + 2 * margin, height + 2 * margin);
+}
+
+struct RectOpts
+{
+    private struct NamedOnly {}
+
+    NamedOnly _ = NamedOnly.init;
+    int x, y, width, height;
+}
+
+Rect makeRect(RectOpts o)
+{
+    return Rect(o.x, o.y, o.width, o.height);
+}
+```
+
+```d [test_positive.d — named args ✅]
+/// Run: dmd -i -run test_positive.d
+import lib;
+
+void main()
+{
+    import std.stdio : writefln;
+
+    auto r1 = lib.inflateRect(x: 10, y: 20, width: 100, height: 200, margin: 5);
+    assert(r1 == lib.Rect(5, 15, 110, 210));
+
+    auto r2 = lib.inflateRect(width: 50, height: 50);
+    assert(r2 == lib.Rect(0, 0, 50, 50));
+
+    auto r3 = lib.makeRect(lib.RectOpts(x: 10, y: 20, width: 100, height: 200));
+    assert(r3 == lib.Rect(10, 20, 100, 200));
+
+    writefln("All positive tests passed.");
+}
+```
+
+```d [test_negative.d — positional ❌]
+/// Run: dmd -i -c test_negative.d
+/// Expected: compilation errors for every call below.
+import lib;
+
+void main()
+{
+    auto r1 = lib.inflateRect(10, 20, 100, 200, 5);  // ❌ cannot pass `int` as `NamedOnly`
+    auto r2 = lib.RectOpts(10, 20, 100, 200);         // ❌ cannot convert `int` to `NamedOnly`
+}
+```
+
+:::

--- a/docs/guidelines/idioms/forced-named-arguments/lib.d
+++ b/docs/guidelines/idioms/forced-named-arguments/lib.d
@@ -1,0 +1,30 @@
+module lib;
+
+/// Sentinel type — private to this module, impossible to name or construct
+/// from the outside.
+private struct NamedOnly {}
+
+struct Rect
+{
+    int x, y, width, height;
+}
+
+/// Free function with sentinel — forces named args from other modules.
+Rect inflateRect(NamedOnly _ = NamedOnly.init, int x = 0, int y = 0, int width = 0, int height = 0, int margin = 0)
+{
+    return Rect(x - margin, y - margin, width + 2 * margin, height + 2 * margin);
+}
+
+/// Struct with sentinel field.
+struct RectOpts
+{
+    private struct NamedOnly {}
+
+    NamedOnly _ = NamedOnly.init;
+    int x, y, width, height;
+}
+
+Rect makeRect(RectOpts o)
+{
+    return Rect(o.x, o.y, o.width, o.height);
+}

--- a/docs/guidelines/idioms/forced-named-arguments/test_negative.d
+++ b/docs/guidelines/idioms/forced-named-arguments/test_negative.d
@@ -1,0 +1,13 @@
+/// Negative tests — these must ALL fail to compile.
+/// Run: dmd -i -c test_negative.d
+/// Expected: compilation errors for every call below.
+import lib;
+
+void main()
+{
+    // Positional function call — cannot pass `int` as `NamedOnly`
+    auto r1 = lib.inflateRect(10, 20, 100, 200, 5);
+
+    // Positional struct init — cannot convert `int` to `NamedOnly`
+    auto r2 = lib.RectOpts(10, 20, 100, 200);
+}

--- a/docs/guidelines/idioms/forced-named-arguments/test_positive.d
+++ b/docs/guidelines/idioms/forced-named-arguments/test_positive.d
@@ -1,0 +1,22 @@
+/// Positive tests — these must compile and produce correct results.
+/// Run: dmd -i -run test_positive.d
+import lib;
+
+void main()
+{
+    import std.stdio : writefln;
+
+    // Function: named args skip the sentinel
+    auto r1 = lib.inflateRect(x: 10, y: 20, width: 100, height: 200, margin: 5);
+    assert(r1 == lib.Rect(5, 15, 110, 210));
+
+    // Function: partial named args (rest get defaults)
+    auto r2 = lib.inflateRect(width: 50, height: 50);
+    assert(r2 == lib.Rect(0, 0, 50, 50));
+
+    // Struct: named field init skips sentinel
+    auto r3 = lib.makeRect(lib.RectOpts(x: 10, y: 20, width: 100, height: 200));
+    assert(r3 == lib.Rect(10, 20, 100, 200));
+
+    writefln("All positive tests passed.");
+}

--- a/lychee.exclude
+++ b/lychee.exclude
@@ -8,3 +8,6 @@
 ^https://github\.com/sackosoft/zbox$
 ^https://github\.com/unvariant/tuile$
 ^https://github\.com/zhfkt/nice$
+^https?://mir-algorithm\.libmir\.org
+^https?://mir-stat\.libmir\.org
+^https://index.scala-lang.org


### PR DESCRIPTION
Add a new subsection under **Named Arguments** in the code style guide documenting the private-sentinel-type idiom for forcing named arguments in D.

## What's added

- **Forcing Named Arguments** section with function and struct examples
- Practical guidelines on when and how to apply the idiom
- Collapsible table of alternative techniques that were investigated but don't work (`@disable`, wrapper types, all-defaults, struct params, `static opCall`)