### PR TITLE
feat(math): add sparkles:math vector primitives package

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -8,3 +8,4 @@ targetPath "build"
 
 subPackage "libs/core-cli"
 subPackage "libs/test-utils"
+subPackage "libs/math"

--- a/libs/math/dub.sdl
+++ b/libs/math/dub.sdl
@@ -1,0 +1,25 @@
+name "math"
+description "Math primitives for games and graphics"
+authors "Petar Kirov"
+copyright "Copyright © 2026, Petar Kirov"
+license "BSL-1.0"
+
+targetPath "build"
+
+dflags "-preview=in" "-preview=dip1000"
+
+configuration "library" {
+    targetType "library"
+    excludedSourceFiles "src/app.d"
+}
+
+configuration "unittest" {
+    excludedSourceFiles "src/app.d"
+
+    dependency "silly" version="~>1.1.1"
+
+    dflags "-checkaction=context" "-allinst"
+    dflags "-defaultlib=libphobos2.so" "-L-fuse-ld=gold" platform="linux-dmd"
+    dflags "--link-defaultlib-shared" "--linker=gold" platform="linux-ldc"
+    lflags "--export-dynamic" platform="linux-ldc"
+}

--- a/libs/math/dub.sdl
+++ b/libs/math/dub.sdl
@@ -7,6 +7,7 @@ license "BSL-1.0"
 targetPath "build"
 
 dflags "-preview=in" "-preview=dip1000"
+dflags "-ftime-trace" "-ftime-trace-file=$PACKAGE_DIR/build/trace.json" "--ftime-trace-granularity=0" platform="ldc"
 
 configuration "library" {
     targetType "library"

--- a/libs/math/dub.selections.json
+++ b/libs/math/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"silly": "1.1.1"
+	}
+}

--- a/libs/math/src/sparkles/math/package.d
+++ b/libs/math/src/sparkles/math/package.d
@@ -1,0 +1,3 @@
+module sparkles.math;
+
+public import sparkles.math.vector : ScreenSize, Vec2f, Vec3f, Vec4f, Vector;

--- a/libs/math/src/sparkles/math/vector.d
+++ b/libs/math/src/sparkles/math/vector.d
@@ -13,6 +13,71 @@ import std.traits : CommonType, isNumeric;
 
 private enum baseFieldNames = ["x", "y", "z", "w"];
 
+private bool hasDuplicateIndices(scope const size_t[] indices)
+@safe pure nothrow @nogc
+{
+    foreach (i; 0 .. indices.length)
+    {
+        foreach (j; i + 1 .. indices.length)
+        {
+            if (indices[i] == indices[j])
+                return true;
+        }
+    }
+
+    return false;
+}
+
+private enum bool hasSingleCharFieldNames(string[] fieldNames) = (()
+{
+    foreach (name; fieldNames)
+    {
+        if (name.length != 1)
+            return false;
+    }
+
+    return true;
+})();
+
+private template fieldIndexForSwizzleChar(string[] fieldNames, char c, size_t i = 0)
+{
+    static if (i >= fieldNames.length)
+    {
+        static assert(
+            0,
+            "Invalid swizzle component `" ~ c ~ "` for this vector"
+        );
+    }
+    else static if (fieldNames[i][0] == c)
+    {
+        enum fieldIndexForSwizzleChar = i;
+    }
+    else
+    {
+        enum fieldIndexForSwizzleChar = fieldIndexForSwizzleChar!(
+            fieldNames,
+            c,
+            i + 1
+        );
+    }
+}
+
+private template swizzleIndices(string[] fieldNames, string swizzle)
+{
+    static assert(
+        hasSingleCharFieldNames!fieldNames,
+        "Swizzling requires vectors with single-character field names"
+    );
+
+    enum size_t[swizzle.length] swizzleIndices = ()
+    {
+        size_t[swizzle.length] result = void;
+        static foreach (i, c; swizzle)
+            result[i] = fieldIndexForSwizzleChar!(fieldNames, c);
+        return result;
+    }();
+}
+
 private string[] makeDefaultFieldNames(size_t N)()
 {
     static if (N <= baseFieldNames.length)
@@ -23,10 +88,11 @@ private string[] makeDefaultFieldNames(size_t N)()
     {
         import std.conv : to;
 
-        string[N] generated = void;
+        string[] generated;
+        generated.length = N;
         static foreach (i; 0 .. N)
             generated[i] = "v" ~ i.to!string;
-        return generated[];
+        return generated;
     }
 }
 
