### PR TITLE
docs(guidelines): add writing-docs skill and guidelines

### DIFF
--- a/.agents/skills/writing-docs/SKILL.md
+++ b/.agents/skills/writing-docs/SKILL.md
@@ -1,0 +1,1 @@
+../../../docs/guidelines/writing-docs-in-sparkles/index.md

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -65,6 +65,36 @@ export default defineConfig({
               },
             ],
           },
+          {
+            text: 'Writing Docs',
+            collapsed: true,
+            items: [
+              {
+                text: 'Overview',
+                link: '/guidelines/writing-docs-in-sparkles/',
+              },
+              {
+                text: 'Markdown Style',
+                link: '/guidelines/writing-docs-in-sparkles/markdown-style',
+              },
+              {
+                text: 'VitePress',
+                link: '/guidelines/writing-docs-in-sparkles/vitepress',
+              },
+              {
+                text: 'Lychee',
+                link: '/guidelines/writing-docs-in-sparkles/lychee',
+              },
+              {
+                text: 'Sparkles MD Tooling',
+                link: '/guidelines/writing-docs-in-sparkles/sparkles-md-tooling',
+              },
+              {
+                text: 'Conventions',
+                link: '/guidelines/writing-docs-in-sparkles/conventions',
+              },
+            ],
+          },
         ],
       },
       {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,6 +4,7 @@ export default defineConfig({
   title: 'Sparkles',
   description: 'D library for building CLI applications',
   base: '/',
+  cleanUrls: true,
 
   // Ignore links to .d source files referenced from docs
   ignoreDeadLinks: [/\.d$/],

--- a/docs/guidelines/writing-docs-in-sparkles/conventions.md
+++ b/docs/guidelines/writing-docs-in-sparkles/conventions.md
@@ -1,0 +1,34 @@
+# Conventions
+
+## Conventional Commits for Docs
+
+```
+docs(<scope>): <description>
+```
+
+### Scopes
+
+- `guidelines` — for guideline/idiom articles
+- `research` — for research survey pages
+- `specs` — for specification documents
+- Topic-specific scopes are also valid: `docs(markdown): ...`
+
+### Examples
+
+```
+docs(guidelines): add forced named arguments idiom
+docs(research): expand Vulkan binding safety research
+docs(guidelines): update code style with new DIP1030 examples
+```
+
+---
+
+## Symlinks for Library Ergonomics
+
+When a spec or doc is canonical under `docs/`, create symlinks from the library directory:
+
+```bash
+ln -s ../../docs/specs/markdown/SPEC.md libs/markdown/SPEC.md
+```
+
+This keeps docs browsable from both the library root and the VitePress site.

--- a/docs/guidelines/writing-docs-in-sparkles/conventions.md
+++ b/docs/guidelines/writing-docs-in-sparkles/conventions.md
@@ -2,6 +2,8 @@
 
 ## Conventional Commits for Docs
 
+Follow the [Conventional Commits][] format:
+
 ```
 docs(<scope>): <description>
 ```
@@ -32,3 +34,5 @@ ln -s ../../docs/specs/markdown/SPEC.md libs/markdown/SPEC.md
 ```
 
 This keeps docs browsable from both the library root and the VitePress site.
+
+[Conventional Commits]: https://www.conventionalcommits.org/

--- a/docs/guidelines/writing-docs-in-sparkles/index.md
+++ b/docs/guidelines/writing-docs-in-sparkles/index.md
@@ -17,6 +17,7 @@ Every docs change must satisfy **all** of these before committing:
 4. `prettier` formatting passes — see [Markdown Style][]
 5. If the page contains runnable D code examples, `verify-md-examples` passes — see [Sparkles MD Tooling][]
 6. Cross-references to/from related pages are added (index pages, sibling docs)
+7. Link to relevant **upstream documentation** where possible (e.g., VitePress feature docs, lychee config reference, language specs)
 
 ---
 

--- a/docs/guidelines/writing-docs-in-sparkles/index.md
+++ b/docs/guidelines/writing-docs-in-sparkles/index.md
@@ -1,0 +1,88 @@
+---
+name: writing-docs
+description: 'Write, edit, or add documentation pages to the VitePress docs site. Use when creating or modifying files under docs/, updating the sidebar, or adding research/guideline articles.'
+---
+
+# Writing Documentation
+
+Guidelines for writing, organizing, and validating documentation in the Sparkles project.
+
+## Quick Checklist
+
+Every docs change must satisfy **all** of these before committing:
+
+1. New page added to sidebar in `docs/.vitepress/config.mts` — see [VitePress][]
+2. All links are **reference-style** — see [Markdown Style][]
+3. `lychee` link check passes — see [Lychee][]
+4. `prettier` formatting passes — see [Markdown Style][]
+5. If the page contains runnable D code examples, `verify-md-examples` passes — see [Sparkles MD Tooling][]
+6. Cross-references to/from related pages are added (index pages, sibling docs)
+
+---
+
+## Directory Structure
+
+### Top-Level Layout
+
+```
+docs/
+├── .vitepress/
+│   ├── config.mts          # Sidebar + nav config
+│   └── theme/              # Theme overrides
+├── guidelines/             # Style guides and idioms
+│   ├── idioms/             # Complex patterns, each in its own directory
+│   │   └── <idiom-name>/
+│   │       ├── index.md    # Main article
+│   │       └── *.d         # Companion source files
+│   └── *.md                # Standalone guideline pages
+├── research/               # Research surveys
+│   └── <topic>/
+│       ├── index.md        # Survey hub / catalog
+│       └── <project>.md    # Per-project deep dives (kebab-case)
+├── specs/                  # Specifications (if present)
+│   └── <project>/
+│       ├── index.md        # Spec overview
+│       ├── SPEC.md         # Main spec
+│       └── TESTING.md      # Testing strategy
+├── index.md                # Site home
+└── overview.md             # Package overview
+```
+
+### When to Use a Directory vs. a Single File
+
+- **Single file** — short, self-contained guideline page (e.g., `ddoc.md`)
+- **Directory with `index.md`** — article that needs companion files (D source, images, data) or has sub-pages. The `index.md` is the main entry point; auxiliary files sit alongside it.
+
+### Naming
+
+- Use **kebab-case** for file and directory names (`forced-named-arguments/`, `haskell-effectful.md`)
+- Research deep-dives: `<language>-<project>.md` (e.g., `rust-vulkano.md`, `scala-zio.md`)
+- Index pages are always `index.md`
+
+---
+
+## Workflow Summary
+
+1. **Create the file** in the appropriate `docs/` subdirectory
+2. **Write content** using the matching [article template][Markdown Style]
+3. **Use reference-style links** throughout; place definitions at EOF
+4. **Cross-link** from relevant index pages and sibling docs
+5. **Add to sidebar** in `docs/.vitepress/config.mts` — see [VitePress][]
+6. **Run pre-commit hooks** to validate formatting, links, and examples — see [Sparkles MD Tooling][]
+7. **Commit** with a `docs(<scope>): ...` message — see [Conventions][]
+
+---
+
+## Topic Guides
+
+- [Markdown Style][] — reference-style links, formatting rules, article structure templates
+- [VitePress][] — sidebar configuration, code groups, collapsible sections, theme
+- [Lychee][] — link checking configuration, exclusions, fixing broken links
+- [Sparkles MD Tooling][] — `run_md_examples`, D code blocks, pre-commit hooks
+- [Conventions][] — conventional commits, symlinks for library ergonomics
+
+[Markdown Style]: markdown-style.md
+[VitePress]: vitepress.md
+[Lychee]: lychee.md
+[Sparkles MD Tooling]: sparkles-md-tooling.md
+[Conventions]: conventions.md

--- a/docs/guidelines/writing-docs-in-sparkles/lychee.md
+++ b/docs/guidelines/writing-docs-in-sparkles/lychee.md
@@ -1,0 +1,41 @@
+# Lychee
+
+Link checking with [lychee][] ensures all URLs in documentation are reachable.
+
+## Configuration
+
+- Config file: `lychee.toml`
+- Shared exclusions: `lychee.exclude` (always applied)
+- CI-only exclusions: `lychee.ci.exclude` (flaky endpoints in GitHub Actions)
+- `fallback_extensions = ["md", "html"]` — links without extensions resolve to `.md` or `.html`
+- `include_verbatim = false` — URLs inside code blocks are not checked
+- `include_fragments = false` — anchor fragments are not checked
+- GitHub blob/tree URLs are rewritten to the Contents API to avoid rate limiting
+- Caching is enabled (`--cache` flag); the `.lycheecache` file is gitignored
+- The hook is restricted to `\.md$` files to avoid false positives in source code
+
+## Adding Exclusions
+
+- **Permanently broken or paywalled URLs** → add to `lychee.exclude`
+- **URLs that work locally but fail in CI** (rate limits, geo-blocks) → add to `lychee.ci.exclude`
+- **Deleted repositories** → add specific URL to `lychee.exclude` and mark the link in docs with strikethrough: `~~[repo](URL)~~ (deleted)`
+- **Academic publishers** (`doi.org`, `dl.acm.org`, `link.springer.com`) → already excluded globally
+- Use anchored regexes: `^https://example\.com/path$`
+
+## Fixing Broken Links
+
+When lychee reports a broken link:
+
+1. **Moved resource** → update URL to the new canonical location
+2. **Deleted page** → replace with a stable alternative (project README, conference talk, Web Archive snapshot, or Gist mirror)
+3. **Deleted repository** → mark as `~~[name](url)~~ (deleted)`, add URL to `lychee.exclude`
+4. **Flaky in CI only** → add to `lychee.ci.exclude`
+5. Always verify the replacement URL is live before committing
+
+## Running Locally
+
+```bash
+lychee docs/path/to/file.md
+```
+
+[lychee]: https://lychee.cli.rs/

--- a/docs/guidelines/writing-docs-in-sparkles/lychee.md
+++ b/docs/guidelines/writing-docs-in-sparkles/lychee.md
@@ -1,10 +1,10 @@
 # Lychee
 
-Link checking with [lychee][] ensures all URLs in documentation are reachable.
+Link checking with [lychee][] ensures all URLs in documentation are reachable. See the [lychee configuration reference][lychee-config] for all available options.
 
 ## Configuration
 
-- Config file: `lychee.toml`
+- Config file: `lychee.toml` (see [configuration docs][lychee-config])
 - Shared exclusions: `lychee.exclude` (always applied)
 - CI-only exclusions: `lychee.ci.exclude` (flaky endpoints in GitHub Actions)
 - `fallback_extensions = ["md", "html"]` — links without extensions resolve to `.md` or `.html`
@@ -39,3 +39,4 @@ lychee docs/path/to/file.md
 ```
 
 [lychee]: https://lychee.cli.rs/
+[lychee-config]: https://lychee.cli.rs/guides/config/

--- a/docs/guidelines/writing-docs-in-sparkles/markdown-style.md
+++ b/docs/guidelines/writing-docs-in-sparkles/markdown-style.md
@@ -1,0 +1,151 @@
+# Markdown Style
+
+## Link Style: Reference-Style Links Only
+
+**Never use inline links.** Always use reference-style links with definitions at the bottom of the file.
+
+### ✅ Correct
+
+```markdown
+See the [effectful][] library for a ReaderT IO approach.
+
+The [Koka][] language uses row-polymorphic effects.
+
+[effectful]: haskell-effectful.md
+[Koka]: koka.md
+```
+
+### ❌ Wrong
+
+```markdown
+See the [effectful](haskell-effectful.md) library.
+```
+
+### Rules
+
+- Place all reference definitions at the **end of the file**, grouped logically
+- Use relative paths for internal links (`./sibling.md`, `../parent/page.md`)
+- Use the document's natural title as the reference label when possible
+- The `fix-markdown-reference-links` pre-commit hook will auto-convert inline links, but write reference-style from the start to avoid noisy diffs
+
+---
+
+## Formatting Rules
+
+- **Prettier** enforces markdown formatting — do not fight it
+- **EditorConfig**: Markdown uses `indent_size = unset` (code blocks may have intentional spacing)
+- Line endings: LF only (`end_of_line = lf`)
+- Files must end with a newline
+- Use GFM-style tables for comparisons and metadata
+
+---
+
+## Article Structure Templates
+
+### Guideline / Idiom Article
+
+```markdown
+# Title
+
+## Problem
+
+Describe the limitation or issue.
+
+## Solution
+
+Describe the pattern/idiom with code examples.
+
+## Guidelines
+
+Rules for when and how to apply the pattern.
+
+## ABI Impact / Technical Analysis
+
+(If applicable) Detailed performance or low-level implications.
+
+## Alternative Techniques Considered
+
+| Technique | Result | Why It Fails |
+| --------- | ------ | ------------ |
+| ...       | ...    | ...          |
+```
+
+### Research Survey Index (`index.md`)
+
+```markdown
+# Topic Name
+
+A one-line summary of the research scope.
+
+**Last reviewed:** Month Day, Year.
+
+---
+
+## Scope
+
+What this survey covers and doesn't cover.
+
+## State of the Art
+
+| Axis | Current Frontier |
+| ---- | ---------------- |
+| ...  | ...              |
+
+## Surveyed Projects
+
+1. [Project A][] — one-line summary
+2. [Project B][] — one-line summary
+
+## Comparative Snapshot
+
+| Feature | Project A | Project B |
+| ------- | --------- | --------- |
+| ...     | ...       | ...       |
+
+## Synthesis / Takeaways
+
+Aggregated findings and actionable design patterns.
+
+[Project A]: project-a.md
+[Project B]: project-b.md
+```
+
+### Research Deep-Dive Page
+
+```markdown
+# Language: Project Name
+
+## Overview
+
+High-level summary: what it solves, design philosophy.
+
+| Field         | Value |
+| ------------- | ----- |
+| Language      | ...   |
+| License       | ...   |
+| Repository    | ...   |
+| Documentation | ...   |
+
+## Core Mechanism
+
+Technical details with code snippets.
+
+## Strengths
+
+- ...
+
+## Limitations
+
+- ...
+
+## D Takeaways
+
+What lessons apply to this project's D codebase.
+
+## Sources
+
+- [Source 1][]
+- [Source 1][]
+
+[Source 1]: https://...
+```

--- a/docs/guidelines/writing-docs-in-sparkles/markdown-style.md
+++ b/docs/guidelines/writing-docs-in-sparkles/markdown-style.md
@@ -2,7 +2,7 @@
 
 ## Link Style: Reference-Style Links Only
 
-**Never use inline links.** Always use reference-style links with definitions at the bottom of the file.
+**Never use inline links.** Always use [reference-style links][md-ref-links] with definitions at the bottom of the file.
 
 ### ✅ Correct
 
@@ -32,8 +32,8 @@ See the [effectful](haskell-effectful.md) library.
 
 ## Formatting Rules
 
-- **Prettier** enforces markdown formatting — do not fight it
-- **EditorConfig**: Markdown uses `indent_size = unset` (code blocks may have intentional spacing)
+- [Prettier][] enforces markdown formatting — do not fight it
+- [EditorConfig][]: Markdown uses `indent_size = unset` (code blocks may have intentional spacing)
 - Line endings: LF only (`end_of_line = lf`)
 - Files must end with a newline
 - Use GFM-style tables for comparisons and metadata
@@ -149,3 +149,7 @@ What lessons apply to this project's D codebase.
 
 [Source 1]: https://...
 ```
+
+[md-ref-links]: https://www.markdownguide.org/basic-syntax/#reference-style-links
+[Prettier]: https://prettier.io/docs/en/
+[EditorConfig]: https://editorconfig.org/

--- a/docs/guidelines/writing-docs-in-sparkles/sparkles-md-tooling.md
+++ b/docs/guidelines/writing-docs-in-sparkles/sparkles-md-tooling.md
@@ -1,0 +1,95 @@
+# Sparkles MD Tooling
+
+## Pre-commit Hooks (docs-related)
+
+| Hook                           | Purpose                                    | Files  |
+| ------------------------------ | ------------------------------------------ | ------ |
+| `editorconfig-checker`         | Whitespace / indentation consistency       | All    |
+| `end-of-file-fixer`            | Ensure trailing newline                    | Text   |
+| `fix-markdown-reference-links` | Convert inline links → reference-style     | `*.md` |
+| `prettier`                     | Format markdown, tables, spacing           | Text   |
+| `lychee`                       | Validate all URLs (internal + external)    | `*.md` |
+| `verify-md-examples`           | Compile/run D code blocks and check output | `*.md` |
+
+All hooks run automatically on `git commit`. To run manually:
+
+```bash
+pre-commit run --files docs/path/to/file.md
+pre-commit run lychee --files docs/path/to/file.md
+```
+
+---
+
+## Runnable D Examples in Markdown
+
+### Structure
+
+Embed D code examples as dub single-file programs inside fenced `d` code blocks:
+
+````markdown
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_my_feature"
+    dependency "sparkles:core-cli" version="*"
++/
+
+import sparkles.core_cli.my_module;
+
+void main()
+{
+    // Example usage
+}
+```
+````
+
+Follow the code block with a bare fenced output block (no language tag) showing the expected output:
+
+````markdown
+```
+Expected output here
+```
+````
+
+### Dependencies
+
+- In **README.md / docs/** examples: use `version="*"` for sparkles dependencies
+- In **libs/\*/examples/\*.d** files: use `path="../../../"` to point to the repo root (avoids resolving against published registry versions)
+
+### Dynamic Output with `<!-- md-example-expected -->`
+
+When output contains dynamic values (timestamps, paths, durations), add an HTML comment directive between the code block and the output block:
+
+<div v-pre>
+
+````markdown
+<!-- md-example-expected
+[ {{_}} | info | {{_}} ]: Server started
+-->
+
+```
+[ 14:32:01 | info | app.d:12 ]: Server started
+```
+````
+
+- `{{_}}` matches any non-empty text
+- The HTML comment is invisible in rendered markdown
+- `--verify` uses the wildcard pattern; the literal block is preserved for readers
+
+</div>
+
+### Verifying Examples
+
+```bash
+# Verify all examples match expected output
+./scripts/run_md_examples.d --verify README.md
+
+# Update output blocks with actual output (golden snapshot)
+./scripts/run_md_examples.d --update README.md
+
+# Just run and display
+./scripts/run_md_examples.d README.md
+
+# Find and verify all markdown files
+./scripts/run_md_examples.d --verify --glob='**/*.md'
+```

--- a/docs/guidelines/writing-docs-in-sparkles/sparkles-md-tooling.md
+++ b/docs/guidelines/writing-docs-in-sparkles/sparkles-md-tooling.md
@@ -1,15 +1,17 @@
 # Sparkles MD Tooling
 
+This project uses custom tooling built on [pre-commit][] and the `run_md_examples.d` script to validate documentation.
+
 ## Pre-commit Hooks (docs-related)
 
-| Hook                           | Purpose                                    | Files  |
-| ------------------------------ | ------------------------------------------ | ------ |
-| `editorconfig-checker`         | Whitespace / indentation consistency       | All    |
-| `end-of-file-fixer`            | Ensure trailing newline                    | Text   |
-| `fix-markdown-reference-links` | Convert inline links → reference-style     | `*.md` |
-| `prettier`                     | Format markdown, tables, spacing           | Text   |
-| `lychee`                       | Validate all URLs (internal + external)    | `*.md` |
-| `verify-md-examples`           | Compile/run D code blocks and check output | `*.md` |
+| Hook                           | Purpose                                                   | Files  |
+| ------------------------------ | --------------------------------------------------------- | ------ |
+| `editorconfig-checker`         | Whitespace / indentation consistency ([EditorConfig][])   | All    |
+| `end-of-file-fixer`            | Ensure trailing newline                                   | Text   |
+| `fix-markdown-reference-links` | Convert inline links → reference-style                    | `*.md` |
+| `prettier`                     | Format markdown, tables, spacing ([Prettier][])           | Text   |
+| `lychee`                       | Validate all URLs (internal + external) ([lychee docs][]) | `*.md` |
+| `verify-md-examples`           | Compile/run D code blocks and check output                | `*.md` |
 
 All hooks run automatically on `git commit`. To run manually:
 
@@ -93,3 +95,8 @@ When output contains dynamic values (timestamps, paths, durations), add an HTML 
 # Find and verify all markdown files
 ./scripts/run_md_examples.d --verify --glob='**/*.md'
 ```
+
+[pre-commit]: https://pre-commit.com/
+[EditorConfig]: https://editorconfig.org/
+[Prettier]: https://prettier.io/docs/en/
+[lychee docs]: https://lychee.cli.rs/

--- a/docs/guidelines/writing-docs-in-sparkles/vitepress.md
+++ b/docs/guidelines/writing-docs-in-sparkles/vitepress.md
@@ -1,8 +1,10 @@
 # VitePress
 
+This project uses [VitePress][] to generate the documentation site. See the [VitePress Markdown Extensions guide][vp-markdown] for the full feature set.
+
 ## Sidebar Configuration
 
-Every new page **must** be added to the sidebar in `docs/.vitepress/config.mts`.
+Every new page **must** be added to the [sidebar][vp-sidebar] in `docs/.vitepress/config.mts`.
 
 ### Structure
 
@@ -33,9 +35,15 @@ sidebar: [
 
 ---
 
+## Frontmatter
+
+VitePress supports [YAML frontmatter][vp-frontmatter] at the top of every Markdown file. Custom keys are silently ignored and accessible via `$frontmatter`. Built-in keys like `title` and `description` set the page's `<meta>` tags. See the [Frontmatter Config Reference][vp-frontmatter-config] for all available options.
+
+---
+
 ## Code Groups
 
-Use `::: code-group` to show related code side-by-side in tabs:
+Use [`::: code-group`][vp-code-groups] to show related code side-by-side in tabs:
 
 ````markdown
 ::: code-group
@@ -50,6 +58,32 @@ Use `::: code-group` to show related code side-by-side in tabs:
 
 :::
 ````
+
+---
+
+## Custom Containers
+
+VitePress provides [custom containers][vp-containers] for callouts:
+
+```markdown
+::: info
+Informational note.
+:::
+
+::: tip
+Helpful tip.
+:::
+
+::: warning
+Warning message.
+:::
+
+::: danger
+Critical warning.
+:::
+```
+
+[GitHub-flavored alerts][vp-github-alerts] (`> [!NOTE]`, `> [!TIP]`, etc.) are also supported and render identically.
 
 ---
 
@@ -68,9 +102,31 @@ Content here.
 
 ---
 
+## Syntax Highlighting
+
+Code blocks are highlighted by [Shiki][vp-syntax]. Additional features:
+
+- [Line highlighting][vp-line-highlight]: ` ```d {2,4-6} ` or `// [!code highlight]`
+- [Line numbers][vp-line-numbers]: ` ```d:line-numbers `
+- [Code snippets from files][vp-code-import]: `<<< @/path/to/file.d`
+
+---
+
+## Markdown File Inclusion
+
+Include another Markdown file's content with [file inclusion][vp-include]:
+
+```markdown
+<!--@include: ./parts/section.md-->
+```
+
+Supports line ranges (`{3,}`, `{,10}`, `{1,10}`) and VS Code region markers.
+
+---
+
 ## Dead Link Exceptions
 
-The VitePress config ignores links to `.d` source files:
+The VitePress config ignores links to `.d` source files (see [ignoreDeadLinks][vp-dead-links]):
 
 ```typescript
 ignoreDeadLinks: [/\.d$/];
@@ -82,10 +138,26 @@ This allows referencing companion D source files from within articles without ge
 
 ## Theme
 
-Theme customizations live in `docs/.vitepress/theme/`:
+Theme customizations live in `docs/.vitepress/theme/` (see [Extending the Default Theme][vp-theme]):
 
 - `index.mts` — entry point; imports base theme and custom CSS
 - `custom.css` — sidebar styling, typography, color overrides
 - `Layout.vue` — layout component overrides
 
 When adding custom fonts, import from `vitepress/theme-without-fonts` to avoid bundling the default Inter font twice.
+
+[VitePress]: https://vitepress.dev/
+[vp-markdown]: https://vitepress.dev/guide/markdown
+[vp-sidebar]: https://vitepress.dev/reference/default-theme-sidebar
+[vp-frontmatter]: https://vitepress.dev/guide/frontmatter
+[vp-frontmatter-config]: https://vitepress.dev/reference/frontmatter-config
+[vp-code-groups]: https://vitepress.dev/guide/markdown#code-groups
+[vp-containers]: https://vitepress.dev/guide/markdown#custom-containers
+[vp-github-alerts]: https://vitepress.dev/guide/markdown#github-flavored-alerts
+[vp-syntax]: https://vitepress.dev/guide/markdown#syntax-highlighting-in-code-blocks
+[vp-line-highlight]: https://vitepress.dev/guide/markdown#line-highlighting-in-code-blocks
+[vp-line-numbers]: https://vitepress.dev/guide/markdown#line-numbers
+[vp-code-import]: https://vitepress.dev/guide/markdown#import-code-snippets
+[vp-include]: https://vitepress.dev/guide/markdown#markdown-file-inclusion
+[vp-dead-links]: https://vitepress.dev/reference/site-config#ignoredeadlinks
+[vp-theme]: https://vitepress.dev/guide/extending-default-theme

--- a/docs/guidelines/writing-docs-in-sparkles/vitepress.md
+++ b/docs/guidelines/writing-docs-in-sparkles/vitepress.md
@@ -1,0 +1,91 @@
+# VitePress
+
+## Sidebar Configuration
+
+Every new page **must** be added to the sidebar in `docs/.vitepress/config.mts`.
+
+### Structure
+
+```typescript
+sidebar: [
+  {
+    text: 'Section Name',
+    collapsed: true, // collapsed by default for large sections
+    items: [
+      { text: 'Page Title', link: '/path/to/page' },
+      {
+        text: 'Subsection',
+        collapsed: true,
+        items: [{ text: 'Child Page', link: '/path/to/child' }],
+      },
+    ],
+  },
+];
+```
+
+### Rules
+
+- Links omit the `.md` extension
+- For `index.md` pages, link to the directory with a trailing slash: `'/guidelines/idioms/forced-named-arguments/'`
+- Keep sidebar ordering consistent with the logical reading order
+- Use `collapsed: true` for sections with many items
+- Match the `text` value to the page's H1 title (or a short form of it)
+
+---
+
+## Code Groups
+
+Use `::: code-group` to show related code side-by-side in tabs:
+
+````markdown
+::: code-group
+
+```d [definition]
+// definition code
+```
+
+```d [usage]
+// usage code
+```
+
+:::
+````
+
+---
+
+## Collapsible Sections
+
+Use `<details>` for secondary information:
+
+```markdown
+<details>
+<summary>Alternative approach (click to expand)</summary>
+
+Content here.
+
+</details>
+```
+
+---
+
+## Dead Link Exceptions
+
+The VitePress config ignores links to `.d` source files:
+
+```typescript
+ignoreDeadLinks: [/\.d$/];
+```
+
+This allows referencing companion D source files from within articles without generating build errors.
+
+---
+
+## Theme
+
+Theme customizations live in `docs/.vitepress/theme/`:
+
+- `index.mts` — entry point; imports base theme and custom CSS
+- `custom.css` — sidebar styling, typography, color overrides
+- `Layout.vue` — layout component overrides
+
+When adding custom fonts, import from `vitepress/theme-without-fonts` to avoid bundling the default Inter font twice.


### PR DESCRIPTION
## Summary

Add documentation writing guidelines under `docs/guidelines/writing-docs-in-sparkles/`, split into focused topic pages. The Amp agent skill symlinks to the index page, reusing YAML frontmatter for both VitePress and the skill system.

## Files

| File | Purpose |
|------|---------|
| `index.md` | Overview, checklist, directory layout, workflow |
| `markdown-style.md` | Reference-style links, formatting rules, article templates |
| `vitepress.md` | Sidebar config, code groups, collapsible sections, theme |
| `lychee.md` | Link checking config, exclusions, fixing broken links |
| `sparkles-md-tooling.md` | `run_md_examples`, D code blocks, pre-commit hooks |
| `conventions.md` | Conventional commits, symlinks for library ergonomics |
| `.agents/skills/writing-docs/SKILL.md` | Symlink → `index.md` |

## Validation

- All pre-commit hooks pass (editorconfig, reference links, lychee, prettier, verify-md-examples)
- VitePress build succeeds
- Sidebar updated with 'Writing Docs' subsection under Guidelines