@@ -115,6 +181,34 @@ if (isNumeric!T && N > 0)
         foreach (i; 0 .. N)
             result += cast(CommonType!(T, U)) data[i] * rhs.data[i];
         return result;
+    }
+
+    /// Swizzle read access (`v.xzy`, `v.xyyzzx`, etc.).
+    @property Vector!(T, swizzle.length) opDispatch(string swizzle)() const
+    {
+        enum indices = swizzleIndices!(fieldNames, swizzle);
+
+        Vector!(T, swizzle.length) result;
+        static foreach (i; 0 .. swizzle.length)
+            result.data[i] = data[indices[i]];
+
+        return result;
+    }
+
+    /// Swizzle write access (`v.xy = ...`) with duplicate-write protection.
+    @property void opDispatch(string swizzle, U, size_t M, string[] rhsFieldNames)(
+        in Vector!(U, M, rhsFieldNames) rhs
+    )
+    if (isNumeric!U && M == swizzle.length)
+    {
+        enum indices = swizzleIndices!(fieldNames, swizzle);
+        static assert(
+            !hasDuplicateIndices(indices),
+            "Swizzle assignment requires unique destination components"
+        );
+
+        static foreach (i; 0 .. M)
+            data[indices[i]] = cast(T) rhs.data[i];
     }
 
     /// Writes the vector as `(name0: value0, name1: value1, ...)`.
@@ -239,6 +333,44 @@ unittest
     auto buf = appender!string();
     Vec3f(1, 2, 3).toString(buf);
     assert(buf[] == "(x: 1, y: 2, z: 3)");
+}
+
+/// Swizzle read access supports arbitrary ordering and duplication.
+@("Vector.swizzle.read")
+@safe pure nothrow @nogc
+unittest
+{
+    auto v = Vec3f(1, 2, 3);
+
+    assert(v.xyyzzx == Vector!(float, 6)(1, 2, 2, 3, 3, 1));
+    assert(v.zxy == Vec3f(3, 1, 2));
+    assert(v.xyz.yx == Vec2f(2, 1));
+}
+
+/// Swizzle write access updates selected components in order.
+@("Vector.swizzle.write")
+@safe pure nothrow @nogc
+unittest
+{
+    Vec3f v = Vec3f(1, 2, 3);
+
+    v.xy = Vec2f(9, 8);
+    assert(v == Vec3f(9, 8, 3));
+
+    v.yz = Vector!(int, 2)(7, 6);
+    assert(v == Vec3f(9, 7, 6));
+}
+
+/// Duplicate destination indices are rejected for swizzle assignments.
+@("Vector.swizzle.writeDuplicateReject")
+@safe pure nothrow @nogc
+unittest
+{
+    static assert(!__traits(compiles,
+    {
+        Vec3f v = Vec3f(1, 2, 3);
+        v.xx = Vec2f(4, 5);
+    }));
 }
 
 /// Floating-point vectors expose an infinity constant.

--- a/libs/math/src/sparkles/math/vector.d
+++ b/libs/math/src/sparkles/math/vector.d
@@ -1,0 +1,252 @@
+/**
+Vector primitives for linear algebra in game and graphics code.
+
+Provides a fixed-size numeric vector type with optional named fields,
+component-wise arithmetic, scalar operations, dot product, and aliases
+for common vector sizes.
+*/
+module sparkles.math.vector;
+
+import std.traits : CommonType, isNumeric;
+
+@safe:
+
+private enum baseFieldNames = ["x", "y", "z", "w"];
+
+private string[] makeDefaultFieldNames(size_t N)()
+{
+    static if (N <= baseFieldNames.length)
+    {
+        return baseFieldNames[0 .. N];
+    }
+    else
+    {
+        import std.conv : to;
+
+        string[N] generated = void;
+        static foreach (i; 0 .. N)
+            generated[i] = "v" ~ i.to!string;
+        return generated[];
+    }
+}
+
+/// Fixed-size numeric vector with optional named components.
+struct Vector(T, size_t N, string[] fieldNames = makeDefaultFieldNames!N)
+if (isNumeric!T && N > 0)
+{
+    static assert(
+        fieldNames.length == N,
+        "fieldNames must have exactly N entries"
+    );
+
+    union
+    {
+        T[N] data = 0;
+        struct
+        {
+            static foreach (field; fieldNames)
+                mixin("T " ~ field ~ ";");
+        }
+    }
+
+    private alias CommonVector(U) = Vector!(CommonType!(T, U), N, fieldNames);
+
+    static foreach (i; 1 .. N + 1)
+    {
+        /// Initializes the first `i` components from constructor arguments.
+        this(T[i] values...)
+        @safe pure nothrow @nogc
+        {
+            data[0 .. i] = values[0 .. i];
+        }
+    }
+
+    /// Component-wise vector addition/subtraction.
+    CommonVector!U opBinary(string op, U)(in Vector!(U, N) rhs) const
+    if ((op == "+" || op == "-") && isNumeric!U)
+    {
+        CommonVector!U result;
+        foreach (i, ref elem; result.data)
+            elem = mixin("this.data[i] " ~ op ~ " rhs.data[i]");
+        return result;
+    }
+
+    /// In-place component-wise vector addition/subtraction.
+    ref Vector opOpAssign(string op)(in Vector rhs)
+    if (op == "+" || op == "-")
+    {
+        foreach (i, ref elem; data)
+            elem = mixin("elem " ~ op ~ " rhs.data[i]");
+        return this;
+    }
+
+    /// Component-wise scalar multiplication/division.
+    CommonVector!U opBinary(string op, U)(U rhs) const
+    if ((op == "*" || op == "/") && isNumeric!U)
+    {
+        CommonVector!U result;
+        foreach (i, ref elem; result.data)
+            elem = mixin("this.data[i] " ~ op ~ " rhs");
+        return result;
+    }
+
+    /// Scalar multiplication/division where scalar is on the left side.
+    CommonVector!U opBinaryRight(string op, U)(U lhs) const
+    if ((op == "*" || op == "/") && isNumeric!U)
+    {
+        static if (op == "*")
+        {
+            return this * lhs;
+        }
+        else
+        {
+            CommonVector!U result;
+            foreach (i, ref elem; result.data)
+                elem = lhs / data[i];
+            return result;
+        }
+    }
+
+    /// Dot product between two vectors.
+    CommonType!(T, U) dot(U)(in Vector!(U, N) rhs) const
+    if (isNumeric!U)
+    {
+        CommonType!(T, U) result = 0;
+        foreach (i; 0 .. N)
+            result += cast(CommonType!(T, U)) data[i] * rhs.data[i];
+        return result;
+    }
+
+    /// Writes the vector as `(name0: value0, name1: value1, ...)`.
+    void toString(W)(scope ref W writer) const
+    {
+        import std.format : formattedWrite;
+
+        formattedWrite(writer, "(");
+        static foreach (i; 0 .. N)
+        {
+            if (i != 0)
+                formattedWrite(writer, ", ");
+            formattedWrite(writer, "%s: %s", fieldNames[i], data[i]);
+        }
+        formattedWrite(writer, ")");
+    }
+
+    static if (__traits(isFloating, T))
+    {
+        /// Vector with all components set to floating-point infinity.
+        enum infinity = ()
+        {
+            typeof(this) result;
+            result.data[] = T.infinity;
+            return result;
+        }();
+    }
+}
+
+/// 2D float vector.
+alias Vec2f = Vector!(float, 2);
+
+/// 3D float vector.
+alias Vec3f = Vector!(float, 3);
+
+/// 4D float vector.
+alias Vec4f = Vector!(float, 4);
+
+/// Named 2D vector for pixel dimensions.
+alias ScreenSize(T) = Vector!(T, 2, ["width", "height"]);
+
+/// Default initialization and partial constructors.
+@("Vector.initialization")
+@safe pure nothrow @nogc
+unittest
+{
+    auto v2 = Vec2f();
+    assert(v2.x == 0);
+    assert(v2.y == 0);
+
+    auto v0 = Vec3f();
+    assert(v0 == Vec3f(0, 0, 0));
+
+    auto v1 = Vec3f(1f);
+    assert(v1 == Vec3f(1, 0, 0));
+
+    auto v3 = Vec3f(1, 2, 3);
+    assert(v3.x == 1);
+    assert(v3.y == 2);
+    assert(v3.z == 3);
+}
+
+/// Component-wise arithmetic and in-place updates.
+@("Vector.arithmetic")
+@safe pure nothrow @nogc
+unittest
+{
+    assert(Vec3f(1, 2, 3) + Vec3f(4, 5, 6) == Vec3f(5, 7, 9));
+    assert(Vec3f(4, 5, 6) - Vec3f(1, 2, 3) == Vec3f(3, 3, 3));
+
+    Vec3f accum = Vec3f(1, 2, 3);
+    accum += Vec3f(4, 5, 6);
+    assert(accum == Vec3f(5, 7, 9));
+
+    accum -= Vec3f(2, 2, 2);
+    assert(accum == Vec3f(3, 5, 7));
+}
+
+/// Scalar operations with vectors on either side.
+@("Vector.scalarArithmetic")
+@safe pure nothrow @nogc
+unittest
+{
+    assert(Vec3f(1, 2, 3) * 2 == Vec3f(2, 4, 6));
+    assert(Vec3f(1, 2, 3) / 2 == Vec3f(0.5, 1, 1.5));
+    assert(2 * Vec2f(1, 2) == Vec2f(2, 4));
+    assert(2 / Vec2f(1, 2) == Vec2f(2, 1));
+}
+
+/// Dot product works for mixed numeric vector types.
+@("Vector.dot")
+@safe pure nothrow @nogc
+unittest
+{
+    assert(Vec2f(1, 2).dot(Vector!(int, 2)(3, 4)) == 11);
+    static assert(is(typeof(Vec2f(1, 2).dot(Vector!(int, 2)(3, 4))) == float));
+}
+
+/// Custom component names and aliases.
+@("Vector.customFieldNames")
+@safe pure nothrow @nogc
+unittest
+{
+    alias Color = Vector!(ubyte, 3, ["r", "g", "b"]);
+    auto pink = Color(255, 192, 203);
+    assert(pink.r == 255);
+    assert(pink.g == 192);
+    assert(pink.b == 203);
+
+    auto screen = ScreenSize!uint(1920, 1080);
+    assert(screen.width == 1920);
+    assert(screen.height == 1080);
+}
+
+/// String formatting for debugging and logging.
+@("Vector.toString")
+@safe
+unittest
+{
+    import std.array : appender;
+
+    auto buf = appender!string();
+    Vec3f(1, 2, 3).toString(buf);
+    assert(buf[] == "(x: 1, y: 2, z: 3)");
+}
+
+/// Floating-point vectors expose an infinity constant.
+@("Vector.infinity")
+@safe pure nothrow @nogc
+unittest
+{
+    const inf = Vec3f.infinity;
+    static foreach (i; 0 .. 3)
+        static assert(inf.data[i] is float.infinity);
+}

--- a/nix/shells/default.nix
+++ b/nix/shells/default.nix
@@ -19,6 +19,10 @@ pkgs.mkShell {
     pkgs.dtools
     pkgs.dub
 
+    # Profiling
+    pkgs.tracy
+    pkgs.capstone
+
     pkgs.mold
 
     # Documentation site

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -5,5 +5,6 @@ root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 while IFS= read -r pkg; do
     echo "Testing sparkles:$(basename "$pkg")"
+    mkdir -p "$root_dir/$pkg/build"
     dub --root "$root_dir" test ":$(basename "$pkg")"
 done < <(grep -o 'subPackage "[^"]*"' "$root_dir/dub.sdl" | sed 's/subPackage "\([^"]*\)"/\1/')


### PR DESCRIPTION
## Summary
- add a new `sparkles:math` dub subpackage and wire it into the root workspace
- seed and harden a new `sparkles.math.vector` module with fixed-size vectors for game/graphics math
- expose public aliases (`Vec2f`, `Vec3f`, `Vec4f`, `ScreenSize`) via `sparkles.math` package module
- add UDA-named unit tests with explicit safety attributes for initialization, arithmetic, scalar ops, dot product, custom field names, formatting, and infinity

## Validation
- `dub --root /home/petar/code/repos/mine/sparkles-linear-algebra test :math`
- `./scripts/run-tests.sh`
