### PR TITLE
docs(research): add UI Layout catalog with 24 library/spec write-ups

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -400,6 +400,157 @@ export default defineConfig({
               },
             ],
           },
+          {
+            text: 'UI Layout',
+            collapsed: true,
+            items: [
+              { text: 'Catalog', link: '/research/ui-layout/' },
+              {
+                text: 'Constraint Systems',
+                collapsed: false,
+                items: [
+                  {
+                    text: 'Android ConstraintLayout',
+                    link: '/research/ui-layout/android-constraintlayout',
+                  },
+                  {
+                    text: 'Auto Layout (Apple)',
+                    link: '/research/ui-layout/auto-layout',
+                  },
+                ],
+              },
+              {
+                text: 'CSS Layout Specs',
+                collapsed: false,
+                items: [
+                  {
+                    text: 'CSS Flexbox',
+                    link: '/research/ui-layout/css-flexbox',
+                  },
+                  {
+                    text: 'CSS Grid',
+                    link: '/research/ui-layout/css-grid',
+                  },
+                  {
+                    text: 'CSS Normal Flow',
+                    link: '/research/ui-layout/css-normal-flow',
+                  },
+                ],
+              },
+              {
+                text: 'Declarative App Frameworks',
+                collapsed: false,
+                items: [
+                  {
+                    text: 'Flutter (Dart)',
+                    link: '/research/ui-layout/flutter',
+                  },
+                  {
+                    text: 'Jetpack Compose (Kotlin)',
+                    link: '/research/ui-layout/jetpack-compose',
+                  },
+                  {
+                    text: 'SwiftUI (Swift)',
+                    link: '/research/ui-layout/swiftui',
+                  },
+                ],
+              },
+              {
+                text: 'Desktop GUI Toolkits',
+                collapsed: false,
+                items: [
+                  {
+                    text: 'GTK 4 (C)',
+                    link: '/research/ui-layout/gtk',
+                  },
+                  {
+                    text: 'Qt Layouts (C++)',
+                    link: '/research/ui-layout/qt-layouts',
+                  },
+                  {
+                    text: 'Swing / MiG Layout (Java)',
+                    link: '/research/ui-layout/swing-mig',
+                  },
+                  {
+                    text: 'Tk Geometry Managers',
+                    link: '/research/ui-layout/tk',
+                  },
+                  {
+                    text: 'WPF / XAML (.NET)',
+                    link: '/research/ui-layout/wpf-xaml',
+                  },
+                ],
+              },
+              {
+                text: 'Foundational Algorithms',
+                collapsed: false,
+                items: [
+                  {
+                    text: 'Cassowary (algorithm)',
+                    link: '/research/ui-layout/cassowary',
+                  },
+                  {
+                    text: 'TeX / Knuth-Plass',
+                    link: '/research/ui-layout/tex-knuth-plass',
+                  },
+                ],
+              },
+              {
+                text: 'Immediate-Mode Layout',
+                collapsed: false,
+                items: [
+                  {
+                    text: 'Dear ImGui (C++)',
+                    link: '/research/ui-layout/dear-imgui',
+                  },
+                  {
+                    text: 'egui (Rust)',
+                    link: '/research/ui-layout/egui',
+                  },
+                ],
+              },
+              {
+                text: 'Renderer-Agnostic Libraries',
+                collapsed: false,
+                items: [
+                  {
+                    text: 'Clay (C)',
+                    link: '/research/ui-layout/clay',
+                  },
+                  {
+                    text: 'Kiwi (C++ / Python)',
+                    link: '/research/ui-layout/kiwi',
+                  },
+                  {
+                    text: 'Stretch (Rust)',
+                    link: '/research/ui-layout/stretch',
+                  },
+                  {
+                    text: 'Taffy (Rust)',
+                    link: '/research/ui-layout/taffy',
+                  },
+                  {
+                    text: 'Yoga (C++)',
+                    link: '/research/ui-layout/yoga',
+                  },
+                ],
+              },
+              {
+                text: 'Tiling / Structural Layout',
+                collapsed: false,
+                items: [
+                  {
+                    text: 'i3 / sway',
+                    link: '/research/ui-layout/i3-sway',
+                  },
+                  {
+                    text: 'xmonad (Haskell)',
+                    link: '/research/ui-layout/xmonad',
+                  },
+                ],
+              },
+            ],
+          },
         ],
       },
     ],

--- a/docs/research/ui-layout/android-constraintlayout.md
+++ b/docs/research/ui-layout/android-constraintlayout.md
@@ -1,0 +1,711 @@
+# Android ConstraintLayout
+
+A flat-hierarchy, constraint-based layout manager for the Android View system that
+replaced years of deeply-nested `LinearLayout` / `RelativeLayout` markup with a single
+container whose children position themselves through declarative relationships to
+siblings, the parent, virtual guides, and barriers. Internally backed by a solver
+derived from the Cassowary linear-arithmetic constraint algorithm.
+
+| Field             | Value                                                                       |
+| ----------------- | --------------------------------------------------------------------------- |
+| Vendor            | Google (Android / AndroidX)                                                 |
+| Language          | Java (consumed from Kotlin and Java); Compose DSL written in Kotlin         |
+| License           | Apache 2.0                                                                  |
+| Maven coordinates | `androidx.constraintlayout:constraintlayout`                                |
+| Compose package   | `androidx.constraintlayout:constraintlayout-compose`                        |
+| Repository        | <https://androidx.tech/artifacts/constraintlayout/constraintlayout/>        |
+| API reference     | <https://developer.android.com/reference/androidx/constraintlayout/widget/> |
+| Version snapshot  | 2.2.1 (View system) / 1.1.1 (Compose, February 2025)                        |
+| First release     | ConstraintLayout 1.0 (Google I/O 2017)                                      |
+
+---
+
+## Overview
+
+`ConstraintLayout` is a [`ViewGroup`](https://developer.android.com/reference/android/view/ViewGroup)
+introduced as part of [AndroidX](https://developer.android.com/jetpack/androidx) (formerly
+Android Support Library) that lets developers express the position and size of every child
+view as a set of **constraints** between anchors. An anchor is one of the four edges of a
+view (`left`, `right`, `top`, `bottom`), the start/end RTL-aware variants (`start`, `end`),
+or the text baseline. Each child must have **at least one horizontal and one vertical
+constraint** in order to be positioned; otherwise it falls back to coordinate (0, 0) and the
+designer surfaces a lint warning.
+
+The library exists to solve a very specific historical problem on Android: the View system's
+older layouts compose by **nesting**. To place three buttons in a row with one centred above
+a header you wrote a `LinearLayout(vertical)` containing a `LinearLayout(horizontal)`
+containing the buttons, plus another nested layout for the header. Each extra
+`ViewGroup` adds a full measure / layout pass over its subtree. Pre-2017 Android codebases
+routinely shipped layout XML 6-10 levels deep, with measurable jank during inflation and
+scrolling. ConstraintLayout's design goal was to express the same UIs in a **single flat
+container** where positioning is described by relationships rather than nesting.
+
+### Where it sits among Android's layout managers
+
+ConstraintLayout is the most recent member of a family of Android View-system layouts. To
+understand its design choices it helps to know what came before:
+
+- **`FrameLayout`** -- the simplest container. Children are all stacked on top of each
+  other in the top-left corner; positioning is via `layout_gravity` only. Useful for
+  single-child overlays (modals, toasts) but offers no real layout logic.
+- **`LinearLayout`** -- the workhorse of pre-ConstraintLayout Android. `orientation` is
+  either `vertical` or `horizontal`; children flow in that direction. Weights
+  (`layout_weight`) distribute leftover space. Nesting (vertical-of-horizontals or
+  horizontal-of-verticals) is how you build grids and forms, and that nesting is the
+  performance problem ConstraintLayout was created to solve.
+- **`RelativeLayout`** -- ConstraintLayout's direct predecessor. Children are positioned
+  via attributes like `layout_below="@id/foo"`, `layout_toRightOf="@id/bar"`,
+  `layout_alignParentBottom="true"`. The syntax is similar in spirit to ConstraintLayout
+  ("position X relative to Y"), but the underlying solver is simpler -- it cannot
+  express percent guides, barriers, ratios, or chains, and circular references silently
+  fail. ConstraintLayout is essentially RelativeLayout reimagined with a proper
+  constraint solver behind it.
+- **`GridLayout`** -- a row/column grid container added in API 14. Useful but limited:
+  rows and columns are fixed once defined, and `RecyclerView` / `GridLayoutManager` is
+  now preferred for any scrolling grid.
+- **`TableLayout`** -- a `LinearLayout(vertical)` of `TableRow` children. Mostly
+  historical.
+
+ConstraintLayout subsumes the use cases of `RelativeLayout`, most uses of `LinearLayout`,
+and many uses of `GridLayout`, while letting you express layouts that none of those could
+without nesting (e.g. "this label's left edge tracks whichever of these three labels is
+widest"). The Android Studio Layout Editor was rewritten around it: the visual designer
+drags constraints onto an anchor diagram and emits the corresponding XML, which made
+ConstraintLayout the de facto default for new XML layouts almost immediately after its
+release.
+
+### History
+
+- **2016, Google I/O preview.** ConstraintLayout demoed alongside the new Layout Editor.
+- **2017, version 1.0.** First stable release. Constraints, guidelines, biases, ratios,
+  chains.
+- **2018, version 1.1.** Barriers, groups, placeholders, percent dimensions, circular
+  positioning.
+- **2020, version 2.0.** Major release. Added **MotionLayout** (a subclass that animates
+  between `ConstraintSet`s), `Helper` classes (`Flow`, `Layer`), and the foundational
+  rewrite that backs the Compose port.
+- **2020-2021, ConstraintLayout for Compose.** A Compose DSL with `createRefs()` /
+  `constrainAs { }` that exposes the same primitives in Kotlin.
+- **2022 onwards.** Maintenance releases (2.1.x, 2.2.x) and continued investment in the
+  Compose port (1.0.x -> 1.1.x).
+
+The View-system library is in maintenance mode -- new Android UI development is steered
+toward Jetpack Compose -- but ConstraintLayout (both XML and Compose flavours) remains
+the recommended choice when constraint-based positioning fits the problem better than
+linear flow.
+
+---
+
+## Layout Model
+
+### Anchors and constraints
+
+A constraint is a directional link from one anchor of view A to another anchor of view B
+(where B is a sibling, the parent, a guideline, or a barrier). The XML attribute names
+encode the source anchor on the left of `_to`, the target anchor on the right, and the
+target view ID in the value:
+
+```
+app:layout_constraint<SourceEdge>_to<TargetEdge>Of="<targetId|parent>"
+```
+
+The full set of attribute pairs:
+
+| Source        | Target attributes                                                                                                     |
+| ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `Left`        | `layout_constraintLeft_toLeftOf`, `layout_constraintLeft_toRightOf`                                                   |
+| `Right`       | `layout_constraintRight_toLeftOf`, `layout_constraintRight_toRightOf`                                                 |
+| `Top`         | `layout_constraintTop_toTopOf`, `layout_constraintTop_toBottomOf`                                                     |
+| `Bottom`      | `layout_constraintBottom_toTopOf`, `layout_constraintBottom_toBottomOf`                                               |
+| `Start` (RTL) | `layout_constraintStart_toStartOf`, `layout_constraintStart_toEndOf`                                                  |
+| `End` (RTL)   | `layout_constraintEnd_toStartOf`, `layout_constraintEnd_toEndOf`                                                      |
+| `Baseline`    | `layout_constraintBaseline_toBaselineOf`, `layout_constraintBaseline_toTopOf`, `layout_constraintBaseline_toBottomOf` |
+| Circular      | `layout_constraintCircle`, `layout_constraintCircleRadius`, `layout_constraintCircleAngle` (since 1.1)                |
+
+The `Start` / `End` family is **RTL-aware** and is preferred over `Left` / `Right` for
+internationalised apps -- the runtime swaps the resolved edges when the layout direction
+is right-to-left. `Baseline` aligns text baselines and is the right anchor for putting a
+label next to an input field so their text rests on the same line regardless of the views'
+heights.
+
+A target value of `"parent"` constrains to the parent `ConstraintLayout`. Otherwise it is
+`"@id/<viewId>"` of a sibling.
+
+### Bias
+
+When a view has **two opposing constraints** (e.g. `Start_toStartOf="parent"` and
+`End_toEndOf="parent"`) and is sized smaller than the available space, the view is
+**centred** by default in the constrained interval. The centre point can be moved using
+the bias attribute, a float in `[0.0, 1.0]`:
+
+```xml
+app:layout_constraintHorizontal_bias="0.25"   <!-- 25% from the left -->
+app:layout_constraintVertical_bias="0.75"     <!-- 75% from the top -->
+```
+
+A value of `0` pins to the start edge of the interval, `1` pins to the end, `0.5` centres
+(the default).
+
+### Dimension constraints
+
+Each child's `android:layout_width` and `android:layout_height` may take one of three
+fundamentally different values inside a `ConstraintLayout`:
+
+- **fixed `dp`** -- a concrete size in density-independent pixels.
+- **`wrap_content`** -- shrink to the natural intrinsic size of the content.
+- **`0dp` (a.k.a. "match constraints")** -- expand to fill the space between the two
+  opposing constraints on that axis. This is the dimension mode that unlocks
+  ConstraintLayout's most expressive sizing behaviours.
+
+When width or height is `0dp`, extra attributes control how the view fills the constrained
+interval:
+
+| Attribute                              | Meaning                                                                                                                                                  |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `layout_constraintWidth_default`       | `spread` (fill the entire interval, default), `wrap` (fit intrinsic content but still respect constraints), or `percent` (size as a fraction of parent). |
+| `layout_constraintWidth_percent`       | A float in `(0, 1]`. With `default=percent`, the view's width is `percent * parent.width`.                                                               |
+| `layout_constraintWidth_min`           | Minimum width in `dp` (only meaningful with `0dp` width).                                                                                                |
+| `layout_constraintWidth_max`           | Maximum width in `dp`.                                                                                                                                   |
+| `layout_constraintHeight_default` etc. | The same attributes mirrored for the vertical axis.                                                                                                      |
+
+### Aspect ratio
+
+Once **one** dimension is `0dp` (match-constraints) and the other is either fixed or
+`wrap_content`, the flexible dimension can be derived from the fixed one via
+`layout_constraintDimensionRatio`. The string is `"width:height"` or
+`"<lockedSide>,width:height"`:
+
+```xml
+android:layout_width="0dp"
+android:layout_height="wrap_content"
+app:layout_constraintDimensionRatio="16:9"
+```
+
+If both dimensions are `0dp` the prefix `"W,..."` or `"H,..."` indicates which axis is
+derived from the other.
+
+### Guidelines
+
+A [`Guideline`](https://developer.android.com/reference/androidx/constraintlayout/widget/Guideline)
+is an invisible helper view that resolves to a single line at a fixed offset from the
+parent's start/top, end/bottom, or as a percentage. Other views constrain to it as if it
+were a sibling. The orientation determines whether it is a vertical line (positioned by an
+x-offset) or a horizontal line (y-offset):
+
+```xml
+<androidx.constraintlayout.widget.Guideline
+    android:id="@+id/start_quarter"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    app:layout_constraintGuide_percent="0.25" />
+```
+
+The three positioning attributes are mutually exclusive:
+
+- `app:layout_constraintGuide_begin="200dp"` -- offset from the start/top edge.
+- `app:layout_constraintGuide_end="80dp"` -- offset from the end/bottom edge.
+- `app:layout_constraintGuide_percent="0.5"` -- fraction of the parent's size on that axis.
+
+Guidelines do not render. They are conceptually the same as guides in a vector design
+tool.
+
+### Barriers
+
+A [`Barrier`](https://developer.android.com/reference/androidx/constraintlayout/widget/Barrier)
+is a virtual anchor that tracks the **extreme edge of a set of referenced views**. The
+canonical use case is forms with right-aligned labels of varying widths: you want every
+input field's left edge to sit just past the **widest** label, without knowing in advance
+which label that is. A barrier pointed `end` and referencing the three labels resolves to
+the maximum of their three end edges:
+
+```xml
+<androidx.constraintlayout.widget.Barrier
+    android:id="@+id/labels_barrier"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    app:barrierDirection="end"
+    app:constraint_referenced_ids="label_name,label_email,label_phone" />
+```
+
+`barrierDirection` is one of `start`, `end`, `left`, `right`, `top`, `bottom`. A barrier
+with direction `bottom` over a set of views resolves to the maximum bottom edge of all
+referenced views.
+
+### Chains
+
+A **chain** is a set of two or more views linked by **bidirectional constraints** along an
+axis. View A points to view B with `End_toStartOf="B"`, and B points back with
+`Start_toEndOf="A"`. Once linked, ConstraintLayout treats the chain as a unit and
+distributes the space between the outer anchors among its members. The first view (the
+"head") declares the chain style:
+
+```xml
+app:layout_constraintHorizontal_chainStyle="spread"
+```
+
+Styles:
+
+- **`spread`** (default) -- distribute leftover space evenly **around** all members
+  (equal gaps including outside the first and last).
+- **`spread_inside`** -- pin the first and last views to the outer constraints; distribute
+  leftover space evenly **between** the remaining views.
+- **`packed`** -- pack all members together with no gaps; the resulting block is
+  positioned within the outer interval according to the horizontal/vertical bias.
+
+Combined with **weights** (`layout_constraintHorizontal_weight` /
+`_vertical_weight`) on members whose dimension is `0dp`, chains additionally express
+"this row of three buttons divides leftover space 2:1:1". This is the ConstraintLayout
+analogue of `LinearLayout`'s `layout_weight`, but with finer control over the
+distribution style.
+
+### Groups
+
+A [`Group`](https://developer.android.com/reference/androidx/constraintlayout/widget/Group)
+is not a positioning helper -- it is a **visibility multiplexer**. It references a set of
+view IDs and applies its own `android:visibility` to all of them. Useful for showing or
+hiding a logical cluster of widgets (a form's "advanced options" section, an error
+banner's icon + text + retry button) with a single property change:
+
+```xml
+<androidx.constraintlayout.widget.Group
+    android:id="@+id/advanced_options"
+    android:visibility="gone"
+    app:constraint_referenced_ids="advanced_label,advanced_field,advanced_help" />
+```
+
+Groups have no size and no rendering -- they exist only to forward visibility changes.
+
+### The solver
+
+Under the hood, every constraint, guideline, barrier, chain, ratio, and bias is encoded
+into a system of linear equations and inequalities and solved each measurement pass by a
+custom **`LinearSystem`** in the `androidx.constraintlayout.core` package. The algorithm
+is derived from the
+[Cassowary](https://constraints.cs.washington.edu/cassowary/) linear-arithmetic constraint
+solver -- the same algorithm family that powers Apple's Auto Layout and the
+[`kasuari`](https://crates.io/crates/kasuari) crate used by [Ratatui](../tui-libraries/ratatui.md).
+ConstraintLayout's implementation is **not a strict Cassowary port**: it is heavily
+optimised for the specific shape of UI-layout problems (small number of variables, tight
+real-time deadlines, repeated incremental solves across measure passes) and trades
+generality for raw speed. The solver lives in the open-source AndroidX repo and can be
+read independently of the View-system glue.
+
+This is the deeper reason ConstraintLayout exists: the View system's `measure` /
+`layout` callback contract is inherently top-down and recursive, but constraint-based UI
+description is naturally a **whole-graph** problem. By owning the entire flat hierarchy
+and solving it as one linear system, ConstraintLayout side-steps the recursive
+measure-pass cost that nested layouts pay.
+
+### MotionLayout
+
+[`MotionLayout`](https://developer.android.com/reference/androidx/constraintlayout/motion/widget/MotionLayout)
+(version 2.0, 2020) is a subclass of `ConstraintLayout` that **animates between two or
+more `ConstraintSet` snapshots**. A `MotionScene` XML file defines the start/end
+constraint sets and a `Transition` block describing the animation -- duration, interpolator,
+and optional `KeyFrame`s that pin a view to a specific position or rotation at a fraction
+of the transition. Because the solver already understands the steady-state layout at any
+point in time, MotionLayout just feeds it intermediate `t` values and produces a smooth
+interpolation "for free":
+
+```xml
+<MotionScene xmlns:motion="http://schemas.android.com/apk/res-auto">
+    <Transition
+        motion:constraintSetStart="@id/start"
+        motion:constraintSetEnd="@id/end"
+        motion:duration="800">
+        <KeyFrameSet>
+            <KeyPosition
+                motion:framePosition="50"
+                motion:motionTarget="@id/title"
+                motion:keyPositionType="parentRelative"
+                motion:percentY="0.2" />
+        </KeyFrameSet>
+    </Transition>
+
+    <ConstraintSet android:id="@+id/start">
+        <Constraint android:id="@id/title"
+            app:layout_constraintTop_toTopOf="parent" />
+    </ConstraintSet>
+
+    <ConstraintSet android:id="@+id/end">
+        <Constraint android:id="@id/title"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </ConstraintSet>
+</MotionScene>
+```
+
+`MotionLayout` only animates **position and size** (the things the solver controls). Other
+properties (colour, text, alpha) require `CustomAttribute` blocks or external animation
+APIs.
+
+### ConstraintLayout for Compose
+
+Jetpack Compose has its own layout primitives (`Row`, `Column`, `Box` -- see
+[`jetpack-compose.md`](../ui-layout/jetpack-compose.md)) but for layouts where constraint
+relationships are clearer than nested rows and columns, the constraintlayout-compose
+artifact provides a Kotlin DSL with the same primitives:
+
+```kotlin
+@Composable
+fun ProfileCard() {
+    ConstraintLayout(modifier = Modifier.fillMaxWidth()) {
+        val (avatar, name, handle, bio) = createRefs()
+
+        Image(
+            painter = painterResource(R.drawable.avatar),
+            contentDescription = null,
+            modifier = Modifier
+                .size(64.dp)
+                .constrainAs(avatar) {
+                    top.linkTo(parent.top, margin = 16.dp)
+                    start.linkTo(parent.start, margin = 16.dp)
+                },
+        )
+
+        Text(
+            text = "Ada Lovelace",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.constrainAs(name) {
+                top.linkTo(avatar.top)
+                start.linkTo(avatar.end, margin = 12.dp)
+            },
+        )
+
+        Text(
+            text = "@ada",
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.constrainAs(handle) {
+                top.linkTo(name.bottom)
+                start.linkTo(name.start)
+            },
+        )
+
+        Text(
+            text = "Mathematician and writer, chiefly known for her work on " +
+                  "Charles Babbage's Analytical Engine.",
+            modifier = Modifier.constrainAs(bio) {
+                top.linkTo(avatar.bottom, margin = 16.dp)
+                start.linkTo(parent.start, margin = 16.dp)
+                end.linkTo(parent.end, margin = 16.dp)
+                width = Dimension.fillToConstraints
+            },
+        )
+    }
+}
+```
+
+The DSL mirrors the XML attributes one-to-one: `linkTo` is the constraint, `width =
+Dimension.fillToConstraints` is `0dp` / match-constraints, `Dimension.percent(0.5f)` is
+`layout_constraintWidth_percent`, `Dimension.ratio("16:9")` is
+`layout_constraintDimensionRatio`. Barriers, guidelines, chains, and groups all have
+direct Compose builders (`createStartBarrier`, `createGuidelineFromTop`,
+`createHorizontalChain`).
+
+---
+
+## Example: a login form (XML)
+
+The following layout puts an app logo at the top, a username field aligned to a label,
+a password field whose label aligns to the widest label, and a submit button stretched
+across a chain. All without any nesting:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <ImageView
+        android:id="@+id/logo"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:src="@drawable/logo"
+        android:contentDescription="@string/logo_desc"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintWidth_default="percent"
+        app:layout_constraintWidth_percent="0.5"
+        app:layout_constraintDimensionRatio="W,3:1" />
+
+    <TextView
+        android:id="@+id/label_username"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/username"
+        app:layout_constraintTop_toBottomOf="@id/logo"
+        app:layout_constraintBaseline_toBaselineOf="@id/field_username"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/label_password"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/password"
+        app:layout_constraintBaseline_toBaselineOf="@id/field_password"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/labels_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="end"
+        app:constraint_referenced_ids="label_username,label_password" />
+
+    <EditText
+        android:id="@+id/field_username"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:inputType="text"
+        android:layout_marginStart="12dp"
+        app:layout_constraintTop_toBottomOf="@id/logo"
+        app:layout_constraintStart_toEndOf="@id/labels_barrier"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <EditText
+        android:id="@+id/field_password"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:inputType="textPassword"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/field_username"
+        app:layout_constraintStart_toEndOf="@id/labels_barrier"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <Button
+        android:id="@+id/btn_cancel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/cancel"
+        app:layout_constraintTop_toBottomOf="@id/field_password"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/btn_submit"
+        app:layout_constraintHorizontal_chainStyle="spread"
+        app:layout_constraintHorizontal_weight="1" />
+
+    <Button
+        android:id="@+id/btn_submit"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/sign_in"
+        android:layout_marginStart="12dp"
+        app:layout_constraintTop_toBottomOf="@id/field_password"
+        app:layout_constraintStart_toEndOf="@id/btn_cancel"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_weight="2" />
+</androidx.constraintlayout.widget.ConstraintLayout>
+```
+
+The same UI written in nested `LinearLayout`s would be a five-deep tree with explicit
+weight rows. The `Barrier` removes the need to hard-code label widths, the chain on the
+two buttons splits the row 1:2 without an extra container, and the `ImageView` with a
+`W,3:1` ratio adapts to any screen width without breaking the rest of the form.
+
+---
+
+## Example: a chain with weights (Compose)
+
+The same chain-of-buttons pattern in Compose:
+
+```kotlin
+@Composable
+fun SubmitRow(onCancel: () -> Unit, onSubmit: () -> Unit) {
+    ConstraintLayout(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp),
+    ) {
+        val (cancel, submit) = createRefs()
+
+        // 1:2 weighted horizontal chain across the parent.
+        createHorizontalChain(
+            cancel, submit,
+            chainStyle = ChainStyle.Spread,
+        )
+
+        OutlinedButton(
+            onClick = onCancel,
+            modifier = Modifier.constrainAs(cancel) {
+                start.linkTo(parent.start)
+                end.linkTo(submit.start, margin = 12.dp)
+                width = Dimension.fillToConstraints.atLeast(96.dp)
+                horizontalChainWeight = 1f
+            },
+        ) { Text("Cancel") }
+
+        Button(
+            onClick = onSubmit,
+            modifier = Modifier.constrainAs(submit) {
+                start.linkTo(cancel.end)
+                end.linkTo(parent.end)
+                width = Dimension.fillToConstraints
+                horizontalChainWeight = 2f
+            },
+        ) { Text("Sign in") }
+    }
+}
+```
+
+`createHorizontalChain` is the Compose equivalent of declaring chain attributes on the
+first member. `horizontalChainWeight` corresponds to `layout_constraintHorizontal_weight`,
+and `Dimension.fillToConstraints` is `0dp`.
+
+---
+
+## Example: an aspect-ratio media card
+
+A common requirement is "video thumbnail at 16:9, title underneath, byline aligned to the
+title baseline, all in a card-width chunk":
+
+```xml
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/thumb"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:scaleType="centerCrop"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintDimensionRatio="H,16:9" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:maxLines="2"
+        android:ellipsize="end"
+        android:textAppearance="?textAppearanceTitleMedium"
+        app:layout_constraintTop_toBottomOf="@id/thumb"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/duration" />
+
+    <TextView
+        android:id="@+id/duration"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBaseline_toBaselineOf="@id/title"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/byline"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="?textAppearanceBodySmall"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>
+```
+
+The `Baseline_toBaselineOf` constraint between `title` and `duration` keeps the duration
+("3:42") sitting on the same text baseline as the first line of the title, regardless of
+the two views' actual heights or font sizes. This is exactly the use case the baseline
+anchor was designed for.
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Flat hierarchy, lower measure-pass cost.** A 30-child `ConstraintLayout` measures and
+  lays out in a single solver pass over a flat list, where the equivalent nested
+  `LinearLayout` design would recurse five layers deep with `weight` measurements
+  performed twice per row. Production app teams reported double-digit percent
+  improvements in frame timings just from flattening hierarchies during the 2017-2018
+  migration wave.
+- **Visual designer integration.** The Android Studio Layout Editor was rewritten around
+  ConstraintLayout and is genuinely productive: dragging an anchor from one view to
+  another emits the correct XML attribute, and the editor surfaces missing-constraint
+  lint warnings live. For designer-developer workflows (and for non-Compose teams
+  building static screens) this is the main productivity advantage.
+- **Expressive primitives.** Guidelines (percent splits), barriers (max-of-set
+  alignment), chains (weighted distribution with three distribution styles), ratios
+  (`16:9`), and biases compose to handle nearly any positioning requirement without
+  fighting the framework. Layouts that would require nesting in `LinearLayout` or
+  `RelativeLayout` collapse to a single container.
+- **Cassowary-family solver.** Numerically stable, incremental, fast. The same algorithm
+  family used by Apple Auto Layout (proven on every iOS screen since 2012) and by
+  modern TUI libraries like Ratatui via `kasuari`.
+- **RTL-aware out of the box.** Using `Start` / `End` attributes instead of `Left` /
+  `Right` makes layouts mirror correctly under right-to-left locales without code
+  changes.
+- **MotionLayout for "free" animations.** Because the solver already knows the steady
+  state of every constraint set, interpolating between two sets is a single API call.
+  Complex coordinated animations (a header collapsing, a button morphing, a label
+  fading) that would require dozens of `ObjectAnimator` calls become a single XML
+  scene.
+- **Compose port preserves the model.** The same primitives transferred to the new UI
+  toolkit with idiomatic Kotlin syntax (`createRefs`, `constrainAs`, `linkTo`). Teams
+  who internalised the XML attribute names find the Compose DSL trivial to adopt.
+
+### Weaknesses
+
+- **XML verbosity.** A single child needs 4-6 `app:layout_constraint*` attributes just to
+  position itself. Real-world XML routinely runs 80 characters wide and a hundred lines
+  long for a moderate screen. The Layout Editor mitigates this for visual editing, but
+  reviewing and merging XML diffs is painful.
+- **Cognitive overhead vs simple flow.** For UI that genuinely is "a vertical list of
+  three things, all the same width" a `LinearLayout(vertical)` or a Compose `Column` is
+  far less code. ConstraintLayout shines when relationships between siblings matter;
+  for trivially linear UIs it is overkill.
+- **Implicit chain definition.** Chains are formed by **bidirectional constraints**
+  without an explicit declaration. A typo on one end silently demotes a chain to two
+  ordinary constraints and the layout breaks in subtle ways. The Compose DSL is better
+  here because `createHorizontalChain` is an explicit call.
+- **Solver behaviour is hard to predict.** When a constraint is over-determined or has
+  conflicting requirements, the solver picks **a** solution but not necessarily the one
+  a developer expected. Debugging a "this should be on the left, why is it stuck at
+  x=0" problem often involves removing constraints one at a time until the broken one
+  becomes obvious.
+- **Performance trade-off vs Compose.** Compose's layout pipeline is its own thing --
+  there is no View-system measure recursion at all -- and for new code, Compose layouts
+  (`Row` / `Column` / `Box` / custom `Layout`) are generally preferred over
+  ConstraintLayout-for-Compose unless the constraint shape is a genuinely better fit.
+- **No equivalent of "flow" or "wrap to next line".** A row of N variable-width chips
+  that needs to wrap to the next line when full has no first-class ConstraintLayout
+  primitive (the `Flow` helper class in 2.0 partially addresses this but is less
+  polished than Compose's `FlowRow`).
+
+### Comparison to neighbours in this catalogue
+
+- vs **Jetpack Compose layouts** ([../ui-layout/jetpack-compose.md](../ui-layout/jetpack-compose.md)) --
+  Compose's `Row` / `Column` / `Box` are more declarative for **simple flow**;
+  ConstraintLayout (and `ConstraintLayout` for Compose) wins for **complex inter-sibling
+  relationships**.
+- vs the underlying **Cassowary solver** ([../ui-layout/cassowary.md](../ui-layout/cassowary.md)) --
+  ConstraintLayout uses a custom optimised variant rather than a faithful port, biased
+  toward UI-shaped problems and incremental re-solves.
+- vs **Apple Auto Layout** -- conceptually almost identical: constraints between view
+  anchors, bias-equivalent (Auto Layout calls it "priority"), solver-backed. The biggest
+  difference is that Auto Layout's constraints are typically built in code, while
+  ConstraintLayout's are XML-first (with a strong visual editor).
+
+---
+
+## References
+
+- **ConstraintLayout developer guide** -- <https://developer.android.com/develop/ui/views/layout/constraint-layout>
+- **`ConstraintLayout` API reference** -- <https://developer.android.com/reference/androidx/constraintlayout/widget/ConstraintLayout>
+- **`Guideline` API reference** -- <https://developer.android.com/reference/androidx/constraintlayout/widget/Guideline>
+- **`Barrier` API reference** -- <https://developer.android.com/reference/androidx/constraintlayout/widget/Barrier>
+- **`Group` API reference** -- <https://developer.android.com/reference/androidx/constraintlayout/widget/Group>
+- **MotionLayout developer guide** -- <https://developer.android.com/develop/ui/views/animations/motionlayout>
+- **`MotionLayout` API reference** -- <https://developer.android.com/reference/androidx/constraintlayout/motion/widget/MotionLayout>
+- **ConstraintLayout for Compose** -- <https://developer.android.com/develop/ui/compose/layouts/constraintlayout>
+- **Source code** -- <https://androidx.tech/artifacts/constraintlayout/constraintlayout/> (also mirrored at <https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/constraintlayout/>)
+- **Cassowary algorithm overview** -- <https://constraints.cs.washington.edu/cassowary/>
+- **Sample code** -- <https://github.com/android/views-widgets-samples/tree/main/ConstraintLayoutExamples>
+- **History of Android layout managers** -- "Build a Responsive UI with ConstraintLayout" tutorial archive, Google I/O 2017 talks

--- a/docs/research/ui-layout/auto-layout.md
+++ b/docs/research/ui-layout/auto-layout.md
@@ -1,0 +1,745 @@
+# Auto Layout (Apple UIKit / AppKit)
+
+Apple's constraint-based layout system, in production on iOS since 2012 and macOS since 2011. Built on the Cassowary linear-arithmetic solver, refined through three major API
+generations -- raw `NSLayoutConstraint`, the Visual Format Language, and the modern
+`NSLayoutAnchor` fluent API -- and capped with `UIStackView` as the high-level wrapper
+that most modern code uses.
+
+| Field             | Value                                                                |
+| ----------------- | -------------------------------------------------------------------- |
+| Platform          | iOS 6+, iPadOS, macOS 10.7+, tvOS, watchOS, visionOS                 |
+| Frameworks        | UIKit (iOS family), AppKit (macOS)                                   |
+| Language          | Objective-C originally; Swift APIs since iOS 8 / Swift 1             |
+| Underlying Solver | Cassowary (incremental linear-arithmetic solver)                     |
+| First Released    | macOS 10.7 Lion (2011), iOS 6 (2012)                                 |
+| Anchors API       | iOS 9 / macOS 10.11 (2015)                                           |
+| UIStackView       | iOS 9 / macOS 10.11 (2015)                                           |
+| Documentation     | <https://developer.apple.com/documentation/uikit/nslayoutconstraint> |
+| Modern Successor  | SwiftUI (2019), built on a different layout model                    |
+
+---
+
+## Overview
+
+Auto Layout is Apple's constraint-based layout system for UIKit and AppKit. Rather than
+positioning views with explicit frames (`view.frame = CGRect(x:10, y:20, w:100, h:30)`)
+or arranging them with parent-driven containers (AWT-style layout managers), Auto Layout
+lets developers declare _relationships_ between view attributes: edges, centers,
+dimensions, baselines. At runtime, a Cassowary-based solver finds frame values that
+satisfy as many of the declared relationships as possible.
+
+**What it solves.** A typical iOS or macOS app must work across many screen sizes, two
+orientations, dynamic type, localization (right-to-left layouts, German strings that are
+30 % longer than English), and split-screen multitasking. Hand-coded frame arithmetic
+becomes a combinatorial nightmare. Auto Layout lets the developer describe the _intent_
+("this button is 16 points below the label, horizontally centered, and at least 44 points
+wide") and lets the system compute the actual frames.
+
+**Design lineage.** Auto Layout productized the Cassowary algorithm published by
+Badros, Borning, and Stuckey in 2001 (see `cassowary.md`). It joins a small set of
+production deployments of Cassowary -- alongside the Mozilla XUL template engine, GTK's
+EMMA constraint system, and more recently kiwi.js, Carthage's Cassowary.swift, and Apple's
+own implementation. Until 2011 there was no widely-deployed constraint-solver-based
+layout system in mainstream OS UI; Auto Layout changed that.
+
+**Why this matters for a TUI / Sparkles.** Terminal cells are discrete and bounded, but
+the _expressiveness_ of constraint-based layout still applies: "this panel is at least 20
+columns wide", "the status bar's height equals the prompt's height", "this label is
+centered in the dialog". A TUI layout engine that adopts the constraint vocabulary --
+intrinsic content size, content hugging, compression resistance, priority-driven
+satisfaction -- inherits 15 years of mobile-UI lessons about how to express robust,
+locale-flexible layouts declaratively.
+
+**History.**
+
+- **2011** -- Auto Layout ships on macOS 10.7 Lion. `NSLayoutConstraint` is the only API;
+  the Visual Format Language (VFL) is offered as a shorthand.
+- **2012** -- iOS 6 brings Auto Layout to mobile. Storyboards introduce a graphical
+  constraint editor in Xcode 4.5.
+- **2014** -- Adaptive layout (`UITraitCollection`, size classes) lets storyboards declare
+  device-class-specific constraints.
+- **2015** -- iOS 9 / macOS 10.11 introduce `NSLayoutAnchor` (the fluent type-safe API)
+  and `UIStackView` / `NSStackView` (a high-level wrapper for linear arrangements).
+- **2019** -- SwiftUI launches with a fundamentally different layout model (size-pass,
+  proposal-based, no constraint solver). Auto Layout remains in maintenance mode as the
+  foundation for UIKit/AppKit.
+- **2024** -- UIKit on visionOS continues to rely on Auto Layout; SwiftUI interop bridges
+  the two systems.
+
+---
+
+## Layout Model
+
+### The Constraint Equation
+
+Every Auto Layout constraint is a linear relation between two view attributes:
+
+```
+item1.attribute1  <relation>  multiplier × item2.attribute2 + constant
+```
+
+where `<relation>` is one of `=`, `<=`, or `>=`. The system collects all constraints in a
+view hierarchy and solves them with a Cassowary-style simplex algorithm to produce
+concrete frame values.
+
+**Concrete example.** "The red view's leading edge is 8 points after the blue view's
+trailing edge":
+
+```
+red.leading = 1.0 × blue.trailing + 8.0
+```
+
+### Attributes
+
+`NSLayoutConstraint.Attribute` enumerates the layout points a constraint can address:
+
+**Size attributes** (no position; just a dimension):
+
+- `.width`
+- `.height`
+
+**Horizontal position attributes:**
+
+- `.leading` -- Leading edge (left in LTR locales, right in RTL).
+- `.trailing` -- Trailing edge.
+- `.left`, `.right` -- Literal left/right; avoid except when interacting with hardware.
+- `.centerX`
+- `.leadingMargin`, `.trailingMargin`, `.leftMargin`, `.rightMargin`, `.centerXWithinMargins`
+
+**Vertical position attributes:**
+
+- `.top`, `.bottom`
+- `.centerY`
+- `.firstBaseline`, `.lastBaseline` -- The text baseline of the first or last line.
+- `.topMargin`, `.bottomMargin`, `.centerYWithinMargins`
+
+**Special:**
+
+- `.notAnAttribute` -- Used for "constant" constraints like `width >= 0 × _ + 40`.
+
+### Relations
+
+Three relation operators are supported:
+
+- `NSLayoutRelation.equal` (`=`)
+- `NSLayoutRelation.greaterThanOrEqual` (`>=`)
+- `NSLayoutRelation.lessThanOrEqual` (`<=`)
+
+Constraints are _not_ assignments. `a.width = b.width + 10` is a relation; the solver may
+satisfy it by adjusting either side (or both) within the constraints of all _other_
+constraints.
+
+### Multiplier and Constant
+
+- **Multiplier** -- A `CGFloat` applied to the right-hand attribute. Defaults to 1.0. Must
+  be 1.0 for position attributes (you can't constrain `leading = 2 × trailing`). Required
+  to be 0.0 when `attribute2 == .notAnAttribute`.
+- **Constant** -- A `CGFloat` offset added to the right-hand side. Defaults to 0.
+
+These two together let constraints express ratios (`width = 1.0 × height × 16/9` via
+`view.widthAnchor.constraint(equalTo: view.heightAnchor, multiplier: 16.0/9.0)`) and
+spacing (`top = superview.top + 20`).
+
+### Priorities
+
+Every constraint carries a `UILayoutPriority` (or `NSLayoutPriority`) in the range
+`1...1000`:
+
+| Constant                | Value | Meaning                                                   |
+| ----------------------- | ----- | --------------------------------------------------------- |
+| `.required`             | 1000  | Must be satisfied; failure produces "unsatisfiable" logs. |
+| `.defaultHigh`          | 750   | Default compression resistance priority.                  |
+| `.dragThatCanResize`    | 510   | Drag operation that can resize a window.                  |
+| `.windowSizeStayPut`    | 500   | Keep window the same size during a drag.                  |
+| `.dragThatCannotResize` | 490   | Drag that just moves without resizing.                    |
+| `.defaultLow`           | 250   | Default content hugging priority.                         |
+| `.fittingSizeLevel`     | 50    | Used by `systemLayoutSizeFitting`.                        |
+
+The solver tries to satisfy constraints in priority order. _Required_ constraints (1000)
+_must_ be satisfied; if they conflict, Auto Layout logs the famous "unsatisfiable
+constraints" wall of text and breaks one. _Optional_ constraints (1-999) are honoured
+when possible; otherwise they're relaxed, often acting as "pull" forces that influence
+but do not dictate the layout.
+
+This priority mechanism is what makes Auto Layout _expressive_ rather than _brittle_: a
+view can say "I'd really like to be 200 points wide (priority 750), but I'd rather shrink
+than be clipped by my neighbour (priority 1000)".
+
+### Intrinsic Content Size
+
+Views with natural sizes (`UILabel` based on its text, `UIImageView` based on its image,
+`UIButton` based on its title and image) report a non-trivial value from
+`intrinsicContentSize`. Auto Layout uses this value as the basis for _two_ generated
+constraints per axis:
+
+**Compression resistance** -- "I don't want to be squashed smaller than my intrinsic
+size":
+
+```
+view.width  >= intrinsicContentSize.width    @ priority 750 (default)
+view.height >= intrinsicContentSize.height   @ priority 750
+```
+
+**Content hugging** -- "I don't want to grow larger than my intrinsic size":
+
+```
+view.width  <= intrinsicContentSize.width    @ priority 250 (default)
+view.height <= intrinsicContentSize.height   @ priority 250
+```
+
+The priorities are independently tunable _per axis_:
+
+```swift
+label.setContentHuggingPriority(.required, for: .horizontal)
+label.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+```
+
+This is the mechanism that lets two labels in a row decide which one shrinks when there
+isn't enough space ("I have a higher horizontal compression resistance than you, so you
+shrink first"). The tunability per-axis is the key feature: a label may resist
+horizontal compression strongly (so its text doesn't truncate) while accepting vertical
+compression freely.
+
+### Generation 1: Raw NSLayoutConstraint
+
+The original API was a single constructor with eight parameters:
+
+```swift
+let c = NSLayoutConstraint(
+    item: button,
+    attribute: .leading,
+    relatedBy: .equal,
+    toItem: view,
+    attribute: .leading,
+    multiplier: 1.0,
+    constant: 16.0
+)
+c.priority = .required
+c.isActive = true
+```
+
+Equivalent in Objective-C is even more verbose. A typical screen had dozens of
+constraints; each was eight lines. This was the API that gave Auto Layout its reputation
+for verbosity.
+
+### Generation 2: Visual Format Language
+
+To compress chains of edge-to-edge constraints, Apple introduced VFL: an ASCII-art
+language inspired by ASCII window diagrams. Vertical bars are superviews, hyphens are
+standard spacing, brackets are subviews, parentheses with numbers are dimensions:
+
+```swift
+let views = ["label": label, "field": field]
+let metrics = ["margin": 16]
+
+// "Horizontal: from superview leading, 16pt gap, label, standard gap, field,
+//  16pt gap, to superview trailing"
+NSLayoutConstraint.activate(NSLayoutConstraint.constraints(
+    withVisualFormat: "H:|-margin-[label]-[field]-margin-|",
+    options: [],
+    metrics: metrics,
+    views: views
+))
+
+// "Vertical: from superview top, 16pt gap, label, 8pt gap, field, no constraint to bottom"
+NSLayoutConstraint.activate(NSLayoutConstraint.constraints(
+    withVisualFormat: "V:|-margin-[label]-8-[field]",
+    options: [],
+    metrics: metrics,
+    views: views
+))
+```
+
+Useful for chains of adjacent views but limited: it can't express ratios, doesn't include
+all the attributes (no baseline, no center), and the syntax is unforgiving (mis-paired
+brackets are runtime errors). VFL is considered legacy code now.
+
+### Generation 3: NSLayoutAnchor
+
+Introduced in iOS 9 / macOS 10.11, [`NSLayoutAnchor`][anchor] is the modern type-safe
+fluent API. Every view has a set of typed anchor properties:
+
+- `view.leadingAnchor`, `view.trailingAnchor`, `view.centerXAnchor`, `view.leftAnchor`,
+  `view.rightAnchor` -- All `NSLayoutXAxisAnchor`.
+- `view.topAnchor`, `view.bottomAnchor`, `view.centerYAnchor`, `view.firstBaselineAnchor`,
+  `view.lastBaselineAnchor` -- All `NSLayoutYAxisAnchor`.
+- `view.widthAnchor`, `view.heightAnchor` -- `NSLayoutDimension`.
+
+The type system prevents constraining a horizontal anchor to a vertical anchor at compile
+time -- a class of error that was a runtime crash with the original `NSLayoutConstraint`
+API.
+
+Methods on each anchor:
+
+```swift
+anchor.constraint(equalTo: otherAnchor)                              // a = b
+anchor.constraint(equalTo: otherAnchor, constant: c)                 // a = b + c
+anchor.constraint(greaterThanOrEqualTo: otherAnchor, constant: c)    // a >= b + c
+anchor.constraint(lessThanOrEqualTo: otherAnchor, constant: c)       // a <= b + c
+
+// NSLayoutDimension also supports multipliers and constants:
+dim.constraint(equalTo: otherDim, multiplier: m)                     // a = m × b
+dim.constraint(equalTo: otherDim, multiplier: m, constant: c)        // a = m × b + c
+dim.constraint(equalToConstant: 100)                                 // a = 100
+dim.constraint(greaterThanOrEqualToConstant: 44)                     // a >= 44
+```
+
+Activation is per-constraint (`isActive = true`) or batched
+(`NSLayoutConstraint.activate([...])` is significantly faster for big batches).
+
+### UIStackView / NSStackView
+
+Hand-writing dozens of anchor constraints for a simple row of buttons is still verbose.
+[`UIStackView`][stack] (iOS 9) and `NSStackView` (macOS 10.11) wrap that pattern as a
+single view that lays out its `arrangedSubviews` along an axis automatically. It is the
+high-level wrapper that most modern iOS code uses.
+
+Configuration:
+
+- **`axis`** -- `.horizontal` or `.vertical` (called `orientation` on macOS).
+- **`spacing`** -- `CGFloat` distance between arranged subviews (or use the
+  `UIStackView.spacingUseSystem` constant for the system default).
+- **`distribution`** -- How space is divided along the main axis:
+  - `.fill` -- Each view at its intrinsic size; one resizable view absorbs slack
+    (determined by compression resistance / hugging priorities).
+  - `.fillEqually` -- All views made equal-size; intrinsic sizes are ignored.
+  - `.fillProportionally` -- All views resized in proportion to their intrinsic sizes.
+  - `.equalSpacing` -- Views at their intrinsic sizes; equal gaps between them.
+  - `.equalCentering` -- Views at their intrinsic sizes; equal distance between centers.
+- **`alignment`** -- Cross-axis alignment:
+  - `.fill` -- Stretch to fill the cross dimension.
+  - `.leading` / `.trailing` (or `.top` / `.bottom` for horizontal stacks).
+  - `.center`
+  - `.firstBaseline` / `.lastBaseline` (horizontal stacks only).
+- **`isLayoutMarginsRelativeArrangement`** -- When `true`, the stack's content respects
+  its `layoutMargins`; when `false`, content extends to the stack's edges.
+- **`isBaselineRelativeArrangement`** (iOS) -- For vertical stacks, spacing is measured
+  baseline-to-baseline.
+
+Stacks compose: a vertical stack of horizontal stacks builds a table-like grid with
+arbitrary alignment per row. Stacks also recognize `setCustomSpacing(_:after:)` for
+exceptions to the default spacing -- useful for grouping ("more space after this
+divider").
+
+### Unsatisfiable Constraints
+
+When the solver finds _required_ (priority 1000) constraints in conflict, it logs a wall
+of text starting with "Unable to simultaneously satisfy constraints" followed by the list
+of conflicting constraints and a chosen victim. Example:
+
+```
+2024-04-12 14:22:01.881 MyApp[12345:67890] Unable to simultaneously satisfy constraints.
+    Probably at least one of the constraints in the following list is one you don't want.
+    Try this:
+        (1) look at each constraint and try to figure out which you don't expect;
+        (2) find the code that added the unwanted constraint or constraints and fix it.
+(
+    "<NSLayoutConstraint:0x600000a01200 H:[UIButton'Login']-(8)-[UIButton'Cancel'] (active)>",
+    "<NSLayoutConstraint:0x600000a01250 H:|-(16)-[UIButton'Login'] (active, names: '|':UIView:0x7f...)>",
+    "<NSLayoutConstraint:0x600000a012a0 UIButton'Login'.width == 200 (active)>",
+    "<NSLayoutConstraint:0x600000a012f0 UIButton'Cancel'.trailing == UIView:0x7f....trailing - 16 (active)>",
+    "<NSLayoutConstraint:0x600000a01340 'UIView-Encapsulated-Layout-Width' UIView:0x7f.... width == 320 (active)>"
+)
+Will attempt to recover by breaking constraint
+<NSLayoutConstraint:0x600000a012a0 UIButton'Login'.width == 200 (active)>
+```
+
+This output is famously hard to parse, especially when constraints lack identifiers.
+Common debugging techniques include:
+
+- Assigning `identifier` strings to constraints so they appear named in the logs.
+- Using `UIView.exerciseAmbiguityInLayout()` to visualize ambiguous layouts.
+- Setting a symbolic breakpoint on `UIViewAlertForUnsatisfiableConstraints`.
+- Calling `view.constraintsAffectingLayout(for: .horizontal)` in the debugger to dump the
+  constraints affecting a specific axis.
+
+The unsatisfiability logs are widely cited as Auto Layout's weakest user experience.
+
+### Performance
+
+Auto Layout uses an _incremental_ Cassowary implementation that re-solves only the
+constraints affected by a change. For most static screens, layout time is negligible.
+However:
+
+- **Adding many constraints at once** is faster via
+  `NSLayoutConstraint.activate([...])` than activating them one-by-one (single solver pass
+  rather than N).
+- **`UITableViewCell` and `UICollectionViewCell`** with self-sizing cells run the solver
+  for every visible cell on every reload; this can dominate scrolling performance.
+- **Deep view hierarchies** with many cross-hierarchy constraints scale poorly. Apple's
+  recommendation is to keep constraints within a single subtree where possible.
+- **Animations** require care: animating constraints means re-solving every frame.
+  Animating frames directly (and not Auto Layout) is sometimes preferable for transient
+  effects.
+
+These performance limits are part of why SwiftUI (which uses a simpler size-pass layout
+model without a constraint solver) was developed: for very large or rapidly changing UIs,
+the Cassowary overhead becomes measurable.
+
+---
+
+## Code Examples
+
+### Example 1 -- Login Form with NSLayoutAnchor
+
+```swift
+import UIKit
+
+class LoginViewController: UIViewController {
+    private let usernameField = UITextField()
+    private let passwordField = UITextField()
+    private let signInButton = UIButton(type: .system)
+    private let cancelButton = UIButton(type: .system)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+
+        [usernameField, passwordField, signInButton, cancelButton].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+
+        usernameField.placeholder = "Username"
+        usernameField.borderStyle = .roundedRect
+        passwordField.placeholder = "Password"
+        passwordField.borderStyle = .roundedRect
+        passwordField.isSecureTextEntry = true
+        signInButton.setTitle("Sign In", for: .normal)
+        cancelButton.setTitle("Cancel", for: .normal)
+
+        let margins = view.layoutMarginsGuide
+        NSLayoutConstraint.activate([
+            // Username: top of safe area + 32, full margins width.
+            usernameField.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: 32),
+            usernameField.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            usernameField.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+
+            // Password: 12 below username, same width.
+            passwordField.topAnchor.constraint(
+                equalTo: usernameField.bottomAnchor, constant: 12),
+            passwordField.leadingAnchor.constraint(equalTo: usernameField.leadingAnchor),
+            passwordField.trailingAnchor.constraint(equalTo: usernameField.trailingAnchor),
+
+            // Sign In: 24 below password, trailing-aligned with the fields.
+            signInButton.topAnchor.constraint(
+                equalTo: passwordField.bottomAnchor, constant: 24),
+            signInButton.trailingAnchor.constraint(equalTo: passwordField.trailingAnchor),
+
+            // Cancel: aligned with Sign In's top, 16 to its left.
+            cancelButton.firstBaselineAnchor.constraint(
+                equalTo: signInButton.firstBaselineAnchor),
+            cancelButton.trailingAnchor.constraint(
+                equalTo: signInButton.leadingAnchor, constant: -16),
+
+            // Minimum width on Sign In so short titles don't squash it.
+            signInButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 88),
+        ])
+    }
+}
+```
+
+Notes:
+
+- `translatesAutoresizingMaskIntoConstraints = false` is required on every constrained
+  view; forgetting it is one of the most common causes of unsatisfiable-constraints logs
+  (the autoresizing constraints conflict with the explicit ones).
+- `safeAreaLayoutGuide` and `layoutMarginsGuide` are pseudo-views with their own anchors;
+  they make layouts naturally respect notches, the home indicator, and platform-standard
+  insets.
+- `firstBaselineAnchor` aligns the buttons' text baselines, not their bottom edges --
+  visually superior when the buttons have different fonts.
+
+### Example 2 -- Same Form with UIStackView
+
+```swift
+import UIKit
+
+class LoginStackViewController: UIViewController {
+    private let usernameField = UITextField()
+    private let passwordField = UITextField()
+    private let signInButton = UIButton(type: .system)
+    private let cancelButton = UIButton(type: .system)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+
+        usernameField.placeholder = "Username"
+        usernameField.borderStyle = .roundedRect
+        passwordField.placeholder = "Password"
+        passwordField.borderStyle = .roundedRect
+        passwordField.isSecureTextEntry = true
+        signInButton.setTitle("Sign In", for: .normal)
+        cancelButton.setTitle("Cancel", for: .normal)
+
+        // Button row: horizontal stack, trailing-aligned.
+        let buttonRow = UIStackView(arrangedSubviews: [cancelButton, signInButton])
+        buttonRow.axis = .horizontal
+        buttonRow.spacing = 16
+        buttonRow.alignment = .firstBaseline
+        buttonRow.distribution = .fill
+
+        // Main column: vertical stack of fields and the button row.
+        let column = UIStackView(arrangedSubviews: [
+            usernameField,
+            passwordField,
+            buttonRow,
+        ])
+        column.axis = .vertical
+        column.spacing = 12
+        column.alignment = .fill
+        column.setCustomSpacing(24, after: passwordField)   // bigger gap before buttons
+        column.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(column)
+
+        let margins = view.layoutMarginsGuide
+        NSLayoutConstraint.activate([
+            column.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 32),
+            column.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            column.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+        ])
+    }
+}
+```
+
+The stack view replaces about a dozen individual constraints with two stack
+configurations. Cross-axis alignment (`.firstBaseline`) is a property of the stack rather
+than per-button. Adding or removing fields means inserting into `arrangedSubviews`, not
+re-running constraint math.
+
+### Example 3 -- Self-Sizing Card via Intrinsic Content Size
+
+```swift
+import UIKit
+
+class CardView: UIView {
+    private let titleLabel = UILabel()
+    private let bodyLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .secondarySystemBackground
+        layer.cornerRadius = 12
+
+        titleLabel.font = .preferredFont(forTextStyle: .headline)
+        titleLabel.numberOfLines = 0
+        bodyLabel.font = .preferredFont(forTextStyle: .body)
+        bodyLabel.numberOfLines = 0
+        bodyLabel.textColor = .secondaryLabel
+
+        let stack = UIStackView(arrangedSubviews: [titleLabel, bodyLabel])
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+        ])
+
+        // Title should resist vertical compression even more than the default,
+        // so when space is scarce, the body shrinks first.
+        titleLabel.setContentCompressionResistancePriority(
+            .required, for: .vertical)
+
+        // Body hugs less strongly horizontally so it expands to fill width.
+        bodyLabel.setContentHuggingPriority(.defaultLow - 1, for: .horizontal)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func configure(title: String, body: String) {
+        titleLabel.text = title
+        bodyLabel.text = body
+    }
+}
+```
+
+The card has no explicit width or height. Its size derives from the intrinsic content
+sizes of the labels, propagated through the stack view and the four edge constraints.
+When the card is placed in a parent with a width constraint, the labels wrap and the
+card grows vertically as needed. This is the canonical "self-sizing" pattern that powers
+`UITableViewCell` automatic heights.
+
+### Example 4 -- Priority-Based Truncation
+
+```swift
+import UIKit
+
+class TruncationDemo: UIViewController {
+    private let leftLabel = UILabel()
+    private let rightLabel = UILabel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+
+        leftLabel.text = "Filename:"
+        rightLabel.text = "/Users/petar/some/very/long/filesystem/path/that-cannot-fit.txt"
+        rightLabel.lineBreakMode = .byTruncatingMiddle
+
+        // Left label should NEVER be truncated.
+        leftLabel.setContentCompressionResistancePriority(
+            .required, for: .horizontal)
+        // Right label MAY be truncated when space is tight.
+        rightLabel.setContentCompressionResistancePriority(
+            .defaultLow, for: .horizontal)
+
+        let row = UIStackView(arrangedSubviews: [leftLabel, rightLabel])
+        row.axis = .horizontal
+        row.spacing = 8
+        row.alignment = .firstBaseline
+        row.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(row)
+
+        let margins = view.layoutMarginsGuide
+        NSLayoutConstraint.activate([
+            row.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 64),
+            row.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+            row.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+        ])
+    }
+}
+```
+
+In a constrained-width row, the solver decides which label gives way under pressure. The
+left label has priority 1000 (`required`) on horizontal compression resistance, so the
+stack cannot shrink it; the right label has the default low priority, so the path is
+truncated. Reversing the priorities produces the opposite behaviour.
+
+This is the clearest demonstration of priority-based satisfaction: there is no "which view
+truncates first" property to set; it falls out naturally from per-view priority on a
+universal sizing dimension.
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Genuinely declarative.** Constraints describe relations, not assignments. The same
+  set of constraints adapts to portrait, landscape, split-screen, dynamic type, and RTL
+  locales without explicit special-casing.
+- **Type-safe modern API.** `NSLayoutAnchor` makes invalid relations (horizontal anchor
+  to vertical anchor) compile-time errors.
+- **Priorities are uniquely expressive.** Few other layout systems offer the
+  per-constraint priority dial. Once internalized, content hugging and compression
+  resistance solve a wide class of "who shrinks first" problems with no custom code.
+- **UIStackView eliminates boilerplate.** For linear arrangements (which are most UIs),
+  the stack view replaces dozens of constraints with three properties (`axis`, `spacing`,
+  `distribution`).
+- **Solid IDE support.** Storyboards and XIBs give a graphical constraint editor;
+  Interface Builder catches conflicts at design time.
+- **Incremental solver performance.** Most screens render in microseconds; the Cassowary
+  re-solve cost is proportional to _changed_ constraints, not the total constraint count.
+- **Used in production for over a decade.** Every iOS app since iOS 6 has had Auto
+  Layout as an option; from iOS 8 onward it is the dominant approach.
+- **Cross-platform within Apple.** The same vocabulary works on iOS, macOS, tvOS,
+  watchOS, and visionOS, lowering the cost of multi-platform apps.
+
+### Weaknesses
+
+- **Verbose without anchors.** Pre-iOS-9 code (raw `NSLayoutConstraint` calls) is
+  painfully long. Even with anchors, complex screens can have hundreds of constraints.
+- **Unsatisfiable-constraints debugging is brutal.** The console output is famous for
+  being inscrutable. Apple has not significantly improved it in over a decade.
+- **`translatesAutoresizingMaskIntoConstraints` foot-gun.** Forgetting to set it to
+  `false` is the most common Auto Layout bug; the autoresizing-translation constraints
+  conflict with explicit ones at runtime.
+- **Performance under stress.** Re-solving on every frame during scrolling of
+  self-sizing cells can cost 5-15ms per frame, contributing to dropped frames on older
+  devices. SwiftUI's simpler model often wins on raw layout throughput.
+- **Hard to compose programmatically.** Reusable layouts are usually expressed as helper
+  functions that return arrays of constraints; there is no first-class "layout component"
+  abstraction below the level of a full `UIView` subclass.
+- **Cassowary cost in interactive scrolling.** Self-sizing table cells, prior to the
+  estimated-height optimizations introduced in iOS 11, could dominate scrolling
+  performance. Still requires careful tuning today.
+- **No first-class grid.** Two-dimensional grids must be built from nested stack views or
+  hand-coded constraints; there is no `UIGridView` in UIKit (AppKit has `NSGridView`,
+  but it is rarely used).
+- **Versus box-flow systems (Flutter, Compose, SwiftUI):** Auto Layout is more flexible
+  but harder to reason about. A SwiftUI body or Flutter `Column` is a single declarative
+  expression; an Auto Layout view controller is a constructor plus dozens of constraint
+  activations. SwiftUI traded expressiveness for predictability.
+
+### Versus Other Layout Models
+
+| Aspect                | Auto Layout                      | Flexbox (Ink/Yoga)               | Ratatui Constraints       |
+| --------------------- | -------------------------------- | -------------------------------- | ------------------------- |
+| Solver type           | Cassowary (linear arithmetic)    | Flexbox spec (greedy passes)     | Kasuari (Cassowary port)  |
+| Constraint scope      | Cross-hierarchy                  | Parent-to-children only          | Single parent rectangle   |
+| Priority system       | 1-1000 per constraint            | None (compile-time `flexGrow`)   | Implicit constraint order |
+| Intrinsic size        | Yes (`intrinsicContentSize`)     | Yes (`minWidth`/`minHeight`)     | Implicit via Length       |
+| Hand-coded ergonomics | Anchors are okay; raw API is bad | Excellent                        | Excellent (areas API)     |
+| Designer tools        | Excellent (Interface Builder)    | None                             | None                      |
+| Debugging             | Painful logs                     | React DevTools / Yoga playground | Manual                    |
+
+The cross-hierarchy expressiveness is Auto Layout's distinguishing feature: a constraint
+can relate a view to its great-grandparent or even an unrelated subtree (through a shared
+ancestor). Flexbox and most TUI layout systems restrict relations to parent-child only,
+which is simpler to reason about but less expressive.
+
+### Lessons for a Sparkles TUI Layout
+
+Auto Layout's vocabulary translates surprisingly well to terminal cells:
+
+- **Anchors** map to `Edge` enums (top/bottom/leading/trailing/centerX/centerY).
+- **`>=`, `<=`, `=` relations** map to D enum tags on a layout DSL.
+- **Priorities** map to integer ranks; the solver picks the highest-priority satisfiable
+  set. The same Cassowary algorithm runs on integers as well as floats.
+- **Intrinsic content size** maps to widget-reported preferred sizes (the same idea as
+  AWT's `getPreferredSize`).
+- **Compression resistance / content hugging** map to per-widget per-axis growth weights,
+  which is exactly Ratatui's `Constraint::Fill(weight)` model.
+- **Stack view distribution modes** are a small enum with well-defined semantics; a
+  similar abstraction (`distribute: .fill | .fillEqually | .equalSpacing`) would let
+  Sparkles users avoid the constraint solver in the common case.
+
+The takeaway: a TUI layout engine doesn't need full Cassowary expressiveness for typical
+dashboard UIs (Ratatui demonstrates this), but the _priority vocabulary_ and the
+_intrinsic-size / hugging / resistance_ trio are concepts worth importing even when the
+solver underneath is simpler.
+
+---
+
+## References
+
+- **Apple Documentation:**
+  - [Auto Layout Guide (Apple Archive)](https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/AutolayoutPG/index.html)
+  - [Anatomy of a Constraint](https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/AutolayoutPG/AnatomyofaConstraint.html)
+  - [`NSLayoutConstraint`](https://developer.apple.com/documentation/uikit/nslayoutconstraint)
+  - [`NSLayoutAnchor`][anchor]
+  - [`NSLayoutXAxisAnchor`](https://developer.apple.com/documentation/uikit/nslayoutxaxisanchor)
+  - [`NSLayoutYAxisAnchor`](https://developer.apple.com/documentation/uikit/nslayoutyaxisanchor)
+  - [`NSLayoutDimension`](https://developer.apple.com/documentation/uikit/nslayoutdimension)
+  - [`UIStackView`][stack]
+  - [`NSStackView`](https://developer.apple.com/documentation/appkit/nsstackview)
+  - [`UILayoutPriority`](https://developer.apple.com/documentation/uikit/uilayoutpriority)
+  - [`UIView` intrinsicContentSize](https://developer.apple.com/documentation/uikit/uiview/1622600-intrinsiccontentsize)
+- **WWDC sessions:**
+  - WWDC 2012 Session 232 "Introduction to Auto Layout for iOS and OS X"
+  - WWDC 2015 Session 218 "Mysteries of Auto Layout, Part 1"
+  - WWDC 2015 Session 219 "Mysteries of Auto Layout, Part 2"
+  - WWDC 2018 Session 220 "High Performance Auto Layout"
+- **Related Sparkles research:**
+  - Cassowary algorithm and incremental solver: `./cassowary.md`
+  - Swing / MiG Layout (constraint strings in a different tradition): `./swing-mig.md`
+  - SwiftUI (Auto Layout's successor with a different layout model): `./swiftui.md`
+  - Ratatui's Cassowary-port-based constraint API: `../tui-libraries/ratatui.md`
+  - Ink / Yoga Flexbox: `../tui-libraries/ink.md`
+- **Algorithm:**
+  - Badros, Borning, Stuckey, "The Cassowary linear arithmetic constraint solving
+    algorithm", ACM Transactions on Computer-Human Interaction (2001).
+
+[anchor]: https://developer.apple.com/documentation/uikit/nslayoutanchor
+[stack]: https://developer.apple.com/documentation/uikit/uistackview

--- a/docs/research/ui-layout/cassowary.md
+++ b/docs/research/ui-layout/cassowary.md
@@ -1,0 +1,775 @@
+# Cassowary
+
+An incremental linear arithmetic constraint solving algorithm designed for interactive user
+interface layout. Cassowary takes a system of linear equalities and inequalities — some
+required, some preferred at varying strengths — and finds an assignment of values to
+variables that satisfies the required constraints while minimizing violations of the
+preferred ones. It is the algorithm that powers Apple's
+[Auto Layout](./auto-layout.md), as well as a long tail of constraint-based UI
+toolkits.
+
+| Field                     | Value                                                                                                                                                                                                                             |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Domain                    | Linear arithmetic constraint solving for interactive UI layout                                                                                                                                                                    |
+| Authors                   | Greg J. Badros, Alan Borning, Peter J. Stuckey                                                                                                                                                                                    |
+| First Published           | 1997 (PhD thesis); 1998 tech report; canonical 2001 ACM TOCHI paper                                                                                                                                                               |
+| Algorithmic Basis         | Incremental simplex (primal for `addConstraint`, dual for `resolve`/edit suggestions), Phase I / Phase II, basic-feasible-solved form                                                                                             |
+| Reference Implementations | Original C++, Smalltalk, and Java distributions from U. Washington; [`kiwi`](./kiwi.md) (modern C++ reimplementation); `cassowary.py`; CassowaryJS                                                                                |
+| Notable Adoption          | Apple Auto Layout (OS X Lion 10.7, 2011; iOS 6, 2012); Matplotlib's `constrained_layout` (via Kiwi); Enaml; GSS / Constraint CSS; Scwm window manager; the Rust `cassowary-rs` / `kasuari` crates used by Ratatui's layout engine |
+| Project Home              | <https://constraints.cs.washington.edu/cassowary/>                                                                                                                                                                                |
+
+---
+
+## Overview
+
+### What It Solves
+
+User interface layout is naturally expressed as a system of relationships: this column is
+twice as wide as that one; this label sits 8 pixels above that text field; this panel
+must be at least 200 pixels tall but should be 400 if it can. Some of these are
+non-negotiable; others are preferences that should be honored when there is room. As
+the window resizes, the dragged splitter moves, or the user types into a field that grows
+its surrounding container, the system must continuously find values that respect the
+non-negotiable constraints and best satisfy the preferences.
+
+Box-flow systems like Flexbox, CSS block layout, and Ratatui's percentage/length
+constraints handle a useful slice of this problem by composing primitives that each have
+a deterministic, local layout rule. They are fast and predictable, but expressing
+non-hierarchical relationships — "align the baseline of these two labels living in
+different parents" or "the gap between A and B should equal the gap between C and D" —
+either requires gymnastics or is outright impossible.
+
+Cassowary takes the more general approach: let the application describe layout as a
+**system of linear constraints** and solve the system. The constraint set can include any
+linear relationship between variables, regardless of where those variables live in the
+view hierarchy. The solver finds an assignment that satisfies all required constraints
+exactly while minimizing the weighted sum of violations across non-required constraints,
+where each non-required constraint carries a **strength** that determines how it competes
+with its peers.
+
+Crucially, the algorithm is **incremental**: adding or removing a single constraint, or
+suggesting a new value for an "edit" variable, runs in time proportional to the work
+needed to repair the existing solution rather than re-solving from scratch. This is what
+makes Cassowary practical for interactive UIs — when the user drags a splitter, the
+solver does not re-derive the entire layout; it propagates the change through the system
+in a few simplex pivots.
+
+### Design Philosophy
+
+Cassowary is built around three commitments that, together, explain almost every design
+choice in the algorithm:
+
+1. **Linear arithmetic only.** Constraints are restricted to linear equalities and
+   inequalities over real-valued variables. This excludes products of variables, absolute
+   values, conditionals, and disjunctions. The restriction is what makes incremental
+   simplex applicable and what keeps the solver tractable. UI layout problems are
+   overwhelmingly linear (positions, sizes, gaps, ratios), so the constraint is
+   acceptable in practice.
+
+2. **Strengths form a strict hierarchy.** Constraints carry one of four strengths —
+   `required`, `strong`, `medium`, `weak` — and any number of `required` violations can
+   never be tolerated to satisfy lower-strength preferences. Among non-required
+   constraints, a single `strong` outweighs any finite combination of `medium` plus
+   `weak`, and a single `medium` outweighs any combination of `weak`. The hierarchy is
+   implemented by giving each strength a symbolic weight (lexicographic comparison) so
+   that floating-point round-off cannot collapse the ordering. This guarantees that the
+   solution is unambiguous and predictable: a designer can layer constraints knowing the
+   strong ones will always win.
+
+3. **The solver is interactive, not batch.** Cassowary maintains the simplex tableau
+   between operations. `addConstraint`, `removeConstraint`, and `suggestValue` each
+   perform a small amount of incremental work to restore the basic-feasible-solved-form
+   invariant, then return. Edit variables — variables flagged as the "current mouse x" or
+   "current splitter position" — get special-cased so that interactive dragging can fire
+   thousands of `suggestValue` calls per second without rebuilding the tableau.
+
+The algorithm is also deliberately deterministic: given the same constraint set and the
+same insertion order, it produces the same solution. There is no randomized pivot
+selection; ties are broken by a fixed lexicographic rule. This matters because UI
+layouts are inspected visually, and any non-determinism — a button shifting by a pixel
+between renders — is immediately noticeable and a debugging nightmare.
+
+### History
+
+Cassowary's lineage runs back through three decades of constraint-based UI research at
+the University of Washington and elsewhere. Alan Borning's **ThingLab** (1979) was an
+early constraint-based simulation environment; **DeltaBlue** (Sannella, Maloney, Freeman-
+Benson, Borning, 1993) introduced multi-way constraints over user interface variables
+using a local-propagation algorithm. **SkyBlue** generalized DeltaBlue to cyclic
+constraint graphs. **Indigo** added inequality constraints. **QOCA** (Marriott, Chok,
+Finlay) brought a quadratic optimizing constraint algorithm into the same problem space.
+
+Cassowary itself emerged from Greg Badros's PhD work at U. Washington (advised by Alan
+Borning), completed in **1997**. The first public description of the algorithm appeared
+in:
+
+- Borning, Marriott, Stuckey, and Xiao, _"Solving Linear Arithmetic Constraints for User
+  Interface Applications"_, ACM UIST 1997.
+
+A more thorough treatment followed as a U. Washington tech report:
+
+- Badros and Borning, _"The Cassowary Linear Arithmetic Constraint Solving Algorithm:
+  Interface and Implementation"_, Technical Report UW-CSE-98-06-04, 1998.
+
+The canonical reference is the longer 2001 journal version:
+
+- Badros, Borning, Stuckey, _"The Cassowary Linear Arithmetic Constraint Solving
+  Algorithm"_, ACM Transactions on Computer-Human Interaction, Vol. 8, No. 4, pp.
+  267–306, December 2001.
+
+The original distribution shipped implementations in **Smalltalk**, **C++**, and
+**Java**, plus bindings for **GNU Guile**, **Python**, and **STk**. Two contemporary
+projects gave Cassowary an immediate audience: the **Amulet** and **Garnet** UI
+toolkits from CMU experimented with constraint-based layout, and the **Scwm** (Scheme
+Constraints Window Manager) used Cassowary to let users lay out X11 windows by
+constraint expressions.
+
+The algorithm's broad public visibility arrived in **2011**, when Apple shipped
+[Auto Layout](./auto-layout.md) in OS X 10.7 Lion and, the following year, in iOS 6.
+Auto Layout is a Cassowary solver in production: developers describe view layouts as
+linear constraints with priorities (Apple's term for strengths), and the system solves
+the same kind of tableau Badros described, scaled to entire screenfuls of UIKit views.
+The Auto Layout API exposes the same primitives — equalities, inequalities, priorities,
+edit-like behavior for the resizing root view — under different names.
+
+After Auto Layout, Cassowary's ideas escaped the desktop. **Grid Style Sheets (GSS)**
+and **Constraint Cascading Style Sheets (CCSS)** were attempts to expose constraint
+layout to the web. **CassowaryJS** by Alex Russell brought the algorithm to browsers.
+And in **2013**, Chris Colbert at Nucleic released [Kiwi](./kiwi.md), a C++
+reimplementation that traded the original's exact lexicographic strengths for
+floating-point weights in exchange for a 10×–500× speedup; Kiwi is now the de-facto
+backend for **Matplotlib**'s `constrained_layout` and `tight_layout`, **Enaml**, and a
+long tail of Python UI work. Rust ports (`cassowary-rs`, `casuarius`, `kasuari`) brought
+the algorithm to **Ratatui**'s [layout engine](../tui-libraries/ratatui.md).
+
+---
+
+## Algorithm
+
+This section describes the algorithm at the level of detail needed to understand how
+Cassowary works, what its operations cost, and why specific design choices were made. It
+is not a substitute for the TOCHI paper, but it covers enough that an implementer could
+write a from-scratch version and understand a reference one.
+
+### The Simplex Method, in One Paragraph
+
+The simplex algorithm solves linear programs: maximize (or minimize) a linear objective
+function over a set of variables subject to linear inequality constraints. It does so by
+representing the constraint system as a **tableau** — a matrix of coefficients — and
+performing **pivot operations** that exchange a _basic_ (currently solved-for) variable
+with a _non-basic_ (currently zero or at a bound) variable. Each pivot preserves the
+constraints while moving along an edge of the feasible polytope. The pivot rule is
+designed so that the objective function improves (or at least does not worsen) at every
+step. The algorithm terminates when no improving pivot exists, at which point the
+current vertex is optimal. The worst-case complexity is exponential, but in practice
+the simplex method is famously fast on the constraint shapes that arise in real
+applications.
+
+Cassowary uses simplex twice over: a **Phase I** simplex finds any feasible solution
+(satisfying the inequalities), and a **Phase II** simplex then minimizes a quasi-linear
+objective representing the violations of non-required constraints. The novel piece is
+that both phases are performed _incrementally_: the algorithm preserves the tableau
+across constraint additions, removals, and suggestions, doing only the local pivoting
+needed to repair feasibility or optimality.
+
+### Variables, Slack, Error, and Dummy
+
+The solver works with three classes of internal variables beyond the user-facing
+**external** variables that the application creates and reads:
+
+- **Slack variables**, introduced one per inequality. The inequality `x + y ≤ 10` is
+  rewritten as the equality `x + y + s = 10` with `s ≥ 0`. Slacks are _non-basic_ in
+  the initial tableau and only allowed to take non-negative values.
+
+- **Error variables**, introduced for non-required constraints. A non-required equality
+  `x = 100` (at some strength `w`) is rewritten as `x - eₚ + eₙ = 100` with
+  `eₚ, eₙ ≥ 0`, and the objective is modified to include `w · (eₚ + eₙ)`. A
+  non-required inequality `x ≤ 100` becomes `x - eₚ + eₙ + s = 100` with `s ≥ 0` and
+  `w · eₙ` in the objective (only the violating direction is penalized). At the
+  optimal solution, either `eₚ = 0` or `eₙ = 0`, and the magnitude reflects how far
+  the constraint is violated.
+
+- **Dummy variables**, introduced for required equalities. A required equality `x = y`
+  becomes `x - y + d = 0` with `d` constrained to zero. Dummies live in the tableau
+  to keep equality constraints in normalized form and to track which required
+  constraints originated each row, which is needed for `removeConstraint`.
+
+The tableau is then a system of equalities in **basic-feasible-solved form**: every
+basic variable appears in exactly one row with coefficient 1, and every non-basic
+variable is currently at its bound (0 for slacks, errors, and dummies). The values of
+the basic variables are the constants on the right-hand side of their rows. Reading off
+a solution is simply: each external variable is either basic (its value is the row's
+constant) or non-basic (its value is its bound, almost always 0).
+
+### Strengths as Symbolic Weights
+
+Cassowary represents strengths as 4-tuples of weights — one component per strength level
+plus required — compared lexicographically. The strength `strong(w_s)` corresponds to
+the vector `(0, w_s, 0, 0)` (interpreting the components as `required`, `strong`,
+`medium`, `weak`), `medium(w_m)` to `(0, 0, w_m, 0)`, and so on. The error variables
+in the objective function are multiplied by these symbolic strengths, and the simplex
+method's pivot rule compares them lexicographically. This guarantees that:
+
+- Any positive amount of `strong` violation is worse than any finite sum of `medium` and
+  `weak` violations.
+- Any positive amount of `medium` violation is worse than any finite sum of `weak`
+  violations.
+- Within a single strength level, violations are weighted by an ordinary scalar.
+
+The TOCHI paper proves that under this scheme, the optimal solution has the **error-
+hierarchy** property: at the optimum, no non-required constraint can be improved by
+worsening only constraints of equal or lower strength. The hierarchy is _strict_:
+floating-point arithmetic on a single scalar weight cannot achieve this property
+exactly, which is why the original Cassowary uses symbolic 4-vectors. (Kiwi famously
+abandons this for floating-point scalars in exchange for a speedup; see
+[Kiwi](./kiwi.md).)
+
+### Required Constraints: `addConstraint`, Phase I
+
+Adding a required constraint runs a small **Phase I** simplex:
+
+1. Rewrite the constraint into normal form: introduce slack/dummy as needed, multiply
+   through to make all coefficients explicit.
+
+2. Substitute out any external variables that are currently basic. After substitution,
+   the new row mentions only non-basic variables on the right-hand side.
+
+3. If the constant on the right is non-negative, the constraint is already feasible
+   given current values; add the row to the tableau with a slack/dummy as the new basic
+   variable, and we are done.
+
+4. Otherwise the row is infeasible. Introduce an **artificial variable** `a` as the
+   initial basic variable for this row (so the row reads `a = ...`), and run Phase I:
+   minimize `a` by pivoting it out of the basis. If `a` can be driven to zero, the
+   constraint is satisfiable and we are done. If `a` cannot be driven below some
+   positive value, the system is over-constrained — the new required constraint
+   conflicts with the existing ones. Cassowary throws a `RequiredFailure` exception.
+
+The cost of `addConstraint` is dominated by the number of pivots Phase I needs, which is
+small in practice — most additions either fall into case 3 (no pivots needed) or
+resolve in one or two pivots.
+
+### Non-Required Constraints: `addConstraint`, Phase II
+
+A non-required constraint adds its error variables to the objective function with the
+appropriate symbolic weights, then proceeds as a required constraint over the augmented
+system. Since the error variables can absorb any infeasibility (they are unbounded
+above), Phase I always succeeds. **Phase II** simplex then minimizes the weighted error
+sum by pivoting error variables out of the basis where possible. Pivots proceed until
+no improving pivot exists, at which point the optimum has been reached and the basic-
+feasible-solved-form is restored.
+
+### Edit Variables and `suggestValue`
+
+Edit variables are the algorithm's interactive workhorse. An application calls
+`addEditVar(v, strength)` to mark `v` as a variable whose value will be repeatedly
+suggested — typically because the user is dragging it. Cassowary responds by adding two
+**edit constraints**: `v = c⁺` and `v = c⁻` (effectively, `v = c`) at the requested
+strength, where `c` is a placeholder constant initialized to `v`'s current value. The
+constraint introduces a pair of error variables `eₚ, eₙ` that absorb the difference
+between the suggested value and the value the rest of the system wants `v` to take.
+
+A subsequent `suggestValue(v, c_new)` is implemented as a **dual simplex** step. The
+algorithm updates the row's constant from `c` to `c_new`, which may render the row
+infeasible (a basic variable now has a negative value). Rather than re-running Phase I,
+Cassowary performs **dual pivots**: it selects the infeasible basic variable to leave
+the basis and the entering variable that preserves dual feasibility (the objective
+remains optimal). After a small number of pivots — typically one or two — the tableau
+is restored to basic-feasible-solved form. The cost is independent of the size of the
+constraint system, only proportional to the local rearrangement.
+
+The result is that `suggestValue` is fast enough to call at interactive frame rates.
+Auto Layout uses precisely this mechanism for window-resize: the window's width and
+height are edit variables, and each pixel of resize fires `suggestValue` calls that
+propagate through the entire view hierarchy in microseconds.
+
+### Stay Constraints
+
+A complementary mechanism, **stay constraints**, addresses the under-constrained case.
+Suppose the user clicks a button to "lay out the window" with a partial set of
+constraints — say, only constraints relating relative positions but nothing absolute.
+The system has many solutions; which should it pick? Cassowary's answer: add a `stay`
+constraint at `weak` strength for every variable, fixing it to its current value. The
+simplex method then finds the solution that minimizes the total displacement from the
+current state. Stays are added implicitly during interactive dragging too: every
+non-edit external variable gets a weak stay, so that values that _can_ remain at their
+current values _do_.
+
+(Notably, Kiwi drops stay constraints in favor of a different strategy — see the Kiwi
+doc — but the original Cassowary treats them as a first-class operation.)
+
+### `removeConstraint`
+
+Removing a constraint is conceptually straightforward but mechanically delicate. The
+row originating from the constraint must be expunged, but the row may have been pivoted
+many times since its addition — its current basic variable may bear no obvious
+relationship to the original constraint. Cassowary tracks each constraint's markers
+(slack, error, or dummy variables introduced at addition time) so it can find the row
+that originated with the constraint. If the marker is currently basic, the row is
+simply dropped. If the marker is non-basic, the algorithm pivots the marker into the
+basis first (using a carefully-chosen leaving variable to preserve feasibility), then
+drops the row. After removal, the objective may no longer be optimal — Phase II is
+re-run incrementally.
+
+The trickiest case is **removing a constraint whose marker has been substituted away
+entirely** during prior pivots. The implementation searches the tableau for a row
+mentioning the marker as a basic variable, or, failing that, picks any row containing
+the marker as a non-basic variable, pivots to make the marker basic, and proceeds.
+
+### Complexity, in Practice
+
+The TOCHI paper reports empirical measurements on layout problems with thousands of
+constraints. The key observations:
+
+- `addConstraint` averaged a few microseconds on 1998-era hardware. Hot operations were
+  dominated by hash-table lookups, not by simplex pivots.
+
+- `suggestValue` was sub-microsecond once the tableau was built — fast enough that the
+  bottleneck for interactive dragging became the redraw, not the constraint solve.
+
+- Worst-case behavior was exponential (it is simplex, after all), but the worst-case
+  inputs were artificial. Real layouts never approached the worst case.
+
+On modern hardware with [Kiwi](./kiwi.md)'s implementation choices (compact tableaux,
+flat arrays instead of hash maps, floating-point strengths), the same operations run
+10×–500× faster, putting `suggestValue` in the tens of nanoseconds.
+
+---
+
+## Constraint Language
+
+Cassowary's constraint language is small but expressive. Every concept maps directly to
+a piece of the simplex tableau.
+
+### Variables
+
+A **variable** is a real-valued unknown. The application creates variables and hands
+them to the solver. After every solve, the solver writes the optimal value back into
+each variable. Variables have stable identity — two references to the same variable
+participate in the same column of the tableau.
+
+In practice, applications wrap variables in domain objects: a UIKit `NSLayoutAnchor`
+points to a variable representing one edge of a view; a Matplotlib `LayoutBox` wraps
+four variables (left, right, top, bottom).
+
+### Expressions
+
+An **expression** is a linear combination of variables plus a constant: `a₁·x₁ + a₂·x₂ +
+... + aₙ·xₙ + c`. Expressions support the usual arithmetic operators:
+
+- `e₁ + e₂` — sum
+- `e₁ - e₂` — difference
+- `k · e` or `e · k` — scaling by a scalar
+- `e / k` — scaling by `1/k` (division by a non-zero scalar)
+
+Multiplication of two variables is **not** linear and is rejected. Expressions are
+typically built using operator overloading or builder methods in whatever host language
+the implementation lives in.
+
+### Constraints
+
+A **constraint** is a comparison between two expressions:
+
+- `e₁ == e₂` — equality
+- `e₁ <= e₂` — less-than-or-equal
+- `e₁ >= e₂` — greater-than-or-equal
+
+Internally, these are normalized to `e == 0` (with slack variables) or `e >= 0` (with a
+negated slack). Strict inequalities are not directly supported — linear programming
+solves over closed feasibility regions.
+
+### Strengths
+
+Every constraint carries a strength:
+
+- **`required`** — must hold exactly. Infeasibility causes `addConstraint` to fail.
+- **`strong`** — should hold; violated only if a higher-strength constraint forces it.
+- **`medium`** — should hold; violated only to satisfy `strong` or `required`.
+- **`weak`** — a hint; violated freely to satisfy anything stronger.
+
+Strengths may optionally carry a **scalar weight** within their level (`strong(2.0)` vs
+`strong(1.0)`), allowing a finer ordering among constraints of the same strength. The
+weights are multiplied into the error variable's contribution to the objective.
+
+A typical UI-layout encoding uses `required` for non-negotiable structure (sizes don't
+go negative, child fits inside parent), `strong` for designer intent (this section is
+60% wide), `medium` for soft sizing hints (preferred width), and `weak` for stays
+(prefer to keep current values).
+
+### Edit and Stay Constraints
+
+Two specialized constraint kinds bridge interactive UI patterns:
+
+- **Edit constraints**, attached via `addEditVar(v, strength)`. Each one creates an
+  internal `v = c` constraint whose right-hand side can be cheaply updated by
+  `suggestValue(v, c_new)`.
+
+- **Stay constraints**, attached via `addStay(v, strength)`. Pins `v` to its current
+  value at the given strength (usually `weak`).
+
+Both are syntactic sugar over ordinary constraints, but their dedicated APIs let the
+solver use the fast incremental paths.
+
+### Example Encoding
+
+To express "labelA is left-aligned with labelB, and both fit inside their parent panel,
+with at least 8 pixels of padding on each side":
+
+```
+required: labelA.left == labelB.left
+required: labelA.left >= panel.left + 8
+required: labelA.right <= panel.right - 8
+required: labelB.left  >= panel.left + 8
+required: labelB.right <= panel.right - 8
+strong:   labelA.width == labelA.intrinsicWidth
+strong:   labelB.width == labelB.intrinsicWidth
+```
+
+The `required` rows enforce the structural relationships; the `strong` rows express the
+labels' content-determined width as a preference that yields if the parent becomes too
+narrow.
+
+---
+
+## Code Examples
+
+These examples show how the constraint language expresses common UI layout problems.
+Syntax is drawn from the original Cassowary C++ API and Kiwi's Python bindings — see
+[Kiwi](./kiwi.md) for runnable code in modern syntax.
+
+### Example 1: Two Views Side-by-Side, Equal Width
+
+The classic split-pane: two children of a parent, occupying its full width with no gap
+between them, each consuming exactly half.
+
+```python
+# Variables
+parent_left  = Variable("parent.left")
+parent_right = Variable("parent.right")
+a_left  = Variable("a.left")
+a_right = Variable("a.right")
+b_left  = Variable("b.left")
+b_right = Variable("b.right")
+
+# Required: A pinned to parent's left edge
+solver.addConstraint(a_left == parent_left)
+# Required: B pinned to parent's right edge
+solver.addConstraint(b_right == parent_right)
+# Required: A and B meet in the middle (no gap)
+solver.addConstraint(a_right == b_left)
+# Required: equal widths
+solver.addConstraint(a_right - a_left == b_right - b_left)
+
+# Strong: parent occupies the window's width
+solver.addConstraint((parent_right - parent_left == window_width) | "strong")
+solver.addConstraint(parent_left == 0)
+```
+
+With six variables and five required equality constraints, the system has one degree of
+freedom (the parent's width). The `strong` constraint resolves it: parent gets the
+window's width, A gets the left half, B gets the right half.
+
+When the window resizes, the application updates `window_width` and calls
+`suggestValue`; Cassowary's dual simplex propagates the change in O(constraints
+touching `window_width`) time — a handful of pivots regardless of how big the tableau is.
+
+### Example 2: Sibling Alignment Across Different Parents
+
+A constraint Flexbox cannot easily express: two text fields that live in different
+parent containers should have aligned baselines, regardless of how their parents resize.
+
+```python
+# Field A is inside containerA, Field B is inside containerB.
+# Both containers grow and shrink with the window, possibly at different rates.
+
+containerA_top = Variable("cA.top")
+containerB_top = Variable("cB.top")
+fieldA_baseline = Variable("fA.baseline")
+fieldB_baseline = Variable("fB.baseline")
+
+# Each field is positioned relative to its container.
+# The 'baseline_offset' is the typographic baseline from the field's top.
+solver.addConstraint(
+    fieldA_baseline == containerA_top + a_padding_top + a_baseline_offset
+)
+solver.addConstraint(
+    fieldB_baseline == containerB_top + b_padding_top + b_baseline_offset
+)
+
+# The cross-hierarchy alignment is a single required constraint.
+solver.addConstraint(fieldA_baseline == fieldB_baseline)
+```
+
+If `containerA` and `containerB` resize independently, Cassowary will adjust whichever
+variables have the most flexibility (those without strong constraints) to keep the
+baselines aligned. If the alignment cannot be achieved without breaking a stronger
+constraint, the violation falls on the weakest competing constraint, predictably.
+
+Box-flow systems handle this either by introducing a virtual "alignment group" widget
+(Yoga's `alignSelf`, Auto Layout's [`UILayoutGuide`](./auto-layout.md)) or by
+pre-computing offsets in user code. Cassowary expresses it as a single equality.
+
+### Example 3: Intrinsic Content Size with Compression Resistance
+
+A `UILabel`-style widget has a natural width that depends on its text content. It would
+prefer to be exactly that wide, but it must shrink before it pushes its parent off the
+screen — and it must shrink before its sibling, which carries critical information.
+
+```python
+# Two labels in a row that must fit in a fixed-width container.
+container_width = Variable("container.width")
+labelA_width = Variable("labelA.width")
+labelB_width = Variable("labelB.width")
+
+# Required: labels and a 4-pixel gap fit exactly in the container.
+solver.addConstraint(labelA_width + labelB_width + 4 == container_width)
+
+# Strong: each label prefers its intrinsic content width.
+solver.addConstraint((labelA_width == labelA_intrinsic) | "strong")
+solver.addConstraint((labelB_width == labelB_intrinsic) | "strong")
+
+# Strong with higher scalar weight: labelB is critical; resist its compression more.
+solver.addConstraint((labelB_width == labelB_intrinsic) | strong(weight=2.0))
+
+# Required: neither label can go negative.
+solver.addConstraint(labelA_width >= 0)
+solver.addConstraint(labelB_width >= 0)
+```
+
+When the container is wide enough, both labels get their intrinsic width only if those
+preferred widths are compatible with the required equality. If the container width differs
+from `labelA_intrinsic + labelB_intrinsic + 4`, the contradiction is resolved by the
+`strong` constraints yielding and the solver picks values that minimize the weighted
+violation.
+
+When the container is too narrow, both `strong` constraints can't be satisfied, and the
+solver minimizes total weighted error: labelB (weight 2.0) shrinks less than labelA
+(weight 1.0). This is the **compression resistance priority** that Auto Layout exposes
+as `setContentCompressionResistancePriority:`.
+
+### Example 4: Interactive Splitter Drag
+
+A vertical splitter sits between two panels. The user can drag it left or right; both
+panels resize to fill the available space. The minimum width of each panel is enforced.
+
+```python
+left_edge = Variable("left")
+splitter  = Variable("splitter")
+right_edge = Variable("right")
+
+# Required: panels are bounded by the window edges and meet at the splitter.
+solver.addConstraint(left_edge == 0)
+solver.addConstraint(right_edge == window_width)
+solver.addConstraint(splitter >= left_edge + 100)   # min 100 for left panel
+solver.addConstraint(splitter <= right_edge - 100)  # min 100 for right panel
+
+# Mark splitter as an edit variable for interactive dragging.
+solver.addEditVariable(splitter, "strong")
+
+# Initial position
+solver.suggestValue(splitter, 400)
+solver.updateVariables()
+
+# In the mouse-move handler:
+def on_mouse_move(x):
+    solver.suggestValue(splitter, x)
+    solver.updateVariables()
+    # Read updated values; redraw.
+    redraw(splitter.value())
+```
+
+The dual-simplex path in `suggestValue` makes the mouse-move handler cheap — a handful
+of pivots per pixel of drag. The required inequality constraints are enforced by the
+solver itself: dragging past the boundary clamps to it automatically (the violation
+falls on the edit constraint, which has finite strength, rather than on the required
+clamp). This kind of "constraint-driven clamping" is far cleaner than the imperative
+`max(min(x, lim), 0)` arithmetic typical of hand-coded layout code.
+
+---
+
+## Bindings / Implementations
+
+Cassowary has been ported to virtually every UI ecosystem. The most notable
+implementations:
+
+| Implementation               | Language                    | Notes                                                                                                                                                                                                             |
+| ---------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Original Cassowary           | C++, Smalltalk, Java        | Reference implementations from the U. Washington group, distributed with the TOCHI paper. Includes Guile, Python, STk bindings.                                                                                   |
+| Apple Auto Layout            | C / Objective-C / Swift     | Production Cassowary inside UIKit and AppKit since 2011. See [auto-layout.md](./auto-layout.md).                                                                                                                  |
+| [Kiwi](./kiwi.md)            | C++ + Python                | Modern reimplementation by Chris Colbert (Nucleic). 10×–500× faster than original Cassowary. Distributed via PyPI as `kiwisolver`. Used by Matplotlib's `constrained_layout`, Enaml, and most current Python UIs. |
+| `cassowary.py`               | Pure Python                 | Direct Python translation of the original; mostly historical.                                                                                                                                                     |
+| CassowaryJS                  | JavaScript                  | Port by Alex Russell, foundation of Grid Style Sheets (GSS).                                                                                                                                                      |
+| `kiwi-js`                    | TypeScript                  | Modern JavaScript port of Kiwi by lume; used by `autolayout.js`.                                                                                                                                                  |
+| `autolayout.js`              | JavaScript                  | Hein Rutjes; implements Apple's Visual Format Language (VFL) atop kiwi-js. Now maintained as `lume/autolayout`.                                                                                                   |
+| `kiwi-java`                  | Java                        | Alex Birkett's line-for-line Java port of Kiwi C++.                                                                                                                                                               |
+| `cassowary-rs` / `casuarius` | Rust                        | Pure-Rust implementations of the original Cassowary, mostly archived.                                                                                                                                             |
+| `kasuari`                    | Rust                        | Currently used by [Ratatui](../tui-libraries/ratatui.md) for its `Layout` engine. A `cassowary-rs` fork with bug fixes.                                                                                           |
+| Dart `cassowary`             | Dart                        | The Flutter team prototyped a Dart port; ultimately superseded by Flutter's own layout system.                                                                                                                    |
+| .NET / C# Cassowary          | C#                          | Multiple community ports of varying maturity.                                                                                                                                                                     |
+| Babelsberg                   | Smalltalk, JavaScript, Ruby | Research language integrating Cassowary as a first-class object-constraint feature; Felgentreff et al.                                                                                                            |
+| GSS / Constraint CSS         | JavaScript                  | Layout DSL that compiled CSS-like syntax to Cassowary constraints.                                                                                                                                                |
+| Scwm                         | Scheme                      | Constraint-based X11 window manager, an early adopter (Badros, Borning).                                                                                                                                          |
+
+The single most-deployed Cassowary in the world is Auto Layout, running in every iOS
+and macOS app. The single most-imported Cassowary is Kiwi via `kiwisolver` on PyPI,
+which is a transitive dependency of Matplotlib and thus of much of the Python
+scientific-computing world.
+
+---
+
+## Strengths and Weaknesses
+
+### For UI Layout
+
+**Strengths.**
+
+- **Expressiveness.** Any linear relationship between layout variables is one
+  `addConstraint` call away. Cross-hierarchy alignment, ratio-based sizing, distributed
+  spacing, baseline alignment, intrinsic-size with priorities — all natural.
+
+- **Composable.** Constraints can be added and removed independently. A view's layout
+  rules are local to the view; combining views combines their constraints. This makes
+  Cassowary a good fit for component-based UI frameworks.
+
+- **Predictable conflict resolution.** The strength hierarchy gives designers a clear
+  mental model: "stronger always wins". No mystery about which constraint a layout
+  engine "chose" — the math determines it.
+
+- **Interactive performance.** `suggestValue` is fast enough for 60fps dragging on
+  hardware several decades old. With Kiwi's optimizations, it is fast enough for
+  multiple thousands of variables and constraints in real time.
+
+- **Resilient under-determination.** Stays (and the implicit weak stay on every
+  variable) keep the layout stable when the constraint set leaves slack: variables
+  don't randomly move.
+
+**Weaknesses.**
+
+- **Linearity restriction.** No quadratic constraints, no products of variables, no
+  conditional logic. Useful patterns like "centered if there's room, otherwise
+  left-aligned" require workarounds (multiple priority levels) or fall outside the
+  algorithm.
+
+- **Debuggability is famously poor.** When the solver reports "unable to satisfy
+  constraints", finding the offending pair (or triple, or n-tuple) of conflicting
+  constraints is hard. Auto Layout's runtime errors of the form _"the constraints
+  cannot be simultaneously satisfied"_ are an industry meme. Production solvers
+  typically have to hand-craft error reporting because the simplex tableau, mid-pivot,
+  is not a useful debugging artifact.
+
+- **Implementation complexity.** A correct Cassowary is a few thousand lines of
+  meticulous code: the tableau, the pivot logic, the marker tracking for
+  `removeConstraint`, the symbolic strengths. Bugs in implementation are subtle and
+  produce ghost layout glitches.
+
+- **Edit-variable plumbing is fiddly.** Forgetting to `addEditVariable` before
+  `suggestValue` is a common source of `Failure` exceptions. Production code wraps
+  this in higher-level APIs.
+
+### For Static One-Shot Rendering
+
+Cassowary is, in some sense, **overkill** for static rendering — for a single layout
+that will not be updated, you do not need incremental updates, you do not need dual
+simplex, you do not need edit variables. A batch LP solver would do the same job in
+roughly the same time, possibly faster because it can choose the entire pivot order
+optimally.
+
+However, even for one-shot rendering, Cassowary's _constraint language_ is valuable:
+expressing a complex layout as a system of equalities and inequalities is often easier
+than threading it through a box-flow system. The cost of overkill is a few microseconds
+per layout — easily affordable.
+
+The reverse case is more interesting: if your layouts will be re-solved many times
+(window resize, animation, scrolling reflow), the incremental architecture turns
+Cassowary's per-update cost from O(constraints) into O(touched-constraints), which can
+be orders of magnitude faster.
+
+### Compared to Box-Flow Systems
+
+| Aspect                        | Box-flow (CSS, Flexbox, Yoga, Ratatui constraints)     | Cassowary                                                             |
+| ----------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------- |
+| **Expressiveness**            | Limited to hierarchical, axis-aligned flows            | Any linear relation                                                   |
+| **Cross-hierarchy alignment** | Requires explicit mechanism (grids, layout guides)     | Natural — single equality                                             |
+| **Speed (cold)**              | O(n), single tree traversal                            | O(n) Phase I + Phase II simplex                                       |
+| **Speed (incremental)**       | O(subtree of changed node)                             | O(touched constraints) — often less                                   |
+| **Cognitive load**            | Low; reuses CSS knowledge                              | Medium; new mental model                                              |
+| **Debuggability**             | Generally easy — local rules                           | Generally hard — non-local conflicts                                  |
+| **Determinism**               | Strict by definition                                   | Strict by design but harder to predict                                |
+| **Production scale**          | All web browsers, [Ink](../tui-libraries/ink.md), Yoga | Auto Layout (billions of devices), Matplotlib (millions of dev users) |
+
+The two approaches are not mutually exclusive. Many modern systems mix them: SwiftUI
+uses constraint-style intent expression but compiles to a custom solver that exploits
+box-flow when possible; Matplotlib's `constrained_layout` uses Kiwi to handle the
+non-trivial alignment cases that the basic grid cannot. Ratatui's percentage-based
+`Layout` uses a stripped-down Cassowary solver (`kasuari`) but pre-filters constraints
+to keep the hot path linear.
+
+The right tool depends on the layout's complexity. For a header / sidebar / body /
+footer dashboard, [Ratatui's box constraints](../tui-libraries/ratatui.md#layout-system)
+or [Ink's Flexbox](../tui-libraries/ink.md#layout-system) suffice. For a layout where
+a button's right edge aligns with a chart's tick mark, Cassowary earns its keep.
+
+---
+
+## References
+
+### Primary Sources
+
+- Badros, Borning, Stuckey. _"The Cassowary Linear Arithmetic Constraint Solving
+  Algorithm."_ ACM Transactions on Computer-Human Interaction (TOCHI), Vol. 8, No. 4,
+  pp. 267–306, December 2001.
+  <https://constraints.cs.washington.edu/solvers/cassowary-tochi.pdf>
+
+- Badros, Borning. _"The Cassowary Linear Arithmetic Constraint Solving Algorithm:
+  Interface and Implementation."_ University of Washington Technical Report
+  UW-CSE-98-06-04, 1998.
+
+- Borning, Marriott, Stuckey, Xiao. _"Solving Linear Arithmetic Constraints for User
+  Interface Applications."_ ACM Symposium on User Interface Software and Technology
+  (UIST '97), 1997.
+
+- Badros, Greg J. _"Extending Interactive Graphical Applications with Constraints."_
+  PhD Thesis, University of Washington, 2000.
+
+### Predecessor and Related Work
+
+- Sannella, Maloney, Freeman-Benson, Borning. _"Multi-way versus One-way Constraints
+  in User Interfaces: Experience with the DeltaBlue Algorithm."_ Software — Practice
+  and Experience, 23(5), 1993.
+
+- Borning. _"The Programming Language Aspects of ThingLab, a Constraint-Oriented
+  Simulation Laboratory."_ ACM TOPLAS, 3(4), 1981.
+
+- Marriott, Chok, Finlay. _"A Tableau Based Constraint Solving Toolkit for Interactive
+  Graphical Applications."_ International Logic Programming Symposium, 1998. (QOCA)
+
+### Project Home and Online Resources
+
+- Cassowary Constraint Solving Toolkit project page:
+  <https://constraints.cs.washington.edu/cassowary/>
+
+- Overconstrained — index of Cassowary implementations:
+  <https://overconstrained.io/>
+
+- Wikipedia article: <https://en.wikipedia.org/wiki/Cassowary_(software)>
+
+### Notable Implementations
+
+- Kiwi (C++): <https://github.com/nucleic/kiwi> — see [kiwi.md](./kiwi.md).
+- kiwisolver (Python via Kiwi): <https://kiwisolver.readthedocs.io/>
+- CassowaryJS: <https://github.com/slightlyoff/cassowary.js>
+- kiwi-js: <https://github.com/IjzerenHein/kiwi.js>
+- autolayout.js: <https://github.com/lume/autolayout>
+- kiwi-java: <https://github.com/alexbirkett/kiwi-java>
+- kasuari (Rust, used by Ratatui): <https://github.com/joshka/kasuari>
+- cassowary-rs: <https://github.com/dylanede/cassowary-rs>
+
+### Related Documents in This Catalog
+
+- [Apple Auto Layout](./auto-layout.md) — Cassowary's most-deployed production user.
+- [Kiwi](./kiwi.md) — the modern C++ reimplementation that dominates Python and other
+  ecosystems.
+- [Ratatui](../tui-libraries/ratatui.md) — uses a Cassowary variant (`kasuari`) for its
+  terminal layout engine.
+- [Ink](../tui-libraries/ink.md) — uses Yoga's Flexbox instead, illustrating the
+  box-flow alternative.

--- a/docs/research/ui-layout/clay.md
+++ b/docs/research/ui-layout/clay.md
@@ -1,0 +1,844 @@
+# Clay (C)
+
+A high-performance, single-header C UI layout library that resolves a nested,
+Flexbox-flavored element tree into a flat, renderer-agnostic list of drawing
+primitives. Clay is designed for real-time graphical UIs (games, editors, video
+demos) and prides itself on microsecond-scale layout passes, an arena-only
+allocation model, and zero dependencies -- including no standard-library
+linkage.
+
+| Field            | Value                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Language         | C99 (also compiles cleanly as C++20)                                                                                   |
+| License          | Zlib                                                                                                                   |
+| Repository       | <https://github.com/nicbarker/clay>                                                                                    |
+| Documentation    | <https://github.com/nicbarker/clay#readme>                                                                             |
+| Version snapshot | `clay.h` reports 0.14 in the local `main` snapshot; the project primarily tracks `main`                                |
+| Notable adoption | Clay's own website (Wasm), termbox2 demos, raylib/SDL2/SDL3/sokol/Cairo examples, multiple community games and tooling |
+
+---
+
+## Overview
+
+### What It Solves
+
+Hand-rolling a UI layout engine in C is a wide rabbit hole: you need a tree
+structure, two-pass sizing (intrinsic + final), a Flexbox-like distribution
+algorithm, text measurement, scroll containers, floating overlays, and some
+form of hit-testing -- all without a garbage collector, all with stable
+addresses, and all fast enough that you can do it sixty times a second on
+a constrained device. Clay packages that engine into a single 4.8k-line
+header file and gives you a declarative DSL on top.
+
+The headline pitch in Clay's README is direct: a Flexbox-like layout model
+for "complex, responsive layouts including text wrapping, scrolling
+containers and aspect ratio scaling," with "microsecond layout
+performance" backed by a static-arena allocator (no `malloc`/`free` in the
+hot path) and an output model that is independent of any specific renderer.
+Clay does not draw anything -- it produces a sorted `Clay_RenderCommandArray`
+of rectangles, borders, text spans, images, scissor regions, and custom
+commands, and hands that array off to whatever backend you are writing
+against. Renderer reference implementations exist for raylib, SDL2, SDL3,
+sokol, Cairo, GLES3, the Win32 GDI, Playdate, termbox2, and a raw ANSI
+terminal renderer, all in-tree under `renderers/` in the repo.
+
+### Design Philosophy
+
+Clay leans hard into a few opinions:
+
+- **Arena allocation, no runtime allocation.** You ask Clay how much memory
+  it needs (`Clay_MinMemorySize()`), give it a single chunk, and from then
+  on Clay never touches the system allocator. Element capacity, text cache
+  capacity, and scroll-container counts are all compile-time knobs.
+- **Immediate-mode authoring, retained-mode friendly output.** You re-declare
+  the entire UI every frame, using a nested macro DSL that reads like JSX.
+  But each emitted render command carries a stable `id`, so retained-mode
+  renderers (e.g., the in-tree HTML renderer) can diff frames and reuse
+  GPU resources.
+- **Layout is decoupled from rendering.** Clay's output is a flat list of
+  axis-aligned commands. The library is silent about how text actually
+  rasterises, how images decode, or how borders are anti-aliased. Those are
+  the renderer's problems.
+- **A C-only macro DSL.** The `CLAY(id, { ... })` macro lets you nest
+  blocks of C inside the layout description. Loops, conditionals, function
+  calls, and ordinary C variables are all in scope inside a layout block --
+  there is no template language to learn.
+- **Single header, zero dependencies.** Drop `clay.h` into your project,
+  `#define CLAY_IMPLEMENTATION` in exactly one translation unit, and you
+  are done. No CMake required, no `libc` required, no `malloc` required.
+
+### History
+
+Clay was created by Nic Barker and went public alongside a [YouTube
+introduction video](https://youtu.be/DYWTw19_8r4) in 2024 that quickly drew
+attention for the macro-DSL trick (see below) and for the live-demo of the
+official Clay website rendered via Wasm. The project has grown steadily on
+GitHub, accumulating renderer backends, language
+bindings, and a transition/animation API. Notable milestones include the
+introduction of the transition API (per-property tweens on stable IDs),
+the addition of clip/scroll containers driven by `Clay_GetScrollOffset()`,
+and the `Clay_ElementDeclaration` style refactor that unified all per-element
+configuration into a single struct passed to the `CLAY()` macro.
+
+---
+
+## Architecture / Layout Model
+
+Clay's mental model is similar to a Flexbox engine:
+
+- The UI is a tree of rectangular **elements**.
+- Each element has a **layout direction** -- `CLAY_LEFT_TO_RIGHT` (default)
+  or `CLAY_TOP_TO_BOTTOM` -- that determines which axis is the "main axis"
+  for child distribution.
+- Each element has a **sizing policy** on each axis (fit/grow/fixed/percent)
+  with optional min/max clamps.
+- Each element has **padding** (four sides, asymmetric), a **child gap**
+  (uniform spacing between siblings on the main axis), and a **child
+  alignment** policy on each axis.
+- The layout pass produces a flat `Clay_RenderCommandArray` of axis-aligned
+  rectangles, text spans, borders, images, scissor (clip) regions, and
+  user-defined custom commands -- in render order, with each command
+  carrying a `boundingBox`, a stable `id`, a `zIndex`, and a
+  command-type-specific payload.
+
+There is no notion of a CSS box model with `box-sizing`; padding is always
+"inside" the element's box and reduces the area available to children.
+There is also no `display: grid`, no `position: absolute` (floating
+elements approximate this), no `flex-wrap`, no `display: contents`, and no
+`align-content`/`justify-content` distinction -- alignment is single-axis,
+single-value on each axis.
+
+### Sizing Primitives
+
+Sizing is the heart of Clay's layout algorithm. Each axis (width, height)
+takes a `Clay_SizingAxis` value built by one of four macros:
+
+| Macro                           | Meaning                                                                                                                                                                                            |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLAY_SIZING_FIT(min, max)`     | Size to the intrinsic size of children (plus padding/gap), clamped to `[min, max]`. This is the default. Omit `max` to let it default to `FLOAT_MAX`. Omit both for unbounded.                     |
+| `CLAY_SIZING_GROW(min, max)`    | Grow to fill the parent's available space along this axis, clamped to `[min, max]`. Multiple grow-siblings share available space, with min/max clamps deciding when a sibling stops participating. |
+| `CLAY_SIZING_FIXED(n)`          | Exactly `n` pixels (or whatever unit your renderer uses). Equivalent to `CLAY_SIZING_FIT(n, n)`.                                                                                                   |
+| `CLAY_SIZING_PERCENT(fraction)` | A fraction of the parent's content size (parent size minus its padding and gaps). `fraction` is in `[0, 1]`.                                                                                       |
+
+Note that Clay's "pixels" are really just `float` units -- the library
+makes no assumptions about what one unit means at the renderer level. The
+official terminal renderer treats one Clay unit as one character cell (see
+the terminal-backend discussion below); the raylib/SDL renderers treat it
+as one screen pixel.
+
+The min/max clamps are first-class: a `CLAY_SIZING_GROW(120, 480)` element
+will never shrink below 120 (even if siblings want more room) and never
+grow past 480 (even if extra space is available). This is the same pattern
+as Flexbox's `flex-basis` + `min-width` + `max-width`, but folded into a
+single constructor.
+
+The layout pass runs in two phases per axis:
+
+1. **Fit pass.** Walk the tree bottom-up, computing the intrinsic
+   "fit" size of each element from its children, padding, and gaps. Text
+   elements call out to the user-provided `MeasureText` callback to
+   determine their natural width.
+2. **Grow/shrink pass.** Walk top-down, distributing each parent's
+   available space among its children. Grow siblings get the leftover
+   space (subject to their min/max clamps); fit/fixed/percent siblings
+   keep their natural sizes; if the children's total exceeds available
+   space, Clay shrinks elements down to their `min`.
+
+This two-pass structure is what makes the entire layout O(n) in element
+count, which is how Clay hits its microsecond-scale targets.
+
+### Padding, Child Gap, and Child Alignment
+
+```c
+typedef struct {
+    uint16_t left;
+    uint16_t right;
+    uint16_t top;
+    uint16_t bottom;
+} Clay_Padding;
+```
+
+Padding is per-side and unsigned 16-bit. The convenience macro
+`CLAY_PADDING_ALL(n)` expands to `{ n, n, n, n }`. Padding is _inside_
+the element's box and reduces the area available to children. There is
+no shorthand for "vertical" or "horizontal" padding pairs analogous to
+Ink's `paddingX`/`paddingY` -- you write them out, or compose with a
+small helper struct.
+
+`childGap` is a single `uint16_t` that controls the spacing between
+adjacent siblings on the main axis. When `layoutDirection ==
+CLAY_LEFT_TO_RIGHT`, `childGap` is horizontal whitespace between children;
+when `layoutDirection == CLAY_TOP_TO_BOTTOM`, it is vertical whitespace.
+There is no separate row-gap/column-gap concept because Clay does not wrap.
+
+`childAlignment` is a `Clay_ChildAlignment` with two axis values:
+
+```c
+typedef struct {
+    Clay_LayoutAlignmentX x;   // CLAY_ALIGN_X_LEFT (default) | CLAY_ALIGN_X_CENTER | CLAY_ALIGN_X_RIGHT
+    Clay_LayoutAlignmentY y;   // CLAY_ALIGN_Y_TOP  (default) | CLAY_ALIGN_Y_CENTER | CLAY_ALIGN_Y_BOTTOM
+} Clay_ChildAlignment;
+```
+
+The crucial nuance: alignment in Clay is _not_ the Flexbox
+`justify-content` / `align-items` split. There is one `childAlignment.x`
+and one `childAlignment.y` per element, applied uniformly. If the layout
+direction is `CLAY_LEFT_TO_RIGHT`, then `childAlignment.x` controls the
+cross-axis packing of the children as a group along the main axis (left,
+center, or right) and `childAlignment.y` controls the per-child cross-axis
+alignment within the row. The roles flip when the direction is
+`CLAY_TOP_TO_BOTTOM`. There is no `space-between` / `space-around` /
+`space-evenly` -- you produce those effects by inserting `flexGrow`-like
+spacer elements (a `CLAY_SIZING_GROW`-on-an-empty-element trick).
+
+### Layout Direction
+
+```c
+typedef enum {
+    CLAY_LEFT_TO_RIGHT = 0,   // default
+    CLAY_TOP_TO_BOTTOM,
+} Clay_LayoutDirection;
+```
+
+Only two directions. There is no right-to-left, no bottom-to-top, and
+no axis-reversal variant analogous to Flexbox's `row-reverse` or
+`column-reverse`. This is a deliberate simplification: the rendering
+primitives Clay emits are also unidirectional, and reversal can be
+expressed by re-ordering child declarations.
+
+### The C-Macro DSL Trick
+
+Clay's nested `CLAY(id, { ... }) { children }` DSL is what makes the
+library feel like JSX in plain C. The trick lives in `clay.h` around line
+146:
+
+```c
+#define CLAY(id, ...)                                                                                  \
+    for (                                                                                              \
+        CLAY__ELEMENT_DEFINITION_LATCH = (                                                             \
+            Clay__OpenElementWithId(id),                                                               \
+            Clay__ConfigureOpenElement(                                                                \
+                CLAY__CONFIG_WRAPPER(Clay_ElementDeclaration, __VA_ARGS__)                             \
+            ),                                                                                         \
+            0                                                                                          \
+        );                                                                                             \
+        CLAY__ELEMENT_DEFINITION_LATCH < 1;                                                            \
+        CLAY__ELEMENT_DEFINITION_LATCH = 1, Clay__CloseElement()                                       \
+    )
+```
+
+The expansion is a single-iteration `for`-loop with three slots:
+
+1. **Initializer**: opens the element (pushes it onto Clay's internal
+   stack), configures it with the variadic-struct designated-initializer,
+   and sets the latch to 0.
+2. **Condition**: checks the latch.
+3. **Post-iteration**: sets the latch to 1 (so the loop exits next
+   check) _and_ calls `Clay__CloseElement()` (pops the stack).
+
+The body of the `for` loop is the block of code that follows the macro
+call -- which is where you write your children. Because it is a real C
+block, you can use `for`, `if`, function calls, local variables, and
+anything else that compiles. `break` and `continue` work too (with the
+expected caveat that `break` will skip the close-element call -- Clay's
+documentation warns against this).
+
+This trick predates Clay (it's a known idiom for "scoped" macros in C),
+but Clay's use of it is one of the most polished examples around: it
+gives the user a JSX-style block-nesting DSL while staying purely in
+the C preprocessor and producing a flat, predictable expansion.
+
+The Odin bindings achieve the same nesting using Odin's
+[`@(deferred_none)`](https://odin-lang.org/docs/overview/) attribute,
+which schedules a cleanup proc to run when the surrounding scope exits.
+That maps the C-macro pattern almost exactly: open on entry, configure
+inline, close on scope exit.
+
+### Measure-Arrange Protocol
+
+Clay does not measure text itself. The user provides a callback:
+
+```c
+typedef Clay_Dimensions (*Clay_MeasureTextFn)(
+    Clay_StringSlice text,
+    Clay_TextElementConfig *config,
+    void *userData
+);
+
+void Clay_SetMeasureTextFunction(Clay_MeasureTextFn fn, void *userData);
+```
+
+This callback is invoked during the fit pass for every text element whose
+natural size has not already been cached. Two important contracts:
+
+- **The string slice is not null-terminated.** Clay slices the original
+  string into segments (e.g., for wrap candidates) and passes pointer +
+  length, not a C-string. Renderers that need a null-terminated string
+  (Raylib's font API, for example) must copy into a scratch buffer.
+- **The callback is on the hot path.** Clay caches measurements per word,
+  but for text-heavy UIs this function still gets called many times per
+  frame. The README warns that a slow `MeasureText` callback can easily
+  dominate frame time even with the cache.
+
+`Clay_ResetMeasureTextCache()` invalidates the cache (call it when DPI or
+font changes), and `Clay_SetMaxMeasureTextCacheWordCount()` adjusts the
+internal cache size before initialization.
+
+The measure-arrange protocol is therefore a hybrid: Clay arranges, the
+host measures text, and Clay caches the measurements. There is no
+separate "arrange" callback -- Clay handles arrangement entirely
+internally using its sizing primitives.
+
+### Render-Command Output Model
+
+`Clay_EndLayout()` returns a `Clay_RenderCommandArray`:
+
+```c
+typedef enum {
+    CLAY_RENDER_COMMAND_TYPE_NONE,
+    CLAY_RENDER_COMMAND_TYPE_RECTANGLE,
+    CLAY_RENDER_COMMAND_TYPE_BORDER,
+    CLAY_RENDER_COMMAND_TYPE_TEXT,
+    CLAY_RENDER_COMMAND_TYPE_IMAGE,
+    CLAY_RENDER_COMMAND_TYPE_SCISSOR_START,
+    CLAY_RENDER_COMMAND_TYPE_SCISSOR_END,
+    CLAY_RENDER_COMMAND_TYPE_OVERLAY_COLOR_START,
+    CLAY_RENDER_COMMAND_TYPE_OVERLAY_COLOR_END,
+    CLAY_RENDER_COMMAND_TYPE_CUSTOM,
+} Clay_RenderCommandType;
+
+typedef struct {
+    Clay_BoundingBox boundingBox;
+    Clay_RenderData renderData;          // union over command-type payloads
+    void *userData;
+    uint32_t id;
+    int16_t zIndex;
+    Clay_RenderCommandType commandType;
+} Clay_RenderCommand;
+```
+
+Every command has an axis-aligned bounding box, a stable id, a z-index,
+and a discriminated union of per-type data. The renderer iterates the
+array once, switching on `commandType`, and dispatches to the
+appropriate drawing primitive.
+
+The `SCISSOR_START`/`SCISSOR_END` pair brackets a region inside which
+all draw commands should be clipped to the start command's bounding
+box -- this is how scroll containers and clip regions are expressed.
+`OVERLAY_COLOR_START`/`OVERLAY_COLOR_END` brackets a region that should
+have a tint applied (used for "fade out" effects).
+`CLAY_RENDER_COMMAND_TYPE_CUSTOM` carries an opaque `void *` payload
+that you populate yourself (typically out of a frame arena), letting you
+inject custom primitives (3D models, video frames, native widgets) into
+the otherwise opaque draw stream.
+
+**What this means for terminal backends.** Clay's render commands are
+in float-pixel space, and rectangles carry RGBA colors plus corner radii.
+A terminal backend has to project all of that onto an integer character
+grid. The in-tree `renderers/terminal/clay_renderer_terminal_ansi.c`
+takes the simplest approach: every rectangle is drawn as a block of
+shaded box-drawing characters (`█`, `▓`, `▒`, `░`) chosen by the
+average channel intensity, every text command is positioned by
+ANSI cursor-move escapes, and there is no color support at all (RGB is
+collapsed to brightness). The termbox2-based renderer is more elaborate,
+mapping Clay colors to xterm-256 cells and using termbox's cell buffer
+to handle diffing. Either way: the renderer is responsible for the
+projection from `float` to cells, for color quantisation, for character
+selection, and for any double-buffer diffing -- Clay itself has no
+opinion. See [Strengths and Weaknesses](#strengths-and-weaknesses) below
+for what this means in practice.
+
+### Code Example 1: A Sidebar-and-Content Layout
+
+A minimal example from the README, lightly trimmed:
+
+```c
+#define CLAY_IMPLEMENTATION
+#include <stdio.h>
+#include <stdlib.h>
+#include "clay.h"
+
+const Clay_Color COLOR_LIGHT = (Clay_Color){ 224, 215, 210, 255 };
+const Clay_Color COLOR_RED   = (Clay_Color){ 168,  66,  28, 255 };
+
+static Clay_Dimensions MeasureText(
+    Clay_StringSlice text,
+    Clay_TextElementConfig *config,
+    void *userData
+) {
+    // Monospace approximation -- a real renderer would consult a font.
+    return (Clay_Dimensions){
+        .width  = text.length * config->fontSize,
+        .height = config->fontSize,
+    };
+}
+
+static void HandleClayErrors(Clay_ErrorData data) {
+    fprintf(stderr, "clay: %.*s\n", data.errorText.length, data.errorText.chars);
+}
+
+int main(void) {
+    uint64_t   sz    = Clay_MinMemorySize();
+    Clay_Arena arena = Clay_CreateArenaWithCapacityAndMemory(sz, malloc(sz));
+    Clay_Initialize(arena, (Clay_Dimensions){ 1920, 1080 },
+                    (Clay_ErrorHandler){ HandleClayErrors });
+    Clay_SetMeasureTextFunction(MeasureText, NULL);
+
+    Clay_BeginLayout();
+
+    CLAY(CLAY_ID("Outer"), {
+        .layout = {
+            .sizing          = { CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0) },
+            .padding         = CLAY_PADDING_ALL(16),
+            .childGap        = 16,
+            .layoutDirection = CLAY_LEFT_TO_RIGHT,
+        },
+        .backgroundColor = { 250, 250, 255, 255 },
+    }) {
+        CLAY(CLAY_ID("Sidebar"), {
+            .layout = {
+                .sizing          = { CLAY_SIZING_FIXED(300), CLAY_SIZING_GROW(0) },
+                .padding         = CLAY_PADDING_ALL(16),
+                .childGap        = 16,
+                .layoutDirection = CLAY_TOP_TO_BOTTOM,
+            },
+            .backgroundColor = COLOR_LIGHT,
+        }) {
+            CLAY_TEXT(CLAY_STRING("Clay - UI Library"),
+                CLAY_TEXT_CONFIG({ .fontSize = 24, .textColor = { 255, 255, 255, 255 } }));
+
+            for (int i = 0; i < 5; i++) {
+                CLAY(CLAY_IDI("Item", i), {
+                    .layout = { .sizing = { CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(50) } },
+                    .backgroundColor = COLOR_RED,
+                }) {}
+            }
+        }
+
+        CLAY(CLAY_ID("Content"), {
+            .layout = {
+                .sizing = { CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0) },
+            },
+            .backgroundColor = COLOR_LIGHT,
+        }) {}
+    }
+
+    Clay_RenderCommandArray cmds = Clay_EndLayout();
+    for (int i = 0; i < cmds.length; i++) {
+        Clay_RenderCommand *c = &cmds.internalArray[i];
+        // dispatch on c->commandType ...
+    }
+}
+```
+
+Things to notice:
+
+- The whole UI is declared inside a single arena. `malloc` is only used
+  to _acquire_ the arena -- after that, Clay never allocates.
+- `CLAY_IDI("Item", i)` is the loop-friendly id macro: it produces a
+  unique element id from a string + integer pair without any runtime
+  string formatting.
+- The `Sidebar` is sized as `CLAY_SIZING_FIXED(300)` on the main axis and
+  `CLAY_SIZING_GROW(0)` on the cross axis -- a fixed-width column that
+  fills the parent's height.
+- `Content` is `GROW(0)` on both axes, so it takes whatever the sidebar
+  leaves.
+
+### Code Example 2: Centered Card with Padding and Gap
+
+```c
+CLAY(CLAY_ID("PageRoot"), {
+    .layout = {
+        .sizing          = { CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0) },
+        .childAlignment  = { .x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_CENTER },
+    },
+}) {
+    CLAY(CLAY_ID("Card"), {
+        .layout = {
+            .sizing          = {
+                CLAY_SIZING_FIT(240, 480),  // grow with content, clamped
+                CLAY_SIZING_FIT(0, 0),      // hug children vertically
+            },
+            .padding         = { 24, 24, 16, 16 },
+            .childGap        = 12,
+            .layoutDirection = CLAY_TOP_TO_BOTTOM,
+            .childAlignment  = { .x = CLAY_ALIGN_X_CENTER, .y = CLAY_ALIGN_Y_TOP },
+        },
+        .backgroundColor = { 30, 30, 36, 255 },
+        .cornerRadius    = CLAY_CORNER_RADIUS(8),
+        .border          = {
+            .color = { 70, 70, 90, 255 },
+            .width = { .left = 1, .right = 1, .top = 1, .bottom = 1, .betweenChildren = 0 },
+        },
+    }) {
+        CLAY_TEXT(CLAY_STRING("Confirm action"),
+            CLAY_TEXT_CONFIG({ .fontSize = 18, .textColor = { 240, 240, 245, 255 } }));
+        CLAY_TEXT(CLAY_STRING("Are you sure you want to proceed?"),
+            CLAY_TEXT_CONFIG({ .fontSize = 14, .textColor = { 200, 200, 210, 255 } }));
+    }
+}
+```
+
+`CLAY_SIZING_FIT(240, 480)` is the clamp idiom: the card wants to hug
+its children's intrinsic width, but never narrower than 240 units and
+never wider than 480. Combined with `childAlignment` on the root, the
+card naturally centers itself in the viewport.
+
+### Code Example 3: Scroll Container
+
+```c
+CLAY(CLAY_ID("Scroll"), {
+    .layout = {
+        .sizing          = { CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(300) },
+        .layoutDirection = CLAY_TOP_TO_BOTTOM,
+        .childGap        = 4,
+    },
+    .clip = {
+        .vertical    = true,
+        .childOffset = Clay_GetScrollOffset(),
+    },
+    .backgroundColor = { 20, 20, 24, 255 },
+}) {
+    for (int i = 0; i < 1000; i++) {
+        CLAY(CLAY_IDI("Row", i), {
+            .layout = { .sizing = { CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(24) } },
+            .backgroundColor = (i & 1) ? (Clay_Color){ 28, 28, 32, 255 }
+                                       : (Clay_Color){ 22, 22, 26, 255 },
+        }) {
+            CLAY_TEXT(rowLabel(i), CLAY_TEXT_CONFIG({ .fontSize = 14, .textColor = { 220, 220, 220, 255 } }));
+        }
+    }
+}
+```
+
+The `.clip = { .vertical = true, .childOffset = Clay_GetScrollOffset() }`
+field is the key. It tells Clay to emit a `SCISSOR_START` at the start
+of this element and a `SCISSOR_END` at the end, _and_ to offset the
+child content vertically by Clay's internally tracked scroll offset.
+`Clay_UpdateScrollContainers()` (called once per frame before
+`BeginLayout`) updates that offset from mouse-wheel / touch-drag deltas.
+A scroll bar is just another element you can position alongside.
+
+### Code Example 4: Odin Bindings
+
+The Odin port mirrors the C API closely. The key trick is that Odin's
+`@(deferred_none = ...)` attribute lets a procedure schedule a cleanup
+proc to run on scope exit, which gives you the same "open-close" pairing
+the C macro provides:
+
+```odin
+import clay "clay-odin"
+
+LandingPageBlob :: proc(
+    index: u32,
+    fontSize: u16,
+    fontId: u16,
+    color: clay.Color,
+    $text: string,
+    image: ^raylib.Texture2D,
+) {
+    if clay.UI(clay.ID("HeroBlob", index))(
+        {
+            layout = {
+                sizing         = { width = clay.SizingGrow({ max = 480 }) },
+                padding        = clay.PaddingAll(16),
+                childGap       = 16,
+                childAlignment = clay.ChildAlignment{ y = .Center },
+            },
+            border       = border2pxRed,
+            cornerRadius = clay.CornerRadiusAll(10),
+        },
+    ) {
+        if clay.UI(clay.ID("CheckImage", index))(
+            {
+                layout      = { sizing = { width = clay.SizingFixed(32) } },
+                aspectRatio = { 1.0 },
+                image       = { imageData = image },
+            },
+        ) {}
+        clay.Text(text, { fontSize = fontSize, fontId = fontId, textColor = color })
+    }
+}
+```
+
+The double-paren syntax (`clay.UI(id)(config)`) reflects that `UI` is a
+curried procedure: the outer call opens the element, and the returned
+procedure receives the element configuration. The `@(deferred_none)`
+attribute on `UI_WithId`/`UI_AutoId` arranges for `_CloseElement` to run
+at the end of the `if` block. Apart from that, every Odin call line-for-line
+matches the equivalent C macro.
+
+---
+
+## Bindings and Language Support
+
+Clay is, by design, a C library. The public API is plain C with no
+templates or generics, so binding it from other languages is a matter of
+exposing the same functions and replicating the macro DSL using the host
+language's idioms.
+
+### Official / In-tree
+
+| Language | Status        | Location                             |
+| -------- | ------------- | ------------------------------------ |
+| C        | Reference     | `clay.h`                             |
+| C++      | Reference     | `clay.h` (compiles cleanly as C++20) |
+| Odin     | Official      | `bindings/odin/clay-odin/`           |
+| Rust     | Official      | <https://github.com/clay-ui-rs/clay> |
+| Zig      | Bindings dir  | `bindings/zig/`                      |
+| C#       | Bindings dir  | `bindings/csharp/`                   |
+| C++      | Idiomatic dir | `bindings/cpp/`                      |
+
+The Odin bindings are particularly polished -- they ship with prebuilt
+static libraries for Linux, macOS (x86_64 and arm64), Windows, and
+WebAssembly, and they include a full port of the Clay-website example.
+The Rust bindings (in a separate repo, `clay-ui-rs/clay`) wrap the C
+header via `bindgen` and expose an ergonomic builder API.
+
+### External / Community
+
+| Language | Project                                                                            |
+| -------- | ---------------------------------------------------------------------------------- |
+| D        | [`clayd`](https://github.com/zkxjzmswkwl/clayd)                                    |
+| D        | [`clayui`](https://github.com/zkxjzmswkwl/clayui)                                  |
+| Go       | [`glay`](https://github.com/soypat/glay)                                           |
+| Go       | [`totallygamerjet/clay`](https://github.com/totallygamerjet/clay) (cxgo transpile) |
+| Go       | [`goclay`](https://github.com/igadmg/goclay)                                       |
+
+The `bindings/d/README` file in the Clay repo is literally just two URLs:
+the `clayd` and `clayui` repositories, both maintained by the same
+external author. There is no in-tree D binding -- if you want to use
+Clay from D today, you either consume one of those external wrappers or
+you generate your own bindings from `clay.h` using `dpp` /
+`dstep` / `htod`. The Sparkles project's preference for `@nogc`,
+templated, statically-known APIs would make a fresh, lean D wrapper an
+attractive option -- Clay's arena-based, allocation-free runtime maps
+unusually well to D's `@nogc` subset.
+
+### What a Binding Has to Provide
+
+The non-obvious part of binding Clay is replicating the nested DSL. The
+binding author has three options:
+
+1. **A scope-guard pattern.** Odin uses `@(deferred_none)`; Zig uses
+   `defer`; Rust uses RAII through `Drop`; D can use `scope(exit)`. The
+   binding exposes a function that opens an element and another that
+   closes it, and the host language's scope-exit hook calls the closer.
+2. **A higher-order function.** Pass a closure that receives a builder.
+   The wrapper opens the element, runs the closure, then closes the
+   element. This is what `clay-ui-rs` does for one of its APIs.
+3. **A literal port of the `for`-loop trick.** Only practical in
+   languages with C-style preprocessors (so basically just C/C++).
+
+All three end up producing the same `Clay_RenderCommandArray`; the
+choice is purely about ergonomics in the host language.
+
+---
+
+## Strengths and Weaknesses
+
+### For Real-Time Graphical UIs (its target)
+
+Clay is excellent at what it was designed for:
+
+- **Microsecond layout passes**. With 8000+ elements the layout pass
+  finishes in single-digit milliseconds on a desktop CPU, which is well
+  inside a 60 Hz frame budget with room to spare.
+- **Zero runtime allocation**. The arena is sized once, never grows.
+  This is enormously valuable in soft-real-time contexts (games,
+  audio software, embedded UIs) where any heap interaction is a tail
+  latency risk.
+- **Single-header, zero-dependency distribution**. Drop `clay.h` into
+  your project, define `CLAY_IMPLEMENTATION` in one file, and you have a
+  layout engine. No CMake, no `libc` required, no build orchestration.
+- **Renderer agnosticism is real**. The in-tree backends -- raylib,
+  SDL2/3, sokol, Cairo, GLES3, Win32 GDI, Playdate, termbox2 -- share
+  no Clay-specific glue beyond consuming the render-command array.
+- **The macro DSL is genuinely pleasant** for C/C++ developers. Nested
+  layout reads like JSX with `for` loops, `if` statements, and ordinary
+  C variables inline -- there is no template language to learn.
+- **Strong debug tooling**. `Clay_SetDebugModeEnabled(true)` injects an
+  inspector panel into the render-command stream, with element
+  bounding-box visualisation and hierarchy navigation, so you do not
+  need to write your own debug overlay.
+
+### For Static One-Shot Rendering (e.g. a Terminal Table)
+
+Clay is a **poor fit** for static one-shot rendering, and it is worth
+unpacking why.
+
+The first mismatch is **abstraction level**. Clay's output is a
+`Clay_RenderCommandArray` of float-coordinate axis-aligned rectangles,
+borders, and text spans. If you want to emit a final ANSI string for a
+terminal table -- the kind of thing the Sparkles `core-cli` `prettyPrint`
+or table-formatter modules produce -- you would have to:
+
+1. Build the element tree (allocate arena, configure padding/sizing).
+2. Provide a `MeasureText` callback that returns column widths.
+3. Run `Clay_EndLayout()` to get the render-command array.
+4. Iterate the array and project each command onto an integer character
+   grid -- choosing block characters for filled rectangles, using cursor
+   moves for text placement, quantising RGB colours to xterm-256 or
+   true-colour SGR escapes, and tracking the
+   `SCISSOR_START`/`SCISSOR_END` pairs to clip text inside scroll
+   regions.
+
+The in-tree `renderers/terminal/clay_renderer_terminal_ansi.c` is 194
+lines, and _most_ of it is the shading lookup that maps RGBA to
+`█`/`▓`/`▒`/`░`. It has no styled-text support, no border-character
+selection, and treats every rectangle as a heat-map cell. The
+termbox2-based renderer is much more sophisticated -- it uses cell
+buffers, mosaic image rendering, and quantises colours into the
+xterm-256 palette -- but it is also nearly 1800 lines, and a non-trivial
+fraction of that is image-rendering scaffolding rather than the layout
+glue.
+
+For Sparkles' use cases -- printing a one-shot table, a help screen, or
+a colorised log line -- this is the **wrong abstraction stack**. You
+do not want to:
+
+- pull in arena allocation, scroll containers, transitions, hit-testing,
+  and a render-command array, just to align two columns;
+- build, then re-interpret, then re-rasterise an intermediate output
+  format whose primitives (RGBA rectangles, float bounding boxes,
+  scissor regions) are themselves a mismatch for the target medium
+  (a 2D grid of styled cells with bounded color depth);
+- maintain a `MeasureText` callback whose contract is "give me a
+  fractional width in float pixels" when you actually know the width
+  in character cells without ambiguity.
+
+Put differently: Clay solves a _layout calculation_ problem that
+terminal CLIs do not have, and then leaves you to solve a _rendering
+projection_ problem (float-pixel commands → integer-cell ANSI) that
+turns out to be most of the work. For a one-shot terminal rendering
+pipeline, a constraint solver that produces (col, row, width, height,
+style) tuples directly -- like Ratatui's `Layout::split` -- is a
+better fit. See [../tui-libraries/ratatui.md](../tui-libraries/ratatui.md)
+for the constraint-and-Rect model Ratatui uses, and
+[../tui-libraries/ink.md](../tui-libraries/ink.md) for the Yoga-based
+approach Ink takes, which is closer to Clay's model but with the
+"float pixels → cells" projection abstracted away by yoga-layout's
+configuration knobs.
+
+The other practical wrinkle for terminal output is the **box model**.
+Clay uses rectangles with optional corner radii, RGBA colours, and
+borders specified as `Clay_BorderElementConfig` with per-side widths
+in floats. A terminal renderer has to choose box-drawing characters
+(`┌`, `─`, `│`, `┐`, ...) for borders, and Clay's renderer-agnostic
+output gives no hint about which character to pick -- you have to
+look at the four neighbours of every cell to decide whether to emit
+a corner or an edge piece. The termbox2 renderer does this; the
+plain ANSI renderer does not, which is why its output looks like
+heatmap blocks instead of crisp boxes.
+
+### Embedding Across Renderers
+
+Where Clay genuinely shines, and where no other library in this
+catalog matches it, is **the same layout tree producing pixel-perfect
+output across radically different backends**. The same C code that
+runs on a Playdate (1-bit framebuffer, 84 MHz Cortex-M7) renders on
+WebAssembly in the browser, on Win32 GDI, on raylib, on SDL2/3, on
+sokol, on Cairo for PDF generation, and on terminal cells. The
+official Clay website is itself a Clay layout running in Wasm, with
+an HTML renderer that converts each render command into a persistent
+DOM element. This is impossible in retained-mode toolkits because
+their primitives are bound to a specific render target.
+
+For Sparkles, this "single tree, many renderers" property is mostly
+moot: the project's renderer is always a terminal, and the
+projection from Clay's command stream to ANSI cells is exactly the
+work being avoided.
+
+### Compared to Alternatives
+
+- **[Yoga](./yoga.md)**. Yoga is the other Flexbox-style layout engine
+  in this catalog. Yoga implements a faithful subset of the CSS
+  Flexbox specification (with proper `justify-content`, `align-items`,
+  `align-content`, `flex-wrap`, RTL support, percentages, gaps); Clay
+  implements a simplified, Clay-shaped flex model with single-value
+  `childAlignment` and no wrapping. Yoga is much larger (hundreds of
+  kilobytes of C++ in the WASM build) and slower per node, but it
+  produces output that web developers immediately recognise. Clay is
+  smaller, faster, and more opinionated. Crucially, Yoga produces
+  `(left, top, width, height)` tuples per node (a "computed style"
+  tree), not a render-command array -- the caller is expected to
+  re-traverse the tree itself to render, which makes Yoga a better
+  fit if you already have a retained-mode renderer (this is exactly
+  what [../tui-libraries/ink.md](../tui-libraries/ink.md) does).
+- **Ratatui's constraint solver**. Ratatui ([../tui-libraries/ratatui.md](../tui-libraries/ratatui.md))
+  uses a Cassowary-style constraint system to subdivide a `Rect`
+  into sub-rects, one constraint per child. It is _not_ a layout
+  engine in the Flexbox sense -- there is no tree, no measurement
+  pass, no intrinsic sizing. It is a one-shot box-splitter. For
+  the terminal-output use case, this is exactly the right shape and
+  one or two orders of magnitude smaller and simpler than Clay.
+- **Dear ImGui's auto-layout**. Dear ImGui has a much weaker layout
+  story -- elements are positioned by cursor movement, with `SameLine`,
+  groups, and tables as escape hatches. Clay's layout model is
+  considerably more expressive and more declarative.
+- **Native toolkits (Qt, GTK, AppKit)**. These ship layout engines too,
+  but bound to a specific widget set and platform. Clay is portable to
+  anywhere C compiles, and the layout output is decoupled from
+  rendering.
+
+---
+
+## References
+
+### Primary
+
+- **Repository**: <https://github.com/nicbarker/clay>
+- **README / API reference**: <https://github.com/nicbarker/clay#readme>
+- **Live demo (Wasm)**: <https://nicbarker.com/clay>
+- **Introduction video**: <https://youtu.be/DYWTw19_8r4>
+- **Discord**: <https://discord.gg/b4FTWkxdvT>
+
+### Source
+
+- **`clay.h`** (single header, 4.8k LOC): <https://github.com/nicbarker/clay/blob/main/clay.h>
+- **The `CLAY()` macro** (lines 146-151 of `clay.h`): the for-loop DSL trick.
+- **Render-command type enum**: `Clay_RenderCommandType` around line 765 of `clay.h`.
+
+### Renderer Backends (in-tree)
+
+- **raylib**: `renderers/raylib/`
+- **SDL2 / SDL3**: `renderers/SDL2/`, `renderers/SDL3/`
+- **sokol**: `renderers/sokol/`
+- **Cairo** (PDF output): `renderers/cairo/`
+- **GLES3**: `renderers/GLES3/`
+- **Win32 GDI**: `renderers/win32_gdi/`
+- **Playdate**: `renderers/playdate/`
+- **Terminal (raw ANSI)**: `renderers/terminal/clay_renderer_terminal_ansi.c`
+- **termbox2**: `renderers/termbox2/clay_renderer_termbox2.c`
+- **Web (HTML)**: `renderers/web/`
+
+### Bindings
+
+- **Odin** (in-tree, official): <https://github.com/nicbarker/clay/tree/main/bindings/odin>
+- **Rust** (separate repo, official): <https://github.com/clay-ui-rs/clay>
+- **Zig** (in-tree): <https://github.com/nicbarker/clay/tree/main/bindings/zig>
+- **C#** (in-tree): <https://github.com/nicbarker/clay/tree/main/bindings/csharp>
+- **C++** (in-tree, idiomatic): <https://github.com/nicbarker/clay/tree/main/bindings/cpp>
+- **D** (external, community): <https://github.com/zkxjzmswkwl/clayd>, <https://github.com/zkxjzmswkwl/clayui>
+- **Go (line-by-line port)**: <https://github.com/soypat/glay>
+- **Go (cxgo transpile)**: <https://github.com/totallygamerjet/clay>
+- **Go (alternative port)**: <https://github.com/igadmg/goclay>
+
+### Cross-References
+
+- [yoga.md](./yoga.md) -- the other Flexbox-style layout engine in this
+  catalog. Faithful CSS-Flexbox subset, used by Ink for terminal layout.
+- [../tui-libraries/ratatui.md](../tui-libraries/ratatui.md) --
+  constraint-based one-shot rectangle splitter; the closest "shape" of
+  layout primitive to what a static terminal renderer wants.
+- [../tui-libraries/ink.md](../tui-libraries/ink.md) -- the
+  Yoga-via-WASM-in-Node story for terminal Flexbox, useful as a
+  contrast to Clay's "emit a command array, you project it onto cells"
+  philosophy.
+- [../tui-libraries/notcurses.md](../tui-libraries/notcurses.md) --
+  another C terminal library that handles cell-level rendering, useful
+  for thinking about what a Clay terminal renderer ultimately has to
+  do at the byte level.
+- [../tui-libraries/ftxui.md](../tui-libraries/ftxui.md) -- a C++
+  layout-and-render system whose `hbox`/`vbox`/`flex` primitives sit
+  closer to Clay's model than to Ratatui's.

--- a/docs/research/ui-layout/css-flexbox.md
+++ b/docs/research/ui-layout/css-flexbox.md
@@ -1,0 +1,715 @@
+# CSS Flexbox (W3C Specification)
+
+A one-dimensional, content-aware layout model standardized by the W3C CSS Working
+Group as the _CSS Flexible Box Layout Module_. Flexbox provides a coordinate-free
+way to distribute, align, and reorder a sequence of boxes along a _main axis_ and a
+perpendicular _cross axis_, with first-class support for growing and shrinking
+items to fit a container.
+
+| Field                        | Value                                                                                                                                                                                                                               |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Specification                | [CSS Flexible Box Layout Module Level 1](https://www.w3.org/TR/css-flexbox-1/)                                                                                                                                                      |
+| Editor's Draft               | <https://drafts.csswg.org/css-flexbox/>                                                                                                                                                                                             |
+| Editors                      | Tab Atkins Jr. (Google), Elika J. Etemad / fantasai (Apple), Rossen Atanassov (Microsoft)                                                                                                                                           |
+| Former Editors               | Alex Mogilevsky, L. David Baron, Neil Deakin, Ian Hickson, David Hyatt                                                                                                                                                              |
+| First Working Draft          | _CSS3 Flexible Box Module_ -- 23 July 2009 (using `display: box`)                                                                                                                                                                   |
+| Modern syntax                | `display: flex` -- introduced in the 22 March 2012 Working Draft revision                                                                                                                                                           |
+| Candidate Recommendation     | 18 September 2012; reinstated to CR with major revisions through 2014-2018                                                                                                                                                          |
+| Current Level (date)         | Candidate Recommendation Draft, 14 October 2025                                                                                                                                                                                     |
+| Reference Implementations    | Blink (Chromium), WebKit (Safari), Gecko (Firefox), Servo                                                                                                                                                                           |
+| Notable Non-browser Adoption | [Yoga](./yoga.md) (Meta), [Taffy](./taffy.md) (Rust), [Stretch](./stretch.md), React Native, [Ink](../tui-libraries/ink.md), [Textual](../tui-libraries/textual.md) (CSS subset), Flutter (`Flex`/`Row`/`Column`), Qt Quick Layouts |
+
+---
+
+## Overview
+
+### What It Solves
+
+Flexbox addresses a category of layout problems that the original CSS 2 box model
+made awkward at best and impossible at worst:
+
+- **Distributing free space.** Given a row of items and a container, how is the
+  surplus or deficit space divided among them?
+- **Centering along two axes.** Vertically centering a block of unknown height
+  inside another block of unknown height was the canonical CSS koan for over a
+  decade.
+- **Reordering visual content independently of source order.** The `order`
+  property lets visual presentation diverge from DOM order without scripting
+  (with carefully documented accessibility caveats).
+- **Equal-height columns.** Two side-by-side blocks whose heights track each
+  other regardless of content length.
+- **Sticky footers, holy-grail layouts, navigation bars.** Patterns that were
+  routinely implemented with floats, negative margins, table-cell hacks, or
+  `position: absolute` arithmetic.
+
+The unifying theme is **direction-agnostic, content-aware distribution of space
+along a single axis**, with a secondary alignment axis. Where the legacy block
+model expressed layout in terms of physical edges (`top`, `left`, `margin-right`,
+clearing floats), flexbox expresses it in terms of logical roles -- _main start_,
+_main end_, _cross start_, _cross end_ -- that adapt to writing mode and
+direction.
+
+### Design Philosophy
+
+The specification frames flexbox as "a CSS box model optimized for user interface
+design." Three design principles stand out:
+
+1. **One dimension at a time.** Flexbox is deliberately a _one-dimensional_
+   model. A flex container lays out children along a single axis; multi-line
+   wrap is supported, but the cross axis is for alignment, not for independent
+   sizing of rows and columns. For two-dimensional layout, the working group
+   later produced CSS Grid (see [css-grid.md](./css-grid.md)).
+
+2. **Content-aware sizing with explicit overrides.** Each flex item carries an
+   intrinsic _hypothetical main size_ derived from its content (and from the
+   `flex-basis` property). The flex algorithm then redistributes free space
+   according to per-item `flex-grow` and `flex-shrink` factors. The author
+   controls _how flexible_ each item is, not _what size_ it is.
+
+3. **Logical, writing-mode-aware.** Flexbox was the first widely adopted CSS
+   layout module to model start/end edges rather than left/right. A
+   `flex-direction: row` container in an Arabic (`dir="rtl"`) document
+   automatically reverses its main axis. Similarly, `flex-direction: column`
+   follows the block axis of the document.
+
+### History
+
+Flexbox is the third generation of CSS "box" specifications and bears scars from
+all three:
+
+- **CSS 2 / CSS 2.1 (1998-2011).** Visual formatting was based on block boxes,
+  inline boxes, floats, and absolute positioning. None of these were designed
+  for application UI. Vertical centering was a recurring pain point; equal-height
+  columns required `display: table-cell`, faux backgrounds, or scripting.
+
+- **`display: box` -- the XUL-flavoured draft (2009).** The first
+  CSS3 Flexible Box draft, published 23 July 2009, used `display: box` with
+  `box-orient`, `box-direction`, `box-flex`, `box-pack`, and `box-align`
+  properties. This vocabulary was inherited from Mozilla's XUL layout language
+  (which had powered Firefox's chrome since 2002) and from analogous primitives
+  in Microsoft's Silverlight `StackPanel`. Browsers shipped vendor-prefixed
+  implementations (`-webkit-box`, `-moz-box`, `-ms-box`) that are still
+  occasionally encountered when supporting very old browsers.
+
+- **`display: flexbox` -- the abandoned middle (2011).** A brief intermediate
+  syntax with two-value `flex()` notation. It never shipped to stable browsers
+  but generated enough churn that the working group's "tweener" syntax remains
+  in some legacy support tables.
+
+- **`display: flex` -- the modern syntax (2012-present).** The 22 March 2012
+  Working Draft introduced the current property names: `flex-direction`,
+  `flex-wrap`, `flex-flow`, `justify-content`, `align-items`, `align-self`,
+  `align-content`, `flex-grow`, `flex-shrink`, `flex-basis`, and the `flex`
+  shorthand. The specification reached W3C Candidate Recommendation in
+  September 2012 and has remained at CR through several editorial revisions.
+  The most recent CR Draft is dated 14 October 2025.
+
+- **Box Alignment Module (2016-).** The alignment properties
+  (`justify-content`, `align-items`, etc.) were generalized into the [CSS Box
+  Alignment Module Level 3](https://www.w3.org/TR/css-align-3/), which now
+  defines them for flexbox, grid, and block layout. Flexbox is therefore both a
+  consumer and a historical source of those properties.
+
+---
+
+## Layout Model
+
+### Containers and Items
+
+A flex container is established by
+
+```css
+.container {
+  display: flex; /* block-level flex container */
+}
+
+.inline-container {
+  display: inline-flex; /* inline-level flex container */
+}
+```
+
+Direct in-flow children of the container become _flex items_. Anonymous flex
+items are generated to wrap runs of text or inline content that appear directly
+inside a flex container.
+
+```html
+<div class="container">
+  Some text becomes an anonymous flex item.
+  <div>Element children become flex items.</div>
+  <span>This too.</span>
+</div>
+```
+
+Within a flex container, several CSS features have no effect or behave
+differently:
+
+- `float` and `clear` do not apply to flex items.
+- `vertical-align` has no effect on flex items (cross-axis alignment is
+  controlled by the alignment properties).
+- Margins on adjacent flex items do not collapse.
+- `::first-line` and `::first-letter` pseudo-elements do not apply to flex
+  containers.
+
+### Main Axis vs Cross Axis
+
+Every flex container has two axes:
+
+- The **main axis** is the axis along which items are laid out, determined by
+  `flex-direction`.
+- The **cross axis** is perpendicular to the main axis.
+
+Each axis has a _start_ and _end_ edge, named logically:
+
+```
+flex-direction: row;                     flex-direction: column;
+                                         (LTR writing mode)
+   main-start ----------> main-end             cross-start
+                                                   |
+   +------+  +------+  +------+                +-------+
+   | item |  | item |  | item |   <- cross   ^ |  item | <- main
+   +------+  +------+  +------+      end     | +-------+    end
+                                             | +-------+
+   <- cross-start                       main | |  item |
+                                       start | +-------+
+                                             | +-------+
+                                             | |  item |
+                                             v +-------+
+                                                cross-end
+```
+
+The four `flex-direction` keywords --- `row`, `row-reverse`, `column`,
+`column-reverse` --- pick which physical edge of the container is _main-start_
+in a given writing mode. In a left-to-right English document, `row` puts
+main-start on the left; in a right-to-left Arabic document, `row` puts
+main-start on the right.
+
+### Lines
+
+If `flex-wrap` is not `nowrap`, the container can produce multiple _flex lines_.
+Each line lays out its own items along the main axis; lines themselves are
+stacked along the cross axis. Single-line containers are by far the most common
+case; multi-line flex containers approach the territory where Grid is usually
+the better answer.
+
+---
+
+## Sizing Model
+
+### Hypothetical Main Size
+
+Before flexibility is resolved, each flex item is assigned a _hypothetical main
+size_. This is derived from:
+
+1. `flex-basis` -- if non-`auto`, this is used directly.
+2. Otherwise the main-size property (`width` for row containers, `height` for
+   column containers).
+3. Otherwise the item's `max-content` size.
+
+`flex-basis: content` (formally specified, supported in modern browsers) forces
+the algorithm to use `max-content` regardless of any explicit main-size
+property.
+
+### Flexibility: grow, shrink, basis
+
+The three flexibility longhands control how an item responds to surplus or
+deficit space:
+
+```css
+.item {
+  flex-grow: <number>; /* default 0; share of positive free space */
+  flex-shrink: <number>; /* default 1; share of negative free space */
+  flex-basis: <length-percentage> | auto | content;
+}
+```
+
+If the sum of hypothetical main sizes is less than the container's main size,
+the surplus is distributed in proportion to each item's `flex-grow`. If the sum
+exceeds the container, the deficit is distributed in proportion to each item's
+`flex-shrink`, scaled by its hypothetical main size (so larger items shrink
+more, which gives more intuitive behaviour).
+
+The `flex` shorthand collapses these into a single declaration. The reserved
+keywords are:
+
+| Keyword         | Expansion  | Behaviour                                         |
+| --------------- | ---------- | ------------------------------------------------- |
+| `flex: initial` | `0 1 auto` | Default. Size from content; can shrink, not grow. |
+| `flex: auto`    | `1 1 auto` | Size from content; grows and shrinks.             |
+| `flex: none`    | `0 0 auto` | Size from content; rigid.                         |
+| `flex: 1`       | `1 1 0%`   | Equal share of container; ignores content size.   |
+| `flex: 2`       | `2 1 0%`   | Twice the share of a sibling with `flex: 1`.      |
+
+The distinction between `flex: 1` (basis `0`) and `flex: auto` (basis `auto`)
+is a frequent source of confusion. `flex: 1` produces _equal-width columns_
+because the basis is `0`; `flex: auto` produces _content-proportional columns_
+because the basis is the items' content size.
+
+### Intrinsic Sizing
+
+Flex items respect their content's minimum size by default. A `min-width: auto`
+or `min-height: auto` flex item refuses to shrink below its `min-content` size
+(roughly: the widest unbreakable token or longest indivisible piece of
+content). This prevents overflow in the common case but can produce surprises
+when a long unbroken string of text refuses to let its container narrow.
+
+The fix is explicit: set `min-width: 0` (for row containers) or `min-height: 0`
+(for column containers).
+
+### Aspect Ratio
+
+The `aspect-ratio` property (from [CSS Sizing Level 4](https://www.w3.org/TR/css-sizing-4/))
+interacts with flexbox: a flex item with an aspect ratio and an indefinite
+cross size derives its cross size from its resolved main size. This is most
+useful for media that needs to scale proportionally inside a flex container.
+
+```css
+.thumb {
+  aspect-ratio: 16 / 9;
+  flex: 1 1 200px;
+}
+```
+
+---
+
+## Alignment
+
+The alignment properties live in the [CSS Box Alignment
+Module](https://www.w3.org/TR/css-align-3/), but flexbox was the layout module
+that drove their design. They split naturally into main-axis vs cross-axis and
+container-level vs item-level.
+
+### Main-Axis Alignment (`justify-content`)
+
+`justify-content` distributes free space along the main axis. It is a
+container-level property; in flexbox there is _no_ `justify-self` for
+individual items (Grid does support `justify-self`).
+
+```css
+.container {
+  display: flex;
+  justify-content: flex-start /* default */ | flex-end | center | space-between
+    /* first/last flush to edges */ | space-around
+    /* half-size gutters on the outside */ | space-evenly
+    /* full-size gutters everywhere */;
+}
+```
+
+### Cross-Axis Alignment (`align-items` / `align-self`)
+
+`align-items` aligns _all_ items along the cross axis; `align-self` overrides
+it for a single item.
+
+```css
+.container {
+  align-items: stretch;
+} /* default: items fill cross axis */
+.container {
+  align-items: flex-start;
+}
+.container {
+  align-items: center;
+}
+.container {
+  align-items: baseline;
+} /* aligns text baselines */
+
+.special-item {
+  align-self: flex-end;
+}
+```
+
+The `baseline` value is particularly useful for aligning rows of form
+controls or text-and-icon pairings; it inspects the dominant baseline of each
+item's content.
+
+### Multi-Line Alignment (`align-content`)
+
+When a container has multiple flex lines (i.e., `flex-wrap: wrap` is in
+effect), `align-content` distributes the lines themselves along the cross axis,
+analogously to how `justify-content` distributes items along the main axis.
+
+```css
+.container {
+  flex-wrap: wrap;
+  align-content: stretch /* default */ | flex-start | center | space-between |
+    space-around | space-evenly;
+}
+```
+
+`align-content` has no effect on single-line flex containers.
+
+### Shorthands
+
+The Box Alignment module defines two shorthands. They are accepted in flexbox
+contexts:
+
+```css
+.container {
+  place-content: <align-content> <justify-content>;
+  place-items: <align-items> <justify-items>;
+}
+```
+
+Note that `justify-items` has no effect on flex items (flexbox does not honor
+per-item `justify-self`), so `place-items` in a flex container is effectively
+just `align-items`.
+
+### Gaps
+
+The `gap` property (and its longhands `row-gap` / `column-gap`) applies to flex
+containers, adding minimum gutters between adjacent items and between adjacent
+lines:
+
+```css
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 0.5rem; /* row-gap, column-gap */
+}
+```
+
+This was originally a Grid feature; it was promoted to flex containers in 2018
+and has wide browser support today.
+
+---
+
+## Code Examples
+
+### 1. Centering an Element
+
+The textbook example, finally a one-liner:
+
+```html
+<div class="centered">
+  <p>Centered both ways.</p>
+</div>
+```
+
+```css
+.centered {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+```
+
+### 2. Navigation Bar with Logo and Action Group
+
+```html
+<nav class="topbar">
+  <a class="logo" href="/">Sparkles</a>
+  <ul class="links">
+    <li><a href="/docs">Docs</a></li>
+    <li><a href="/blog">Blog</a></li>
+    <li><a href="/contact">Contact</a></li>
+  </ul>
+  <button class="cta">Sign in</button>
+</nav>
+```
+
+```css
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+}
+
+.topbar .links {
+  display: flex;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  margin-inline-start: auto; /* push links and CTA to the end */
+}
+```
+
+The `margin-inline-start: auto` idiom consumes all free space on the main
+axis and so pushes the element (and everything after it) to the end. It
+predates `justify-content: space-between` but remains the most flexible way
+to split a flex row into "stuck to start" and "stuck to end" groups.
+
+### 3. Sticky Footer
+
+A footer that hugs the bottom of the viewport when content is short, and is
+pushed below the content when it is long.
+
+```html
+<body class="layout">
+  <header>Header</header>
+  <main>...page content...</main>
+  <footer>Footer</footer>
+</body>
+```
+
+```css
+.layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.layout > main {
+  flex: 1; /* 1 1 0 -- main grows to fill remaining space */
+}
+```
+
+### 4. Equal-Height Cards
+
+A row of cards where each card grows to fill available width and the row's
+height is determined by the tallest card.
+
+```html
+<div class="cards">
+  <article class="card">
+    <h3>First</h3>
+    <p>Short.</p>
+  </article>
+  <article class="card">
+    <h3>Second</h3>
+    <p>Quite a bit longer body...</p>
+  </article>
+  <article class="card">
+    <h3>Third</h3>
+    <p>Medium-length body.</p>
+  </article>
+</div>
+```
+
+```css
+.cards {
+  display: flex;
+  gap: 1rem;
+  align-items: stretch; /* default; cards stretch to row height */
+}
+
+.card {
+  flex: 1 1 0; /* equal width regardless of content */
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.card p {
+  flex: 1; /* push card footer to bottom if present */
+}
+```
+
+### 5. Wrapped Tag List with Responsive Reflow
+
+```html
+<ul class="tags">
+  <li>typescript</li>
+  <li>rust</li>
+  <li>flexbox</li>
+  <li>css-grid</li>
+  <li>terminal-ui</li>
+  <li>layout-engines</li>
+</ul>
+```
+
+```css
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tags li {
+  padding: 0.25rem 0.5rem;
+  background: #eef;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+```
+
+When the viewport narrows, items wrap onto additional lines automatically
+without media queries.
+
+---
+
+## Interaction with Other Layout Modes
+
+- **Inline children of flex containers** are _blockified_: an inline element
+  that becomes a flex item is treated as if its `display` were the corresponding
+  block-level value.
+- **`position: absolute` flex items** are removed from the flow as in any
+  layout mode; their static position is determined by their alignment
+  properties.
+- **`float` and `clear`** have no effect on flex items.
+- **Tables inside flex containers** retain their own internal layout but
+  participate as a single flex item.
+- **Grid items can also be flex containers** and vice versa. The common pattern
+  is a Grid page-level skeleton with flex-laid rows inside each named area.
+- **Block containers can adopt flex semantics for their children** simply by
+  changing `display: block` to `display: flex` -- there is no requirement to
+  restructure the markup.
+- **Vertical-writing-mode interactions:** under `writing-mode: vertical-rl`,
+  the `row` main axis becomes physically vertical. This is by design but is
+  occasionally a source of confusion when porting layouts to Japanese or
+  Mongolian content.
+
+---
+
+## Strengths and Weaknesses
+
+### For App Layout
+
+**Strengths.** Flexbox excels at the _components_ of an application UI: tool
+bars, button groups, side-by-side panels with one fixed and one elastic side,
+sticky footers, vertically-centred dialogs. The alignment vocabulary is direct
+and matches how designers describe interfaces ("space these out", "centre this
+on the cross axis"). `flex: 1` gives an immediately readable "this part fills
+the rest" semantics that legacy CSS could not approach.
+
+**Weaknesses.** Flexbox is one-dimensional. As soon as a layout needs _both_
+columns and rows to line up (a table-like data grid, a magazine-style page
+template, an album cover gallery with consistent row heights), the model
+strains. Authors often nest flex containers to fake two-dimensional behaviour,
+but the result is fragile -- changing the content of one cell in column 2 will
+not affect column 3 as a 2D model would expect.
+
+The minimum-content default (`min-width: auto`) catches authors off-guard. The
+`order` property is widely useful but has well-documented accessibility
+pitfalls because screen-reader and keyboard navigation order follows DOM order,
+not visual order.
+
+### For Typography and Flowing Text
+
+**Strengths.** Baseline alignment makes flex containers good for rows of mixed
+content where text must align by baseline (an icon next to a label, a numeric
+field next to its unit). The `gap` property gives consistent spacing without
+margin-collapsing surprises.
+
+**Weaknesses.** Flexbox does not flow text _between_ items. There is no
+multi-column text layout, no equivalent of CSS columns, no automatic
+hyphenation across boxes. Multi-line flex containers wrap _items_, not
+content within items. For long-form prose, block layout (or [CSS
+Multi-column](https://www.w3.org/TR/css-multicol-1/)) remains the right tool.
+
+### For Static One-Shot Rendering (e.g., Embedding in a Terminal Renderer)
+
+This is the angle most relevant to Sparkles. Several non-browser engines
+implement a flexbox subset for _headless_ rendering -- computing geometry once
+and emitting either ANSI cells, a native view tree, or a printable image.
+
+**Strengths.**
+
+- The algorithm is well-defined and produces deterministic output for a given
+  tree, container size, and writing mode.
+- Most CLI/TUI layouts are one-dimensional in practice: a header row, a body
+  region split horizontally, a footer row. Flexbox maps naturally.
+- Content-aware sizing is exactly what a terminal wants: text has a measurable
+  cell width, and `min-content` is "the longest token".
+- `flex-grow` / `flex-shrink` provide the same expressiveness as Ratatui's
+  constraint solver (`Length`, `Min`, `Max`, `Fill`) but with a more familiar
+  vocabulary.
+
+**Weaknesses.**
+
+- The full algorithm is large. A faithful implementation (Yoga, Taffy) is on
+  the order of 5-10 KLoC, and a fair share of it deals with edge cases that
+  rarely matter for terminal output (`writing-mode`, `aspect-ratio` plus
+  intrinsic ratios, baseline of unrelated rows).
+- Percentages depend on definite containing-block sizes, which interacts
+  awkwardly with content-measured widths in terminals.
+- Float, absolute positioning, and inline layout interactions are
+  underspecified for non-browser use; implementers either reject those
+  features outright (Yoga, Taffy) or approximate them.
+- The performance characteristics assume a tree that mostly fits in cache;
+  for very deep trees, each level can require two passes (one for
+  hypothetical sizes, one for resolved sizes plus alignment).
+
+---
+
+## Non-browser Implementations
+
+A short tour of the most influential non-browser flexbox engines:
+
+- **[Yoga](./yoga.md)** -- Meta's C++ flexbox engine, originally extracted from
+  React Native's iOS bridge. Used by React Native, the original Litho, and
+  several JavaScript runtimes (notably [Ink](../tui-libraries/ink.md), which
+  uses `yoga-layout` to lay out terminal output). Yoga implements a flexbox
+  subset plus a handful of useful extensions (`PositionType.Absolute` without
+  CSS box-generation rules, `MeasureFunc` callbacks for content-measured
+  nodes).
+
+- **[Taffy](./taffy.md)** -- A pure-Rust layout engine implementing flexbox,
+  Grid (Level 1), and a "block" mode for nested containers. Used by the
+  [Bevy](https://bevyengine.org/) game engine for UI and by various Rust GUI
+  toolkits. Taffy is notable for being one of the few engines to ship a
+  practical Grid implementation outside browsers.
+
+- **[Stretch](./stretch.md)** -- An earlier Rust port of Yoga. No longer
+  actively maintained; Taffy is its de facto successor.
+
+- **Servo's `layout_2020`** -- Servo's experimental layout engine includes a
+  flexbox implementation that has been ported into Firefox via Stylo.
+
+- **[Ink](../tui-libraries/ink.md)** -- A React renderer for terminals that
+  embeds Yoga. Box elements participate in flex layout, and the resulting
+  geometry drives ANSI cell emission. See the Ink research note for details
+  of the embedding.
+
+- **[Textual](../tui-libraries/textual.md)** -- A Python TUI framework that
+  implements a _subset of CSS_, including flexbox-style alignment via its own
+  layout algorithm. Not a literal flexbox engine, but it borrows the
+  vocabulary and the mental model.
+
+- **Flutter** -- The `Row` / `Column` / `Flex` widgets implement a model
+  closely modeled on flexbox, with `MainAxisAlignment`, `CrossAxisAlignment`,
+  `flex` factors on `Expanded`, and intrinsic-sizing-aware `Flexible` widgets.
+
+- **Qt Quick Layouts (`RowLayout`, `ColumnLayout`)** -- Qt's QML layout
+  primitives also borrow the flexbox vocabulary, with `Layout.fillWidth`,
+  `Layout.preferredWidth`, and alignment enumerations.
+
+---
+
+## References
+
+### Specifications
+
+- [CSS Flexible Box Layout Module Level 1](https://www.w3.org/TR/css-flexbox-1/) (W3C CR)
+- [CSS Flexible Box Layout Editor's Draft](https://drafts.csswg.org/css-flexbox/) (CSSWG)
+- [CSS Box Alignment Module Level 3](https://www.w3.org/TR/css-align-3/) -- alignment properties shared with Grid and Block
+- [CSS Sizing Module Level 3](https://www.w3.org/TR/css-sizing-3/) and [Level 4](https://www.w3.org/TR/css-sizing-4/) -- `min-content`, `max-content`, `fit-content`, `aspect-ratio`
+- [CSS Writing Modes Module Level 4](https://www.w3.org/TR/css-writing-modes-4/) -- logical direction definitions
+
+### MDN
+
+- [CSS flexible box layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout)
+- [Basic concepts of flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Basic_concepts_of_flexbox)
+- [Aligning items in a flex container](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Aligning_items_in_a_flex_container)
+- [Controlling ratios of flex items along the main axis](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Controlling_ratios_of_flex_items_along_the_main_axis)
+- [Ordering flex items](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Ordering_flex_items)
+- [Mastering wrapping of flex items](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Mastering_wrapping_of_flex_items)
+- [Typical use cases of flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Typical_use_cases_of_flexbox)
+- [Relationship of flexbox to other layout methods](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Relationship_of_flexbox_to_other_layout_methods)
+
+### Articles and Talks
+
+- Rachel Andrew, _Flexbox: don't forget about old browsers_, Smashing Magazine (2016).
+- Rachel Andrew, _The Difference Between Width and Flex-Basis_ -- 24ways.org / Smashing Magazine.
+- Jen Simmons, _The Layout Layer_ -- talk discussing flexbox, grid, and their complementary roles.
+- Chris Coyier et al., _A Complete Guide to Flexbox_, CSS-Tricks (continuously updated since 2013).
+- Tab Atkins Jr., personal blog posts on the evolution of flexbox and the
+  alignment module (`xanthir.com`).
+
+### Sister Documents in This Catalog
+
+- [CSS Grid](./css-grid.md) -- two-dimensional sibling specification.
+- [Yoga](./yoga.md) -- Meta's reference flexbox-subset engine.
+- [Taffy](./taffy.md) -- Rust flexbox+grid engine.
+- [Stretch](./stretch.md) -- earlier Rust port of Yoga.
+- [Ink](../tui-libraries/ink.md) -- Node.js TUI framework embedding Yoga.
+- [Textual](../tui-libraries/textual.md) -- Python TUI framework with a CSS subset.

--- a/docs/research/ui-layout/css-grid.md
+++ b/docs/research/ui-layout/css-grid.md
@@ -1,0 +1,879 @@
+# CSS Grid (W3C Specification)
+
+A two-dimensional, line-based layout model standardized by the W3C CSS Working
+Group as the _CSS Grid Layout Module_. Grid lets authors carve a container into
+named or numbered tracks, place children explicitly into rows and columns, and
+distribute remaining space along _both_ axes simultaneously -- the feature that
+sets it apart from flexbox.
+
+| Field                        | Value                                                                                                                                                                                                      |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Specification (Level 1)      | [CSS Grid Layout Module Level 1](https://www.w3.org/TR/css-grid-1/)                                                                                                                                        |
+| Specification (Level 2)      | [CSS Grid Layout Module Level 2](https://www.w3.org/TR/css-grid-2/)                                                                                                                                        |
+| Editor's Draft               | <https://drafts.csswg.org/css-grid/>                                                                                                                                                                       |
+| Editors                      | Tab Atkins Jr. (Google), Elika J. Etemad / fantasai (Apple), Rossen Atanassov (Microsoft), Oriol Brufau (Igalia)                                                                                           |
+| Former Editor (Level 1)      | Rachel Andrew (until 2017)                                                                                                                                                                                 |
+| First public Working Draft   | _CSS Grid Layout Module_ -- 7 April 2011                                                                                                                                                                   |
+| First Level 1 CR             | 9 September 2016                                                                                                                                                                                           |
+| Level 1 became W3C Rec       | 18 December 2020                                                                                                                                                                                           |
+| Current Level 2 (date)       | Candidate Recommendation Draft, 26 March 2025                                                                                                                                                              |
+| Browser ship date            | March 2017 (Chrome 57, Firefox 52, Safari 10.1; Edge later)                                                                                                                                                |
+| Reference Implementations    | Blink (Chromium), WebKit (Safari), Gecko (Firefox), Servo                                                                                                                                                  |
+| Notable Non-browser Adoption | [Taffy](./taffy.md) (Rust -- among the few non-browser engines with practical Grid support), Servo's `layout_2020`, Mozilla's Stylo; partial support in some design tools (Webflow, Framer, Figma plugins) |
+
+---
+
+## Overview
+
+### What It Solves
+
+CSS Grid addresses a class of layout problems that _neither_ the original block
+model _nor_ flexbox can express cleanly:
+
+- **Two-dimensional alignment.** Items that need to line up _both_ with their
+  row neighbours _and_ their column neighbours -- the canonical example being a
+  data table or a card gallery with consistent row heights and column widths.
+- **Page-level templates.** "Header at top, sidebar on the left, main in the
+  middle, ads on the right, footer at the bottom" expressed as a single
+  declaration rather than five nested containers.
+- **Overlapping items.** Multiple grid items can occupy the same cell. Combined
+  with `z-index`, this gives a clean alternative to absolutely-positioned
+  overlay layouts.
+- **Source-order independence.** A grid item can be placed at any cell
+  regardless of its position in the DOM, with documented accessibility caveats.
+- **Responsive track counts without media queries.** `repeat(auto-fill,
+minmax(min, 1fr))` produces a layout that adapts the _number_ of columns to
+  the container width.
+
+The unifying theme is **first-class two-dimensional structure**: rows and
+columns are explicit, line-named geometry that items refer to, rather than an
+emergent property of how children happen to wrap.
+
+### Design Philosophy
+
+The specification frames CSS Grid as "a two-dimensional grid-based layout
+system, optimized for user interface design." Several design principles
+distinguish it from flexbox:
+
+1. **Top-down sizing.** Where flexbox sizes the container around its content,
+   Grid lets the _container_ dictate the track sizes (the explicit grid) and
+   the items adjust. Authors can size tracks first, then assign items to them.
+2. **Explicit and implicit tracks.** The author declares the _explicit_ grid;
+   any items placed outside it cause the engine to materialize _implicit_
+   tracks, sized by `grid-auto-rows` / `grid-auto-columns`.
+3. **Line-based placement.** Items are positioned by _grid lines_, not by
+   their siblings. A change in one item's source order has no effect on the
+   layout of the others.
+4. **Two-axis alignment.** Both `justify-self` and `align-self` are honoured
+   for grid items -- unlike flexbox, where `justify-self` does nothing.
+5. **Overlapping is a feature, not a bug.** Grid explicitly supports multiple
+   items in one cell, and the auto-placement algorithm does the right thing
+   when only some items are explicitly placed.
+
+### History
+
+CSS Grid is the third major attempt at a two-dimensional CSS layout model and
+the first to ship interoperably.
+
+- **`<table>` abuse (1996-2010).** Through the late 1990s and 2000s, most
+  multi-column web layouts were built with HTML `<table>` elements used purely
+  for presentation. This worked but was semantically incorrect, hostile to
+  assistive technology, and inflexible (cells could not be reordered without
+  rewriting markup).
+
+- **CSS 2.1 `display: table-*` (2011).** CSS 2.1 codified table-cell layout as
+  a `display` value, letting authors get table-like behaviour from `<div>`
+  elements. This was an improvement on the markup hack but inherited all the
+  layout inflexibility of real tables (no overlapping, no row-spanning across
+  groups, no source-order independence).
+
+- **XUL grids (Mozilla, 2002-2017).** Mozilla's XUL layout language, which
+  powered Firefox's chrome until the late 2010s, supported a grid box model
+  with named cells and explicit rows/columns. Several XUL ideas (named lines,
+  named areas, explicit-vs-implicit grids) flowed into the W3C specification.
+
+- **Silverlight `Grid` (Microsoft, 2008).** Silverlight, Microsoft's
+  short-lived Flash competitor, included a `Grid` panel with `Grid.Row`,
+  `Grid.Column`, `Grid.RowSpan`, `Grid.ColumnSpan`, and proportional sizing via
+  the `*` unit. Phil Cupp at Microsoft drove much of this work and later
+  brought it to the W3C as the _CSS Grid Layout Module_ in 2011, when
+  Microsoft shipped an early `-ms-grid` implementation in IE 10.
+
+- **`-ms-grid` (IE 10, 2012).** Internet Explorer 10 shipped the first
+  browser-side implementation, prefixed and based on the early draft. It
+  introduced track-list syntax with the proportional `fr`-equivalent (called
+  `*` in `-ms-grid`) and named lines, but lacked named areas, subgrid, and
+  most of the auto-placement algorithm. Many of its quirks persisted in Edge
+  legacy until Edge switched to Blink in 2020.
+
+- **CSS Grid Level 1 (2011-2017).** Rachel Andrew became the level's
+  evangelist and an editor of the specification. Through the mid-2010s she
+  ran [Grid by Example](https://gridbyexample.com/) and a series of
+  conference talks; Jen Simmons (then at Mozilla) ran the _Layout Land_
+  YouTube series and the _Resilient Web Design_ book chapter. Their advocacy
+  drove rapid implementation in all major browsers, culminating in
+  near-simultaneous shipping in **March 2017** (Chrome 57, Firefox 52, Safari
+  10.1). Level 1 became a W3C Recommendation on 18 December 2020.
+
+- **CSS Grid Level 2 -- subgrid (2018-).** Level 2 adds the `subgrid` keyword,
+  letting a nested grid adopt the parent grid's lines along one or both axes.
+  Firefox shipped subgrid in 2019; Safari followed in 2022; Chromium shipped
+  it in late 2023 (Chrome 117). As of 2025, subgrid is Baseline Widely
+  Available.
+
+- **CSS Grid Level 3 -- masonry (proposed).** A separate Level 3 draft adds a
+  _masonry_ track sizing keyword, modeled on Pinterest-style staggered
+  layouts. The proposal was contested in 2024 (Apple and Google initially
+  disagreed on whether to put masonry under `grid` or a new `display:
+masonry`); the working group converged on a Grid-based syntax in early 2025
+  and Safari shipped an experimental implementation. As of late 2025 it is
+  not yet broadly interoperable.
+
+---
+
+## Layout Model
+
+### Tracks, Lines, Cells, Areas
+
+A grid container introduces a coordinate system over its child area:
+
+- **Tracks** are the rows and columns themselves -- the _spaces_ between
+  adjacent lines.
+- **Lines** are the dividers between tracks. Lines are numbered starting at 1
+  on the leading edge of the first track, and authors can name them.
+- **Cells** are the intersection of a row track and a column track -- the
+  smallest unit of the grid.
+- **Areas** are rectangular regions of one or more cells, typically named via
+  `grid-template-areas` and referenced by `grid-area`.
+
+```
+                   col-line 1    col-line 2    col-line 3    col-line 4
+                       v             v             v             v
+       row-line 1 ---> +-------------+-------------+-------------+
+                       |  cell 1,1   |  cell 1,2   |  cell 1,3   |
+                       |             |             |             |
+       row-line 2 ---> +-------------+-------------+-------------+
+                       |  cell 2,1   |  cell 2,2   |  cell 2,3   |
+                       |             |             |             |
+       row-line 3 ---> +-------------+-------------+-------------+
+
+                       <-- col 1 --> <-- col 2 --> <-- col 3 -->
+```
+
+### Containers and Items
+
+A grid container is established by `display: grid` (block-level) or
+`display: inline-grid` (inline-level). In-flow children become _grid items_.
+
+```css
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto auto;
+  gap: 1rem;
+}
+```
+
+As in flexbox, several CSS features are suppressed inside grid containers:
+
+- `float` and `clear` do not apply to grid items.
+- `vertical-align` has no effect.
+- Margin collapsing does not occur between grid items.
+- `::first-line` / `::first-letter` do not apply to the grid container.
+
+Inline grid items are blockified just as flex items are.
+
+### Explicit vs Implicit Grid
+
+The _explicit grid_ is the one declared by the author via
+`grid-template-columns`, `grid-template-rows`, and/or `grid-template-areas`.
+
+The _implicit grid_ is generated automatically by the engine when items are
+placed outside the explicit grid (e.g., assigned to row 10 of a 3-row explicit
+grid) or when there are more items than the explicit grid has cells to hold
+them. The size of implicit tracks is controlled by `grid-auto-rows` and
+`grid-auto-columns`; the direction in which new tracks are created is
+controlled by `grid-auto-flow`.
+
+```css
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr); /* explicit: 4 columns */
+  grid-template-rows: 100px; /* explicit: 1 row */
+
+  grid-auto-rows: 80px; /* implicit rows: 80px each */
+  grid-auto-flow: row dense; /* fill row-by-row, dense packing */
+}
+```
+
+`grid-auto-flow: dense` makes the auto-placement algorithm backfill earlier
+holes when later items would fit, at the cost of decoupling visual order from
+DOM order more aggressively.
+
+---
+
+## Sizing Model
+
+Track sizing is where Grid's vocabulary is richest. Each track size accepts a
+`<track-size>` value, which can be a length, percentage, `fr`, intrinsic
+keyword, or a `minmax()` / `fit-content()` function.
+
+### The `fr` Unit
+
+The `fr` unit means _fraction of the remaining space_. After all non-flexible
+track sizes are subtracted from the grid's inline (or block) size, what is
+left is divided in proportion to each track's `fr` factor.
+
+```css
+.three-col {
+  display: grid;
+  grid-template-columns: 200px 1fr 2fr;
+}
+/* If container is 800px and gap is 0:
+     col1 = 200px
+     col2 = (800 - 200) * (1 / 3) = 200px
+     col3 = (800 - 200) * (2 / 3) = 400px
+*/
+```
+
+`fr` is _not_ a percentage. It does not interact with `box-sizing`. It is
+unique to grid track sizing.
+
+### Intrinsic Sizing Keywords
+
+Grid track sizes accept the intrinsic keywords from [CSS Sizing
+Level 3](https://www.w3.org/TR/css-sizing-3/):
+
+- **`min-content`** -- the smallest size the track can take without overflowing,
+  determined by the longest unbreakable token in the track's content.
+- **`max-content`** -- the largest size the track would take if given infinite
+  space.
+- **`auto`** -- behaves like `minmax(auto, max-content)`; the track is sized to
+  fit content but can shrink when there is not enough room.
+- **`fit-content(<length-percentage>)`** -- equivalent to
+  `minmax(auto, max-content)` clamped at the given limit.
+
+### `minmax(min, max)`
+
+Defines a track size with both a minimum and maximum. Either bound can be a
+length, percentage, intrinsic keyword, or (for `max`) an `fr` value.
+
+```css
+.responsive {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  /* `minmax(0, 1fr)` is the standard "let me shrink below content" idiom;
+     without the `0` minimum, fr tracks default to a min of auto/min-content. */
+}
+```
+
+### `repeat()`, `auto-fill`, and `auto-fit`
+
+The `repeat()` notation is the workhorse for non-trivial track lists:
+
+```css
+grid-template-columns: repeat(12, 1fr); /* fixed count */
+grid-template-columns: repeat(2, 100px 1fr 100px); /* repeated pattern */
+grid-template-columns: 20px repeat(6, 1fr) 20px; /* mixed with fixed */
+```
+
+For _responsive_ track counts -- letting the container decide how many
+columns to draw -- `auto-fill` and `auto-fit` are essential:
+
+```css
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+```
+
+- **`auto-fill`** keeps track slots even when they are empty, producing a
+  consistent column rhythm.
+- **`auto-fit`** _collapses_ empty trailing tracks down to zero, allowing
+  remaining tracks to grow into the space.
+
+In a grid with three items and `minmax(220px, 1fr)`:
+
+- With `auto-fill`, on a 1200 px container you get five 220 px slots, three
+  filled, two empty but reserving space.
+- With `auto-fit`, you get three items that each take ~400 px.
+
+### Aspect Ratio
+
+The `aspect-ratio` property applies to grid items the same way it applies to
+flex items: an item with an aspect ratio and an indefinite size on one axis
+derives the other axis from the ratio. This is widely used for media thumbnails
+in card grids.
+
+```css
+.thumb {
+  aspect-ratio: 1 / 1;
+  width: 100%;
+}
+```
+
+### Named Lines
+
+Any track-list slot can carry a name in square brackets:
+
+```css
+.page {
+  display: grid;
+  grid-template-columns:
+    [page-start] 1fr
+    [content-start] 720px
+    [content-end] 1fr
+    [page-end];
+}
+
+article {
+  grid-column: content-start / content-end;
+}
+```
+
+A single line can have multiple names (`[a b c]`), which is occasionally
+convenient for "this is both the end of column 2 and the start of column 3"
+patterns.
+
+### Named Areas (`grid-template-areas`)
+
+`grid-template-areas` is one of the most distinctive parts of Grid. It defines
+_and_ names a 2D template using ASCII art:
+
+```css
+.page {
+  display: grid;
+  grid-template-columns: 220px 1fr 220px;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    'header  header  header'
+    'nav     main    aside'
+    'footer  footer  footer';
+  min-height: 100vh;
+}
+
+header {
+  grid-area: header;
+}
+nav {
+  grid-area: nav;
+}
+main {
+  grid-area: main;
+}
+aside {
+  grid-area: aside;
+}
+footer {
+  grid-area: footer;
+}
+```
+
+Each token is an area name. A dot (`.`) marks an empty cell. Rules:
+
+- All rows must have the same number of cells.
+- Each named area must be rectangular (contiguous, no L shapes).
+- Area names also create implicit named lines: `header-start` / `header-end`
+  on both axes.
+
+### Subgrid (Level 2)
+
+A nested grid container with `grid-template-columns: subgrid` (or
+`grid-template-rows: subgrid`) does _not_ create new track sizes -- it adopts
+the parent grid's tracks across the cells it spans. This is the answer to a
+long-standing pain point: in Level 1, a nested grid would establish its own
+independent track sizes, breaking column alignment across nested cards.
+
+```css
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.card {
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-row: span 3; /* a card spans three rows of the outer grid */
+  gap: 0.5rem;
+}
+```
+
+Now the card's three inner rows align with the outer grid's row tracks,
+keeping titles, bodies, and footers across cards on the same baselines.
+
+As of 2025, subgrid is Baseline Widely Available (Firefox 71, Safari 16,
+Chrome 117). It is the headline feature of Grid Level 2.
+
+### Masonry (Level 3, in progress)
+
+The proposed masonry feature would let one axis of a grid pack items
+Pinterest-style (consecutive items flow into the shortest available column),
+while the other axis retains regular track behaviour. The current 2025 syntax
+proposal is:
+
+```css
+.feed {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-rows: masonry;
+}
+```
+
+Safari ships this experimentally; other browsers had not converged at the
+time of writing.
+
+---
+
+## Alignment
+
+Grid is _the_ layout module with the richest alignment support. It honours
+both `justify-*` (inline axis) and `align-*` (block axis) at both container
+and item levels.
+
+### Item-level Alignment
+
+```css
+.item {
+  justify-self: stretch | start | center | end | left | right | baseline;
+  align-self: stretch | start | center | end | baseline;
+}
+```
+
+- `justify-self` aligns the item within its grid area along the _inline_ axis.
+- `align-self` aligns it along the _block_ axis.
+
+Stretch (the default) makes the item fill its area; non-stretch values let
+the item be smaller than its area and choose where in the area to sit.
+
+### Container-level Item Alignment
+
+```css
+.grid {
+  justify-items: stretch | start | center | end | left | right | baseline;
+  align-items: stretch | start | center | end | baseline;
+}
+```
+
+These set the default alignment for _all_ items in the container; per-item
+`justify-self` / `align-self` override them.
+
+### Track Alignment
+
+When the explicit tracks do not consume all of the container's size, free
+space is distributed by `justify-content` / `align-content`:
+
+```css
+.grid {
+  justify-content: start | end | center | stretch | space-between | space-around
+    | space-evenly;
+  align-content: start | end | center | stretch | space-between | space-around |
+    space-evenly;
+}
+```
+
+Note that `stretch` only stretches tracks whose size is `auto`; `fr` tracks
+already consume free space, so on an `fr`-heavy grid there is rarely
+free space left for `justify-content` to redistribute.
+
+### Shorthands
+
+```css
+.grid {
+  place-self: <align-self> <justify-self>;
+  place-items: <align-items> <justify-items>;
+  place-content: <align-content> <justify-content>;
+}
+```
+
+### Gaps
+
+The `gap` property and its longhands work in grid containers the same way
+they do in flex containers:
+
+```css
+.grid {
+  display: grid;
+  gap: 1rem 0.5rem; /* row-gap column-gap */
+}
+```
+
+Gaps reduce the space available before track sizing, so a 3-column grid with
+`grid-template-columns: repeat(3, 1fr)` and `gap: 16px` divides the
+_post-gap_ free space into three equal fractions.
+
+---
+
+## Code Examples
+
+### 1. Holy-Grail Page Layout in One Container
+
+```html
+<div class="page">
+  <header>Header</header>
+  <nav>Navigation</nav>
+  <main>Main content</main>
+  <aside>Sidebar</aside>
+  <footer>Footer</footer>
+</div>
+```
+
+```css
+.page {
+  display: grid;
+  grid-template-columns: 200px 1fr 220px;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    'header  header  header'
+    'nav     main    aside'
+    'footer  footer  footer';
+
+  min-height: 100vh;
+  gap: 1rem;
+}
+
+.page > header {
+  grid-area: header;
+}
+.page > nav {
+  grid-area: nav;
+}
+.page > main {
+  grid-area: main;
+}
+.page > aside {
+  grid-area: aside;
+}
+.page > footer {
+  grid-area: footer;
+}
+```
+
+The same layout in pre-Grid CSS required nested wrappers, floats, and
+fragile width arithmetic. With Grid it is declarative and trivially
+restructured -- swapping `nav` and `aside` in the template flips them on the
+page without touching the DOM.
+
+### 2. Responsive Card Grid (no media queries)
+
+```html
+<section class="cards">
+  <article class="card">...</article>
+  <article class="card">...</article>
+  <article class="card">...</article>
+  <!-- ...arbitrary number of cards... -->
+</section>
+```
+
+```css
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+```
+
+On a 1280 px viewport this produces five 240+ px columns; at 800 px it falls
+back to three columns; on a phone at 360 px it becomes a single column. No
+breakpoints needed.
+
+### 3. Aligned Card Internals via Subgrid
+
+```html
+<section class="cards">
+  <article class="card">
+    <h3>Title</h3>
+    <p>Body text.</p>
+    <a class="cta" href="#">Read more</a>
+  </article>
+  <!-- ... -->
+</section>
+```
+
+```css
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-template-rows: repeat(3, auto);
+  gap: 1rem;
+}
+
+.card {
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-row: span 3; /* each card occupies three outer rows */
+  gap: 0.5rem;
+  padding: 1rem;
+  border: 1px solid #ddd;
+}
+```
+
+Titles, bodies, and CTAs across all cards now share row baselines without
+any per-card sizing.
+
+### 4. Explicit Two-Dimensional Placement with Overlapping
+
+```html
+<div class="dashboard">
+  <div class="hero">Featured</div>
+  <div class="kpi-a">Users</div>
+  <div class="kpi-b">Revenue</div>
+  <div class="kpi-c">Churn</div>
+  <div class="badge">NEW</div>
+</div>
+```
+
+```css
+.dashboard {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: 200px 100px;
+  gap: 1rem;
+}
+
+.hero {
+  grid-column: 1 / 3;
+  grid-row: 1 / 3;
+}
+.kpi-a {
+  grid-column: 3;
+  grid-row: 1;
+}
+.kpi-b {
+  grid-column: 4;
+  grid-row: 1;
+}
+.kpi-c {
+  grid-column: 3 / 5;
+  grid-row: 2;
+}
+
+.badge {
+  grid-column: 1 / 2;
+  grid-row: 1;
+  justify-self: end;
+  align-self: start;
+  z-index: 2;
+}
+```
+
+The `.badge` sits in the same cell as `.hero` and is anchored to the
+top-right of the cell via `justify-self: end; align-self: start;`.
+
+### 5. Named Lines for a Magazine-Style Article
+
+```css
+article {
+  display: grid;
+  grid-template-columns:
+    [full-start] 1fr
+    [wide-start] 2fr
+    [content-start] minmax(0, 65ch) [content-end]
+    2fr [wide-end]
+    1fr [full-end];
+
+  row-gap: 1rem;
+}
+
+article > * {
+  grid-column: content-start / content-end;
+}
+article > .wide {
+  grid-column: wide-start / wide-end;
+}
+article > .full-bleed {
+  grid-column: full-start / full-end;
+}
+```
+
+Most paragraphs default to a comfortable 65-character measure; `.wide`
+elements break out one step; `.full-bleed` elements (background images,
+oversized pull quotes) span the entire viewport. The named-line vocabulary
+makes the intent legible to readers of the stylesheet.
+
+---
+
+## Interaction with Other Layout Modes
+
+- **Grid items can themselves be flex containers** (and vice versa). The
+  common combination is "Grid for page skeleton, Flexbox for the contents of
+  each cell".
+- **`position: absolute` grid items** participate in placement (their static
+  position is determined by their grid area) but are removed from the
+  in-flow layout, so they do not occupy a cell for the purpose of
+  auto-placement.
+- **Inline children of a grid container** are blockified, mirroring flexbox.
+- **Floats and clear** have no effect on grid items.
+- **Vertical writing modes** behave logically: `grid-template-rows` always
+  refers to the block axis. The named-line convention follows the writing
+  mode, so a layout authored for English LTR mostly works in Arabic RTL or
+  Japanese vertical-rl, modulo content-specific adjustments.
+- **Table layout inside a grid** retains its internal box model but
+  participates externally as a single grid item.
+- **The grid container has its own intrinsic sizing.** When sized by content,
+  it asks each track for its `min-content` / `max-content` contribution, much
+  as a flex container does.
+
+---
+
+## Strengths and Weaknesses
+
+### For App Layout
+
+**Strengths.** Grid is the strongest fit for two-dimensional UIs: dashboards,
+page templates, settings screens with paired label/control rows that need to
+line up across sections. Named areas turn the stylesheet into a readable
+diagram; the responsive `repeat(auto-fill, minmax(...))` pattern eliminates
+many media queries. Subgrid removes the last major reason to flatten DOM
+hierarchies for alignment.
+
+**Weaknesses.** The learning curve is real: track sizing, the auto-placement
+algorithm, and intrinsic vs flexible sizing interact in subtle ways that take
+practice. The masonry feature is not yet broadly interoperable, so masonry
+layouts still require third-party libraries. Performance can suffer when the
+implicit grid grows unexpectedly large (a misplaced `grid-row: 9999` is a
+classic foot-gun).
+
+### For Typography and Flowing Text
+
+**Strengths.** Named lines give a clean way to express the magazine-style
+"normal / wide / full-bleed" measure pattern that has become common in
+long-form web design.
+
+**Weaknesses.** Grid does not flow text _across_ tracks. Each grid item is an
+independent block; multi-column text flow remains the job of [CSS
+Multi-column](https://www.w3.org/TR/css-multicol-1/) (or, at much greater
+cost, [CSS Regions](https://www.w3.org/TR/css-regions-1/), which is
+effectively dead).
+
+### For Static One-Shot Rendering (e.g., Embedding in a Terminal Renderer)
+
+**Strengths.**
+
+- The track model maps neatly to terminal coordinates: track sizes are
+  integers in cell units, gaps are integer cell gutters, and `1fr` divides
+  remaining cells via integer arithmetic.
+- Named areas would be a fantastic match for TUI layout: `"header header
+header" / "sidebar main main" / "footer footer footer"` is exactly how a
+  developer would describe a TUI's regions on a whiteboard.
+- The explicit/implicit grid distinction lets a small UI scale to many
+  generated items (log lines, file lists, search results) without recomputing
+  templates.
+
+**Weaknesses.**
+
+- The algorithm is substantially more complex than flexbox's. The
+  auto-placement algorithm alone is several pages of normative prose, and a
+  conforming implementation must handle `dense` packing, sparse cells, and
+  named-area resolution.
+- Intrinsic sizing in grid is more involved than in flex: tracks have a
+  _base size_ and a _growth limit_ that are resolved in stages, with separate
+  passes for `min-content`, `max-content`, and `fr` distribution.
+- Subgrid adds another level of difficulty: a subgrid needs to coordinate
+  with its parent across track-sizing passes.
+- Few non-browser engines implement Grid. Where flexbox engines proliferate
+  (Yoga, Stretch, Taffy, multiple TUI libraries), Grid implementations
+  outside browsers are essentially limited to Taffy and Servo.
+
+For terminal renderers, Grid Level 1 (without subgrid) is achievable but
+costly; Grid Level 2 with subgrid raises the implementation budget
+significantly. Most TUI libraries that want grid-like behaviour today either
+fake it with nested flex or implement a much-restricted "table-with-spans"
+primitive instead.
+
+---
+
+## Non-browser Implementations
+
+Compared to flexbox, the universe of non-browser Grid implementations is
+sparse:
+
+- **[Taffy](./taffy.md)** -- A pure-Rust layout engine. Notable for being one
+  of the very few non-browser engines with a _practical_ Grid implementation,
+  spec-aligned for Grid Level 1 and adding subgrid support as the
+  specification has stabilized. Taffy is used by the [Bevy](https://bevyengine.org/)
+  game engine's UI system and by various Rust GUI experiments.
+
+- **Servo's `layout_2020`** -- Servo's modern layout engine implements Grid
+  Level 1 and Level 2; portions of it have been ported into Firefox via
+  Mozilla's Stylo project.
+
+- **[Stretch](./stretch.md)** -- Stretch's flexbox model has been extended in
+  some forks with table-like behaviour, but it does not implement CSS Grid.
+
+- **[Yoga](./yoga.md)** -- Yoga is _flexbox only_. There is no Grid mode and
+  no announced plan to add one. Meta's UI frameworks (React Native, Litho)
+  achieve grid-like layouts via nested flex.
+
+- **[Ink](../tui-libraries/ink.md)** -- Ink relies on Yoga and so inherits
+  Yoga's flex-only model. Grid-style layouts in Ink are flex hacks.
+
+- **[Textual](../tui-libraries/textual.md)** -- Textual's CSS subset includes
+  a Grid layout mode that closely tracks CSS Grid's vocabulary (rows,
+  columns, fr units, named areas), making it a notable exception in the TUI
+  space. It is one of the very few terminal frameworks that ships a
+  legitimate Grid implementation.
+
+- **Design tools (partial).** Webflow, Framer, and various Figma plugins
+  expose subsets of CSS Grid in their layout panels. These are not
+  general-purpose engines but are worth noting as evidence that Grid's
+  vocabulary has begun to permeate non-browser design workflows.
+
+The general pattern is that _Grid is hard_, _Grid is large_, and the
+non-browser ecosystem has converged on "use flexbox or invent a bespoke
+table primitive" for most applications.
+
+---
+
+## References
+
+### Specifications
+
+- [CSS Grid Layout Module Level 1](https://www.w3.org/TR/css-grid-1/) (W3C REC, 18 December 2020)
+- [CSS Grid Layout Module Level 2](https://www.w3.org/TR/css-grid-2/) (W3C CR Draft, 26 March 2025)
+- [CSS Grid Layout Editor's Draft](https://drafts.csswg.org/css-grid/) (CSSWG)
+- [CSS Box Alignment Module Level 3](https://www.w3.org/TR/css-align-3/) -- alignment properties shared with Flexbox and Block
+- [CSS Sizing Module Level 3](https://www.w3.org/TR/css-sizing-3/) and [Level 4](https://www.w3.org/TR/css-sizing-4/) -- intrinsic sizing keywords, `aspect-ratio`
+- [CSS Writing Modes Module Level 4](https://www.w3.org/TR/css-writing-modes-4/) -- logical direction definitions
+
+### MDN
+
+- [CSS grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout)
+- [Basic concepts of grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout)
+- [Relationship of grid layout with other layout methods](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Relationship_of_grid_layout_with_other_layout_methods)
+- [Line-based placement with CSS grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_using_line-based_placement)
+- [Grid template areas](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Grid_template_areas)
+- [Layout using named grid lines](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Layout_using_named_grid_lines)
+- [Auto-placement in grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Auto-placement_in_grid_layout)
+- [Box alignment in grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Box_alignment_in_grid_layout)
+- [Grid layout and accessibility](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Grid_layout_and_accessibility)
+- [Subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid)
+- [Realizing common layouts using grids](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Realizing_common_layouts_using_grids)
+
+### Articles, Talks, and Resources
+
+- Rachel Andrew, [Grid by Example](https://gridbyexample.com/) -- canonical
+  pattern library for CSS Grid, maintained throughout the spec's
+  pre-shipping period.
+- Rachel Andrew, _The New CSS Layout_ (A Book Apart, 2017).
+- Jen Simmons, [Layout Land](https://www.youtube.com/c/LayoutLand) -- YouTube
+  series demystifying grid and intrinsic web design.
+- Jen Simmons, talks: _Everything You Know About Web Design Just Changed_
+  and _Designing Intrinsic Layouts_.
+- Eric Meyer, _Generating `repeat()` `auto-fill` Patterns_ -- explorations on
+  Meyer's blog.
+- Chris House, [CSS Grid Cheatsheet](https://grid.malven.co/).
+- Chris Coyier et al., _A Complete Guide to Grid_, CSS-Tricks (continuously
+  updated).
+- _CSS Grid Garden_ (game) -- interactive tutorial at cssgridgarden.com.
+
+### Sister Documents in This Catalog
+
+- [CSS Flexbox](./css-flexbox.md) -- one-dimensional sibling specification.
+- [Yoga](./yoga.md) -- Meta's flexbox-only engine (no grid).
+- [Taffy](./taffy.md) -- Rust engine with practical CSS Grid support.
+- [Stretch](./stretch.md) -- earlier Rust port of Yoga, flexbox-only.
+- [Ink](../tui-libraries/ink.md) -- Node.js TUI framework using Yoga (no grid).
+- [Textual](../tui-libraries/textual.md) -- Python TUI framework whose CSS
+  subset includes a grid layout mode.

--- a/docs/research/ui-layout/css-normal-flow.md
+++ b/docs/research/ui-layout/css-normal-flow.md
@@ -1,0 +1,747 @@
+# CSS Normal Flow
+
+The original CSS layout model — the substrate on which every later mechanism
+(floats, positioning, flex, grid) is layered. Normal flow stacks block boxes
+vertically inside a _block formatting context_ and arranges inline boxes
+horizontally inside line boxes within an _inline formatting context_, governed
+by the box model (content / padding / border / margin) and the margin-collapse
+rules. Although surveys of layout systems often jump straight to Flexbox and
+Grid, normal flow remains the default value of `display`, the fallback when
+nothing else applies, and the only model the CSS engine reaches for when
+rendering a paragraph of running text.
+
+| Field           | Value                                                                                                                                                                                                                              |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Spec            | [CSS 2.2 Visual Formatting Model](https://www.w3.org/TR/CSS22/visuren.html), [CSS Display Module Level 3](https://www.w3.org/TR/css-display-3/), [CSS Box Model Module Level 3](https://www.w3.org/TR/css-box-3/)                  |
+| Editors         | Bert Bos, Tantek Çelik, Ian Hickson, Håkon Wium Lie (CSS 2.2); Tab Atkins Jr., Elika J. Etemad (`fantasai`) for css-display-3 and css-box-3                                                                                        |
+| Date            | CSS 1: 17 December 1996. CSS 2.1: 7 June 2011 (Recommendation). CSS 2.2: ongoing editorial maintenance. css-display-3: Candidate Recommendation Snapshot 30 March 2023. css-box-3: W3C Recommendation 11 April 2024.               |
+| Implementations | Every modern browser engine (Blink/Chromium, Gecko/Firefox, WebKit/Safari, Servo, legacy Trident/EdgeHTML). HTML rendering engines in email clients (Outlook, Apple Mail). Embedded engines (Qt WebEngine, Electron, wkhtmltopdf). |
+
+---
+
+## Overview
+
+### What It Solves
+
+Normal flow is the layout model of _documents_. Its primary job is to render a
+flowing stream of mixed block-level and inline content — headings, paragraphs,
+lists, anchor links inside running prose — into a two-dimensional surface in a
+way that mirrors what typewriters, printing presses, and word processors had
+been doing for centuries. The author specifies the _content order_; the model
+decides where every glyph lands.
+
+The mechanism is decomposed into two complementary primitives:
+
+- A **block formatting context (BFC)** in which boxes stack one after the other,
+  vertically, each occupying the full width of the containing block (unless
+  otherwise constrained). This is the model for "the body is a sequence of
+  paragraphs."
+
+- An **inline formatting context (IFC)** in which boxes flow horizontally, one
+  after the other, breaking onto a new _line box_ whenever the current line is
+  exhausted. This is the model for "a paragraph is a sequence of words and
+  styled spans."
+
+The box model unifies geometry across both contexts: every generated box has a
+_content_ area surrounded by a _padding_ area, then a _border_ area, then a
+_margin_ area, with the box-edge keywords (`content-box`, `padding-box`,
+`border-box`, `margin-box`) used by other specs to refer to specific edges.
+
+### Design Philosophy
+
+The visual formatting model in [CSS 2.2 §9](https://www.w3.org/TR/CSS22/visuren.html)
+encodes several deliberate choices that have aged surprisingly well:
+
+- **Content order is layout order, by default.** No "constraint solver", no
+  declarative ordering. The DOM tree (or any tree of _generated boxes_, after
+  `display`, `::before`, `::after`, and CSS-generated content are accounted for)
+  _is_ the layout, walked in document order.
+
+- **Boxes know nothing about their siblings or descendants.** The block
+  formatting context lays out children top-to-bottom without any "look-ahead"
+  beyond the requirement that adjacent vertical margins collapse. This is what
+  allows incremental, streaming, line-by-line rendering on a slow modem in 1996.
+
+- **Inline content is text-first.** Line boxes are formed by the IFC algorithm
+  to hold one line's worth of inline content; their height is the maximum of
+  the contributing inline boxes' line heights. The model is literally a
+  typesetter's notion of "set this line, then move down to the next baseline."
+
+- **Geometry is local.** A box's position is computed from its containing
+  block's edges. The containing block is, in most cases, the nearest
+  block-level ancestor's content edge — a recursive, local computation that
+  requires no global solver.
+
+- **Layout falls back to the model.** Even when later mechanisms (floats,
+  absolute positioning, flex, grid) take over, every page still has a root
+  block formatting context, every paragraph still has an inline formatting
+  context, and any box that escapes those contexts re-enters them at its
+  position in the box tree.
+
+### History
+
+- **1990–1993: CSS prehistory.** Håkon Wium Lie proposes "Cascading HTML Style
+  Sheets" while at CERN. Tim Berners-Lee's WorldWideWeb browser and the early
+  Mosaic browser render HTML using ad-hoc layout rules that already resemble
+  normal flow: blocks stack, inlines flow.
+
+- **17 December 1996: CSS Level 1 Recommendation.** [CSS 1](https://www.w3.org/TR/CSS1/)
+  codifies the box model (content, padding, border, margin), the `display`
+  property (with values `block`, `inline`, `list-item`, `none`), and the basics
+  of float-and-clear. It does not yet have a formal "formatting context"
+  vocabulary — the model is described prosaically.
+
+- **12 May 1998: CSS Level 2 Recommendation.** [CSS 2](https://www.w3.org/TR/REC-CSS2/)
+  introduces the _visual formatting model_ as a named, structured concept,
+  formalizing block and inline formatting contexts, the positioning schemes
+  (`static`/`relative`/`absolute`/`fixed`), and `display: inline-block` and the
+  `table-*` display values.
+
+- **2002–2011: CSS 2.1 revisions.** The Working Group spends nearly a decade
+  refining ambiguities in the original spec. [CSS 2.1](https://www.w3.org/TR/CSS21/)
+  becomes a Recommendation on 7 June 2011, with substantially tightened
+  formatting-context and margin-collapse rules.
+
+- **CSS 2.2 (ongoing).** [CSS 2.2](https://www.w3.org/TR/CSS22/) is an
+  editorial update of CSS 2.1; it preserves the same model with editorial
+  clarifications and references to newer modules.
+
+- **2012: CSS Flexbox** becomes a Candidate Recommendation. Flex is _not_ a
+  replacement for normal flow — it is a _new inner display type_ selected by
+  `display: flex`. Inside a flex container, flow rules are suspended; outside,
+  the parent still lays the container out in normal flow.
+
+- **2017: CSS Grid** ships in major browsers. Same story: `display: grid` opts
+  the children in to a grid formatting context, but the grid container itself
+  is positioned by whatever context its parent establishes (normal flow by
+  default).
+
+- **2018–2023: CSS Display Module Level 3.** [css-display-3](https://www.w3.org/TR/css-display-3/)
+  factors the `display` property into two independent axes (_outer_ and
+  _inner_), introduces `display: contents` (which makes an element disappear
+  from the box tree while its children remain), and clarifies the
+  blockification / inlinification rules used by abspos, flex, and grid.
+
+- **2024: CSS Box Model Module Level 3.** [css-box-3](https://www.w3.org/TR/css-box-3/)
+  becomes a W3C Recommendation, replacing the margin and padding definitions
+  from CSS 2.1 with a cleaner specification, defining the box-edge keywords
+  (`content-box`, `padding-box`, `border-box`, `margin-box`) used by other
+  modules.
+
+Throughout this evolution, the _default_ `display` value remains
+flow-based — meaning that for a vast amount of real-world web content
+(documentation sites, blog posts, news articles, MDN, Wikipedia, this very
+page), normal flow does the bulk of the layout work. Flex and grid only
+participate where opted in.
+
+---
+
+## Layout Model
+
+### The Box Model
+
+Every element in normal flow generates a _box_ with four concentric rectangular
+areas:
+
+```
++------- margin area -----------------------+
+|                                           |
+|  +---- border area --------------------+  |
+|  |                                     |  |
+|  |  +-- padding area --------------+   |  |
+|  |  |                              |   |  |
+|  |  |  +--- content area -------+  |   |  |
+|  |  |  |                        |  |   |  |
+|  |  |  |   (text, children)     |  |   |  |
+|  |  |  |                        |  |   |  |
+|  |  |  +------------------------+  |   |  |
+|  |  |                              |   |  |
+|  |  +------------------------------+   |  |
+|  |                                     |  |
+|  +-------------------------------------+  |
+|                                           |
++-------------------------------------------+
+```
+
+Edges, from inside out, are: **content edge**, **padding edge**, **border
+edge**, **margin edge**. Background colors and images are painted through the
+border edge by default. The visual outline is the border edge.
+
+Each side is controlled by individual longhand properties — `padding-top`,
+`padding-right`, `padding-bottom`, `padding-left`, and analogous `margin-*` and
+`border-*-width` properties — or by 1-to-4-value shorthand (`padding`,
+`margin`, `border-width`).
+
+```css
+/* Two equivalent ways to give a card 16px padding top/bottom, 24px left/right */
+.card {
+  padding-top: 16px;
+  padding-right: 24px;
+  padding-bottom: 16px;
+  padding-left: 24px;
+}
+.card {
+  padding: 16px 24px;
+} /* shorthand */
+```
+
+### `box-sizing`
+
+A long-standing source of confusion: by default (`box-sizing: content-box`),
+the `width` and `height` properties size the _content area only_. Padding and
+border are added on top:
+
+```css
+.a {
+  box-sizing: content-box;
+  width: 200px;
+  padding: 20px;
+  border: 2px solid;
+}
+/* Total border-box width = 200 + 2*20 + 2*2 = 244px */
+```
+
+This is the original CSS 1 / CSS 2 behavior and matches the prose specification
+of "width is the content width."
+
+`box-sizing: border-box` (added in [CSS Backgrounds and Borders Level 3](https://www.w3.org/TR/css-backgrounds-3/))
+inverts the relationship: `width` and `height` describe the border-box, and the
+content area shrinks to accommodate padding and border:
+
+```css
+.b {
+  box-sizing: border-box;
+  width: 200px;
+  padding: 20px;
+  border: 2px solid;
+}
+/* Total border-box width = 200px; content area = 200 - 2*20 - 2*2 = 156px */
+```
+
+The `border-box` model matches Microsoft's pre-standards Internet Explorer
+behavior and is widely considered the more intuitive default for app UI; many
+codebases ship a universal reset:
+
+```css
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+```
+
+### `display` and Formatting-Context Selection
+
+The `display` property is the keystone of normal flow. Its value determines
+both the _outer_ role of a box (how it participates in its parent's flow) and
+the _inner_ model (how it lays out its own children).
+
+[CSS Display Module Level 3](https://www.w3.org/TR/css-display-3/) introduces a
+two-value syntax that makes the two axes explicit:
+
+```css
+display: block flow; /* the classic <p>, <div> default */
+display: inline flow; /* the classic <span>, <em> default */
+display: inline flow-root; /* equivalent to legacy `inline-block` */
+display: block flex; /* a block-level flex container */
+display: inline grid; /* an inline-level grid container */
+```
+
+The single-value keywords most authors still type today (`block`, `inline`,
+`inline-block`, `flex`, `grid`, etc.) all map to canonical two-value pairs.
+
+Legacy single values that still matter to normal flow:
+
+- **`block`** — generates a block-level box. Children form a block formatting
+  context (unless the block becomes a flex/grid container, etc.).
+- **`inline`** — generates one or more inline-level boxes that flow inside an
+  inline formatting context.
+- **`inline-block`** — an _inline-level_ box on the outside (participates in
+  line boxes) whose interior is an _independent_ block formatting context. The
+  box is sized like a block but flows like an inline.
+- **`list-item`** — generates a principal block-level box and a marker box
+  (the bullet or number). Special-cased so that `<li>` retains its bullet
+  regardless of what other display roles are layered on.
+- **`run-in`** — a historically tricky value that merges a leading "lead-in"
+  box into the following block. Marked at-risk in css-display-3; most engines
+  do not implement it.
+- **`none`** — generates _no box at all_; the element and all its descendants
+  vanish from the box tree. Distinct from `visibility: hidden`, which still
+  reserves space.
+- **`contents`** — new in css-display-3. The element itself disappears, but
+  its children are "promoted" to the parent's box tree as if the element were
+  unwrapped. Replaced elements, form controls, and SVG/MathML elements compute
+  `display: contents` to `display: none` instead. Useful for un-nesting a
+  wrapper without removing it from the DOM.
+- **`table`, `table-row`, `table-cell`, `table-row-group`, ...** — generates
+  CSS table boxes. Their inner model is the table formatting context, which is
+  not strictly normal flow but is part of the legacy display set.
+
+### Block Formatting Context (BFC)
+
+Inside a block formatting context, boxes are laid out one after another,
+**vertically**, starting at the top of the containing block. The horizontal
+position of each box is determined by the containing block's left content edge
+(in left-to-right writing modes) — no horizontal stacking of siblings unless
+floats intervene.
+
+Key properties of a BFC:
+
+- A block-level box's _width_ defaults to filling its containing block's
+  content width. Set `width` to constrain it; use `margin: auto` (with an
+  explicit width) to center it.
+- A block-level box's _height_ defaults to "auto", meaning _fit-content_ — the
+  smallest height that contains all in-flow children plus any cleared floats.
+- Vertical margins between adjacent siblings _collapse_ (see below).
+- Floats contained in a BFC participate in the layout of subsequent in-flow
+  content unless cleared.
+
+A BFC is _established_ by:
+
+- The root element (the `<html>` element's principal box always establishes
+  one).
+- Floats (`float: left | right`).
+- Absolutely positioned elements (`position: absolute | fixed`).
+- Block containers that are inline-blocks, table-cells, table-captions, or
+  flex/grid items (each item establishes an independent formatting context).
+- Block boxes with `overflow` not equal to `visible` (a common trick for
+  forcing a new BFC, e.g. `overflow: hidden` or `overflow: auto`).
+- Block boxes with `display: flow-root` (the explicit, side-effect-free way to
+  create a new BFC, added in css-display-3).
+
+Establishing a new BFC has important side effects: floats inside it are
+contained (no leakage to following siblings) and margins of children no longer
+collapse with margins outside the new BFC.
+
+### Inline Formatting Context (IFC)
+
+Within an IFC, boxes are laid out _horizontally_, one after another, starting
+at the top of the containing block. The horizontal direction is determined by
+the writing mode (left-to-right for English, right-to-left for Arabic /
+Hebrew). The vertical direction is determined by `writing-mode` (top-to-bottom
+for most scripts).
+
+The IFC algorithm groups consecutive inline-level content into **line boxes**.
+A line box is a horizontal slice of the IFC, exactly tall enough to contain
+the tallest inline content it holds (subject to `line-height`,
+`vertical-align`, and the strut). When the inline content on a line exceeds
+the containing block's width, the layout _breaks_ — typically at a permissible
+break point such as a whitespace character — and the next inline box starts a
+new line box below the previous one.
+
+```html
+<p>This is a <em>paragraph</em> with <strong>mixed</strong> styled spans.</p>
+```
+
+renders by:
+
+1. Establishing a BFC for the document body containing the `<p>` element.
+2. The `<p>` itself is a block box in that BFC, with its own (inner) IFC.
+3. The inner IFC walks the inline children:
+   - Anonymous inline box `"This is a "` (text run)
+   - `<em>` inline box, containing inline text `"paragraph"`
+   - Anonymous inline box `" with "` (text run)
+   - `<strong>` inline box, containing inline text `"mixed"`
+   - Anonymous inline box `" styled spans."` (text run)
+4. Line boxes are formed at every break point; their heights are the max of
+   the contained inline boxes' line heights.
+
+If a block-level element appears inside an IFC, **anonymous block boxes** are
+generated around the surrounding inline content to "block-ify" the local
+layout — preserving the invariant that a BFC contains only block-level boxes
+and that inline content always lives inside an IFC.
+
+### Margin Collapsing
+
+The single most surprising aspect of normal flow. _Adjacent vertical margins
+collapse_ into a single margin equal to the maximum (for positive margins) or
+minimum (for negative margins, by absolute value), or their sum (for mixed
+signs). The rules apply in three configurations:
+
+**1. Adjacent siblings.** The bottom margin of one block-level box and the top
+margin of the next collapse:
+
+```html
+<style>
+  p {
+    margin: 16px 0;
+  }
+</style>
+<p>First.</p>
+<p>Second.</p>
+```
+
+The space between the two `<p>` elements is `16px`, not `32px`.
+
+**2. Parent and first/last child.** If a parent has no `border`, no `padding`,
+no inline content separating it from its first child, the first child's top
+margin collapses _through_ the parent and out the top:
+
+```html
+<style>
+  .outer {
+    margin-top: 20px;
+  }
+  .inner {
+    margin-top: 30px;
+  }
+</style>
+<div class="outer"><div class="inner">Hello</div></div>
+```
+
+The visible top margin above `.inner` is `30px` from the outer container, not
+`50px`. This is the source of countless "why is my margin escaping the parent"
+bug reports. The fix is to establish a new BFC on `.outer` (e.g.
+`overflow: hidden`, `display: flow-root`) or to add padding/border to block the
+collapse.
+
+**3. Empty blocks.** A block with no content, no padding, no border, and no
+inline content has its top and bottom margins collapse with each other and with
+adjacent siblings.
+
+Margins **never collapse** for:
+
+- Horizontal margins (only vertical, in horizontal writing modes — the
+  collapse direction follows the _block axis_).
+- Floats.
+- Absolutely positioned elements.
+- Inline-block elements.
+- Elements with `overflow` other than `visible`.
+- Flex / grid items.
+- Anything that establishes a new block formatting context.
+
+### Floats
+
+`float: left` or `float: right` removes a box from normal flow, shifts it to
+the left or right edge of the containing block, and lets subsequent inline
+content flow _around_ it. Originally introduced for the "image with text
+wrapping" pattern of magazine layout; widely repurposed (1998 – 2012) as a
+poor-man's column-layout mechanism.
+
+Float behavior in summary:
+
+- A float is taken out of the normal block flow, but inline content (line
+  boxes) shortens to make room for it.
+- Subsequent block-level siblings still flow as if the float were not present
+  (their boxes overlap the float's region), but their _line boxes_ shorten to
+  avoid the float.
+- The `clear` property (`left`, `right`, `both`) on a subsequent element
+  forces its top margin to push past any floats on the specified side.
+- Floats establish a new block formatting context for their own children.
+
+```html
+<style>
+  .figure {
+    float: left;
+    width: 200px;
+    margin: 0 16px 16px 0;
+  }
+  .caption {
+    clear: left;
+  }
+</style>
+<article>
+  <img class="figure" src="..." alt="..." />
+  <p>Lorem ipsum dolor sit amet, ... text wraps around the image.</p>
+  <p class="caption">This caption appears below the image.</p>
+</article>
+```
+
+A long-standing wart: a parent whose only in-flow content is floated has
+`height: 0`, because the floats are not "in flow." This is the _collapsing
+parent_ problem, traditionally solved with the **clearfix hack**:
+
+```css
+.clearfix::after {
+  content: '';
+  display: block;
+  clear: both;
+}
+```
+
+The modern equivalent is `display: flow-root` on the parent, which establishes
+a new BFC and contains the floats cleanly.
+
+### Positioning
+
+The `position` property selects one of five **positioning schemes**, layered
+on top of normal flow:
+
+- **`static`** _(default)_ — the box is laid out in normal flow. `top`,
+  `right`, `bottom`, `left`, and `z-index` have no effect.
+
+- **`relative`** — the box is laid out in normal flow, _then_ visually offset
+  by `top` / `right` / `bottom` / `left`. The box's _layout position_ is
+  unchanged; surrounding boxes are unaffected. The offset is purely visual.
+  Also establishes a containing block for absolutely positioned descendants.
+
+- **`absolute`** — the box is removed from normal flow entirely and positioned
+  relative to its **containing block**, which is the nearest ancestor with a
+  `position` other than `static` (or, lacking such ancestor, the initial
+  containing block, which is the viewport in continuous media). `top`,
+  `right`, `bottom`, `left` describe offsets from the corresponding edges of
+  the containing block.
+
+- **`fixed`** — like `absolute`, but the containing block is always the
+  viewport (or the page area in paginated media). Stays anchored as the page
+  scrolls.
+
+- **`sticky`** — a hybrid added in [CSS Positioned Layout Module Level 3](https://www.w3.org/TR/css-position-3/).
+  The box is laid out in normal flow until its scroll-port edge would cross
+  one of the specified offset thresholds, at which point it acts like a
+  position-fixed element relative to its nearest scrollable ancestor.
+
+The containing block rules are subtle:
+
+| For a position with... | the containing block is...                                                    |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `static`, `relative`   | the nearest block-level ancestor's _content edge_                             |
+| `absolute`             | the nearest ancestor with `position != static`, taken to its _padding edge_   |
+| `fixed`                | the viewport (initial containing block)                                       |
+| `sticky`               | same as `static`/`relative` for layout; nearest scroll container for sticking |
+
+This recursion is the secret machinery of complex normal-flow-derived layouts:
+a `position: relative` wrapper "captures" absolutely positioned descendants,
+letting authors build popovers, tooltips, and overlays without leaving the
+flow.
+
+### Putting It Together: Annotated Walk-Through
+
+Consider a simple page with a header, a paragraph containing a floated figure,
+and a footer:
+
+```html
+<style>
+  body {
+    margin: 0;
+  }
+  header {
+    background: #eef;
+    padding: 16px;
+  }
+  main {
+    padding: 16px;
+  }
+  .fig {
+    float: right;
+    width: 160px;
+    margin: 0 0 12px 16px;
+  }
+  footer {
+    background: #efe;
+    padding: 16px;
+  }
+</style>
+<header><h1>Title</h1></header>
+<main>
+  <img class="fig" src="..." alt="..." />
+  <p>Lorem ipsum dolor sit amet ...</p>
+</main>
+<footer>Footer text.</footer>
+```
+
+Layout walk:
+
+1. The root `<html>` element establishes the initial containing block, sized
+   to the viewport, and the root BFC.
+2. `<body>` is a block-level child of the BFC; its width is the viewport
+   width, height is auto (computed from children).
+3. `<header>`, `<main>`, `<footer>` stack vertically inside body's BFC. Each
+   has its own internal layout.
+4. Inside `<header>`, the `<h1>` establishes its own inline formatting
+   context for "Title", laying down one line box.
+5. Inside `<main>`:
+   - The `<img class="fig">` is _floated right_. It is removed from normal
+     flow, snapped to the right padding edge of `<main>`.
+   - The `<p>` is a block-level box in `<main>`'s BFC. Its width is the full
+     content width of `<main>`. Its IFC lays down line boxes for the
+     paragraph text — but each line box _shortens_ to avoid the floated
+     image's region, producing the classic wrap-around-image effect.
+6. `<footer>` follows below `<main>`, vertically; its top margin would
+   collapse with `<main>`'s bottom margin if both were nonzero.
+
+No constraint solver runs. No second pass. The browser walks the tree once,
+asking each box "what is your size?" and "where are you in your formatting
+context?" and writes pixels.
+
+---
+
+## Strengths and Weaknesses
+
+### For Document Layout (target domain)
+
+**Strengths.** Normal flow is _exceptionally_ good at what it was designed
+for: rendering long-form documents with mixed inline styling, where the author
+specifies content order and the rendering engine handles line breaking,
+hyphenation, justification, and the placement of figures alongside text. A
+six-thousand-word article, a research paper, a long technical manual — these
+are essentially direct expressions of normal flow's model. There are no
+declared widths, no grid templates, no flex containers; the model adapts to
+the viewport by reflowing line boxes.
+
+The model also has remarkable algorithmic properties:
+
+- **Single-pass.** A naive implementation can walk the box tree in one
+  traversal, emitting pixels as it goes. Incremental rendering works "for
+  free" — old dial-up browsers could display a partial page as bytes streamed
+  in.
+- **Composable.** Nested elements compose by establishing their own
+  formatting contexts. Most authoring is a matter of "what do I want this
+  container to be? block or inline?" with the model handling the rest.
+- **Author-friendly.** The HTML defaults map naturally to normal flow: a
+  `<p>` is a block, an `<em>` is inline. Authors who write semantic HTML
+  often produce reasonable layouts with zero CSS.
+
+### For Static One-Shot Rendering
+
+Normal flow is well-suited to _batch_ rendering pipelines that generate static
+output: PDF generation (via wkhtmltopdf, headless Chromium, Puppeteer),
+email-template rendering, server-side React/Vue/Astro that emits HTML+CSS,
+print stylesheets, ePub generation. The model's locality and single-pass
+nature make it cheap to compute for a known viewport size, and the absence of
+runtime interactivity is fine — the page renders once.
+
+For sparkles-style **static, one-shot CLI output** (write a styled report to
+stdout, exit), the _philosophy_ of normal flow carries over:
+
+- A printed terminal "page" is fundamentally block-based: a sequence of lines.
+- Inline styling within a line — colored spans, bold runs — is a perfect fit
+  for IFC-style line boxes containing styled inline boxes.
+- A "report" is a tree of blocks: section headers, paragraphs, tables, code
+  blocks. Each is a block formatting context; their internal text is an
+  inline formatting context.
+
+The box-model concept (padding around content, margin between blocks) also
+maps cleanly onto terminal-cell space, though border characters and margin
+collapsing have to be re-implemented for the medium. Sparkles' `prettyPrint`
+already inhabits this design space.
+
+**Weaknesses for one-shot static output.**
+
+- The model is _width-aware_ but not naturally _aligned-into-columns_. Lining
+  two columns up by their first character requires inline-block / table /
+  flex tricks.
+- Vertical centering inside a block is famously awkward in normal flow.
+- "Take the remaining space" is not expressible — block boxes are
+  fit-content-tall by default; the parent can be `height: 100%`, but
+  filling the parent requires positioning or flex.
+
+### For App UIs
+
+This is where normal flow shows its age. Application interfaces — toolbars,
+side panels, tab strips, modal dialogs, resizable splitters, virtualized
+lists — are _not_ sequences of paragraphs. They are 2-D arrangements of
+panels with specific size relationships and alignment requirements. The
+historical pain points include:
+
+- **Two-column layouts.** Before flex / grid, the classic three-column
+  "holy grail" layout required either floats with negative margins, or
+  `display: table`, or absolutely-positioned columns. All three had failure
+  modes (sticky footers, equal-height columns, source-order independence)
+  that normal flow could not address natively.
+- **Vertical centering.** "Center this box vertically in the viewport"
+  required `position: absolute; top: 50%; transform: translateY(-50%)` or
+  `display: table-cell; vertical-align: middle` — both feel like fighting the
+  model.
+- **Equal-height columns.** Block boxes are individually fit-content; making
+  two sibling block boxes match each other's height for visual alignment
+  required the _faux columns_ hack (background images) or, again, table
+  display.
+- **"Fill remaining height" sidebars.** Until flex/grid, this was unachievable
+  in normal flow without absolute positioning and explicit math.
+- **Source order vs. visual order.** Floats and absolute positioning gave
+  some flexibility, but reordering blocks visually without changing the DOM
+  required hacks.
+
+It was precisely these app-UI pain points that drove the design of Flexbox
+([css-flexbox.md](./css-flexbox.md)) and later CSS Grid
+([css-grid.md](./css-grid.md)). Both are _inner display types_ that suspend
+normal flow inside the container while remaining compatible with normal flow
+outside it.
+
+### Compared to Alternatives
+
+| Aspect                           | Normal flow                                   | Flexbox                        | Grid                      | Constraint-based (e.g. Auto Layout, Cassowary) |
+| -------------------------------- | --------------------------------------------- | ------------------------------ | ------------------------- | ---------------------------------------------- |
+| Primary axis                     | Block (vertical for horizontal writing modes) | One-dimensional (configurable) | Two-dimensional           | Arbitrary linear constraints                   |
+| Spec age                         | 1996 (CSS 1)                                  | 2012 (CR)                      | 2017 (Rec)                | Cassowary 1997, Auto Layout 2011               |
+| Suited for                       | Documents, prose                              | App UI rows/columns            | 2-D app UI grids          | Complex IDE-like layouts                       |
+| Reflow on resize                 | Excellent (single-pass)                       | Excellent                      | Excellent                 | Good (but solver cost)                         |
+| "Fill remaining space"           | No (use `height: 100%` games)                 | `flex: 1`                      | `1fr`                     | Yes, with inequality constraints               |
+| Vertical centering               | Hard                                          | `align-items: center`          | `align-items: center`     | Trivial                                        |
+| Order-independent of source      | No                                            | `order` property               | Grid placement properties | Trivial                                        |
+| Browsers / runtimes implementing | Universal                                     | Universal                      | Universal (since 2017)    | Native iOS/macOS, web via solvers like kasuari |
+
+The most important point: **normal flow is not "obsolete."** Inside a flex
+item or a grid cell, the _contents_ are laid out by whatever inner display
+type the item itself selects — and by default, that is normal flow. A typical
+modern web page uses a top-level grid or flex layout for the page chrome and
+_normal flow_ for the actual content of each panel.
+
+### When Normal Flow Wins
+
+- **Rendering arbitrary HTML.** If you do not control the markup (RSS feed,
+  Markdown-rendered docs, user-submitted comments), normal flow is what makes
+  it look reasonable without ad-hoc styling.
+- **Print and PDF.** Pagination and line-breaking are first-class concerns of
+  the visual formatting model; flex and grid have weaker print stories.
+- **Vertical streaming output.** Logs, REPLs, terminal output, transcript-style
+  UIs — fundamentally "append a block at the bottom" interactions are direct
+  expressions of a BFC.
+- **Localizable content.** Reflow handles language-specific line-breaking,
+  hyphenation, and writing-mode changes without author intervention.
+
+### When Normal Flow Loses
+
+- **Pixel-perfect 2-D layouts** with sibling alignment in both axes — use
+  grid.
+- **Variable-content rows** that need consistent vertical alignment of items
+  with mixed sizes — use flexbox.
+- **Dynamic resizing with min/max relationships** between siblings — use
+  flexbox or constraint-based.
+- **Source-order independent visual order** — use flex/grid's `order` /
+  placement properties.
+
+---
+
+## References
+
+### Primary Specifications
+
+- **CSS 2.2 Visual Formatting Model.** <https://www.w3.org/TR/CSS22/visuren.html>
+- **CSS 2.2 Box Model.** <https://www.w3.org/TR/CSS22/box.html>
+- **CSS Display Module Level 3.** <https://www.w3.org/TR/css-display-3/>
+- **CSS Box Model Module Level 3.** <https://www.w3.org/TR/css-box-3/>
+- **CSS Positioned Layout Module Level 3.** <https://www.w3.org/TR/css-position-3/>
+- **CSS Backgrounds and Borders Module Level 3.** <https://www.w3.org/TR/css-backgrounds-3/> (defines `box-sizing`).
+
+### Earlier Versions
+
+- **CSS Level 1 (W3C Recommendation, 17 December 1996).** <https://www.w3.org/TR/CSS1/>
+- **CSS Level 2 (W3C Recommendation, 12 May 1998).** <https://www.w3.org/TR/REC-CSS2/>
+- **CSS Level 2.1 (W3C Recommendation, 7 June 2011).** <https://www.w3.org/TR/CSS21/>
+
+### Tutorials and Reference Material
+
+- **MDN — Block formatting context.** <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Block_formatting_context>
+- **MDN — Inline formatting context.** <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Inline_formatting_context>
+- **MDN — Normal Flow.** <https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow>
+- **MDN — Mastering margin collapsing.** <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing>
+- **MDN — Floats.** <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_floating_floats>
+- **MDN — Positioning.** <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout>
+- **MDN — Containing block.** <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_display/Containing_block>
+
+### Historical Context
+
+- **Håkon Wium Lie, "Cascading HTML style sheets — a proposal" (1994).** <https://www.w3.org/People/howcome/p/cascade.html>
+- **Bert Bos, "A brief history of CSS until 2016."** <https://www.w3.org/Style/CSS20/history.html>
+- **Chris Coyier, "The Difficulties of Vertical Centering" (CSS-Tricks, 2013–2020).** <https://css-tricks.com/centering-css-complete-guide/>
+- **PPK (Peter-Paul Koch), "CSS layout: an introduction" — quirksmode.org.** <https://www.quirksmode.org/css/>
+
+### Adjacent Sparkles Research
+
+- **Flexbox layout model (sibling doc):** [css-flexbox.md](./css-flexbox.md)
+- **Grid layout model (sibling doc):** [css-grid.md](./css-grid.md)
+- **TUI library that uses Yoga (a Flex implementation) on top of a normal-flow-shaped output stream:** [../tui-libraries/ink.md](../tui-libraries/ink.md)
+- **TUI library with a constraint-based layout that does _not_ use normal flow:** [../tui-libraries/ratatui.md](../tui-libraries/ratatui.md)
+- **Tk geometry managers (the proto-flex / proto-grid / proto-abspos of the GUI world, predating CSS):** [tk.md](./tk.md)

--- a/docs/research/ui-layout/dear-imgui.md
+++ b/docs/research/ui-layout/dear-imgui.md
@@ -1,0 +1,605 @@
+# Dear ImGui (C++)
+
+A bloat-free, immediate-mode graphical user interface library for C++ aimed at tools,
+debug overlays, content-creation editors, and engine-side UIs. The canonical reference
+implementation of the immediate-mode GUI paradigm in mainstream use, and the inspiration
+for a wide family of ports (including [`imtui`](../tui-libraries/imtui.md), which renders
+Dear ImGui in a terminal).
+
+| Field            | Value                                                 |
+| ---------------- | ----------------------------------------------------- |
+| Author           | Omar Cornut (@ocornut), with hundreds of contributors |
+| Language         | C++ (single-header-style, no STL required)            |
+| License          | MIT                                                   |
+| Repository       | <https://github.com/ocornut/imgui>                    |
+| Wiki             | <https://github.com/ocornut/imgui/wiki>               |
+| Version snapshot | 1.92.x (2026 release line)                            |
+| First release    | 2014                                                  |
+
+---
+
+## Overview
+
+Dear ImGui (the "Dear" prefix is a deliberate disambiguator from the more generic phrase
+"imgui") is a C++ library for building graphical user interfaces that follows the
+**immediate-mode GUI** model. Originally written by Omar Cornut in 2014 -- initially used
+internally at Media Molecule during development of _Tearaway Unfolded_ on the PS Vita --
+it has since become the de facto standard for in-tool and in-engine UI across the
+game-development industry and a substantial chunk of the graphics-programming world. It
+ships with virtually every major game engine integration (Unity, Unreal, Godot, Bevy
+[via egui's parallel evolution], and dozens of homebrew engines) and is the UI behind
+high-profile creator tools (Sketchfab's viewers, NVIDIA's various profiling overlays,
+the editors in many indie engines).
+
+**What it solves.** Building a GUI for an in-house tool with a retained-mode framework
+(Qt, GTK, WPF) means writing a widget class hierarchy, wiring signals/slots, owning
+widget state separately from the underlying data model, and synchronising the two on
+every change. For a five-engineer game studio that just wants "a slider for this float
+and a checkbox for this bool" attached to a live game world, that overhead is
+disproportionate. Dear ImGui eliminates it: the UI is just a sequence of function calls,
+re-issued every frame, with no persistent widget objects.
+
+**Design philosophy.** Three principles dominate the design:
+
+1. **State lives in the application.** The library stores only enough internal state to
+   manage windows, layout cursors, focus, and animations. The data being edited
+   (`float volume`, `bool enabled`, `int selected_index`) is owned by the application;
+   Dear ImGui reads and writes it directly through pointer arguments.
+2. **The UI is rebuilt every frame from scratch.** There is no widget tree. Each frame
+   you call `ImGui::NewFrame()`, issue a sequence of widget calls in the order they
+   should appear, and call `ImGui::Render()`. The library's job is to record those
+   calls into a draw list and let your application's renderer (OpenGL, Vulkan, DirectX,
+   Metal, software, terminal) submit them.
+3. **The library does not own anything.** Not the window, not the renderer, not the
+   event loop, not the input source. The application provides input each frame and a
+   backend renders the produced vertex/index/command buffers. Dear ImGui ships
+   reference backends for every major windowing and graphics API in the `backends/`
+   directory, but they are opt-in glue.
+
+This philosophy yields a particular ergonomic signature: the "two-line slider". To put a
+slider on screen that edits a float, you write:
+
+```cpp
+float volume = 0.5f;
+ImGui::SliderFloat("Volume", &volume, 0.0f, 1.0f);
+```
+
+Two lines (one of them the variable declaration, which already existed). The slider
+appears, the variable is updated when the user drags, and there is no widget object, no
+event handler, no model-view binding. This 2-line ergonomic is the **central advantage** of
+the immediate-mode model and the reason Dear ImGui dominates the tooling space.
+
+### History
+
+- **2014.** Omar Cornut publishes `imgui` on GitHub. Initial design drew on Casey
+  Muratori's "immediate-mode GUIs" talks and on internal tooling work at Media Molecule.
+- **2014-2017.** Steady iteration. Widget set fills out (input boxes, combos, plots,
+  trees, menus, popups, drag-and-drop). The renderer-agnostic draw-list architecture
+  stabilises.
+- **2018.** The library is renamed **Dear ImGui** to disambiguate from generic "imgui"
+  references.
+- **2019.** Version 1.71 lands the **docking branch** -- separate branch of development
+  introducing dockable windows and multi-viewport (host-OS window) support. Used in
+  production by many users from the docking branch directly.
+- **2020.** Version 1.80 (released January 2021) ships the **modern Tables API**, a
+  ground-up replacement for the legacy `Columns()` system. Tables become competitive
+  with retained-mode UI tables (sortable, resizable, freezable, scrollable).
+- **2020.** Multi-viewport and docking work continues in parallel on the docking branch.
+- **2023-2024.** Docking and multi-viewport features merge into the main branch over
+  several releases through 1.89 / 1.90.
+- **Present.** Active development continues. The Tables API and docking are mature; new
+  work focuses on multi-select, text editing, performance, and platform polish.
+
+The library has been remarkably stable across this decade-plus of development: code
+written against the 1.50 API in 2016 generally still compiles and runs against current
+1.91, with at most cosmetic warnings about deprecated function names.
+
+---
+
+## Layout Model
+
+Dear ImGui's layout is fundamentally a **cursor-based, paragraph-flow model**. Each
+window maintains a "cursor" -- an `(x, y)` position in window-local coordinates. When you
+issue a widget call, the widget is drawn at the cursor position, the cursor advances
+**downward** by the widget's height plus an item-spacing gap, and the next widget
+follows. The flow is vertical by default; explicit calls move the cursor sideways or
+back up.
+
+This is not a constraint solver. It is not a flexbox. It is a moving caret, exactly like
+text flowing in a paragraph -- which is also why the model feels natural when adding
+"another control" to an existing window.
+
+### Windows
+
+Everything visible in Dear ImGui lives inside a window. A window is a movable, resizable,
+collapsible container; it has a title bar, borders, optional scrollbars, and a content
+region. Windows are opened with `Begin` and closed with `End`:
+
+```cpp
+ImGui::Begin("Inspector");
+// widget calls here
+ImGui::End();
+```
+
+`Begin`/`End` must be matched. The return value of `Begin` indicates whether the window
+is currently visible (collapsed or hidden windows skip rendering); widgets inside an
+invisible window are not drawn but their state is still processed. The full signature is:
+
+```cpp
+bool ImGui::Begin(const char* name,
+                  bool* p_open = nullptr,
+                  ImGuiWindowFlags flags = 0);
+```
+
+`p_open` is an optional pointer to a `bool`; if non-null, a close button appears in the
+title bar and the library sets `*p_open = false` when the user clicks it.
+`ImGuiWindowFlags` controls everything from "no title bar" through "no resize", "no
+move", "always auto-resize", "tooltip semantics", "popup semantics", etc.
+
+**Child windows** are nested regions inside a parent window with their own scrollbar and
+clipping rectangle:
+
+```cpp
+ImGui::BeginChild("Log",
+                  ImVec2(0, 200),
+                  ImGuiChildFlags_Borders);
+for (const auto& line : log_lines) ImGui::TextUnformatted(line.c_str());
+ImGui::EndChild();
+```
+
+A child of size `(0, 200)` means "full available width, 200 pixels tall". The `0` in
+either axis means "use available space"; a negative value means "available space minus
+this amount".
+
+### Docking
+
+Since the docking work merged from branch (long used as 1.71+ on the docking branch) and
+landed in main around 1.89 / 1.90, windows can be **docked** into a parent dock node,
+split a dock region into halves, or be torn off into separate OS windows
+(multi-viewport). Docking is opt-in per ImGui context:
+
+```cpp
+ImGuiIO& io = ImGui::GetIO();
+io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable; // optional, multi-viewport
+```
+
+Applications typically create one full-window dockspace at the top of each frame using
+`DockSpaceOverViewport(...)`, then `Begin`-ed windows automatically dock into it on
+first appearance.
+
+### The cursor and flow
+
+Inside a window, layout is **vertical by default**. Each call to a widget function
+(`Button`, `Text`, `Checkbox`, `SliderFloat`, etc.) advances the cursor by the widget's
+height plus `ItemSpacing.y`:
+
+```cpp
+ImGui::Text("Position");
+ImGui::SliderFloat3("##pos", &pos.x, -100.0f, 100.0f);
+ImGui::Checkbox("Visible", &visible);
+ImGui::Button("Reset");
+```
+
+This produces four widgets stacked vertically, each on its own row.
+
+To put two widgets on the same row, call `ImGui::SameLine()` between them. `SameLine`
+moves the cursor **back to the previous line's vertical position** and advances `x` by
+`ItemSpacing.x` (or by an explicit offset):
+
+```cpp
+if (ImGui::Button("OK")) confirm();
+ImGui::SameLine();
+if (ImGui::Button("Cancel")) cancel();
+```
+
+Other layout primitives that nudge the cursor:
+
+- **`ImGui::NewLine()`** -- forces a blank line of `FontSize` height; the cursor goes
+  back to the left margin on the next row.
+- **`ImGui::Spacing()`** -- inserts a small vertical gap (one `ItemSpacing.y`).
+- **`ImGui::Dummy(ImVec2 size)`** -- inserts an invisible widget of the given size,
+  consuming layout space. Useful for "leave 50 px of vertical breathing room here".
+- **`ImGui::Indent(float w = 0)` / `ImGui::Unindent(float w = 0)`** -- shifts the left
+  margin right or left by `w` (or by `IndentSpacing` if `0`). Used for nested sections,
+  tree-view bodies, etc.
+- **`ImGui::Separator()`** -- draws a horizontal line and advances the cursor.
+
+### Sizing widgets
+
+By default each widget chooses its own size: text takes its measured size, sliders take
+a fraction of the available width, buttons hug their label, and so on. Three layers
+control item width:
+
+- **`ImGui::SetNextItemWidth(float w)`** -- one-shot override for the **next** widget
+  only. `w > 0` is an absolute pixel width; `w < 0` is `availableWidth + w` (so `-1.0f`
+  means "available width minus 1 pixel").
+- **`ImGui::PushItemWidth(float w)` / `ImGui::PopItemWidth()`** -- stack-scoped override
+  for all widgets between push and pop. Same convention for negative widths.
+- **`ImGui::CalcItemWidth()`** -- queries the current default item width (taking pushes
+  and the window's content region into account). Useful inside custom widgets that need
+  to pick their own size while respecting the caller's `PushItemWidth`.
+
+To find out how much space remains in the current content region:
+
+```cpp
+ImVec2 avail = ImGui::GetContentRegionAvail();
+// avail.x: remaining width to the right of the cursor
+// avail.y: remaining height below the cursor
+```
+
+This is the read-side counterpart to `Dummy`/`SetNextItemWidth` and is how responsive
+layouts adapt to varying window sizes.
+
+### Style stack
+
+Spacing, padding, frame rounding, alpha, colours, and a long list of similar visual
+parameters live on a per-context **style** stack. To temporarily override one for a
+section of UI, push it, draw, then pop:
+
+```cpp
+ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(2.0f, 2.0f));
+ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(40, 40, 60, 255));
+
+ImGui::Button("Tight 1");
+ImGui::Button("Tight 2");
+
+ImGui::PopStyleColor();
+ImGui::PopStyleVar();
+```
+
+`ImGuiStyleVar_ItemSpacing` is the spacing between widgets on the same row and between
+rows -- the same value `SameLine` uses for its default x-offset. Other commonly pushed
+style vars are `FramePadding` (padding inside button frames), `WindowPadding` (margin
+between window edges and content), `IndentSpacing`, and `FrameRounding`.
+
+### Tables (modern API, since 1.80)
+
+Up through 1.71, Dear ImGui shipped a `Columns()` API for splitting a region into
+side-by-side columns. It is still present for backwards compatibility but is
+**deprecated for new code** and feature-frozen. Since 1.80 (released January 2021), the
+modern **Tables API** is the recommended way to lay out tabular data and grid-like UI.
+
+The Tables API is far richer than `Columns()`: columns can be resized, reordered,
+hidden, sorted, frozen against scrolling, and given per-column width policies
+(fixed-width, stretch, auto-fit), and the table itself can have headers, scroll on both
+axes, draw bordered cells, and persist user customisation across runs.
+
+The basic skeleton is:
+
+```cpp
+ImGuiTableFlags flags =
+    ImGuiTableFlags_Resizable |
+    ImGuiTableFlags_Reorderable |
+    ImGuiTableFlags_Hideable |
+    ImGuiTableFlags_Sortable |
+    ImGuiTableFlags_RowBg |
+    ImGuiTableFlags_BordersV;
+
+if (ImGui::BeginTable("processes", 4, flags))
+{
+    ImGui::TableSetupColumn("PID",    ImGuiTableColumnFlags_WidthFixed,   64.0f);
+    ImGui::TableSetupColumn("Name",   ImGuiTableColumnFlags_WidthStretch, 0.0f);
+    ImGui::TableSetupColumn("CPU%",   ImGuiTableColumnFlags_WidthFixed,   72.0f);
+    ImGui::TableSetupColumn("Memory", ImGuiTableColumnFlags_WidthFixed,   96.0f);
+    ImGui::TableHeadersRow();
+
+    for (const Process& p : processes)
+    {
+        ImGui::TableNextRow();
+
+        ImGui::TableSetColumnIndex(0);
+        ImGui::Text("%d", p.pid);
+
+        ImGui::TableNextColumn();
+        ImGui::TextUnformatted(p.name.c_str());
+
+        ImGui::TableNextColumn();
+        ImGui::Text("%.1f%%", p.cpu_percent);
+
+        ImGui::TableNextColumn();
+        ImGui::Text("%llu KiB", p.rss_bytes / 1024);
+    }
+    ImGui::EndTable();
+}
+```
+
+The core entry points:
+
+- **`BeginTable(id, columnCount, flags = 0, outerSize = ImVec2(0,0), innerWidth = 0)`**
+  Opens a table with the given identifier and column count. Returns `false` if the
+  table is clipped or otherwise skipped; in that case do not issue cell calls and do
+  not call `EndTable`.
+- **`TableSetupColumn(label, flags = 0, initWidth = 0.0f, userId = 0)`** Declares a
+  column. Must be called between `BeginTable` and the first row. Columns can be added
+  in arbitrary order via `userId` but visually appear in declaration order unless
+  reordered by the user.
+- **`TableHeadersRow()`** Emits a header row using the labels passed to
+  `TableSetupColumn`. Header cells are clickable for sorting if the column is sortable.
+- **`TableNextRow(flags = 0, minRowHeight = 0)`** Advances to the next row.
+- **`TableSetColumnIndex(int n)`** Jumps the cell cursor to column `n` of the current
+  row. Returns `false` if that column is hidden.
+- **`TableNextColumn()`** Advances to the next column of the current row (or, if at the
+  end of the row, starts a new row). Returns `false` if the column is hidden -- a
+  convenient way to write "if visible, draw this cell".
+
+Selected `ImGuiTableFlags`:
+
+| Flag                              | Meaning                                                                |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| `Resizable`                       | User can drag column edges to resize.                                  |
+| `Reorderable`                     | User can drag column headers to reorder.                               |
+| `Hideable`                        | User can hide columns via header context menu.                         |
+| `Sortable`                        | Header clicks toggle sort. Use `TableGetSortSpecs` to read sort state. |
+| `RowBg`                           | Alternate row background colour.                                       |
+| `BordersInnerH` / `BordersOuterH` | Horizontal border lines.                                               |
+| `BordersInnerV` / `BordersOuterV` | Vertical border lines.                                                 |
+| `ScrollX` / `ScrollY`             | Enable horizontal / vertical scrolling.                                |
+| `SizingFixedFit`                  | Columns default to `WidthFixed`, fit content.                          |
+| `SizingStretchProp`               | Columns default to `WidthStretch`, weights proportional.               |
+| `SizingStretchSame`               | Columns default to `WidthStretch`, equal weights.                      |
+| `PadOuterX` / `NoPadInnerX`       | Padding tweaks.                                                        |
+
+Selected `ImGuiTableColumnFlags`:
+
+| Flag                             | Meaning                                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------------------- |
+| `WidthStretch`                   | Column shares leftover width with other stretch columns, proportional to the init weight.   |
+| `WidthFixed`                     | Column is a fixed pixel width (initial value from `TableSetupColumn`, then user-resizable). |
+| `WidthAuto`                      | Column auto-fits to its content (no user resizing).                                         |
+| `AutoResizeToFit`                | Column resizes to fit content each frame.                                                   |
+| `NoResize`                       | Disable user resizing of this column.                                                       |
+| `NoReorder`                      | Pin column position.                                                                        |
+| `NoHide`                         | Disable user hiding via the header context menu.                                            |
+| `NoClip`                         | Disable clipping of cells against the column edge.                                          |
+| `NoSort` / `Sort*`               | Disable sorting, or force descending/ascending default.                                     |
+| `IndentEnable` / `IndentDisable` | Apply or skip the window indent for cells in this column (default: column 0 indents).       |
+| `DefaultHide`                    | Column starts hidden until toggled by user.                                                 |
+
+The Tables API is what makes Dear ImGui competitive for **structured data UIs** -- log
+viewers, asset browsers, profilers, entity inspectors -- and is the most significant
+single feature added since the library's creation.
+
+### Other layout helpers worth knowing
+
+A handful of additional functions round out the cursor model and come up frequently in
+real-world Dear ImGui code:
+
+- **`ImGui::GetCursorPos()` / `SetCursorPos(ImVec2)`** -- read or write the layout
+  cursor's window-local position. Useful for "draw this widget exactly here" overrides;
+  use sparingly, since manually positioning widgets breaks the implicit flow and makes
+  layouts fragile to font/scale changes.
+- **`ImGui::GetCursorScreenPos()` / `SetCursorScreenPos(ImVec2)`** -- the same but in
+  absolute screen coordinates. Required when bridging to the draw-list API
+  (`ImGui::GetWindowDrawList()->AddLine(...)`) which works in screen space.
+- **`ImGui::AlignTextToFramePadding()`** -- shifts the cursor down by `FramePadding.y`
+  so that a `Text` call sits on the same baseline as the framed widget (`Button`,
+  `InputText`) on the same `SameLine` row. Essential for getting "label: [input]" rows
+  visually aligned.
+- **`ImGui::BeginGroup()` / `EndGroup()`** -- treat a sequence of widgets as a single
+  layout item. `IsItemHovered()` after `EndGroup` reports hover over any of the
+  contained items, and `SameLine` after the group treats the group as one block.
+- **`ImGui::PushID(id)` / `PopID()`** -- pushes onto the ID stack so two widgets with
+  the same label inside two different scopes (e.g. one row per item in a list, all
+  containing a "Delete" button) don't collide. The library uses label text as the
+  default ID; the ID stack disambiguates duplicates.
+
+### Sample skeleton: a full frame
+
+Putting the pieces together, a typical Dear ImGui main loop looks like:
+
+```cpp
+void render_ui(AppState& app)
+{
+    // ---- Inspector window with two widgets per row ----
+    ImGui::Begin("Inspector");
+
+    ImGui::Text("Camera");
+    ImGui::PushItemWidth(120.0f);
+    ImGui::SliderFloat("Fov",    &app.camera.fov,    20.0f, 120.0f);
+    ImGui::SameLine();
+    ImGui::SliderFloat("Near",   &app.camera.znear,   0.01f, 10.0f);
+    ImGui::SameLine();
+    ImGui::SliderFloat("Far",    &app.camera.zfar,    10.0f, 5000.0f);
+    ImGui::PopItemWidth();
+
+    ImGui::Separator();
+    ImGui::Spacing();
+
+    ImGui::Checkbox("Wireframe", &app.wireframe);
+    ImGui::SameLine();
+    ImGui::Checkbox("VSync",     &app.vsync);
+
+    ImGui::End();
+
+    // ---- Log child inside a second window ----
+    ImGui::Begin("Logs");
+    {
+        ImGui::BeginChild("##logregion",
+                          ImVec2(0, -ImGui::GetFrameHeightWithSpacing()),
+                          ImGuiChildFlags_Borders);
+        for (const auto& line : app.log)
+            ImGui::TextUnformatted(line.c_str());
+        if (app.log_autoscroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY())
+            ImGui::SetScrollHereY(1.0f);
+        ImGui::EndChild();
+
+        ImGui::Checkbox("Auto-scroll", &app.log_autoscroll);
+        ImGui::SameLine();
+        if (ImGui::Button("Clear")) app.log.clear();
+    }
+    ImGui::End();
+}
+```
+
+Each frame, your main loop calls `ImGui::NewFrame()`, then `render_ui(app)`, then
+`ImGui::Render()`, and finally hands the resulting draw data to your renderer backend.
+The application state is just a plain struct that the UI reads and writes directly.
+
+---
+
+### Example: a per-row action button list
+
+A pattern that exercises `PushID`, `SameLine`, and selectable rows -- the classic
+"list of items, each with inline action buttons" UI:
+
+```cpp
+void render_task_list(std::vector<Task>& tasks)
+{
+    if (ImGui::BeginTable("tasks", 3,
+            ImGuiTableFlags_RowBg |
+            ImGuiTableFlags_BordersInnerH |
+            ImGuiTableFlags_SizingFixedFit))
+    {
+        ImGui::TableSetupColumn("Done", ImGuiTableColumnFlags_WidthFixed,   48.0f);
+        ImGui::TableSetupColumn("Title", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("",      ImGuiTableColumnFlags_WidthFixed, 120.0f);
+        ImGui::TableHeadersRow();
+
+        for (size_t i = 0; i < tasks.size(); ++i)
+        {
+            ImGui::PushID(static_cast<int>(i));
+            ImGui::TableNextRow();
+
+            ImGui::TableSetColumnIndex(0);
+            ImGui::Checkbox("##done", &tasks[i].done);
+
+            ImGui::TableSetColumnIndex(1);
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextUnformatted(tasks[i].title.c_str());
+
+            ImGui::TableSetColumnIndex(2);
+            if (ImGui::SmallButton("Edit"))   begin_edit(tasks[i]);
+            ImGui::SameLine();
+            if (ImGui::SmallButton("Delete")) tasks.erase(tasks.begin() + i);
+
+            ImGui::PopID();
+        }
+        ImGui::EndTable();
+    }
+}
+```
+
+Note the use of `PushID(i)` so the two `"##done"` checkboxes (and the two `"Edit"`
+buttons) in different rows are treated as distinct widgets. Without it, Dear ImGui's
+internal ID hashing would collapse them to the same control and clicking any row's
+"Delete" would activate the first row.
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **The two-line slider.** The central advantage of immediate-mode GUI is the
+  cost-per-control: adding "one more float to tweak" is one function call, end of story.
+  For tooling, debug overlays, profilers, and engine-side inspectors, this productivity
+  edge is unmatched. Retained-mode frameworks cannot beat it because their model
+  requires a widget object plus state-sync plumbing for every control.
+- **No framework lock-in.** Dear ImGui does not own the event loop, the window, the
+  renderer, the input source, or the state. It plugs into any host -- a custom engine, a
+  Vulkan sample, a Unity inspector overlay, a terminal renderer (see
+  [`imtui`](../tui-libraries/imtui.md)) -- with a small backend file.
+- **C++ but C-ABI friendly.** The public API is essentially a free-function namespace
+  with POD parameters and pointers. Bindings exist in dozens of languages (Rust via
+  `imgui-rs`, Python via `pyimgui`, D via `bindbc-imgui`, Go, C#, Lua, Zig, ...).
+- **Single-context, single-thread simplicity.** One `ImGuiContext`, called from one
+  thread per frame. No reactive graph, no virtual DOM, no scheduler. Trivial to reason
+  about.
+- **Stable API across a decade.** Code from 2015 still mostly works in 2025. Deprecated
+  functions usually keep working with warnings for years.
+- **The Tables API is competitive with retained-mode tables.** Modern Tables (since
+  1.80) cover the use cases that retained-mode UI tables traditionally win on --
+  sorting, resizing, freezing, scrolling, custom cells. The mental cost of a Dear ImGui
+  table is comparable to a HTML table but with full live-state behaviour.
+- **Docking and multi-viewport.** Editor-style "drag a panel out into its own OS
+  window" is supported natively.
+- **Renderer-agnostic draw output.** The library emits a list of vertex/index/command
+  buffers; the application's renderer is in full control of how to display them.
+- **Industry-tested at scale.** Used in shipping AAA-game tools, NVIDIA's developer
+  tools, robotics simulators, scientific viewers, and countless indie projects. Years
+  of real-world abuse have shaken out the edge cases.
+
+### Weaknesses
+
+- **Cursor-based layout fights responsive design.** The flow model is paragraph-style,
+  not constraint-based. Building a UI that genuinely adapts to width changes (a panel
+  that switches between one-column and two-column layouts at a breakpoint, or a control
+  bar that wraps when narrow) takes manual `GetContentRegionAvail` queries and explicit
+  branching. There is no flexbox, no constraint solver, no `Stretch` / `Fill`
+  primitive other than `WidthStretch` columns inside tables.
+- **No semantic state model.** Because state lives in the application, Dear ImGui has
+  no built-in answer to "undo / redo across UI edits", "two-way binding to a backing
+  store", or "form validation". Applications either grow their own machinery or accept
+  that the UI is direct manipulation of live state.
+- **Performance scales linearly with widget count per frame.** Each visible widget is
+  re-issued every frame. For UIs with thousands of widgets (deep tree views with many
+  expanded nodes, very long lists) you must use **list clippers**
+  (`ImGuiListClipper`) to skip off-screen items, or your frame rate dies. Tables and
+  scrolling regions already do this for you; trees and custom widgets do not.
+- **No accessibility story.** Dear ImGui draws pixels (or terminal cells, in
+  [`imtui`](../tui-libraries/imtui.md)'s case). Screen readers, AT-SPI, and platform
+  accessibility APIs see nothing. This is a fundamental consequence of immediate-mode
+  rendering and a hard reason not to ship Dear ImGui in consumer end-user UIs.
+- **Mediocre i18n.** Right-to-left scripts, complex shaping (Arabic, Indic), and
+  bidirectional text are not first-class. The font atlas system supports any glyphs you
+  bake in but the layout itself is left-to-right paragraph flow.
+- **Immediate-mode is not output-driven.** The mental model of Dear ImGui is
+  **frame-driven**: every frame is one-shot, full re-issue. This is fine for a
+  60-Hz-driven application but is a poor fit for **static, one-shot terminal output**
+  where you want to print a snapshot and stop. Frameworks like
+  [`ratatui`](../tui-libraries/ratatui.md) (immediate-mode rendering, but also
+  frame-driven) share this property; truly static "print a styled report and exit" use
+  cases are not what immediate-mode GUI tools are designed for. (Sparkles itself targets
+  this static-output niche, which is conceptually orthogonal to Dear ImGui's frame
+  loop.)
+- **`Columns()` legacy.** The old columns API is still present and visible in old
+  tutorials, which can mislead newcomers. Use Tables for new code.
+
+### Comparison to neighbours in this catalogue
+
+- vs **[`imtui`](../tui-libraries/imtui.md)** -- imtui is **literally Dear ImGui ported
+  to the terminal**. It reuses Dear ImGui's API, layout cursor, widgets, and tables
+  almost unchanged, with a custom backend that rasterises into a character grid instead
+  of triangles. The strengths and weaknesses analysis above carries over essentially
+  verbatim; the only difference is that imtui's draw target is terminal cells.
+- vs **[`ratatui`](../tui-libraries/ratatui.md)** -- both are immediate-mode in the
+  re-render-every-frame sense, but ratatui's layout system is **constraint-based**
+  (Cassowary, via the `kasuari` crate). Where Dear ImGui has a moving cursor and
+  `SameLine`, ratatui has a `Layout` that subdivides a `Rect` according to a list of
+  `Constraint`s. Ratatui is therefore far better at responsive resizing; Dear ImGui is
+  far better at the two-line slider ergonomic.
+- vs **[`ink`](../tui-libraries/ink.md)** -- Ink uses a real flexbox layout engine
+  (Yoga) and a retained virtual-DOM model. It is the opposite end of the spectrum from
+  Dear ImGui on essentially every axis: retained vs immediate, declarative React-style
+  components vs imperative function calls, flexbox vs cursor-flow.
+- vs **Android's ConstraintLayout** ([`android-constraintlayout.md`](./android-constraintlayout.md))
+  -- ConstraintLayout is a Cassowary-family solver doing whole-graph constraint
+  resolution; Dear ImGui is a moving caret. Different problems, different tools. The
+  comparison is most useful as a reminder that "immediate-mode" addresses
+  **interaction ergonomics** (state ownership, call-site brevity), while "constraint
+  layout" addresses **spatial reasoning** (declaring relationships between things). A
+  hypothetical library could have one without the other in either direction.
+
+---
+
+## References
+
+- **GitHub repository** -- <https://github.com/ocornut/imgui>
+- **Wiki landing page** -- <https://github.com/ocornut/imgui/wiki>
+- **FAQ** -- <https://github.com/ocornut/imgui/blob/master/docs/FAQ.md>
+- **Tables API documentation** -- <https://github.com/ocornut/imgui/wiki/Tables-API>
+  (and the main tracking issue [#3740](https://github.com/ocornut/imgui/issues/3740))
+- **Examples and backends** -- <https://github.com/ocornut/imgui/tree/master/examples>
+- **`imgui.h` (public API)** -- <https://github.com/ocornut/imgui/blob/master/imgui.h>
+- **`imgui_demo.cpp` (canonical example of every feature)** --
+  <https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp>
+- **Background reading on immediate-mode GUIs** -- Casey Muratori's "Immediate-Mode
+  Graphical User Interfaces" talk, archived at <https://caseymuratori.com/blog_0001>
+- **Selected ports and bindings:**
+  - `imtui` (terminal port): <https://github.com/ggerganov/imtui> -- see
+    [`../tui-libraries/imtui.md`](../tui-libraries/imtui.md)
+  - `imgui-rs` (Rust): <https://github.com/imgui-rs/imgui-rs>
+  - `pyimgui` (Python): <https://github.com/pyimgui/pyimgui>
+  - `cimgui` (auto-generated C API used by most bindings):
+    <https://github.com/cimgui/cimgui>
+- **Industry adoption examples** -- the [Dear ImGui Gallery](https://github.com/ocornut/imgui/issues?q=label%3Agallery)
+  issues showcase shipping tools using the library.

--- a/docs/research/ui-layout/egui.md
+++ b/docs/research/ui-layout/egui.md
@@ -1,0 +1,640 @@
+# egui (Rust)
+
+A pure-Rust immediate-mode GUI library that combines the simplicity of Dear ImGui's
+single-pass rendering with per-id retained sizing memory, so application code stays
+stateless while the layout system still produces stable, well-sized widgets after the
+second frame.
+
+| Field            | Value                                                |
+| ---------------- | ---------------------------------------------------- |
+| Language         | Rust                                                 |
+| License          | MIT OR Apache-2.0                                    |
+| Repository       | <https://github.com/emilk/egui>                      |
+| Documentation    | <https://docs.rs/egui/latest/egui/>                  |
+| Version snapshot | 0.34.x release line (2026)                           |
+| Author           | Emil Ernerfeldt ([@emilk](https://github.com/emilk)) |
+
+---
+
+## Overview
+
+egui (pronounced "e-gooey", originally spelled `Emigui`) is an immediate-mode GUI
+library written in pure Rust. It targets three deployment modes from the same source:
+WebAssembly in the browser, native desktop on Windows/macOS/Linux/Android, and
+embedded inside game engines (Bevy, Macroquad, custom renderers). The official
+windowing/integration crate is `eframe`, which wraps `winit` + `wgpu` (or `glow`) and
+hides platform setup behind a single `App` trait.
+
+**What it solves.** Most retained-mode GUI toolkits force you to mirror application
+state into a widget tree, keep it in sync with reactive callbacks, and reason about
+ownership across UI and domain layers. egui collapses that mirror: every frame, the
+application walks a single function and emits the entire UI top-to-bottom from
+current state. There is no scene graph to mutate, no widget identity to track, no
+diffing reconciler. The trade-off is that some layout decisions that retained-mode
+toolkits make once (during measure/arrange) must be made every frame here — and
+sometimes, with information that is only available _after_ the first frame has
+already been drawn.
+
+**Design philosophy.** The README states egui "aims to be the easiest-to-use Rust
+GUI library, and the simplest way to make a web app in Rust." That goal drives three
+concrete choices: (1) no callbacks — interaction is observed by inspecting the
+`Response` returned from widget calls in the same frame; (2) no manual memory
+management of widget identity — `Ui::push_id` and stable source locations form an
+implicit id stack; (3) no asynchronous redraw triggers — the application requests
+repaints explicitly via `ctx.request_repaint()`, and otherwise egui is content to
+sleep until input arrives.
+
+**History.** Emil Ernerfeldt started the project around 2019 as `Emigui` and renamed
+it to `egui` in 2020. It rapidly attracted contributors after the WebAssembly demo
+went viral on Rust forums. The project is now sponsored and partially staffed by
+[Rerun.io](https://rerun.io), a data-visualization startup whose flagship product —
+the Rerun Viewer — is the most ambitious application built on egui to date. Other
+notable users include game-development tools, blockchain explorers, scientific
+visualisation prototypes, and a long tail of internal tooling that benefits from
+shipping the same UI to a browser and a native binary.
+
+**Where it sits on the paradigm spectrum.** egui is firmly in the **immediate-mode**
+camp alongside [Dear ImGui](dear-imgui.md), but it differs from classical ImGui in
+important ways: it is _Rust-native_ (no FFI, no `unsafe` in user code), it owns its
+own font rasterisation and tessellation pipeline (no platform-specific text
+rendering), and it persists certain pieces of per-widget state across frames in an
+internal `Memory` store keyed on `Id`. That last point is what produces egui's
+characteristic "first frame the size is wrong, second frame it's right" behaviour —
+discussed in detail under [Layout Model](#layout-model).
+
+Conceptually, egui is the **opposite** of retained-mode toolkits like GTK, Qt, or
+Flutter, and it is _closer to but not identical to_ Dear ImGui. Inside the broader
+UI-layout catalog, the most analogous TUI design is [nottui](../tui-libraries/nottui.md),
+which uses an immediate-mode declarative API for terminals; the spiritually
+opposite design is [Textual](../tui-libraries/textual.md)'s reactive
+component tree.
+
+---
+
+## Layout Model
+
+### Immediate-mode with per-id retained memory
+
+The fundamental rendering primitive is the `Ui`. A `Ui` represents a rectangular
+region with a current cursor and a `Layout` (direction + alignment policy). The
+application receives a top-level `Ui` from a panel or window, and recursively
+nests child `Ui`s via `ui.horizontal(...)`, `ui.vertical(...)`, `ui.scope(...)`,
+and friends. Each widget call advances the cursor by the widget's _measured_ size
+and returns a `Response`.
+
+Crucially, while the layout pass is _single-pass_ (no separate measure/arrange
+phases), egui retains a small piece of state per widget: the widget's `Id` (derived
+from its source location and an id stack) maps into `Memory` to recall the size the
+widget had on the _previous_ frame. This lets containers that would otherwise need
+to know their children's sizes in advance (e.g., `Grid` aligning columns, `Window`
+auto-shrinking to fit content, `CollapsingHeader` animating open) "remember" the
+right size and use it as a hint _this_ frame.
+
+The consequence is the canonical egui quirk:
+
+> The first frame the size is wrong, the second frame it's right.
+
+Concretely: a `Grid` with two columns must lay out cell 0 before it knows the width
+of cell 0; it must lay out cell 1 before it knows whether cell 0 in row 2 is wider.
+On frame 1, egui guesses (using a small default or zero), draws the grid, _records_
+the maximum width each column actually used, and on frame 2 uses those recorded
+widths as hints. The result is a single-frame flicker on initial display and after
+any structural change. The library mitigates this in two ways:
+
+1. **`Context::request_discard()`** — a widget that knows its first-frame layout is
+   wrong can request that egui discard the painted output and immediately re-run
+   the UI function with the now-correct sizing memory. The user sees only the
+   corrected frame. `Grid` uses this internally for its first measurement pass.
+
+2. **Double-pass rendering opt-in** — applications that prefer to pay the cost
+   unconditionally can configure egui to always run two passes per frame, treating
+   the first as a measurement pass whose output is discarded.
+
+This is the architectural compromise that distinguishes egui from Dear ImGui:
+Dear ImGui also retains some per-id state (open/closed flags, scroll offsets,
+window positions) but does _not_ retain per-widget sizing, which is why ImGui is
+sometimes criticised for layout fragility in complex containers like its table API.
+
+### The Ui API
+
+A `Ui` is the main interaction surface. Selected methods from the public API:
+
+| Method                                | Effect                                                  |
+| ------------------------------------- | ------------------------------------------------------- |
+| `ui.horizontal(\|ui\| { ... })`       | Lay out children left-to-right.                         |
+| `ui.vertical(\|ui\| { ... })`         | Lay out children top-to-bottom.                         |
+| `ui.horizontal_wrapped(\|ui\| ...)`   | Like `horizontal`, wrapping to next line on overflow.   |
+| `ui.columns(n, \|cols\| { ... })`     | Split current space into `n` equal columns.             |
+| `ui.scope(\|ui\| { ... })`            | Run a closure with temporary style/spacing changes.     |
+| `ui.group(\|ui\| { ... })`            | Visually frame a sub-region with a stroke.              |
+| `ui.allocate_space(size)`             | Reserve a rectangle of exactly `size`, return its rect. |
+| `ui.allocate_exact_size(size, sense)` | Reserve exact size + return a `Response` for hit-test.  |
+| `ui.allocate_at_least(size, sense)`   | Reserve at least `size`; may grow.                      |
+| `ui.allocate_ui_with_layout(...)`     | Allocate a size and run a closure with a custom layout. |
+| `ui.available_size()`                 | Remaining size before the cursor hits the edge.         |
+| `ui.set_min_size(size)` / `set_max_*` | Constrain the `Ui`'s reported size.                     |
+
+Every widget call returns a `Response`, which is the _only_ mechanism for handling
+interaction. There are no event callbacks. A `Response` carries:
+
+- `clicked()`, `double_clicked()`, `secondary_clicked()`, `triple_clicked()`
+- `hovered()`, `has_focus()`, `gained_focus()`, `lost_focus()`
+- `dragged()`, `drag_started()`, `drag_stopped()`, `drag_delta()`
+- `rect`, `interact_rect`, `sense`, `id`
+- `changed()` — for input widgets (text edit, slider, drag value)
+
+The `Response` model means hit-testing is intrinsically coupled to layout: a widget
+_is_ at a known rectangle on this frame, so the click test is `if response.rect
+.contains(pointer_pos) && pointer_pressed { ... }`. Because every widget is
+drawn-and-tested in one shot, there is no separate event-routing tree.
+
+### The Layout struct
+
+`Layout` describes how children are arranged inside a `Ui`. It is constructed via
+named factories and modifier methods:
+
+```rust
+use egui::{Align, Layout};
+
+// Top-to-bottom, left-aligned (default for vertical panels).
+let l = Layout::top_down(Align::LEFT);
+
+// Left-to-right, vertically centered (default for horizontal rows).
+let l = Layout::left_to_right(Align::Center);
+
+// Right-to-left, useful for trailing action buttons.
+let l = Layout::right_to_left(Align::Center);
+
+// With wrap and justification:
+let l = Layout::top_down(Align::LEFT)
+    .with_main_align(Align::Center)
+    .with_cross_align(Align::Min)
+    .with_main_wrap(true)
+    .with_main_justify(true);
+```
+
+The two axes are:
+
+- **Main axis** — the direction children are stacked (vertical for `top_down`,
+  horizontal for `left_to_right`).
+- **Cross axis** — perpendicular to main; controls how a child is aligned within
+  its allotted band.
+
+Modifiers:
+
+| Modifier                 | Effect                                                                      |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `.with_main_align(a)`    | Where children sit along the main axis (Min/Center/Max).                    |
+| `.with_cross_align(a)`   | Where each child sits in its cross-axis band.                               |
+| `.with_main_wrap(b)`     | If `true`, children that overflow wrap to a new line/column.                |
+| `.with_main_justify(b)`  | If `true`, stretch the _first_ widget per row to fill remaining main-space. |
+| `.with_cross_justify(b)` | Stretch each child to fill the full cross-axis extent of the `Ui`.          |
+
+The combinatorics are deliberate: rather than a Flexbox-style enum
+(`justify-content: space-between` etc.), egui composes alignment + justification +
+wrap as orthogonal toggles on top of a direction. This produces fewer named
+options but cleaner semantics — every combination is meaningful.
+
+### Panels and containers
+
+The top-level layout primitives are **panels**, which subtract their region from a
+remaining `CentralPanel`:
+
+| Panel                    | Position                       | Notes                                             |
+| ------------------------ | ------------------------------ | ------------------------------------------------- |
+| `SidePanel::left`        | Anchored to left edge          | Resizable handle on right side.                   |
+| `SidePanel::right`       | Anchored to right edge         | Resizable handle on left side.                    |
+| `TopBottomPanel::top`    | Anchored to top edge           | Used for menu bars, toolbars.                     |
+| `TopBottomPanel::bottom` | Anchored to bottom edge        | Used for status bars, footers.                    |
+| `CentralPanel`           | Fills remaining space          | Must be added last; absorbs leftover area.        |
+| `Window`                 | Floating, draggable, resizable | Lives in its own pseudo-z-layer.                  |
+| `Area`                   | Free-positioned region         | Low-level primitive; `Window` is built on `Area`. |
+
+The canonical "shell" of an egui app is exactly this stack of panels:
+
+```rust
+egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
+    egui::menu::bar(ui, |ui| {
+        ui.menu_button("File", |ui| {
+            if ui.button("Open").clicked() { /* ... */ }
+            if ui.button("Quit").clicked() { /* ... */ }
+        });
+    });
+});
+
+egui::SidePanel::left("sidebar")
+    .default_width(200.0)
+    .resizable(true)
+    .show(ctx, |ui| {
+        ui.heading("Files");
+        for file in &app.files {
+            ui.selectable_label(app.selected == Some(file.id), &file.name);
+        }
+    });
+
+egui::TopBottomPanel::bottom("status").show(ctx, |ui| {
+    ui.label(&app.status_text);
+});
+
+egui::CentralPanel::default().show(ctx, |ui| {
+    ui.heading("Content");
+    // ... main content area ...
+});
+```
+
+`Grid` is a 2-D table primitive that aligns columns _across rows_:
+
+```rust
+egui::Grid::new("settings_grid")
+    .striped(true)
+    .num_columns(2)
+    .spacing([12.0, 4.0])
+    .show(ui, |ui| {
+        ui.label("Name");
+        ui.text_edit_singleline(&mut app.name);
+        ui.end_row();
+
+        ui.label("Threads");
+        ui.add(egui::Slider::new(&mut app.threads, 1..=32));
+        ui.end_row();
+
+        ui.label("Enabled");
+        ui.checkbox(&mut app.enabled, "");
+        ui.end_row();
+    });
+```
+
+This is where the "first frame is wrong" effect is most visible: the second column
+cannot know its width until row 1 is drawn, but row 0 has already been drawn
+before row 1 exists. `Grid` resolves this by storing each column's maximum
+observed width in `Memory` (keyed on the grid id `"settings_grid"`) and reusing it
+next frame. On the very first frame, columns appear at their natural widths;
+starting frame 2, they are aligned. Apps that cannot tolerate the flicker enable
+`Context::request_discard()` to force a second pass before the user sees anything.
+
+`ScrollArea` is a container that clips its child to a fixed viewport and exposes
+scrollbars:
+
+```rust
+egui::ScrollArea::vertical()
+    .max_height(300.0)
+    .auto_shrink([false, false])
+    .show(ui, |ui| {
+        for line in &app.log_lines {
+            ui.monospace(line);
+        }
+    });
+```
+
+The `auto_shrink` axis flags are important: by default a `ScrollArea` shrinks to
+fit its content (which is usually wrong inside a panel), so most real applications
+pass `[false, false]`. `CollapsingHeader` is the "twisty" disclosure widget:
+
+```rust
+egui::CollapsingHeader::new("Advanced options")
+    .default_open(false)
+    .show(ui, |ui| {
+        ui.checkbox(&mut app.use_simd, "Use SIMD");
+        ui.checkbox(&mut app.profile, "Enable profiler");
+    });
+```
+
+Its open/closed state is stored in `Memory` under the header's `Id`, surviving
+across frames without any application-level state.
+
+### Size hints: `desired_size`, `available_size`, allocation
+
+Widgets and containers communicate sizing through three channels:
+
+1. **`desired_size`** — what the widget _wants_ in an unconstrained world.
+   Computed by the widget from its content (e.g., `Label::desired_size` measures
+   the text). The `Widget` trait does not expose this directly; instead, the
+   widget calls `ui.allocate_*` with its desired size and the parent decides what
+   to grant.
+
+2. **`available_size`** — what the parent `Ui` has _left_. Returned by
+   `ui.available_size()`. Widgets that should stretch (text inputs, drag areas,
+   custom canvases) typically allocate exactly this.
+
+3. **Allocation API** — three flavors:
+
+   ```rust
+   // Reserve exactly `size`. Always returns a rect of that exact size.
+   let rect = ui.allocate_space(vec2(100.0, 24.0));
+
+   // Same as above but also returns a Response for interaction.
+   let (rect, response) = ui.allocate_exact_size(
+       vec2(100.0, 24.0),
+       egui::Sense::click(),
+   );
+
+   // Reserve at least `size`. Parent may grant more (e.g., to fill remaining
+   // space when using cross_justify).
+   let (rect, response) = ui.allocate_at_least(
+       vec2(100.0, 24.0),
+       egui::Sense::drag(),
+   );
+   ```
+
+   `allocate_ui_with_layout` is the heavy-weight escape hatch:
+
+   ```rust
+   ui.allocate_ui_with_layout(
+       vec2(ui.available_width(), 200.0),
+       Layout::right_to_left(Align::Center),
+       |ui| {
+           if ui.button("Cancel").clicked() { /* ... */ }
+           if ui.button("OK").clicked() { /* ... */ }
+       },
+   );
+   ```
+
+   This is the standard pattern for trailing action buttons: allocate a slab of
+   space, install a right-to-left layout, and put your "primary" button first.
+
+### Full layout example
+
+A small but complete egui application that exercises the panel stack, a resizable
+`SidePanel`, a `Grid`, a `ScrollArea`, and `Window`:
+
+```rust
+use eframe::egui;
+use egui::{Align, Layout, Vec2};
+
+struct DemoApp {
+    files: Vec<String>,
+    selected: Option<usize>,
+    detail_text: String,
+    log_lines: Vec<String>,
+    show_about: bool,
+}
+
+impl Default for DemoApp {
+    fn default() -> Self {
+        Self {
+            files: (0..40).map(|i| format!("file_{i:02}.txt")).collect(),
+            selected: None,
+            detail_text: String::new(),
+            log_lines: (0..200).map(|i| format!("log line {i}")).collect(),
+            show_about: false,
+        }
+    }
+}
+
+impl eframe::App for DemoApp {
+    fn update(&mut self, ctx: &egui::Context, _: &mut eframe::Frame) {
+        // Menu bar at the top.
+        egui::TopBottomPanel::top("menu_bar").show(ctx, |ui| {
+            egui::menu::bar(ui, |ui| {
+                ui.menu_button("File", |ui| {
+                    if ui.button("Quit").clicked() {
+                        ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
+                });
+                ui.menu_button("Help", |ui| {
+                    if ui.button("About...").clicked() {
+                        self.show_about = true;
+                        ui.close_menu();
+                    }
+                });
+            });
+        });
+
+        // Resizable file list on the left.
+        egui::SidePanel::left("file_list")
+            .default_width(180.0)
+            .min_width(120.0)
+            .resizable(true)
+            .show(ctx, |ui| {
+                ui.heading("Files");
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false; 2])
+                    .show(ui, |ui| {
+                        for (i, name) in self.files.iter().enumerate() {
+                            let resp = ui.selectable_label(
+                                self.selected == Some(i),
+                                name,
+                            );
+                            if resp.clicked() {
+                                self.selected = Some(i);
+                                self.detail_text = format!("Contents of {name}");
+                            }
+                        }
+                    });
+            });
+
+        // Status bar.
+        egui::TopBottomPanel::bottom("status").show(ctx, |ui| {
+            ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
+                ui.label(format!(
+                    "{} files | selection: {}",
+                    self.files.len(),
+                    self.selected
+                        .map(|i| self.files[i].as_str())
+                        .unwrap_or("(none)"),
+                ));
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    ui.hyperlink_to("egui docs", "https://docs.rs/egui");
+                });
+            });
+        });
+
+        // Main content area.
+        egui::CentralPanel::default().show(ctx, |ui| {
+            // A two-column grid showing metadata.
+            egui::Grid::new("meta_grid")
+                .striped(true)
+                .num_columns(2)
+                .spacing([16.0, 4.0])
+                .show(ui, |ui| {
+                    ui.label("Selection:");
+                    ui.monospace(
+                        self.selected
+                            .map(|i| self.files[i].as_str())
+                            .unwrap_or("-"),
+                    );
+                    ui.end_row();
+
+                    ui.label("Detail length:");
+                    ui.label(format!("{} chars", self.detail_text.len()));
+                    ui.end_row();
+                });
+
+            ui.separator();
+
+            // Scrollable text region.
+            egui::ScrollArea::vertical()
+                .auto_shrink([false; 2])
+                .show(ui, |ui| {
+                    ui.add(
+                        egui::TextEdit::multiline(&mut self.detail_text)
+                            .desired_width(f32::INFINITY)
+                            .desired_rows(10),
+                    );
+                    ui.collapsing("Log", |ui| {
+                        for line in &self.log_lines {
+                            ui.monospace(line);
+                        }
+                    });
+                });
+        });
+
+        // Floating "About" window, only shown when toggled.
+        if self.show_about {
+            egui::Window::new("About")
+                .collapsible(false)
+                .resizable(false)
+                .default_size(Vec2::new(280.0, 120.0))
+                .show(ctx, |ui| {
+                    ui.label("egui demo application.");
+                    ui.label("Built with eframe + egui.");
+                    if ui.button("Close").clicked() {
+                        self.show_about = false;
+                    }
+                });
+        }
+    }
+}
+
+fn main() -> eframe::Result<()> {
+    eframe::run_native(
+        "egui demo",
+        eframe::NativeOptions::default(),
+        Box::new(|_cc| Ok(Box::new(DemoApp::default()))),
+    )
+}
+```
+
+Three things to notice in this example:
+
+- The panel insertion order (`top`, `left`, `bottom`, `Central`) is _significant_:
+  each panel subtracts from the remaining region in registration order, so
+  `CentralPanel` must come last to absorb leftover space.
+
+- All interaction is observed through `Response::clicked()` immediately after the
+  widget call. There is no `on_click=` callback, no event bus.
+
+- The `Window` for "About" only exists when `self.show_about == true`. Because
+  egui uses retained `Memory` keyed on `Id`, the window's position and size persist
+  across show/hide cycles — re-opening the window restores it to where the user
+  last dragged it.
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Pure Rust, end-to-end.** No FFI to C++ or platform libraries. No `unsafe` in
+  user code. The font rasteriser (`epaint`), tessellator, and renderer back-ends
+  are all Rust crates. Distribution is trivial — a single `cargo build` produces
+  a self-contained binary, and `wasm-pack` produces a self-contained web app.
+
+- **Web target is a first-class citizen.** The same `App::update` runs in the
+  browser via WebAssembly with no platform-specific branches. This is unusual for
+  GUI libraries and is the main reason for egui's adoption in browser-first tools
+  (Rerun's web viewer, in-browser Rust playgrounds, etc.).
+
+- **No callbacks, no state synchronisation.** The application owns all state, and
+  the UI is a function of state. This removes the entire class of bugs where
+  retained widget state diverges from application state.
+
+- **Immediate-mode ergonomics for tools.** For developer tools, debug overlays,
+  level editors, and visualisation surfaces — workloads with hundreds of small
+  controls that change shape frequently — immediate-mode lets you prototype an
+  entire panel in twenty lines without naming any widgets.
+
+- **`Response` ties layout to interaction.** Because hit-testing happens at the
+  same point as drawing, there is exactly one place to look for "what does this
+  button do" — the line that called `ui.button(...)`.
+
+- **Sensible defaults with deep customisation.** Style, spacing, fonts, and visual
+  tokens are all configurable via `egui::Style` and `egui::Visuals`, but the
+  out-of-the-box appearance is usable without any tweaking.
+
+- **Excellent integration story.** `eframe` handles desktop + web. `bevy_egui`
+  embeds it in a Bevy game. `egui-wgpu` and `egui-glow` are reusable renderer
+  back-ends. The library makes no assumption about the host event loop.
+
+### Weaknesses
+
+- **First-frame flicker.** As discussed in [Layout Model](#layout-model), any
+  container that needs to know its children's sizes in advance produces a wrong
+  layout on frame 1. Mitigations exist (`request_discard`, double-pass mode), but
+  they cost a redundant layout pass and complicate the mental model.
+
+- **Re-runs the entire UI every frame.** For very large UIs (thousands of widgets),
+  this is wasteful. Retained-mode toolkits skip subtrees that have not changed;
+  egui does not. The library compensates by being fast (sub-millisecond UI
+  evaluation for typical panels) and by sleeping when input is idle, but apps with
+  pathologically large UI surfaces should partition them across panels/tabs.
+
+- **No accessibility tree, only AccessKit hooks.** AccessKit integration exists
+  and is improving, but screen-reader support is not yet on par with retained
+  toolkits whose every widget naturally has an identity.
+
+- **Custom widgets must allocate first, draw second.** The two-step pattern
+  (allocate a `Rect`, then paint into it) is correct but unfamiliar; new users
+  often try to paint and then ask "where did it go?".
+
+- **One-shot rendering is conceptually opposite to reactive systems.** Developers
+  coming from React, SwiftUI, or Flutter find the lack of declarative data binding
+  (`@State`, `@ObservedObject`, etc.) jarring. The application _is_ the binding.
+
+- **Floating windows are not real OS windows.** A `Window` is a movable region
+  inside a single OS surface, not a separate top-level window. Multi-window apps
+  are possible via `eframe`'s viewport API, but each viewport is its own egui
+  context with its own memory.
+
+- **Text shaping is approximate.** Complex scripts (Arabic, Indic, vertical CJK)
+  and OpenType features (ligatures, contextual alternates) are limited. egui uses
+  its own simple shaper rather than HarfBuzz.
+
+### Lessons for `sparkles`
+
+egui is unusual among the libraries in this catalog because it is a graphical
+GUI rather than a TUI — yet it is the closest cousin to several patterns already
+present in sparkles' core-cli:
+
+- **Immediate-mode + `@nogc` is a natural fit.** Like Ratatui's draw closure (see
+  [ratatui.md](../tui-libraries/ratatui.md)), egui's `update` function rebuilds
+  the entire UI from current state. In D this maps cleanly onto stack-allocated
+  widget structs with `@nogc` rendering paths.
+
+- **Per-id retained memory is a real win for TUI layouts too.** A `drawTable`
+  equivalent in sparkles could memo column widths from the previous frame keyed
+  on a stable id, eliminating the "first frame is misaligned, then it jumps" UX.
+
+- **`Response`-style return values pair well with UFCS chains.** A D equivalent
+  would let users write `ui.button("Save").clicked` as the conditional directly,
+  using the `Response` struct as an in-band signal rather than an event callback.
+
+- **The `Layout` modifier composition is cleaner than Flexbox enums.** Splitting
+  alignment / wrap / justify into orthogonal toggles produces fewer surprising
+  combinations than CSS's `justify-content` × `align-items` × `flex-wrap` matrix.
+
+---
+
+## References
+
+- **Project homepage:** <https://www.egui.rs> — interactive demo runs in the
+  browser via WebAssembly.
+- **GitHub repository:** <https://github.com/emilk/egui>
+- **API documentation:** <https://docs.rs/egui/latest/egui/>
+- **`eframe` crate:** <https://docs.rs/eframe/> — the official integration crate.
+- **Rerun viewer:** <https://github.com/rerun-io/rerun> — the largest production
+  application built on egui; a good source of advanced layout patterns.
+- **`Ui` API reference:** <https://docs.rs/egui/latest/egui/struct.Ui.html>
+- **`Layout` reference:** <https://docs.rs/egui/latest/egui/struct.Layout.html>
+- **`Response` reference:** <https://docs.rs/egui/latest/egui/response/struct.Response.html>
+- **`Grid` reference:** <https://docs.rs/egui/latest/egui/struct.Grid.html>
+- **`ScrollArea` reference:** <https://docs.rs/egui/latest/egui/containers/scroll_area/struct.ScrollArea.html>
+- **Related catalog entries:**
+  - [Dear ImGui](dear-imgui.md) — the canonical C++ immediate-mode GUI, egui's
+    closest paradigm cousin.
+  - [Ratatui (TUI)](../tui-libraries/ratatui.md) — the TUI equivalent design:
+    immediate-mode `draw` closure with a back-buffer diff.
+  - [nottui (TUI)](../tui-libraries/nottui.md) — declarative immediate-mode TUI
+    that shares egui's "function-as-UI" model.
+  - [Textual (TUI)](../tui-libraries/textual.md) — a counterpoint: reactive,
+    retained component tree.

--- a/docs/research/ui-layout/flutter.md
+++ b/docs/research/ui-layout/flutter.md
@@ -1,0 +1,987 @@
+# Flutter (Dart)
+
+Google's portable UI toolkit, built around a one-pass constraint-propagation layout
+protocol summarised by the slogan _"Constraints go down. Sizes go up. Parent sets
+position."_ A retained-mode widget tree compiles into an underlying render-object tree
+that performs all layout in a single recursive walk.
+
+| Field            | Value                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------- |
+| Language         | Dart                                                                                  |
+| License          | BSD-3-Clause                                                                          |
+| Repository       | <https://github.com/flutter/flutter>                                                  |
+| Documentation    | <https://docs.flutter.dev>                                                            |
+| Version snapshot | Flutter docs reflect 3.41.5 as of May 2026; 3.44 targeted the May 2026 release window |
+| First Release    | Sky / Flutter announced 2015; 1.0 in December 2018                                    |
+| Renderer         | Impeller (default since 3.10 / 2023); Skia legacy path                                |
+| Used By          | Google Pay, BMW iX app, Alibaba Xianyu, eBay Motors, Toyota IVI                       |
+
+---
+
+## Overview
+
+### What It Is
+
+Flutter is Google's cross-platform UI framework. It targets iOS, Android, web, Windows,
+macOS, Linux, and embedded devices from a single Dart codebase, rendering every pixel
+itself rather than wrapping native platform widgets. The layout system at the heart of
+Flutter is the focus of this document: a strict, deterministic, single-pass constraint
+protocol that decides where every widget sits and how big it is.
+
+### What It Solves
+
+Cross-platform UI frameworks historically had to choose between two unsatisfying
+options: wrap native widgets (and inherit their idiosyncrasies and platform drift), or
+draw everything custom and pay the cost of reinventing layout, accessibility,
+theming, and input. Flutter chose the second path and committed fully -- the framework
+ships with its own widget set, its own text shaping, its own scrolling physics, and its
+own layout algorithm.
+
+For layout specifically, Flutter solves a problem that web CSS, Auto Layout, and
+WPF/XAML all struggle with: making the layout algorithm _predictable_ and _bounded_ in
+time. CSS reflow is famously hard to reason about; Auto Layout solves a constraint
+system that can be slow or ambiguous; WPF performs two full passes. Flutter pins down
+exactly one rule: each render object is visited once, given constraints from its
+parent, returns a size, and the parent positions it. Everything else falls out of that.
+
+### Design Philosophy
+
+Flutter's layout philosophy can be expressed in three principles.
+
+1. **Single-pass layout.** A render object is laid out exactly once per frame. There is
+   no measure-then-arrange, no constraint solver, no reflow. The render tree is walked
+   top-down with constraints; sizes propagate back up; parents position children.
+
+2. **Constraints are passed by value.** A `BoxConstraints` value -- four doubles, plus
+   helpers -- is passed from parent to child. The child cannot ask its parent any
+   questions, cannot peek at siblings, and cannot know its own position. It just
+   receives constraints and returns a size that satisfies them.
+
+3. **Composition over inheritance.** Layout behaviour is _composed_ from small,
+   single-purpose widgets. `Padding` adds padding. `Center` centres. `SizedBox`
+   imposes a tight size. `Expanded` claims remaining flex space. A complex layout is a
+   tree of these primitives, not a single configurable container with many flags.
+
+### History
+
+- **2015 -- Sky.** Announced at the Dart Developer Summit as "Sky", an experiment in
+  running Dart UI at 120 Hz. The render-object layout protocol existed from the
+  earliest prototypes.
+- **2017 -- Flutter alpha.** Rebranded as Flutter; iOS/Android targets; `Material`
+  and `Cupertino` widget catalogues appeared.
+- **December 2018 -- Flutter 1.0.** First stable release.
+- **2021-2022 -- 2.0 / 3.0.** Stable web; stable macOS and Linux desktop.
+- **2023 -- Impeller default on iOS.** New renderer precompiles shaders to eliminate
+  jank, replacing the Skia backend.
+- **2024-2025 -- 3.16-3.27.** Impeller default on Android; finer-grained slivers.
+
+Production users include Google Pay, the BMW iX companion app, Alibaba's Xianyu
+marketplace, eBay Motors, and Toyota's IVI cockpit system.
+
+### Comparison to TUI Frameworks
+
+For terminal-UI comparators see [Ratatui](../tui-libraries/ratatui.md) and
+[Ink](../tui-libraries/ink.md). Ratatui uses an immediate-mode constraint solver
+(Cassowary via the `kasuari` crate) where the application explicitly splits a
+rectangle into sub-rectangles each frame; Ink uses Flexbox via Yoga. Flutter's
+constraint protocol is closer in spirit to Ratatui's "give me a rect" model than to
+Ink's CSS-style cascade -- but Flutter goes further by formalising the contract
+between every parent and every child as a typed value object.
+
+---
+
+## Layout Model
+
+### The Core Rule
+
+The Flutter layout system is summarised on a single page of the official docs by
+three sentences:
+
+> **Constraints go down. Sizes go up. Parent sets position.**
+
+Each phrase corresponds to a step of the layout algorithm.
+
+1. **Constraints go down.** A parent calls `child.layout(constraints,
+parentUsesSize: bool)`. The `constraints` argument is a `BoxConstraints` -- four
+   doubles, `minWidth`/`maxWidth`/`minHeight`/`maxHeight`. The child cannot peek at its
+   parent, siblings, or position. All it gets is the constraint envelope.
+
+2. **Sizes go up.** Inside `performLayout()`, the child first lays out its own children
+   (passing them whatever constraints it sees fit) and then sets `this.size` to a
+   `Size` value. The size _must_ satisfy the constraints passed in. If the child sets
+   a size outside the constraint envelope, Flutter throws in debug mode.
+
+3. **Parent sets position.** After all children return their sizes, the parent walks
+   them and assigns `child.parentData.offset` to position each one. Children never know
+   where they are; only the parent knows.
+
+This three-step protocol is _the entire layout algorithm_. Every Row, Column, Stack,
+Padding, Container, custom widget -- everything -- is implemented in terms of this
+contract.
+
+### BoxConstraints
+
+```dart
+class BoxConstraints {
+  const BoxConstraints({
+    this.minWidth = 0.0,
+    this.maxWidth = double.infinity,
+    this.minHeight = 0.0,
+    this.maxHeight = double.infinity,
+  });
+
+  // A constraint is "tight" if min == max on the relevant axis.
+  bool get hasTightWidth  => minWidth  >= maxWidth;
+  bool get hasTightHeight => minHeight >= maxHeight;
+  bool get isTight        => hasTightWidth && hasTightHeight;
+
+  // A constraint is "bounded" if max is finite.
+  bool get hasBoundedWidth  => maxWidth  < double.infinity;
+  bool get hasBoundedHeight => maxHeight < double.infinity;
+
+  // Helper constructors.
+  BoxConstraints.tight(Size size);
+  BoxConstraints.loose(Size size);
+  BoxConstraints.expand({double? width, double? height});
+  BoxConstraints.tightFor({double? width, double? height});
+  BoxConstraints.tightForFinite({double width = ..., double height = ...});
+}
+```
+
+The terminology matters. A widget receiving _tight_ constraints has its size fixed by
+the parent (`min == max`). A widget receiving _loose_ constraints has `min == 0` and
+some finite `max`. A widget receiving _unbounded_ constraints has `max == infinity` --
+this is what scrollables pass down on their scroll axis.
+
+Most layout bugs in Flutter applications come from confusing these three categories.
+"Why doesn't my `Container(width: 100)` show as 100 pixels?" -- because the parent
+imposed _tight_ constraints, and the child's `width` request is just a hint.
+
+### The RenderBox.layout Method
+
+Underneath the widget tree is a parallel _render tree_ of `RenderObject` instances.
+Box-protocol render objects extend `RenderBox`. The layout entry point is non-virtual:
+
+```dart
+// In RenderObject (simplified):
+void layout(Constraints constraints, {bool parentUsesSize = false}) {
+  // 1. Short-circuit if nothing changed and parent doesn't need our size.
+  if (!_needsLayout &&
+      constraints == _constraints &&
+      !parentUsesSize) {
+    return;
+  }
+  _constraints = constraints;
+  // 2. Delegate to subclass-specific layout.
+  performLayout();
+  _needsLayout = false;
+}
+```
+
+Subclasses override `performLayout()`:
+
+```dart
+class RenderPadding extends RenderShiftedBox {
+  @override
+  void performLayout() {
+    final BoxConstraints constraints = this.constraints;
+    if (child == null) {
+      size = constraints.constrain(Size(
+        _resolvedPadding!.horizontal,
+        _resolvedPadding!.vertical,
+      ));
+      return;
+    }
+    final BoxConstraints innerConstraints =
+        constraints.deflate(_resolvedPadding!);
+    child!.layout(innerConstraints, parentUsesSize: true);
+    final BoxParentData childParentData = child!.parentData! as BoxParentData;
+    childParentData.offset = Offset(
+      _resolvedPadding!.left,
+      _resolvedPadding!.top,
+    );
+    size = constraints.constrain(Size(
+      _resolvedPadding!.horizontal + child!.size.width,
+      _resolvedPadding!.vertical   + child!.size.height,
+    ));
+  }
+}
+```
+
+Three things to notice:
+
+1. `constraints.deflate(padding)` shrinks the constraints by the padding before passing
+   them down. The child sees a smaller envelope, not the same envelope plus a flag.
+2. `parentUsesSize: true` tells the layout system that this parent looks at the
+   child's size after the call. Flutter uses this flag for relayout-boundary
+   optimisations: if a child's size doesn't affect its parent, a relayout can stop at
+   the child.
+3. `size = constraints.constrain(...)` clamps the computed size back into the
+   parent's envelope. This is how Flutter guarantees every render object returns a
+   size that satisfies its constraints, even if the math says otherwise.
+
+### Relayout Boundaries
+
+A subtle but important optimisation: Flutter does not always walk the full tree on
+every layout pass. A `RenderObject` is a _relayout boundary_ if its size is fully
+determined by its constraints (i.e., the parent passed `parentUsesSize: false` _or_
+the constraints are tight). Inside a relayout boundary, marking a descendant dirty
+does not propagate the dirty flag up past the boundary -- the next layout pass starts
+at the boundary, not the root.
+
+This is what makes Flutter's "rebuild the whole UI on every frame" performance model
+work. The vast majority of the tree is sitting inside a relayout boundary that does
+not need to be revisited.
+
+### Intrinsics
+
+The constraint protocol has one major weakness: a child cannot ask its parent
+questions like "how wide will you let me be?" before deciding its own size. To support
+widgets that genuinely need this information -- e.g., a `Table` that wants its columns
+all to be the same width, or an `IntrinsicHeight` row where every child must match the
+tallest -- Flutter offers _intrinsic dimensions_.
+
+```dart
+abstract class RenderBox extends RenderObject {
+  double getMinIntrinsicWidth(double height);
+  double getMaxIntrinsicWidth(double height);
+  double getMinIntrinsicHeight(double width);
+  double getMaxIntrinsicHeight(double width);
+}
+```
+
+These methods ask: "If you had unlimited height, what is the smallest width you could
+reasonably take?" (and three variants thereof). They are computed _separately from
+layout_ and are conceptually free to recurse through the whole subtree.
+
+That recursion is exactly the problem. Computing `IntrinsicHeight` of a `Row` with N
+children traverses each child's subtree to ask for its intrinsic height. If one of
+those children is itself an `IntrinsicHeight` wrapping another `Row`, the cost
+explodes to O(N^2) or worse. The Flutter docs explicitly warn:
+
+> Intrinsic operations are relatively expensive, because they require performing
+> layout in a special mode... Avoid using them in performance-critical code.
+
+In practice, `IntrinsicWidth`/`IntrinsicHeight` are useful for forms and small
+toolbars where you genuinely need every child to match. They are catastrophic inside
+`ListView` or `Column`s with hundreds of children.
+
+### Tight vs Loose vs Unbounded: The Three Worlds
+
+A widget's behaviour depends fundamentally on which category of constraints it
+receives:
+
+| Category      | Definition                             | Typical Parent                                                                                                        | Child Behaviour                            |
+| ------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| **Tight**     | `min == max` on both axes              | screen, `SizedBox`, `Expanded`                                                                                        | Size is dictated; `width:` is ignored      |
+| **Loose**     | `min == 0`, `max` finite               | `Center`, `Align`, `Padding`                                                                                          | Free within envelope; child decides        |
+| **Unbounded** | `max == infinity` on at least one axis | `ListView`, `SingleChildScrollView`, `Column` (cross-axis is fine; main axis can be unbounded if parent is unbounded) | Child must be intrinsic-sized or it errors |
+
+The 28 worked examples in Flutter's `understandingconstraints` doc all turn on which
+category the constraint falls into. Two especially load-bearing examples:
+
+- **Example 2**: `Container(width: 100, height: 100, color: red)` as the root of a
+  page. The screen passes _tight_ constraints (= screen size). The Container's `width`
+  and `height` arguments are hints to be satisfied _if possible_, but tight constraints
+  override them. Result: the red box fills the screen.
+- **Example 14**: `UnconstrainedBox(child: Container(width: double.infinity))`. The
+  UnconstrainedBox unties the parent's constraints (passes unbounded), and the
+  Container then tries to be infinity wide -- which throws in debug mode.
+
+### Multi-Child Layout: Flex
+
+`Row` and `Column` extend `Flex`. The layout algorithm in `RenderFlex.performLayout`
+runs in two passes over its children:
+
+```
+Pass 1: Lay out all *non-flex* children with the cross-axis constraint and an
+        unbounded main axis. Sum their main-axis sizes.
+
+Pass 2: Compute remaining main-axis space (= maxMainAxisExtent - sum from Pass 1).
+        Distribute remaining space across *flex* children proportional to their flex
+        factors. Lay out each flex child with TIGHT main-axis constraints equal to its
+        allocation (or LOOSE if it's a Flexible with fit: FlexFit.loose).
+
+Pass 3: Position all children along the main axis according to MainAxisAlignment.
+        Set this.size based on MainAxisSize.
+```
+
+Key participants:
+
+- **`Expanded(child: ...)`** = `Flexible(fit: FlexFit.tight, ...)`. Forces the child
+  to fill its allocation.
+- **`Flexible(child: ...)`** = `Flexible(fit: FlexFit.loose, ...)`. Lets the child be
+  smaller than its allocation if it wants.
+- **`MainAxisAlignment`**: `start`, `end`, `center`, `spaceBetween`, `spaceAround`,
+  `spaceEvenly`. Controls how leftover space (after laying out non-flex children) is
+  distributed.
+- **`CrossAxisAlignment`**: `start`, `end`, `center`, `stretch`, `baseline`.
+- **`MainAxisSize`**: `max` (Flex fills available main-axis space) or `min` (Flex is
+  only as large as its children).
+
+The most common Flex error -- "RenderFlex overflowed by N pixels" -- happens when
+non-flex children sum to more main-axis space than the Flex received. The standard
+fix is to wrap one of them in `Expanded`/`Flexible`, or to wrap text children in
+`Expanded(child: Text(...))` so they receive a bounded width and can wrap.
+
+---
+
+## Widget Catalogue (Layout)
+
+### Single-Child Layout Primitives
+
+| Widget                 | What It Does                                                       |
+| ---------------------- | ------------------------------------------------------------------ |
+| `Container`            | Composite: padding + border + decoration + alignment + transform.  |
+| `Padding`              | Wraps child with `EdgeInsets`. Shrinks constraints by padding.     |
+| `Center`               | Aligns child to centre. Passes loose constraints down.             |
+| `Align`                | Centre with arbitrary `Alignment(x, y)`. Loose constraints.        |
+| `SizedBox`             | Imposes a tight size (or one dimension tight, other pass-through). |
+| `ConstrainedBox`       | Combines parent's constraints with additional ones (intersection). |
+| `LimitedBox`           | Only applies its `maxWidth/maxHeight` when parent is unbounded.    |
+| `FractionallySizedBox` | Sizes child as fraction of parent (`widthFactor`, `heightFactor`). |
+| `AspectRatio`          | Sizes child to a given aspect ratio.                               |
+| `Transform`            | Applies matrix transform; does not affect layout.                  |
+| `FittedBox`            | Scales child to fit (`BoxFit.contain` / `cover` / etc.).           |
+| `OverflowBox`          | Allows child to exceed parent's bounds without warning.            |
+| `IntrinsicWidth`       | Forces child to its `getMaxIntrinsicWidth`. Expensive.             |
+| `IntrinsicHeight`      | Forces child to its `getMaxIntrinsicHeight`. Expensive.            |
+
+### Multi-Child Layout Primitives
+
+| Widget                   | What It Does                                                         |
+| ------------------------ | -------------------------------------------------------------------- |
+| `Row`                    | Flex with horizontal main axis.                                      |
+| `Column`                 | Flex with vertical main axis.                                        |
+| `Flex`                   | Configurable-axis row/column (rarely used directly).                 |
+| `Stack`                  | Z-stacked children; positioning via `Positioned`.                    |
+| `Wrap`                   | Like a `Row` that wraps to a new line/column when full.              |
+| `Table`                  | Grid with column/row sizing (`FixedColumnWidth`, `FlexColumnWidth`). |
+| `CustomMultiChildLayout` | Caller-controlled layout via a `MultiChildLayoutDelegate`.           |
+| `IndexedStack`           | Stack that shows one child at a time (others still laid out).        |
+
+### Flex Modifiers
+
+| Widget     | What It Does                                                        |
+| ---------- | ------------------------------------------------------------------- |
+| `Expanded` | Mandates a flex factor with `FlexFit.tight` (must fill allocation). |
+| `Flexible` | Mandates a flex factor with `FlexFit.loose` (may be smaller).       |
+| `Spacer`   | `Expanded` with no child; just claims space.                        |
+
+### Slivers (Scroll-Aware Layout)
+
+For scrollable layouts, the box protocol is replaced by the _sliver protocol_, which
+uses a richer constraint type (`SliverConstraints`) that includes scroll offset and
+viewport size. Slivers are the building blocks of `CustomScrollView`.
+
+```dart
+CustomScrollView(
+  slivers: [
+    SliverAppBar(
+      pinned: true,
+      expandedHeight: 200,
+      flexibleSpace: FlexibleSpaceBar(title: Text('Title')),
+    ),
+    SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (context, i) => ListTile(title: Text('Item $i')),
+        childCount: 1000,
+      ),
+    ),
+    SliverGrid(
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 3,
+      ),
+      delegate: SliverChildBuilderDelegate(
+        (context, i) => Card(child: Text('Tile $i')),
+        childCount: 60,
+      ),
+    ),
+    SliverToBoxAdapter(child: Container(height: 100, color: Colors.amber)),
+  ],
+)
+```
+
+Slivers are critical because they enable lazy materialisation: only the slivers (and
+the children within them) that intersect the viewport are laid out and painted. A
+1,000,000-item `SliverList` is feasible because off-screen items never run through
+the layout pipeline.
+
+Common slivers: `SliverList`, `SliverGrid`, `SliverFixedExtentList`, `SliverAppBar`,
+`SliverPersistentHeader`, `SliverToBoxAdapter`, `SliverFillRemaining`,
+`SliverMainAxisGroup`, `SliverCrossAxisGroup`, `SliverPadding`.
+
+### Per-Element Properties
+
+Unlike WPF, Flutter does not attach per-element layout properties via attached
+properties. Instead, each modifier is its own widget that wraps the child:
+
+```dart
+// WPF style (attached):  Grid.Row="1" Grid.Column="2" Margin="5"
+// Flutter style (wrap):
+Padding(
+  padding: EdgeInsets.all(5),
+  child: GridItem(row: 1, column: 2, child: ...),
+)
+```
+
+The Flutter approach forces every layout decoration to be an explicit, visible widget
+in the tree. The cost is verbosity; the benefit is no hidden state and a tree that
+exactly mirrors the rendered output.
+
+---
+
+## Code Examples
+
+### Example 1: Dashboard With Flex
+
+A two-column dashboard built from `Row`, `Column`, `Expanded`, and `Padding`. This is
+the bread-and-butter Flutter layout.
+
+```dart
+import 'package:flutter/material.dart';
+
+class Dashboard extends StatelessWidget {
+  const Dashboard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Header card -- fixed height, full width.
+          SizedBox(
+            height: 80,
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    const Icon(Icons.dashboard, size: 32),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: const [
+                          Text('Welcome back',
+                              style: TextStyle(fontSize: 18)),
+                          Text('Pipeline status: green',
+                              style: TextStyle(color: Colors.grey)),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          // Body -- two columns sharing remaining vertical space.
+          Expanded(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  flex: 1,
+                  child: Card(
+                    child: ListView(
+                      padding: const EdgeInsets.all(8),
+                      children: const [
+                        ListTile(title: Text('Overview')),
+                        ListTile(title: Text('Builds')),
+                        ListTile(title: Text('Logs')),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  flex: 3,
+                  child: Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: const [
+                          Text('System Overview',
+                              style: TextStyle(
+                                fontSize: 20, fontWeight: FontWeight.bold)),
+                          SizedBox(height: 16),
+                          Text('CPU: 23%   MEM: 4.2 GB   Disk: 87%'),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+What this example demonstrates:
+
+- The header is a `SizedBox(height: 80, ...)`: a tight vertical constraint, but
+  horizontal stretches because the parent `Column` has `crossAxisAlignment: stretch`.
+- `Expanded(flex: 1)` and `Expanded(flex: 3)` divide the body row 1:3 -- the sidebar
+  takes a quarter, the main pane takes three quarters.
+- The body `Row` is wrapped in an `Expanded` so it consumes all remaining vertical
+  space inside the outer `Column`.
+- `SizedBox(width: 16)` and `SizedBox(height: 16)` serve as gutters -- a more
+  type-safe alternative to margin.
+
+### Example 2: A Custom RenderBox
+
+When you need a layout that no built-in widget expresses, you drop down to the
+render-object protocol directly. Here is a single-child widget that lays its child
+out with the parent's constraints but vertically centres it inside a fixed-height
+band, ignoring the child's height. (This is what `Center` plus `SizedBox(height: H)`
+does, but written as a single render object.)
+
+```dart
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+class BandedCenter extends SingleChildRenderObjectWidget {
+  const BandedCenter({super.key, required this.bandHeight, super.child});
+
+  final double bandHeight;
+
+  @override
+  RenderBandedCenter createRenderObject(BuildContext context) =>
+      RenderBandedCenter(bandHeight: bandHeight);
+
+  @override
+  void updateRenderObject(BuildContext context, RenderBandedCenter renderObject) {
+    renderObject.bandHeight = bandHeight;
+  }
+}
+
+class RenderBandedCenter extends RenderShiftedBox {
+  RenderBandedCenter({double bandHeight = 0, RenderBox? child})
+      : _bandHeight = bandHeight,
+        super(child);
+
+  double _bandHeight;
+  double get bandHeight => _bandHeight;
+  set bandHeight(double value) {
+    if (_bandHeight == value) return;
+    _bandHeight = value;
+    markNeedsLayout();
+  }
+
+  @override
+  void performLayout() {
+    // 1. Lay out the child with loose constraints, height capped at bandHeight.
+    final BoxConstraints childConstraints = BoxConstraints(
+      minWidth: constraints.minWidth,
+      maxWidth: constraints.maxWidth,
+      minHeight: 0,
+      maxHeight: bandHeight,
+    );
+    if (child != null) {
+      child!.layout(childConstraints, parentUsesSize: true);
+      // 2. Position the child centred vertically within our band.
+      final BoxParentData parentData = child!.parentData! as BoxParentData;
+      parentData.offset = Offset(
+        0,
+        (bandHeight - child!.size.height) / 2,
+      );
+    }
+    // 3. Our own size: full width from constraints, bandHeight tall.
+    size = constraints.constrain(Size(constraints.maxWidth, bandHeight));
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) => bandHeight;
+
+  @override
+  double computeMaxIntrinsicHeight(double width) => bandHeight;
+}
+```
+
+Three things stand out:
+
+1. The implementation lives entirely in `performLayout()`. There is no measure pass,
+   no second arrange step. The render object does everything in one call.
+2. Constraints flow down (`child.layout(childConstraints)`); the child's size flows
+   back up (`child!.size.height`); the parent (us) sets the child's position
+   (`parentData.offset = ...`); we then set our own size.
+3. We override `computeMin/MaxIntrinsicHeight` so that widgets that ask "how tall do
+   you want to be?" (e.g., an enclosing `IntrinsicHeight`) get a sensible answer
+   without needing to lay us out.
+
+### Example 3: Slivers for Lazy Scrolling
+
+A long news feed with a collapsible header and a grid section, lazily materialised:
+
+```dart
+import 'package:flutter/material.dart';
+
+class NewsFeedScreen extends StatelessWidget {
+  const NewsFeedScreen({super.key, required this.articles});
+
+  final List<Article> articles;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          // Collapsible header that shrinks as you scroll.
+          SliverAppBar(
+            pinned: true,
+            expandedHeight: 200,
+            flexibleSpace: FlexibleSpaceBar(
+              title: const Text('News'),
+              background: Image.network(
+                'https://example.com/banner.jpg',
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          // A trending grid: lazily materialised tiles.
+          SliverPadding(
+            padding: const EdgeInsets.all(8),
+            sliver: SliverGrid(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                mainAxisSpacing: 8,
+                crossAxisSpacing: 8,
+                childAspectRatio: 1.5,
+              ),
+              delegate: SliverChildBuilderDelegate(
+                (context, i) => _TrendingCard(article: articles[i]),
+                childCount: 6,
+              ),
+            ),
+          ),
+          // The main feed: lazily materialised list rows.
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, i) {
+                final article = articles[i + 6];
+                return _FeedRow(article: article);
+              },
+              childCount: articles.length - 6,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrendingCard extends StatelessWidget {
+  const _TrendingCard({required this.article});
+  final Article article;
+  @override
+  Widget build(BuildContext context) =>
+      Card(child: Center(child: Text(article.title)));
+}
+
+class _FeedRow extends StatelessWidget {
+  const _FeedRow({required this.article});
+  final Article article;
+  @override
+  Widget build(BuildContext context) =>
+      ListTile(title: Text(article.title), subtitle: Text(article.summary));
+}
+
+class Article {
+  Article(this.title, this.summary);
+  final String title;
+  final String summary;
+}
+```
+
+Slivers solve a problem the box protocol cannot: composing multiple lazily-laid-out
+scrollable regions inside a single scrollable. The header, the grid, and the list all
+share one scroll position, but each one materialises its own children on demand. The
+sliver protocol does this by passing a `SliverConstraints` -- containing scroll offset,
+remaining viewport extent, axis direction, and cache extent -- to each sliver in
+turn, and each sliver reports back a `SliverGeometry` describing how much main-axis
+extent it consumed and how it interacts with the viewport.
+
+### Example 4: Reading and Reacting to Constraints
+
+The `LayoutBuilder` widget surfaces the constraints from the layout pass into the
+build pass, so you can branch your widget tree based on available space:
+
+```dart
+import 'package:flutter/material.dart';
+
+class ResponsiveLayout extends StatelessWidget {
+  const ResponsiveLayout({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < 600) return const _PhoneLayout();
+        if (constraints.maxWidth < 1000) return const _TabletLayout();
+        return const _DesktopLayout();
+      },
+    );
+  }
+}
+```
+
+`LayoutBuilder` is the principled escape hatch from "I want to know how much space
+I have before deciding what to build". The cost is that the widget's build runs inside
+the layout pass, so it cannot return a widget that depends on its own size (the
+algorithm would not terminate).
+
+---
+
+## Common Gotchas
+
+### Unbounded Constraints in the Scroll Axis
+
+The most-cited Flutter error is `Vertical viewport was given unbounded height.` It
+happens when a scrollable (`ListView`, `SingleChildScrollView`) tries to lay out a
+descendant that needs a finite main-axis constraint -- typically an `Expanded`:
+
+```dart
+SingleChildScrollView(
+  child: Column(children: [
+    Expanded(child: SomeWidget()),  // Expanded needs a finite parent main-axis.
+  ]),
+)  // ERROR.
+```
+
+Fix: provide a finite height via `SizedBox`/`ConstrainedBox`, or replace `Expanded`
+with `Flexible` (loose fit).
+
+### Row/Column Overflow
+
+`A RenderFlex overflowed by 42 pixels on the right.` -- a `Row` got non-flex children
+summing to more main-axis space than it received. Fix: wrap one child in `Expanded`,
+or wrap text children in `Expanded(child: Text(...))` so they get a finite `maxWidth`
+and wrap.
+
+### Container's `width` Is a Hint
+
+A `Container(width: 100)` inside a `Row` does not produce a 100-pixel box. Loose
+parent constraints mean `width` is just a hint, and an undecorated `Container` sizes
+to fit its child. Fix: use `SizedBox(width: 100, child: Container(...))` -- `SizedBox`
+imposes a tight constraint that overrides the loose parent constraints.
+
+### Intrinsic Dimensions Are O(N^2)
+
+`IntrinsicHeight` inside a `Row` walks every descendant's intrinsic-height
+implementation, which itself may recurse. A frequent source of frame-time
+regressions. Prefer explicit `SizedBox` heights, or use intrinsics only at the top
+of a small subtree.
+
+### LayoutBuilder Causes Rebuilds
+
+`LayoutBuilder` reruns its builder whenever constraints change. Putting it high in a
+tree means every resize causes a full subtree rebuild. Keep it low.
+
+---
+
+## Rendering: A Brief Note on Impeller
+
+Flutter's renderer is largely orthogonal to its layout system, but worth a paragraph
+for completeness. Until 2023, Flutter rendered via _Skia_ -- the same 2D library that
+powers Chrome. Skia compiled shaders lazily at runtime, which produced visible jank
+on first display ("shader compilation jank"). Impeller replaces Skia with a renderer
+designed around precompiled shaders, Metal/Vulkan/OpenGL backends, and a more
+predictable performance profile. As of Flutter 3.27, Impeller is default on iOS,
+Android, and is stabilising on macOS.
+
+This matters for layout only insofar as Impeller does not change the layout protocol
+-- the `RenderObject` tree's `performLayout` calls are unchanged. The change is purely
+in the paint phase that consumes the laid-out tree.
+
+---
+
+## Strengths
+
+- **Predictable single-pass layout.** Every widget is visited exactly once per frame
+  during layout. The algorithm's time complexity is straightforward O(N) in the
+  number of render objects (with the caveat that `IntrinsicWidth`/`Height` introduce
+  extra passes). This is dramatically simpler than the two-pass WPF model or the
+  iterative constraint solving of CSS reflow.
+- **The constraint protocol is clean.** Once "constraints down, sizes up, parent
+  positions" clicks, every layout widget makes sense. There is no special "panel
+  protocol" vs "control protocol" -- everything is a `RenderBox` (or `RenderSliver`)
+  and obeys the same rules.
+- **Relayout boundaries make rebuilds cheap.** A tight-constrained subtree is a
+  relayout boundary; marking a deep descendant dirty does not bubble up. Combined
+  with `const` widgets and the element-reconciliation system, this is what makes
+  60 Hz UIs feasible from a "rebuild the world" programming model.
+- **Composable primitives.** `Padding`, `Center`, `SizedBox`, `Expanded`, and a
+  handful of others compose to express any conceivable layout. The widget tree
+  reflects the rendered output exactly -- no hidden state, no implicit defaults.
+- **Slivers unlock scrollable composition.** The sliver protocol is one of the most
+  underappreciated parts of Flutter -- it lets you build a screen with a collapsible
+  header, a grid, a list, a footer, and an infinite-scroll section all sharing one
+  scroll position, all lazily materialised.
+- **Excellent debug tooling.** `flutter inspector` shows the live widget tree;
+  `debugDumpRenderTree()` prints the render objects and their sizes; `debugPaintSizeEnabled`
+  overlays bounding boxes. Layout errors come with a "stack trace" of widgets that
+  contributed to the failed constraint.
+- **Cross-platform consistency.** The same layout code runs identically on iOS,
+  Android, web, Windows, macOS, Linux, and embedded. No platform-specific layout
+  quirks.
+
+---
+
+## Weaknesses
+
+- **Intrinsic dimensions are a performance landmine.** Using `IntrinsicHeight` or
+  `IntrinsicWidth` -- often the most "obvious" way to express "make these the same
+  size" -- can silently turn O(N) layout into O(N^2). The documentation warns about
+  it, but the API surface does not.
+- **Unbounded-constraint errors are confusing.** "Vertical viewport was given
+  unbounded height" is not a useful error for someone who hasn't internalised the
+  constraint categories. The mental model has a steep onboarding cost.
+- **No attached properties means more nesting.** Where WPF expresses a button's
+  margin and grid position with five attributes on one element, Flutter wraps the
+  button in `Padding`, then `Align`, then `Expanded` -- three additional tree levels.
+  The tree is faithful but verbose.
+- **No declarative layout language.** Unlike XAML, Flutter has no markup; you compose
+  widgets in Dart. This is great for refactoring and bad for designers who want a
+  visual designer that round-trips with code.
+- **Container's hint behaviour confuses newcomers.** `Container(width: 100)` does not
+  always produce a 100-pixel box; whether it does depends on the parent's constraint
+  category. The `SizedBox` idiom solves this but is one of the first things experts
+  internalise that beginners do not.
+- **Layout cannot consult the platform.** A Flutter widget cannot ask the host
+  platform's text-rendering library "how wide is this string in 12pt Verdana?" --
+  Flutter draws its own text, so this works inside Flutter but cannot be deferred to
+  platform metrics. (This is also a strength: cross-platform consistency.)
+- **Heavyweight runtime.** Flutter's layout system is part of a 5+ MB framework with
+  its own renderer, text shaper, and accessibility tree. For UIs that could be a few
+  hundred lines of HTML, Flutter is overkill.
+
+---
+
+## Lessons for D / Sparkles
+
+The Flutter constraint protocol translates _remarkably_ well to terminal UIs. Three
+specific patterns are worth highlighting.
+
+### Constraints-Down-Sizes-Up Maps Directly to Terminal Tables
+
+A terminal table or panel layout is exactly the problem the box protocol solves:
+"given this rectangular envelope, how big does each child want to be, and where do I
+position them?" A D port of the box protocol could look like:
+
+```d
+struct BoxConstraints {
+    ushort minWidth, maxWidth;
+    ushort minHeight, maxHeight;
+
+    bool isTight() const => minWidth == maxWidth && minHeight == maxHeight;
+    bool isBoundedWidth() const => maxWidth < ushort.max;
+
+    Size constrain(Size unconstrained) const {
+        return Size(
+            clamp(unconstrained.width, minWidth, maxWidth),
+            clamp(unconstrained.height, minHeight, maxHeight),
+        );
+    }
+}
+
+// Single-pass layout via duck-typed renderObject:
+enum isRenderBox(T) = is(typeof((T t, BoxConstraints c, ref Buffer buf) {
+    auto size = t.layout(c);
+    t.paint(buf, Position(0, 0));
+}));
+```
+
+Because terminals have a single, fixed cell size and small dimensions, the constraint
+arithmetic is simpler than Flutter's (`ushort` instead of `double`; no sub-pixel
+rounding; no relayout boundaries because the whole screen is small enough to relayout
+in a single millisecond).
+
+### Static Layouts Become CTFE-Friendly
+
+Flutter performs all layout at runtime because constraints depend on the window size.
+For terminal UIs where the table column widths are known at compile time, D's CTFE
+can run the entire constraint protocol _at compile time_ -- the box widget's
+`performLayout()` is a pure function from constraints to size, which means a
+sufficiently-pure tree can fold to a constant.
+
+```d
+enum tableLayout = box(
+    direction: Direction.row,
+    children: [
+        box(width: 20),     // sidebar
+        box(flexGrow: 1),   // main content
+    ],
+).layout(BoxConstraints.tight(Size(80, 24)));
+// tableLayout is now a compile-time-known array of positioned rects.
+```
+
+### Strict Constraint Categories Catch Bugs at Compile Time
+
+Flutter discovers unbounded-constraint errors at runtime. In D, the constraint
+category (`tight`, `loose`, `unbounded`) could be a compile-time type parameter, with
+template constraints rejecting widgets that need a bounded envelope from an unbounded
+parent:
+
+```d
+enum ConstraintKind { tight, loose, unbounded }
+
+void layoutFlex(ConstraintKind kind)(Flex flex, BoxConstraints!kind c)
+if (kind != ConstraintKind.unbounded)  // Flex cannot accept unbounded main axis.
+{
+    // ...
+}
+```
+
+Strict static dispatch like this turns the most painful Flutter runtime error into
+a compile-time error.
+
+### Render Objects as Output-Range Consumers
+
+Flutter's `paint(canvas, offset)` maps cleanly onto Sparkles' output-range pattern. A
+`RenderBox`-style widget for a terminal can be a pure `@nogc @safe` struct -- the
+constraint protocol uses only 4-tuple value types and 2-tuple positions, so no heap
+allocations are needed.
+
+---
+
+## References
+
+- **Layout Constraints (the foundational article):**
+  <https://docs.flutter.dev/ui/layout/constraints>
+- **Layout Cheat Sheet:** <https://docs.flutter.dev/ui/layout>
+- **Slivers:**
+  - Concept: <https://docs.flutter.dev/ui/layout/scrolling/slivers>
+  - `CustomScrollView`: <https://api.flutter.dev/flutter/widgets/CustomScrollView-class.html>
+- **API Reference:**
+  - `Widget`: <https://api.flutter.dev/flutter/widgets/Widget-class.html>
+  - `StatelessWidget`: <https://api.flutter.dev/flutter/widgets/StatelessWidget-class.html>
+  - `StatefulWidget`: <https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html>
+  - `BoxConstraints`: <https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html>
+  - `RenderBox`: <https://api.flutter.dev/flutter/rendering/RenderBox-class.html>
+  - `RenderObject`: <https://api.flutter.dev/flutter/rendering/RenderObject-class.html>
+  - `Row` / `Column` / `Flex`: <https://api.flutter.dev/flutter/widgets/Flex-class.html>
+  - `Expanded` / `Flexible`: <https://api.flutter.dev/flutter/widgets/Expanded-class.html>
+  - `Stack` / `Positioned`: <https://api.flutter.dev/flutter/widgets/Stack-class.html>
+  - `LayoutBuilder`: <https://api.flutter.dev/flutter/widgets/LayoutBuilder-class.html>
+  - `CustomMultiChildLayout`: <https://api.flutter.dev/flutter/widgets/CustomMultiChildLayout-class.html>
+- **Rendering pipeline:**
+  - Impeller architecture: <https://docs.flutter.dev/perf/impeller>
+- **Talks and articles:**
+  - Adam Barth, "How Flutter renders widgets" (Google I/O 2019):
+    <https://www.youtube.com/watch?v=996ZgFRENMs>
+  - "Inside Flutter":
+    <https://docs.flutter.dev/resources/inside-flutter>
+- **Cross-reference:**
+  - Ratatui (Rust TUI, immediate-mode constraint solver):
+    [../tui-libraries/ratatui.md](../tui-libraries/ratatui.md)
+  - Ink (JS TUI, retained-mode Flexbox via Yoga):
+    [../tui-libraries/ink.md](../tui-libraries/ink.md)

--- a/docs/research/ui-layout/gtk.md
+++ b/docs/research/ui-layout/gtk.md
@@ -1,0 +1,684 @@
+# GTK 4 Layout Managers
+
+A widget-tree toolkit that, since GTK 4, cleanly separates _what a widget
+contains_ from _how a widget arranges its children_: every `GtkWidget`
+delegates layout to a swappable `GtkLayoutManager` subclass, including the
+familiar box and grid arrangements as well as a Cassowary-based constraint
+solver.
+
+| Field          | Value                                                              |
+| -------------- | ------------------------------------------------------------------ |
+| Language       | C (with first-class bindings: Rust, Python, JavaScript, Vala, C++) |
+| License        | LGPLv2.1+                                                          |
+| Vendor         | The GNOME Project                                                  |
+| Documentation  | <https://docs.gtk.org/gtk4/>                                       |
+| First Released | GTK+ 1.0 (1998); GTK 4.0 in 2020                                   |
+| Layout API     | <https://docs.gtk.org/gtk4/class.LayoutManager.html>               |
+| Predecessor    | GTK 3 (2011), where each container widget hardcoded its own layout |
+
+---
+
+## Overview
+
+GTK has been the canonical widget toolkit on Linux desktops for more than two
+decades. Originally written as the toolkit for the GIMP (hence "GIMP
+ToolKit"), it has gone through four major versions, with each one
+reorganizing how widgets compose. The layout story in GTK 4 (released in
+December 2020) is one of the biggest API redesigns in the toolkit's history:
+_layout policy is no longer an attribute of the widget_, but a separately
+attached `GtkLayoutManager` object.
+
+**What GTK 4 layouts solve.** Most desktop UIs need a small set of layout
+primitives: linear stacks, grids, centered content, overlays, and the
+occasional pixel-precise positioning. GTK 4 ships exactly that as a set of
+focused `GtkLayoutManager` classes, each implementing the same `measure()` and
+`allocate()` virtual methods. This means that any widget can swap its layout
+algorithm without changing its widget-tree structure — the children stay the
+same, only the policy changes.
+
+**Why the redesign mattered.** Before GTK 4, every container widget owned its
+own layout. `GtkBox` had its own packing code; `GtkGrid` had its own row/column
+solver; `GtkFixed` had its own absolute-positioning logic. Layout-related
+properties (homogeneous, spacing, packing) were duplicated across many widget
+classes. Worse, you could not _change_ a widget's layout policy without
+replacing the widget — and replacing a widget meant migrating all its
+children, signal connections, accessibility metadata, and CSS state.
+
+GTK 4 fixes this by separating concerns: a widget owns its children
+(`gtk_widget_set_parent`) and is responsible for size negotiation
+(`gtk_widget_measure`, `gtk_widget_size_allocate`), but it delegates the
+algorithm to a `GtkLayoutManager` object set via
+`gtk_widget_set_layout_manager`. The result is a much smaller, more focused
+widget API and a layout subsystem that is fully extensible (you can write
+your own `GtkLayoutManager`).
+
+**Design philosophy.** GTK 4 layout managers are deliberately small and
+single-purpose. There are no megaclasses with dozens of toggles; instead,
+each manager does one thing well and you compose them by nesting widgets. The
+toolkit ships eight concrete `GtkLayoutManager` subclasses, which together
+cover the vast majority of GUI compositions. Custom managers are encouraged
+for niche needs.
+
+**Lineage and influences.** The split between widget and layout manager
+mirrors Qt's long-standing `QLayout`/`QWidget` distinction (see
+[`qt-layouts.md`](./qt-layouts.md)), with one key difference: in Qt the
+layout is _contained by_ the widget, while in GTK the layout is _attached as
+a strategy_ via a property setter. GTK 4 also introduced `GtkConstraintLayout`,
+a port of the Cassowary linear-arithmetic constraint solver that Apple's
+AutoLayout (iOS/macOS) popularized in 2011 — bringing GTK closer to platform
+parity for declarative constraint-based UI.
+
+---
+
+## Layout Model
+
+### The `GtkLayoutManager` protocol
+
+Every layout manager implements four virtual methods (and a couple of
+lifecycle hooks):
+
+```c
+struct _GtkLayoutManagerClass {
+    GObjectClass parent_class;
+
+    GtkSizeRequestMode (* get_request_mode)  (GtkLayoutManager *manager,
+                                              GtkWidget        *widget);
+
+    void               (* measure)           (GtkLayoutManager *manager,
+                                              GtkWidget        *widget,
+                                              GtkOrientation    orientation,
+                                              int               for_size,
+                                              int              *minimum,
+                                              int              *natural,
+                                              int              *minimum_baseline,
+                                              int              *natural_baseline);
+
+    void               (* allocate)          (GtkLayoutManager *manager,
+                                              GtkWidget        *widget,
+                                              int               width,
+                                              int               height,
+                                              int               baseline);
+
+    GtkLayoutChild *   (* create_layout_child)(GtkLayoutManager *manager,
+                                               GtkWidget        *widget,
+                                               GtkWidget        *for_child);
+
+    void               (* root)              (GtkLayoutManager *manager);
+    void               (* unroot)            (GtkLayoutManager *manager);
+};
+```
+
+The two essential methods are `measure()` and `allocate()`. `measure()`
+returns four numbers — minimum, natural, minimum*baseline, natural_baseline —
+for a given orientation and a constraint along the \_other* orientation
+(`for_size`). `allocate()` is called once the parent has decided on a final
+width/height; the manager walks its children and calls
+`gtk_widget_size_allocate` on each.
+
+The optional `create_layout_child()` returns a `GtkLayoutChild` object that
+stores per-child layout properties — for example, a `GtkGridLayoutChild`
+holds `row`, `column`, `row-span`, `column-span` for one child of a
+`GtkGridLayout`. These objects are cached by the framework and looked up via
+`gtk_layout_manager_get_layout_child(manager, child)`.
+
+### Size request modes
+
+The `GtkSizeRequestMode` enum tells GTK how a widget's sizing depends on its
+orthogonal axis:
+
+| Value              | Meaning                                                                     |
+| ------------------ | --------------------------------------------------------------------------- |
+| `CONSTANT_SIZE`    | Width is independent of height, and vice versa. Most widgets.               |
+| `HEIGHT_FOR_WIDTH` | The widget needs to know its width before it can compute its height.        |
+| `WIDTH_FOR_HEIGHT` | The widget needs to know its height before it can compute its width (rare). |
+
+Height-for-width is GTK's standout feature for text-heavy UIs. A wrapped label
+in `HEIGHT_FOR_WIDTH` mode: GTK first measures it horizontally (asking for
+minimum and natural widths); then, after allocating a width, GTK calls
+`measure(VERTICAL, for_size=allocated_width)` to ask how tall the label
+needs to be. The label's `measure()` implementation runs Pango's line breaker
+at the allocated width and returns the resulting height.
+
+The orientation-aware measure protocol is rare among widget toolkits.
+Qt approximates it via `QSizePolicy::hasHeightForWidth()`, which adds a
+second pass after the initial measure; GTK bakes it directly into the
+measure protocol, so any widget can participate without extra ceremony.
+
+### Per-widget layout properties
+
+Every widget — _regardless of which `GtkLayoutManager` its parent uses_ —
+exposes a small set of layout properties read by the manager:
+
+- **`halign`, `valign`** — alignment within the widget's allocation. Values
+  from `GtkAlign`: `FILL`, `START`, `END`, `CENTER`, `BASELINE_FILL`,
+  `BASELINE_CENTER`. `FILL` is the default; the others let a widget refuse
+  to consume its full allocation and instead anchor to one edge.
+- **`margin-start`, `margin-end`, `margin-top`, `margin-bottom`** — outer
+  margins in pixels. Always part of the widget's measurement, so a margin
+  on a child propagates correctly into the parent's `sizeHint`.
+- **`hexpand`, `vexpand`** — request extra space from the parent if the
+  parent has any to give. The corresponding `hexpand-set`/`vexpand-set`
+  flags distinguish between "explicitly false" and "default false (inferred
+  from children)".
+- **`width-request`, `height-request`** — minimum size requests, equivalent
+  to a per-axis floor.
+
+These properties live on `GtkWidget` itself (not on the layout manager), so
+they are _universally available_ and behave the same across all layouts.
+This is a major usability win compared to GTK 3, where many of these
+properties were duplicated on each container.
+
+### Built-in layout managers
+
+GTK 4 ships eight concrete `GtkLayoutManager` subclasses:
+
+| Class                 | Purpose                                                                         | Common widgets                                   |
+| --------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `GtkBoxLayout`        | Linear horizontal or vertical packing with spacing and homogeneous mode.        | `GtkBox`, `GtkActionBar`                         |
+| `GtkGridLayout`       | 2D grid with per-cell row/column placement and spans.                           | `GtkGrid`                                        |
+| `GtkCenterLayout`     | Three slots: start, center, end. Holds three children at most.                  | `GtkCenterBox`, `GtkHeaderBar`                   |
+| `GtkBinLayout`        | Single child, sized to the parent. Trivial pass-through.                        | `GtkFrame`, `GtkWindowHandle`, many leaf widgets |
+| `GtkOverlayLayout`    | One main child + N overlay children. Overlays float over the main child.        | `GtkOverlay`                                     |
+| `GtkFixedLayout`      | Explicit `GskTransform` per child. Pixel-precise positioning.                   | `GtkFixed`                                       |
+| `GtkConstraintLayout` | Cassowary-based linear constraint solver. AutoLayout-style.                     | (user-installed; no dedicated widget)            |
+| `GtkCustomLayout`     | Trampolines into user-supplied measure/allocate callbacks. No `GtkLayoutChild`. | (anonymous, application-specific)                |
+
+### `GtkBoxLayout`
+
+Arranges children linearly along an orientation (`GTK_ORIENTATION_HORIZONTAL`
+or `GTK_ORIENTATION_VERTICAL`). Spacing between children is a constant
+pixel value; the `homogeneous` flag forces all children to the same size.
+
+```c
+GtkWidget *box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, /*spacing=*/6);
+gtk_widget_set_margin_start(box, 8);
+gtk_widget_set_margin_end(box, 8);
+
+GtkWidget *search = gtk_search_entry_new();
+gtk_widget_set_hexpand(search, TRUE);     // absorb leftover width
+
+GtkWidget *go     = gtk_button_new_with_label("Go");
+GtkWidget *cancel = gtk_button_new_with_label("Cancel");
+
+gtk_box_append(GTK_BOX(box), search);     // hexpand=TRUE -> grows
+gtk_box_append(GTK_BOX(box), go);         // hexpand=FALSE -> at natural size
+gtk_box_append(GTK_BOX(box), cancel);
+```
+
+Equivalent in PyGObject:
+
+```python
+box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6,
+              margin_start=8, margin_end=8)
+search = Gtk.SearchEntry(hexpand=True)
+box.append(search)
+box.append(Gtk.Button(label="Go"))
+box.append(Gtk.Button(label="Cancel"))
+```
+
+Notable properties on `GtkBoxLayout` (which `GtkBox` exposes through its own
+properties):
+
+- `orientation` (from `GtkOrientable`).
+- `spacing` (px between children).
+- `homogeneous` (force equal sizes).
+- `baseline-position` (where to place the baseline within the extra space
+  along the orthogonal axis).
+- `baseline-child` (added in 4.12: nominate one child as the baseline source
+  in a vertical box).
+
+Unlike GTK 3, there is **no `pack_start` vs. `pack_end`** distinction; you
+simply append children in the order you want, and use `halign`/`hexpand` on
+each child to control placement and growth. This is a deliberate
+simplification: the old "fill" / "expand" / "padding" per-child arguments
+were merged into the universal widget properties.
+
+### `GtkGridLayout` and `GtkGridLayoutChild`
+
+A two-dimensional grid. Children are positioned by setting properties on
+the per-child `GtkGridLayoutChild` object:
+
+```c
+GtkWidget *grid_widget = gtk_grid_new();
+GtkGrid   *grid        = GTK_GRID(grid_widget);
+
+gtk_grid_set_row_spacing(grid, 4);
+gtk_grid_set_column_spacing(grid, 8);
+gtk_grid_set_row_homogeneous(grid, FALSE);
+gtk_grid_set_column_homogeneous(grid, FALSE);
+
+// gtk_grid_attach(grid, child, column, row, width, height)
+gtk_grid_attach(grid, gtk_label_new("Name:"),    0, 0, 1, 1);
+gtk_grid_attach(grid, name_entry,                1, 0, 1, 1);
+gtk_grid_attach(grid, gtk_label_new("Email:"),   0, 1, 1, 1);
+gtk_grid_attach(grid, email_entry,               1, 1, 1, 1);
+gtk_grid_attach(grid, gtk_label_new("Comment:"), 0, 2, 1, 1);
+gtk_grid_attach(grid, comment_view,              1, 2, 1, 1);
+
+// Make the field column absorb extra horizontal space.
+gtk_widget_set_hexpand(name_entry, TRUE);
+gtk_widget_set_hexpand(email_entry, TRUE);
+gtk_widget_set_hexpand(comment_view, TRUE);
+gtk_widget_set_vexpand(comment_view, TRUE);
+```
+
+`GtkGridLayoutChild` properties (set via `g_object_set` or via
+`gtk_grid_attach`):
+
+- `column`, `row` — the top-left cell occupied by the child.
+- `column-span`, `row-span` — how many cells the child spans.
+
+`GtkGridLayout` itself exposes:
+
+- `row-spacing`, `column-spacing` — pixel gap between cells.
+- `row-homogeneous`, `column-homogeneous` — force equal sizes.
+- `baseline-row` — which row aligns to the parent's baseline.
+
+Unlike `QGridLayout`, GTK does not have per-row or per-column stretch
+factors. Instead, distribution of extra space comes from the children's
+`hexpand`/`vexpand` flags: a column where at least one child has
+`hexpand=TRUE` is an "expanding" column, and all expanding columns share
+extra horizontal space evenly.
+
+### `GtkCenterLayout` and `GtkCenterBox`
+
+Holds exactly three children — start, center, end — with the start child at
+the leading edge, the end child at the trailing edge, and the center child
+centered in the leftover space. This is what `GtkHeaderBar` uses.
+
+```c
+GtkWidget *center = gtk_center_box_new();
+gtk_center_box_set_start_widget (GTK_CENTER_BOX(center), back_button);
+gtk_center_box_set_center_widget(GTK_CENTER_BOX(center), title_label);
+gtk_center_box_set_end_widget   (GTK_CENTER_BOX(center), menu_button);
+```
+
+The center child is _truly centered relative to the parent_, not relative
+to the space between the start and end children — meaning that if the
+start child is wider than the end child, the center child is still placed
+at the geometric center of the parent (clipping if needed). The
+`shrink-center-last` property lets the center child yield space to the
+start/end children when it would otherwise overlap.
+
+### `GtkBinLayout`
+
+The trivial case: one child, allocated the full parent size minus margins.
+Used by leaf widgets like `GtkFrame`, `GtkWindowHandle`, `GtkRevealer`, and
+many others. Most application developers never touch `GtkBinLayout`
+directly; it is the default layout manager for any widget that doesn't
+declare another.
+
+### `GtkOverlayLayout` and `GtkOverlay`
+
+A main child plus zero or more overlay children floating on top. Overlays
+are positioned via their own `halign`/`valign` and can be measured
+independently of the main child.
+
+```c
+GtkWidget *overlay = gtk_overlay_new();
+gtk_overlay_set_child(GTK_OVERLAY(overlay), document_view);
+
+GtkWidget *toast = gtk_label_new("Saved!");
+gtk_widget_set_halign(toast, GTK_ALIGN_END);
+gtk_widget_set_valign(toast, GTK_ALIGN_END);
+gtk_widget_set_margin_end(toast, 16);
+gtk_widget_set_margin_bottom(toast, 16);
+gtk_overlay_add_overlay(GTK_OVERLAY(overlay), toast);
+```
+
+Overlays are GTK's answer to floating notifications, scroll indicators,
+loading spinners on top of content, and similar transient UI.
+
+### `GtkFixedLayout` and `GtkFixed`
+
+Pixel-precise placement via per-child `GskTransform` matrices. Unlike older
+GTK 3 `GtkFixed`, which was simple `(x, y)` placement, the GTK 4 version
+takes a 2D transform — you can rotate, scale, or skew children.
+
+```c
+GtkWidget *fixed = gtk_fixed_new();
+GskTransform *t = gsk_transform_translate(NULL,
+                      &GRAPHENE_POINT_INIT(40, 80));
+gtk_fixed_put(GTK_FIXED(fixed), my_label, 40, 80);
+gtk_fixed_set_child_transform(GTK_FIXED(fixed), my_label, t);
+gsk_transform_unref(t);
+```
+
+`GtkFixedLayout` is _the_ escape hatch when none of the other layouts fit
+(typically: custom canvases, game-style UI, complex diagram editors). It
+does not participate in dynamic resizing; the application is responsible
+for repositioning children when the parent changes size.
+
+### `GtkConstraintLayout`
+
+GTK 4 ships a port of the **Cassowary linear-arithmetic constraint solver**
+as `GtkConstraintLayout`. Each constraint is a relation
+`target.attr (=|≥|≤) multiplier * source.attr + constant` at a given
+_strength_. The solver finds an assignment of all widget edges that
+satisfies the strongest possible set of constraints.
+
+```c
+GtkLayoutManager *clay = gtk_constraint_layout_new();
+gtk_widget_set_layout_manager(parent, clay);
+
+GtkConstraintLayout *cl = GTK_CONSTRAINT_LAYOUT(clay);
+
+// Pin button.left to parent.left + 8.
+gtk_constraint_layout_add_constraint(cl,
+    gtk_constraint_new(button, GTK_CONSTRAINT_ATTRIBUTE_LEFT,
+                       GTK_CONSTRAINT_RELATION_EQ,
+                       parent, GTK_CONSTRAINT_ATTRIBUTE_LEFT,
+                       /*multiplier=*/1.0, /*constant=*/8.0,
+                       GTK_CONSTRAINT_STRENGTH_REQUIRED));
+
+// button.width >= 80.
+gtk_constraint_layout_add_constraint(cl,
+    gtk_constraint_new_constant(button, GTK_CONSTRAINT_ATTRIBUTE_WIDTH,
+                                GTK_CONSTRAINT_RELATION_GE, 80.0,
+                                GTK_CONSTRAINT_STRENGTH_REQUIRED));
+```
+
+Constraints can also be expressed in **Visual Format Language** (VFL),
+borrowed from Cocoa AutoLayout:
+
+```c
+const char *vfl[] = {
+    "H:|-[button(>=80)]-[entry]-|",   // left margin, button>=80, gap, entry, right margin
+    "V:|-[button]-|",
+    "V:|-[entry(==button)]-|",
+};
+gtk_constraint_layout_add_constraints_from_description(
+    cl, vfl, G_N_ELEMENTS(vfl), /*hspacing=*/8, /*vspacing=*/8,
+    /*error=*/NULL);
+```
+
+`GtkConstraintGuide` objects act as named invisible rectangles that
+constraints can reference — useful for shared edges, alignment guides, or
+content area markers without adding actual widgets.
+
+The Cassowary algorithm is incremental: adding or removing a constraint
+re-solves only the affected portion of the system. This makes constraint
+layouts cost-effective for moderately complex compositions (tens to
+hundreds of constraints) but does add a real cost for very large hierarchies
+relative to the simpler box/grid managers.
+
+For deeper background on the Cassowary algorithm, see the planned
+`./cassowary.md` companion doc in this catalog, which covers the underlying
+linear-arithmetic simplex solver shared between AutoLayout, kiwi.js,
+Ratatui's `kasuari`, and GTK's `GtkConstraintLayout`.
+
+### Widgets that use these managers
+
+GTK 4 widgets pair a `GtkLayoutManager` with a thin wrapper that exposes
+ergonomic API:
+
+| Widget                                 | Layout manager                              | Purpose                                                    |
+| -------------------------------------- | ------------------------------------------- | ---------------------------------------------------------- |
+| `GtkBox`                               | `GtkBoxLayout`                              | Horizontal/vertical container.                             |
+| `GtkGrid`                              | `GtkGridLayout`                             | Row/column container.                                      |
+| `GtkCenterBox`, `GtkHeaderBar`         | `GtkCenterLayout`                           | Three-slot bar.                                            |
+| `GtkOverlay`                           | `GtkOverlayLayout`                          | Main child + floating overlays.                            |
+| `GtkFixed`                             | `GtkFixedLayout`                            | Pixel-precise placement.                                   |
+| `GtkFrame`, `GtkRevealer`, `GtkButton` | `GtkBinLayout`                              | Single-child decorators.                                   |
+| `GtkScrolledWindow`                    | Custom (`GtkScrolledWindow` private layout) | Adds scrollbars, handles overshoot.                        |
+| `GtkPaned`                             | Custom                                      | Two children with a draggable separator.                   |
+| `GtkStack`                             | Custom                                      | Show one of N children with optional cross-fade animation. |
+| `GtkNotebook`                          | Custom                                      | Tabbed pages.                                              |
+| `GtkExpander`                          | `GtkBinLayout`                              | Collapsible single-child container.                        |
+
+A separate family of widgets implements **list-style scrollable views**
+with their own internal layouts:
+
+- **`GtkListBox`** — vertical list of rows. Children must be `GtkListBoxRow`
+  widgets. Selection, filtering, and sorting are handled by the list.
+- **`GtkFlowBox`** — children flow horizontally and wrap to multiple lines.
+  Selectable like `GtkListBox` but in 2D.
+- **`GtkListView`** — list view backed by a `GListModel`. Replaces the older
+  `GtkTreeView` for modern scrolling lists; uses an internal recycling
+  layout that does not allocate widgets for off-screen rows.
+- **`GtkColumnView`** — multi-column variant of `GtkListView` with sortable
+  columns. The closest thing to a traditional spreadsheet/grid view.
+- **`GtkGridView`** — 2D grid view backed by a `GListModel`, with
+  customizable cell size.
+
+These widget-internal layouts are not pluggable `GtkLayoutManager`s — they
+are tightly coupled to the widget that hosts them. But conceptually they
+behave like specialized layouts. For comparable patterns in TUI land, see
+the [`../tui-libraries/textual.md`](../tui-libraries/textual.md) doc on
+Textual's `ListView` / `OptionList` widgets.
+
+### A complete example: form with constraint-based alignment
+
+```c
+GtkWidget *win = gtk_window_new();
+gtk_window_set_default_size(GTK_WINDOW(win), 480, 320);
+
+GtkWidget *area = gtk_widget_new(GTK_TYPE_WIDGET, NULL);
+gtk_window_set_child(GTK_WINDOW(win), area);
+
+GtkLayoutManager *clay = gtk_constraint_layout_new();
+gtk_widget_set_layout_manager(area, clay);
+GtkConstraintLayout *cl = GTK_CONSTRAINT_LAYOUT(clay);
+
+GtkWidget *name_label = gtk_label_new("Name:");
+GtkWidget *name_entry = gtk_entry_new();
+GtkWidget *mail_label = gtk_label_new("Email:");
+GtkWidget *mail_entry = gtk_entry_new();
+GtkWidget *ok_button  = gtk_button_new_with_label("Save");
+
+gtk_widget_set_parent(name_label, area);
+gtk_widget_set_parent(name_entry, area);
+gtk_widget_set_parent(mail_label, area);
+gtk_widget_set_parent(mail_entry, area);
+gtk_widget_set_parent(ok_button,  area);
+
+const char *vfl[] = {
+    "H:|-12-[name_label]-8-[name_entry]-12-|",
+    "H:|-12-[mail_label]-8-[mail_entry]-12-|",
+    "H:[ok_button(>=80)]-12-|",
+    "V:|-12-[name_label]-8-[mail_label]-(>=16)-[ok_button]-12-|",
+    "V:[name_entry(==name_label)]",
+    "V:[mail_entry(==mail_label)]",
+};
+
+GHashTable *views = g_hash_table_new(g_str_hash, g_str_equal);
+g_hash_table_insert(views, (gpointer)"name_label", name_label);
+g_hash_table_insert(views, (gpointer)"name_entry", name_entry);
+g_hash_table_insert(views, (gpointer)"mail_label", mail_label);
+g_hash_table_insert(views, (gpointer)"mail_entry", mail_entry);
+g_hash_table_insert(views, (gpointer)"ok_button",  ok_button);
+
+GError *err = NULL;
+gtk_constraint_layout_add_constraints_from_descriptionv(
+    cl, vfl, G_N_ELEMENTS(vfl), 8, 8, views, &err);
+
+gtk_window_present(GTK_WINDOW(win));
+```
+
+In about 30 lines, this composes a two-field form with consistent baseline
+alignment between labels and entries, a save button anchored to the bottom
+right, and a flexible vertical gap that absorbs window resize. The same
+layout in `GtkBox`/`GtkGrid` would need explicit nesting and several
+expansion flags; in `GtkConstraintLayout` it reads almost like the visual
+description.
+
+### Comparing GTK 4 to GTK 3
+
+The key shift from GTK 3 to GTK 4 in the layout space:
+
+| Concept                   | GTK 3                                                                      | GTK 4                                                                 |
+| ------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Layout algorithm location | Each container subclasses `GtkContainer` and implements its own algorithm. | Separate `GtkLayoutManager` object attached via `set_layout_manager`. |
+| Pack semantics            | `gtk_box_pack_start`/`pack_end` with `expand`/`fill`/`padding` per child.  | `gtk_box_append`/`prepend` + widget's universal `hexpand`/`halign`.   |
+| Margins                   | `margin-left`/`margin-right` (LTR-specific).                               | `margin-start`/`margin-end` (logical, RTL-aware).                     |
+| Custom layouts            | Subclass `GtkContainer` (large, complex base class).                       | Subclass `GtkLayoutManager` (small, focused base class).              |
+| Constraint solving        | Not built in.                                                              | `GtkConstraintLayout` ships with the toolkit.                         |
+| `GtkAlignment` widget     | Used to wrap a child for alignment.                                        | Removed — use universal `halign`/`valign` properties.                 |
+| `GtkVBox`, `GtkHBox`      | Distinct widget classes.                                                   | Removed — use `GtkBox` with `orientation` property.                   |
+
+Migration is mostly mechanical: the new APIs are smaller and more orthogonal
+than the old ones. The biggest gain is composability — once you understand
+`GtkLayoutManager`, you can mix and match layouts in ways that GTK 3
+required widget surgery to achieve.
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Clean separation of widget and layout.** In GTK 4 the algorithm is a
+  swappable strategy object. Changing a `GtkBox` from horizontal to vertical,
+  or replacing its `GtkBoxLayout` with a `GtkConstraintLayout`, does not
+  require touching the children. This is a strictly better architecture than
+  GTK 3's per-container hardcoded layouts.
+- **Height-for-width is first-class.** GTK is rare among toolkits in
+  modeling orientation-dependent measurement as part of the base widget
+  protocol. Text-heavy and resizable UIs work without per-widget hacks.
+- **Universal per-widget layout properties.** `halign`, `valign`, `margin-*`,
+  `hexpand`, `vexpand` live on every `GtkWidget` and behave identically
+  regardless of the parent's layout manager. No equivalent of Qt's "this
+  property only matters in `QHBoxLayout`" surprises.
+- **Constraint solver in the box.** `GtkConstraintLayout` brings Cassowary
+  to the toolkit. For complex compositions that would require deeply nested
+  box/grid trees, constraints provide a flatter, more readable description.
+- **Logical RTL by default.** `margin-start`/`margin-end` and
+  `Layout.alignment` semantics flip automatically for right-to-left
+  locales. No conditional code is needed for Arabic/Hebrew layouts.
+- **Small, focused layout classes.** Each `GtkLayoutManager` does one thing.
+  This is easier to learn than a single sprawling layout class with two
+  dozen toggles.
+- **Custom layout managers are first-class.** Subclassing `GtkLayoutManager`
+  is far simpler than subclassing GTK 3's `GtkContainer`. Hobbyist projects
+  routinely ship their own layouts now (e.g. masonry, force-directed,
+  hexagon grids).
+- **GtkBuilder XML.** Layouts can be expressed declaratively in XML and
+  loaded at runtime. The Glade-style designer (now Cambalache) generates
+  these files directly.
+- **List-view performance.** `GtkListView`/`GtkColumnView`/`GtkGridView`
+  recycle row widgets and only instantiate enough widgets to fill the
+  viewport, scaling cleanly to millions of items.
+
+### Weaknesses
+
+- **Smaller built-in library than Qt.** Qt ships five core layouts plus
+  several specialized variants. GTK 4 has seven layouts in total, several
+  of which are very narrow in purpose (`GtkBinLayout`, `GtkCenterLayout`).
+  You frequently end up nesting boxes when a single richer layout would do.
+- **No per-row/column stretch factors on `GtkGridLayout`.** Distribution of
+  extra space comes from `hexpand`/`vexpand` flags on children, which is
+  less direct than Qt's `setColumnStretch(col, n)`. Achieving "this column
+  is twice as wide as that column" requires either explicit width requests
+  or constraint expressions.
+- **Per-child layout properties are opaque.** Setting grid placement
+  requires going through `GtkGridLayoutChild` or the wrapper API
+  (`gtk_grid_attach`), which is fine in C but feels indirect in language
+  bindings — Python, JavaScript, and Vala all have to surface a child
+  property mechanism.
+- **`GtkConstraintLayout` performance.** Cassowary scales well for moderate
+  systems but is measurably slower than `GtkBoxLayout` for the simple cases.
+  Most app developers default to nested boxes/grids and use constraints
+  only for the parts that really need them.
+- **Custom layouts must implement measure precisely.** Bugs in `measure()`
+  or `allocate()` cause subtle clipping, jitter, and crash-on-resize
+  problems. GTK 4 is stricter than GTK 3 about this contract.
+- **Migration cost from GTK 3 is significant.** Apps with extensive layout
+  code have to relearn the model. There are no automatic translation tools
+  for `pack_start`/`pack_end` semantics.
+- **Limited declarative syntax.** Unlike Qt Quick's QML, GTK has no
+  reactive/declarative layout language. GtkBuilder XML describes a static
+  tree, not a function of state. Some projects use Blueprint
+  (<https://gnome.pages.gitlab.gnome.org/blueprint-compiler/>) to get a
+  more readable surface, but it still produces a static description.
+- **Mixing of measure-time and CSS styling.** GTK 4 uses CSS for visual
+  styling (colors, fonts, borders) and ignores most layout properties from
+  CSS. Newcomers from the web frequently expect `display: flex` to work.
+
+### Comparison to other systems
+
+- **Qt.** See [`./qt-layouts.md`](./qt-layouts.md). Qt's `QLayout`
+  hierarchy is conceptually similar but predates GTK 4 by 15 years. Qt
+  ships a richer built-in layout library; GTK 4 ships a more orthogonal one
+  and adds the Cassowary solver.
+- **Cocoa AutoLayout.** GTK's `GtkConstraintLayout` is directly inspired by
+  AutoLayout and uses the same VFL syntax (`H:|-[button]-|`, etc.). The
+  underlying solver is the same Cassowary algorithm.
+- **CSS Flexbox / Grid.** GTK's `GtkBoxLayout` is similar in spirit to
+  flexbox single-axis behavior; `GtkGridLayout` is similar to CSS Grid but
+  without subgrid or named lines. Both Qt Quick layouts and GTK are less
+  expressive than CSS Grid for complex 2D arrangements.
+- **Ratatui constraints.** Ratatui (see
+  [`../tui-libraries/ratatui.md`](../tui-libraries/ratatui.md)) uses the
+  same Cassowary solver via the `kasuari` crate, but applies it to 1D
+  splits of rectangles rather than full 2D constraint systems.
+- **Ink / Yoga.** See [`../tui-libraries/ink.md`](../tui-libraries/ink.md).
+  Yoga implements CSS flexbox over terminal-cell coordinates; the
+  layout-manager-as-strategy concept is broadly similar to GTK's, though
+  Yoga is a single layout algorithm rather than a family.
+- **Textual.** Textual's CSS-like layout syntax (see
+  [`../tui-libraries/textual.md`](../tui-libraries/textual.md)) is closer
+  to CSS than to GTK, but both share the idea that layout is a separate
+  concern from widget identity.
+
+---
+
+## References
+
+- **GTK 4 documentation root.** <https://docs.gtk.org/gtk4/>
+- **`GtkLayoutManager` class reference.**
+  <https://docs.gtk.org/gtk4/class.LayoutManager.html>
+- **Built-in layout managers.**
+  - `GtkBoxLayout`: <https://docs.gtk.org/gtk4/class.BoxLayout.html>
+  - `GtkGridLayout`: <https://docs.gtk.org/gtk4/class.GridLayout.html>
+  - `GtkGridLayoutChild`: <https://docs.gtk.org/gtk4/class.GridLayoutChild.html>
+  - `GtkCenterLayout`: <https://docs.gtk.org/gtk4/class.CenterLayout.html>
+  - `GtkBinLayout`: <https://docs.gtk.org/gtk4/class.BinLayout.html>
+  - `GtkOverlayLayout`: <https://docs.gtk.org/gtk4/class.OverlayLayout.html>
+  - `GtkFixedLayout`: <https://docs.gtk.org/gtk4/class.FixedLayout.html>
+  - `GtkCustomLayout`: <https://docs.gtk.org/gtk4/class.CustomLayout.html>
+  - `GtkConstraintLayout`: <https://docs.gtk.org/gtk4/class.ConstraintLayout.html>
+- **Constraint primitives.**
+  - `GtkConstraint`: <https://docs.gtk.org/gtk4/class.Constraint.html>
+  - `GtkConstraintGuide`: <https://docs.gtk.org/gtk4/class.ConstraintGuide.html>
+- **Widget protocol.**
+  - `GtkWidget` (measure, allocate, alignment, margins):
+    <https://docs.gtk.org/gtk4/class.Widget.html>
+  - `GtkSizeRequestMode`:
+    <https://docs.gtk.org/gtk4/enum.SizeRequestMode.html>
+  - `GtkAlign`: <https://docs.gtk.org/gtk4/enum.Align.html>
+- **Container widgets.**
+  - `GtkBox`: <https://docs.gtk.org/gtk4/class.Box.html>
+  - `GtkGrid`: <https://docs.gtk.org/gtk4/class.Grid.html>
+  - `GtkCenterBox`: <https://docs.gtk.org/gtk4/class.CenterBox.html>
+  - `GtkOverlay`: <https://docs.gtk.org/gtk4/class.Overlay.html>
+  - `GtkFixed`: <https://docs.gtk.org/gtk4/class.Fixed.html>
+  - `GtkPaned`: <https://docs.gtk.org/gtk4/class.Paned.html>
+  - `GtkStack`: <https://docs.gtk.org/gtk4/class.Stack.html>
+  - `GtkRevealer`: <https://docs.gtk.org/gtk4/class.Revealer.html>
+  - `GtkScrolledWindow`: <https://docs.gtk.org/gtk4/class.ScrolledWindow.html>
+- **List/grid views.**
+  - `GtkListBox`: <https://docs.gtk.org/gtk4/class.ListBox.html>
+  - `GtkFlowBox`: <https://docs.gtk.org/gtk4/class.FlowBox.html>
+  - `GtkListView`: <https://docs.gtk.org/gtk4/class.ListView.html>
+  - `GtkColumnView`: <https://docs.gtk.org/gtk4/class.ColumnView.html>
+  - `GtkGridView`: <https://docs.gtk.org/gtk4/class.GridView.html>
+- **GTK 4 migration and history.**
+  - Migration guide (GTK 3 to 4):
+    <https://docs.gtk.org/gtk4/migrating-3to4.html>
+  - GTK 4.0 release announcement (2020):
+    <https://blog.gtk.org/2020/12/16/gtk-4-0/>
+  - Visual index / widget gallery:
+    <https://docs.gtk.org/gtk4/visual_index.html>
+- **Constraint solver background.**
+  - Cassowary algorithm paper, Badros & Borning (1998):
+    <https://constraints.cs.washington.edu/solvers/cassowary-tochi.pdf>
+  - Cocoa AutoLayout (the original VFL):
+    <https://developer.apple.com/library/archive/documentation/UserExperience/Conceptual/AutolayoutPG/>
+- **Cross-references in this catalog.**
+  - Qt layouts: [`./qt-layouts.md`](./qt-layouts.md)
+  - Ratatui constraint layout:
+    [`../tui-libraries/ratatui.md`](../tui-libraries/ratatui.md)
+  - Ink / Yoga / Flexbox:
+    [`../tui-libraries/ink.md`](../tui-libraries/ink.md)
+  - Textual CSS-like layout:
+    [`../tui-libraries/textual.md`](../tui-libraries/textual.md)

--- a/docs/research/ui-layout/i3-sway.md
+++ b/docs/research/ui-layout/i3-sway.md
@@ -1,0 +1,632 @@
+# i3 and Sway (tiling window managers)
+
+A pair of tree-based tiling window managers — i3 for X11 and Sway for Wayland — that
+model the entire screen as a single hierarchical tree of split containers, where
+each leaf is a window and each internal node has a split direction. They are
+included in this UI-layout catalog because their tree-of-splits model is _the_
+production-proven solution to the same problem TUI authors face: dividing a fixed
+rectangle into nested resizable panes.
+
+| Field          | i3                                     | Sway                                      |
+| -------------- | -------------------------------------- | ----------------------------------------- |
+| Author         | Michael Stapelberg                     | Drew DeVault                              |
+| Started        | 2009                                   | 2015                                      |
+| Language       | C                                      | C                                         |
+| Display server | X11                                    | Wayland                                   |
+| License        | BSD-3-Clause                           | MIT                                       |
+| Repository     | <https://github.com/i3/i3>             | <https://github.com/swaywm/sway>          |
+| Documentation  | <https://i3wm.org/docs/userguide.html> | <https://man.archlinux.org/man/sway.5.en> |
+| Config syntax  | Declarative; same dialect as Sway      | Drop-in compatible with i3 config syntax  |
+| IPC tool       | `i3-msg`                               | `swaymsg`                                 |
+
+---
+
+## Overview
+
+**i3** is a tiling window manager built around an explicit, user-visible tree of
+container nodes. Michael Stapelberg started it in 2009 in reaction to what he saw
+as design flaws in earlier tiling WMs like wmii, xmonad, and dwm: those projects
+hard-coded a single layout algorithm (dynamic master/stack, manual, or
+flat tagged), which made certain arrangements awkward or impossible. i3's
+contribution was to _expose_ the tiling tree as a first-class data structure that
+the user manipulates directly — splitting a node, moving a leaf, swapping siblings,
+or marking a node by name — rather than choosing from a fixed menu of layouts.
+
+**Sway** is a Wayland compositor that reimplements i3's behaviour from scratch on
+top of `wlroots` (the reference Wayland library co-developed by Drew DeVault and
+others). Drew DeVault started Sway in 2015 with an explicit compatibility goal:
+existing i3 config files should work unchanged. The bet paid off — Sway is today
+the dominant Wayland tiling compositor and the _de facto_ migration path for i3
+users moving off X11.
+
+**Why discuss tiling WMs in a UI-layout catalog?** Because the tree-of-splits is
+exactly the data structure a TUI library like [Ratatui](../tui-libraries/ratatui.md)
+or [Textual](../tui-libraries/textual.md) builds to subdivide its terminal area
+into resizable panes. Tiling WMs are the same idea operating one level higher: the
+"terminal" is the monitor, the "widgets" are application windows, and the layout
+is constructed _by direct user manipulation_ over a session of hours or days
+rather than by a programmer in source code. The interaction patterns (split
+horizontally, split vertically, change parent's orientation, resize within
+siblings) translate one-for-one to programmatic TUI layout APIs.
+
+**Comparison to other tiling WMs.** Several other tiling window managers exist,
+each with a different layout abstraction:
+
+| Project       | Layout model                                              |
+| ------------- | --------------------------------------------------------- |
+| **dwm**       | Master area + stack; one window is "master", rest stack.  |
+| **xmonad**    | Layout algorithms as first-class typeclass; user picks.   |
+| **bspwm**     | Binary tree similar to i3; layout via `bspc` IPC.         |
+| **awesome**   | Lua-scripted layouts; multiple algorithms per tag.        |
+| **i3 / Sway** | User-manipulated explicit tree; tabbed and stacked nodes. |
+| **Hyprland**  | Dynamic tiling on Wayland; similar to Sway with effects.  |
+| **river**     | Dynamic tiling on Wayland; layouts as external processes. |
+
+The defining feature of i3/Sway compared to bspwm (which also uses a binary tree)
+is that **internal nodes are themselves containers with their own layout mode** —
+not just split directions. An internal node can be `splith`, `splitv`, `tabbed`,
+or `stacking`, which transforms the visual representation of its children without
+changing the tree structure.
+
+---
+
+## Layout Model
+
+### The tree
+
+The entire screen state is one tree, rooted at the display server (X11 root or
+Wayland output set). The i3 user guide describes the levels:
+
+> The root node is the X11 root window, followed by the X11 outputs, then dock
+> areas and a content container, then workspaces and finally the windows
+> themselves.
+
+Simplified, the hierarchy is:
+
+```
+Root
+├── Output 0  (monitor)
+│   ├── Workspace 1
+│   │   └── (root container of WS 1; layout = splith, splitv, tabbed, or stacking)
+│   │       ├── Container (leaf: window)
+│   │       └── Container (internal: another split)
+│   │           ├── Window
+│   │           └── Window
+│   └── Workspace 2
+│       └── ...
+├── Output 1
+│   └── Workspace 3
+└── Output 2
+    └── ...
+```
+
+Two invariants govern this tree:
+
+1. **Each output displays exactly one workspace at a time.** Other workspaces
+   on the same output exist but are not painted. Switching workspaces is O(1) —
+   the compositor flips which subtree it renders.
+
+2. **Every leaf is a window; every internal node is a container with a layout.**
+   There is no separate notion of "window" and "non-window"; a leaf-window can be
+   converted into an internal node by splitting it, and an internal node with a
+   single child collapses.
+
+### Container types and layout modes
+
+A container's _layout mode_ dictates how its children are arranged visually:
+
+| Layout     | Visual representation                                                           |
+| ---------- | ------------------------------------------------------------------------------- |
+| `splith`   | Children laid out left-to-right, each taking a share of horizontal space.       |
+| `splitv`   | Children laid out top-to-bottom, each taking a share of vertical space.         |
+| `tabbed`   | All children stacked in z-order; one tab bar at the top selects which is shown. |
+| `stacking` | All children stacked in z-order; tab list along the top, each on its own line.  |
+
+`tabbed` and `stacking` are the genius move of the i3 design: they let the _same_
+tree expose a _different_ visual idiom. A `tabbed` internal node looks like a tab
+container in a GUI; a `splitv` internal node containing two `tabbed` children
+looks like a side-by-side pair of tab strips. The user reshapes the layout by
+changing layout modes on internal nodes, without ever restructuring the tree.
+
+The sway(5) man page describes the rule for `stacking`:
+
+> When using the stacking layout, only the focused window in the container is
+> displayed, with the opened windows' list on the top of the container.
+
+The `tabbed` variant differs only in _how_ the title list is rendered (one
+horizontal strip vs. one entry per row).
+
+### Window-insertion rule
+
+When the user opens a new application window, where in the tree does it land?
+The rule is deceptively simple and is the core of how i3 feels:
+
+**A new window opens as a sibling of the focused container.**
+
+That is: if the focused container's parent has layout `splith`, the new window
+joins the row to the right of the focus. If the parent is `splitv`, it stacks
+below. If the parent is `tabbed` or `stacking`, the new window becomes a new tab.
+
+When the user explicitly wants a _split_ (a nested orientation change), they run
+`split horizontal` or `split vertical` on the focused window first. This wraps the
+focused window in a new internal node with the chosen orientation, so the next
+window opens as a sibling within that nested node.
+
+In effect, the workflow is:
+
+```text
++----------------+        +----------------+        +----------------+
+|                |        |                |   ->   |        | new   |
+|     focus      |  ->    |     focus      |        | focus  | win   |
+|                |        |                |        |        |       |
++----------------+        +----------------+        +----------------+
+   (splitv parent)         (after `split h`,         (next new window
+                            focus is now in a         lands here)
+                            splith child)
+```
+
+This is the same pattern a TUI layout API expresses with:
+
+```rust
+// Pseudocode: ratatui-style nested split
+let [top, bottom] = Layout::vertical([..]).areas(area);
+let [left, right] = Layout::horizontal([..]).areas(top);
+```
+
+— with the difference that i3 builds the tree _interactively_ via a long sequence
+of keybindings, and persists it across the WM's runtime.
+
+### Commands and keybindings
+
+The i3/Sway command vocabulary is small but composable. Selected commands from
+the user guide and sway(5):
+
+```text
+# Layout-mode changes on the focused container.
+layout splith
+layout splitv
+layout tabbed
+layout stacking
+layout toggle split           # cycle splith <-> splitv
+layout toggle all             # cycle through all four layouts
+
+# Splits — wrap the focused window in a new internal node.
+split horizontal
+split vertical
+split toggle                  # flip parent's orientation
+
+# Focus.
+focus left | right | up | down
+focus parent | child
+focus next | prev
+focus output left | right | <name>
+
+# Move containers within the tree.
+move left | right | up | down [<px> px]
+move container to workspace <name>
+move container to output left | right | <name>
+move workspace to output <direction|name>
+
+# Mark and reference.
+mark --add MyMark
+[con_mark="MyMark"] focus
+unmark MyMark
+swap container with mark MyMark
+
+# Resize.
+resize grow   width  10 px or 10 ppt
+resize shrink height 10 px or 10 ppt
+resize set width 600 px
+
+# Floating.
+floating enable
+floating disable
+floating toggle
+```
+
+The `or` keyword in resize commands is the canonical example of how i3 thinks
+about sizes: try the `px` size first; if that hits a tree-level constraint (the
+target container can't actually shrink/grow by that many pixels), fall back to
+the `ppt` (percentage-points) size, which always succeeds because it operates on
+proportional weights between siblings.
+
+### Resize as proportions
+
+Resizing inside a `splith` or `splitv` parent does _not_ mean "this window is 600
+px wide". It means "this window's share of its parent's space is 0.45 vs. its
+sibling's 0.55". When the parent itself shrinks (because the user resized the
+parent, or the monitor changed resolution, or a sibling was added), the children
+re-divide the new space proportionally.
+
+This is structurally identical to Ratatui's `Constraint::Ratio(num, denom)` (or
+Flexbox's `flex-grow`): the unit of layout is a fraction of an ancestor, not an
+absolute pixel count. The resize command `resize grow width 10 ppt` adjusts the
+proportion by 0.1, leaving the parent's total share alone.
+
+### Floating: escape the tree
+
+A floating window is one that is _not_ a leaf in the tiling tree of its workspace.
+Instead, it lives in a per-workspace "floating layer" with an absolute position
+and size, painted on top of the tiled area. The tree still tracks it (so it can
+be marked, focused, moved), but layout commands like `resize grow width 10 ppt`
+are interpreted as absolute pixel resizes when applied to a floating window.
+
+Floating exists because some applications — file dialogs, password prompts,
+ephemeral popovers — are conceptually modal and ill-served by tiling. Sway and i3
+auto-detect many of these via window-type hints (`_NET_WM_WINDOW_TYPE_DIALOG`),
+and `for_window` rules let the user opt others in.
+
+### Workspaces and outputs
+
+Each workspace owns its own tree. The compositor maintains an `outputs` array
+(monitors), and at any moment each output is showing exactly one workspace.
+Switching workspaces means re-pointing one output's "currently-shown" pointer at
+a different workspace subtree. Moving a workspace to another output (`move
+workspace to output right`) reassigns the parent edge in the global tree.
+
+Workspaces are named or numbered:
+
+```text
+bindsym $mod+1 workspace 1: mail
+bindsym $mod+2 workspace 2: www
+bindsym $mod+3 workspace 3: code
+
+# Move the focused window to workspace 2.
+bindsym $mod+Shift+2 move container to workspace 2: www
+```
+
+This is a _very_ lightweight abstraction: a workspace is just a node in the tree
+plus a name. There is no per-workspace "layout policy" or "tag" mechanism — the
+tree's structure _is_ the layout.
+
+### Example config — full layout
+
+A minimal but complete i3 / Sway config that demonstrates the layout primitives:
+
+```text
+# ~/.config/sway/config   (or ~/.config/i3/config — same syntax)
+
+# Modifier key (Super / "Windows" key).
+set $mod Mod4
+
+# Terminal.
+bindsym $mod+Return exec foot
+
+# Kill focused window.
+bindsym $mod+Shift+q kill
+
+# --- Split orientation ----------------------------------------------
+# Wrap focused window in a new horizontal split (next new window opens to
+# the right of focus, inside a fresh splith parent).
+bindsym $mod+h split h
+# Wrap focused window in a new vertical split.
+bindsym $mod+v split v
+
+# --- Layout mode ----------------------------------------------------
+# Change the focused container's layout.
+bindsym $mod+s   layout stacking
+bindsym $mod+w   layout tabbed
+bindsym $mod+e   layout toggle split
+
+# --- Focus movement (vim-style) -------------------------------------
+bindsym $mod+j focus left
+bindsym $mod+k focus down
+bindsym $mod+l focus up
+bindsym $mod+semicolon focus right
+bindsym $mod+a focus parent
+bindsym $mod+d focus child
+
+# --- Container movement ---------------------------------------------
+bindsym $mod+Shift+j move left
+bindsym $mod+Shift+k move down
+bindsym $mod+Shift+l move up
+bindsym $mod+Shift+semicolon move right
+
+# --- Workspaces -----------------------------------------------------
+bindsym $mod+1 workspace 1
+bindsym $mod+2 workspace 2
+bindsym $mod+3 workspace 3
+bindsym $mod+Shift+1 move container to workspace 1
+bindsym $mod+Shift+2 move container to workspace 2
+bindsym $mod+Shift+3 move container to workspace 3
+
+# --- Resize mode ----------------------------------------------------
+# Enter a sub-mode where jkl; resize, Escape exits.
+mode "resize" {
+    bindsym j resize grow   width  10 ppt or 10 px
+    bindsym k resize grow   height 10 ppt or 10 px
+    bindsym l resize shrink height 10 ppt or 10 px
+    bindsym semicolon resize shrink width 10 ppt or 10 px
+
+    bindsym Escape mode "default"
+    bindsym Return mode "default"
+}
+bindsym $mod+r mode "resize"
+
+# --- Floating -------------------------------------------------------
+bindsym $mod+Shift+space floating toggle
+floating_modifier $mod
+
+# --- Multi-monitor outputs ------------------------------------------
+# (sway-only — i3 reads xrandr instead.)
+output HDMI-A-1 resolution 2560x1440 position 0,0
+output DP-1      resolution 1920x1080 position 2560,360
+
+# Pin workspace 1 to the primary monitor, 2 to the secondary.
+workspace 1 output HDMI-A-1
+workspace 2 output DP-1
+```
+
+This is the _entire_ layout policy for a usable system: no algorithms to pick, no
+layout objects to instantiate, no z-order arithmetic. The user constructs the
+layout interactively, and the config exists only to bind a vocabulary of
+mutations to keys.
+
+### Marks, scratchpad, and criteria
+
+Two further mechanisms enrich the basic tree model:
+
+**Marks** are user-assigned string labels on containers, modelled directly on
+Vim's mark feature. A mark is attached with `mark --add MyMark` on the focused
+container; subsequent commands can target it via the criteria syntax
+`[con_mark="MyMark"]`. Marks are workspace-spanning — a command like:
+
+```text
+bindsym $mod+grave [con_mark="terminal"] focus
+```
+
+teleports focus to the marked terminal regardless of which workspace it lives on.
+The `swap container with mark MyMark` command exchanges the focused container
+with the marked one _in-place_, preserving each one's tree position. This is
+remarkably useful when juggling layouts: mark a window, build a new layout
+elsewhere, then swap the two with a single key.
+
+**Scratchpad** is a special hidden workspace that holds windows on standby. A
+container moved to the scratchpad (`move scratchpad`) disappears from view; the
+keybinding `scratchpad show` toggles a floating-window display of one scratchpad
+container at a time. This is the i3/Sway equivalent of "minimise to tray" — used
+for chat clients, music players, and other always-running auxiliaries the user
+wants to summon quickly.
+
+**Criteria** are filter expressions that prefix a command, restricting it to
+matching windows. The syntax is square-bracketed `[key=value, key=value]`:
+
+```text
+# Make all Firefox dialog windows float by default.
+for_window [class="Firefox" window_type="dialog"] floating enable
+
+# Move all VS Code windows to workspace 3.
+for_window [class="Code"] move container to workspace 3
+
+# Border style per application.
+for_window [class="foot"] border pixel 1
+for_window [app_id="firefox"] border none
+```
+
+Available criteria keys include `class`, `app_id` (Wayland), `instance`, `title`,
+`window_role`, `window_type`, `con_mark`, `con_id`, `urgent`, and `tiling` /
+`floating`. The criteria language is small but compositional, and it lets users
+encode layout policies declaratively without scripting.
+
+### Reading the tree at runtime
+
+Both i3 and Sway expose the current tree over a JSON IPC. `i3-msg -t get_tree`
+(or `swaymsg -t get_tree`) dumps the entire hierarchy. A truncated example:
+
+```json
+{
+  "type": "root",
+  "nodes": [
+    {
+      "type": "output",
+      "name": "HDMI-A-1",
+      "nodes": [
+        {
+          "type": "workspace",
+          "name": "1",
+          "layout": "splith",
+          "nodes": [
+            {
+              "type": "con",
+              "layout": "splitv",
+              "nodes": [
+                { "type": "con", "window_properties": { "class": "foot" } },
+                { "type": "con", "window_properties": { "class": "Firefox" } }
+              ]
+            },
+            { "type": "con", "window_properties": { "class": "code" } }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+This makes the tree _introspectable_ — you can write external tools that walk it,
+script layouts, or build status bars that display the layout structure. The
+sparkles equivalent for a TUI layout would be a serialisable layout-node type.
+
+### Comparison to a Ratatui split layout
+
+The same two-column-with-nested-rows layout, expressed in three idioms:
+
+**i3/Sway (interactively):**
+
+```text
+$mod+v          # wrap focus in vertical split
+$mod+Return     # spawn a terminal (lands below focus)
+$mod+h          # wrap focus in horizontal split
+$mod+Return     # spawn another terminal (lands to the right)
+```
+
+**Ratatui (programmatically):**
+
+```rust
+let [left, right] = Layout::horizontal([
+    Constraint::Percentage(60),
+    Constraint::Fill(1),
+]).areas(area);
+
+let [top_right, bottom_right] = Layout::vertical([
+    Constraint::Ratio(1, 2),
+    Constraint::Ratio(1, 2),
+]).areas(right);
+```
+
+**Textual (declaratively):**
+
+```python
+with Horizontal():
+    yield SidebarPanel()
+    with Vertical():
+        yield DetailPanel()
+        yield LogPanel()
+```
+
+All three produce the same logical structure: a tree of split nodes whose leaves
+are content regions. The difference is _who builds the tree_: a user with a
+keyboard (i3/Sway), a programmer at compile time (Ratatui), or a framework via a
+component graph (Textual).
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Predictable and inspectable.** The tree _is_ the layout. There is no hidden
+  algorithm to reverse-engineer when something looks wrong. `swaymsg -t get_tree`
+  shows exactly what the compositor will paint.
+
+- **Fast.** Layout is a tree walk, O(n) in the number of nodes. There is no
+  constraint solver, no flexbox-style two-pass measure/arrange. Resizing
+  propagates by adjusting sibling weights at one level.
+
+- **Composable layout modes.** `splith`, `splitv`, `tabbed`, and `stacking` cover
+  almost every practical arrangement. Tabbed+stacked nested inside split
+  containers yields layouts that retained-mode toolkits implement as separate
+  widget classes (TabView, SplitView, AccordionView), here all unified into one
+  primitive.
+
+- **Sway's drop-in compatibility with i3.** A single config file works on both,
+  which is rare and valuable when a community migrates display protocols.
+
+- **Scripting via IPC.** `i3-msg` / `swaymsg` accept any command the keybinding
+  system accepts. External tools can apply layouts, query state, react to events
+  (workspace changes, window focus changes) over a Unix socket subscription
+  channel.
+
+- **No layout configuration burden.** Unlike dwm or xmonad, the user does not
+  pick a layout algorithm; they construct the layout they want by direct
+  manipulation. The cognitive model is small.
+
+### Weaknesses
+
+- **Unfamiliar mental model for new users.** Most computer users have learned
+  the _floating_ window paradigm (overlapping, draggable rectangles). Tree-of-
+  splits requires unlearning that and thinking about the focused-window's parent
+  layout when opening a new window. Documentation helps, but the learning curve
+  is real.
+
+- **No persistent layout templates.** Once you close all windows in a workspace,
+  the tree is empty. Re-creating the exact same layout next session requires
+  external tools (`i3-save-tree` / `i3-resurrect`) and is not a first-class
+  concept. (Contrast: tmux sessions can be saved and restored verbatim via
+  `tmuxinator`-style configs.)
+
+- **Floating windows are a second-class citizen.** They escape the tree, which
+  is _correct_ for modal dialogs but awkward when an application's intended UX is
+  many small floating panels (image editors, 3D modelling tools).
+
+- **Multi-monitor layout is workspace-coarse.** Outputs always show entire
+  workspaces; there is no concept of "this workspace's tree spans both monitors".
+  Users who want one logical screen split across two physical monitors have to
+  pretend each is a separate workspace.
+
+- **No animation, by design.** Transitions are instantaneous. i3 considers this
+  a feature; Hyprland (a newer Sway-compatible compositor) has made the opposite
+  bet with animations as a headline feature. Personal preference.
+
+- **Wayland-specific Sway quirks.** Sway inherits Wayland's restrictions: no
+  global hotkeys for external apps, no screen-capture APIs in older versions, no
+  arbitrary window positioning by applications. These are Wayland constraints,
+  not Sway bugs, but they affect ports of X11 software.
+
+### Lessons for `sparkles` and TUI layout design
+
+- **Split-pane TUI layouts map directly onto the i3 tree model.** A `drawTable`
+  primitive is admittedly a stretch — tables are 2-D arrays of cells, not
+  hierarchical splits — but a _layout container_ for sparkles would benefit from
+  exposing `splith`, `splitv`, `tabbed`, and `stacking` as first-class layout
+  modes, with the same composition rules. Both [Ratatui](../tui-libraries/ratatui.md)
+  and [Textual](../tui-libraries/textual.md) build similar split-pane layouts
+  inside a single terminal; i3's model is the design they converge on.
+
+- **Make the tree introspectable.** i3/Sway's IPC tree dump (`get_tree`) is
+  invaluable for debugging. A D layout library that can serialise its current
+  tree as JSON or pretty-printed text — using the existing
+  `sparkles.core_cli.prettyprint` machinery — would make layout bugs orders of
+  magnitude easier to diagnose.
+
+- **Proportional sizing is the right default.** i3's `ppt` resize is the same
+  abstraction as Ratatui's `Constraint::Ratio` and Flexbox's `flex-grow`. Pixel
+  sizes are useful for chrome (status bar height, separator thickness), but the
+  main content area almost always wants to be expressed as a fraction of
+  available space.
+
+- **The "wrap in a new split" operation is a useful API primitive.** Most TUI
+  libraries make you specify the entire layout structure upfront, but the
+  operation "take this region and split it into two" is sometimes more natural,
+  particularly for dynamic UIs like log-viewer-with-detail-pane that should
+  appear on demand.
+
+- **Tabbed/stacking inside splith/splitv is a force multiplier.** This single
+  feature would let a sparkles TUI layout collapse what would otherwise be three
+  separate widget types (Split, TabView, Accordion) into one.
+
+---
+
+## References
+
+### i3
+
+- **User guide:** <https://i3wm.org/docs/userguide.html>
+- **Project site:** <https://i3wm.org/>
+- **IPC documentation:** <https://i3wm.org/docs/ipc.html>
+- **Repository:** <https://github.com/i3/i3>
+- **History:** <https://i3wm.org/downloads/> (release archive going back to 2009)
+
+### Sway
+
+- **Project site:** <https://swaywm.org/>
+- **Repository:** <https://github.com/swaywm/sway>
+- **`sway(5)` config man page:** <https://man.archlinux.org/man/sway.5.en>
+- **`sway(1)` invocation man page:** <https://man.archlinux.org/man/sway.1.en>
+- **`wlroots`:** <https://gitlab.freedesktop.org/wlroots/wlroots> — the Wayland
+  compositor library Sway is built on.
+
+### Related projects
+
+- **bspwm:** <https://github.com/baskerville/bspwm> — another binary-tree tiling
+  WM, with all state mutation via the `bspc` IPC tool.
+- **Hyprland:** <https://hyprland.org/> — Wayland compositor with i3-style tiling
+  and modern animations.
+- **river:** <https://codeberg.org/river/river> — Wayland tiling with dynamic
+  layouts implemented as external "layout generator" processes.
+- **dwm:** <https://dwm.suckless.org/> — minimal master/stack X11 tiler.
+- **xmonad:** <https://xmonad.org/> — Haskell-scripted tiling with first-class
+  layout algorithms.
+
+### Catalog cross-links
+
+- [Ratatui](../tui-libraries/ratatui.md) — TUI library whose `Layout` with nested
+  `horizontal` / `vertical` splits matches the i3 tree exactly, statically.
+- [Textual](../tui-libraries/textual.md) — TUI framework whose `Horizontal` /
+  `Vertical` containers and CSS grid build the same tree declaratively.
+- [Brick](../tui-libraries/brick.md) — Haskell TUI library; `hBox` / `vBox`
+  combinators are the functional analogue of i3 splits.
+- [FTXUI](../tui-libraries/ftxui.md) — C++ TUI with `hbox` / `vbox` /
+  `dbox` / `gridbox` decorators; another point on the same design axis.
+- [tree-view case study](../tui-libraries/tree-view-case-study.md) — relevant
+  background on rendering tree structures in a constrained 2-D area.

--- a/docs/research/ui-layout/index.md
+++ b/docs/research/ui-layout/index.md
@@ -1,0 +1,218 @@
+# UI Layout Catalog
+
+A breadth-first survey of UI layout libraries and the layout subsystems embedded in major UI/TUI/GUI frameworks. This catalog complements the [TUI Libraries Catalog](../tui-libraries/index.md) by zooming in on the **layout** dimension specifically: how widgets get sizes and positions, what primitives are exposed to the developer, and what algorithm runs underneath.
+
+The scope is deliberately broad. We cover renderer-agnostic layout libraries (Clay, Yoga, Taffy), web platform layout specifications (CSS Flexbox, CSS Grid, Normal Flow), modern declarative GUI frameworks (SwiftUI, Jetpack Compose, Flutter), traditional desktop GUI layouts (WPF/XAML, Qt, GTK), JVM and Apple stacks (Swing/MiG, Auto Layout), Android (ConstraintLayout), classical Tk geometry managers, immediate-mode UI layout (Dear ImGui, egui), tiling window managers (i3/sway, xmonad), and the foundational typesetting algorithm of Knuth-Plass. Each entry has its own detailed write-up.
+
+## Renderer-agnostic layout libraries
+
+| Library                   | Language | Layout Model                   | Sizing Vocabulary                               | Status   | Links                                                                          |
+| ------------------------- | -------- | ------------------------------ | ----------------------------------------------- | -------- | ------------------------------------------------------------------------------ |
+| **[Clay](clay.md)**       | C        | Box-flow (row/column)          | `FIT` / `GROW` / `FIXED` / `PERCENT` + min/max  | Active   | [repo](https://github.com/nicbarker/clay)                                      |
+| **[Yoga](yoga.md)**       | C++      | Flexbox (CSS subset)           | `flex-grow` / `flex-shrink` / `flex-basis`      | Active   | [repo](https://github.com/facebook/yoga) / [docs](https://www.yogalayout.dev/) |
+| **[Taffy](taffy.md)**     | Rust     | Flexbox + CSS Grid + CSS Block | CSS `Length` / `Percent` / `Auto` / `Fr` / etc. | Active   | [repo](https://github.com/DioxusLabs/taffy)                                    |
+| **[Stretch](stretch.md)** | Rust     | Flexbox (CSS subset)           | `flex-grow` / `flex-shrink` / `flex-basis`      | Archived | [repo](https://github.com/vislyhq/stretch)                                     |
+| **[Kiwi](kiwi.md)**       | C++ / Py | Linear constraint solver       | `Variable` + `Constraint` + `Strength`          | Active   | [repo](https://github.com/nucleic/kiwi)                                        |
+
+## Foundational algorithms
+
+| Algorithm                             | Domain             | Year | Reference Implementations                                         | Links                                                                      |
+| ------------------------------------- | ------------------ | ---- | ----------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **[Cassowary](cassowary.md)**         | Linear constraints | 1997 | Apple Auto Layout, GTK 4, kiwisolver, Cassowary.js, Cassowary.py  | [paper](https://constraints.cs.washington.edu/solvers/cassowary-tochi.pdf) |
+| **[Knuth-Plass](tex-knuth-plass.md)** | Line breaking      | 1981 | TeX, LuaTeX, SILE, knuth-plass.js, several CSS engine experiments | [paper](https://www.eprg.org/G53DOC/pdfs/knuth-plass-breaking.pdf)         |
+
+## Web platform layout specs
+
+| Specification                             | Level / Year               | Browsers Interop | Non-browser Implementations                                                                                                       |
+| ----------------------------------------- | -------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **[CSS Normal Flow](css-normal-flow.md)** | CSS 2.1 (2011) / Display 3 | Universal        | Foundational; every other CSS layout mode is a deviation from it                                                                  |
+| **[CSS Flexbox](css-flexbox.md)**         | Level 1 (2017) / Level 2   | Universal        | [Yoga](yoga.md), [Taffy](taffy.md), [Stretch](stretch.md), [Ink](../tui-libraries/ink.md), [Textual](../tui-libraries/textual.md) |
+| **[CSS Grid](css-grid.md)**               | Level 1 (2017) / Level 2   | Universal        | [Taffy](taffy.md); rare in TUI libraries                                                                                          |
+
+## Modern declarative GUI framework layouts
+
+| Framework                                 | Language | Layout Protocol            | Sizing Vocabulary                      | Cross-link                                                          |
+| ----------------------------------------- | -------- | -------------------------- | -------------------------------------- | ------------------------------------------------------------------- |
+| **[SwiftUI](swiftui.md)**                 | Swift    | Propose-and-respond        | min / ideal / max preferred sizes      | Apple-only                                                          |
+| **[Jetpack Compose](jetpack-compose.md)** | Kotlin   | Measure / place            | `Constraints(minWidth, maxWidth, ...)` | [Mosaic](../tui-libraries/mosaic.md) ports the runtime to terminals |
+| **[Flutter](flutter.md)**                 | Dart     | Constraints down, sizes up | `BoxConstraints` (tight / loose)       | -                                                                   |
+
+## Traditional desktop GUI layouts
+
+| Framework                              | Language          | Layout Model                 | Sizing Vocabulary                                     | Notable lineage                                                                  |
+| -------------------------------------- | ----------------- | ---------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **[WPF / XAML](wpf-xaml.md)**          | .NET (XAML+C#)    | Two-pass Measure / Arrange   | `Auto` / `Star (*)` / pixel + alignment               | Inherited by Silverlight, UWP, .NET MAUI, Avalonia, Uno                          |
+| **[Qt Layouts](qt-layouts.md)**        | C++ / QML         | Box / Grid / Form / Stacked  | `QSizePolicy` + stretch factor                        | QHBoxLayout / QVBoxLayout / QGridLayout / QFormLayout                            |
+| **[GTK 4](gtk.md)**                    | C (with bindings) | Pluggable `GtkLayoutManager` | halign / valign + hexpand / vexpand                   | GtkBoxLayout, GtkGridLayout, GtkConstraintLayout (Cassowary)                     |
+| **[Swing / MiG Layout](swing-mig.md)** | Java              | `LayoutManager` interface    | preferred / min / max + per-manager constraints       | FlowLayout, BorderLayout, GridLayout, BoxLayout, GridBagLayout, GroupLayout, MiG |
+| **[Tk geometry managers](tk.md)**      | Tcl/Tk            | `pack` / `grid` / `place`    | -side, -fill, -expand (pack); -sticky, -weight (grid) | Originated 1990; predates most modern layout APIs                                |
+
+## Apple / Android constraint-based
+
+| System                                                      | Platform       | Solver               | Adoption                                                      |
+| ----------------------------------------------------------- | -------------- | -------------------- | ------------------------------------------------------------- |
+| **[Auto Layout](auto-layout.md)**                           | UIKit / AppKit | Cassowary            | macOS 10.7 (2011), iOS 6 (2012), still the substrate of UIKit |
+| **[Android ConstraintLayout](android-constraintlayout.md)** | Android Views  | Cassowary-derivative | Android Studio default for new layouts since 2017             |
+
+## Immediate-mode layout
+
+| Library                         | Language | Layout Style                      | Companion TUI Port                 |
+| ------------------------------- | -------- | --------------------------------- | ---------------------------------- |
+| **[Dear ImGui](dear-imgui.md)** | C++      | Cursor-based + Tables API         | [ImTui](../tui-libraries/imtui.md) |
+| **[egui](egui.md)**             | Rust     | Cursor-based with retained sizing | -                                  |
+
+## Tiling and structural layout
+
+| System                      | Algorithm                                 | Configuration           |
+| --------------------------- | ----------------------------------------- | ----------------------- |
+| **[i3 / sway](i3-sway.md)** | Binary split-container tree               | Plain text config + IPC |
+| **[xmonad](xmonad.md)**     | Functional layout combinators (typeclass) | Haskell                 |
+
+## TUI layout models (cross-references)
+
+These libraries are documented in the [TUI Libraries Catalog](../tui-libraries/index.md); this section pulls out their **layout subsystem** for direct comparison with the dedicated layout libraries above.
+
+| Library                                                  | Layout Approach                                    | Sizing Vocabulary                                                               |
+| -------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------- |
+| **[Ratatui](../tui-libraries/ratatui.md)** (Rust)        | Constraint solver on Rects                         | `Length(n)` / `Percentage(p)` / `Ratio(a, b)` / `Min(n)` / `Max(n)` / `Fill(n)` |
+| **[Textual](../tui-libraries/textual.md)** (Python)      | CSS subset (Flexbox-like + Grid)                   | CSS keywords (`auto`, `1fr`, `100%`, fixed) plus dock                           |
+| **[Ink](../tui-libraries/ink.md)** (JavaScript)          | Yoga (Flexbox)                                     | Yoga `flex-grow` / `flex-basis` etc. - see [Yoga](yoga.md)                      |
+| **[FTXUI](../tui-libraries/ftxui.md)** (C++)             | Functional combinators (`hbox`, `vbox`, `gridbox`) | `size(WIDTH, EQUAL, n)` decorators                                              |
+| **[Brick](../tui-libraries/brick.md)** (Haskell)         | Pure-functional combinators                        | `padLeftRight`, `hLimit`, `vLimit`, `padded`, `border`                          |
+| **[tview](../tui-libraries/tview.md)** (Go)              | Flex with proportions                              | Fixed size + proportional weight                                                |
+| **[Cursive](../tui-libraries/cursive.md)** (Rust)        | LinearLayout / nested views                        | Min size with caller-controlled bounds                                          |
+| **[Notcurses](../tui-libraries/notcurses.md)** (C)       | Planes (absolute positioning) + helpers            | Manual rectangle math                                                           |
+| **[Mosaic](../tui-libraries/mosaic.md)** (Kotlin)        | Jetpack Compose runtime on terminal                | See [Jetpack Compose](jetpack-compose.md)                                       |
+| **[Nottui](../tui-libraries/nottui.md)** (OCaml)         | Functional reactive layout                         | Box combinators with stretch                                                    |
+| **[libvaxis](../tui-libraries/libvaxis.md)** (Zig)       | Imperative                                         | Manual                                                                          |
+| **[ImTui](../tui-libraries/imtui.md)** (C++)             | Dear ImGui on terminal                             | See [Dear ImGui](dear-imgui.md)                                                 |
+| **[snacks.nvim](../tui-libraries/snacks-nvim.md)** (Lua) | Floating windows on Neovim's window/buffer model   | Window-row/col grid + size hints                                                |
+| **[broot](../tui-libraries/broot.md)** (Rust)            | Custom (built on Ratatui)                          | -                                                                               |
+
+---
+
+## Architectural Taxonomy
+
+### By Sizing Vocabulary
+
+| Vocabulary                         | Description                                                                         | Libraries                                                                                                                                                  |
+| ---------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fit / Grow / Fixed / Percent**   | Small primitives with optional min/max clamps; siblings with `GROW` share equally   | [Clay](clay.md)                                                                                                                                            |
+| **Flex-grow / shrink / basis**     | CSS Flexbox sibling weighting along main axis                                       | [Yoga](yoga.md), [CSS Flexbox](css-flexbox.md), [Taffy](taffy.md), [Stretch](stretch.md), [Ink](../tui-libraries/ink.md)                                   |
+| **Linear constraints (Cassowary)** | Variables linked by `=`, `<=`, `>=` with strength priorities                        | [Cassowary](cassowary.md), [Kiwi](kiwi.md), [Auto Layout](auto-layout.md), [Android ConstraintLayout](android-constraintlayout.md), GTK 4 ConstraintLayout |
+| **Grid template (`fr`, minmax)**   | Track-based two-axis grid with named lines / areas                                  | [CSS Grid](css-grid.md), [Taffy](taffy.md), WPF `Grid` (`*` star sizing close cousin)                                                                      |
+| **Star sizing**                    | Proportional sibling weights (`*`, `2*`)                                            | [WPF / XAML](wpf-xaml.md), [Qt](qt-layouts.md) (stretch factor)                                                                                            |
+| **Per-side stickiness / fill**     | Anchor to one or more edges of a cell                                               | [Tk](tk.md) (`grid -sticky nsew`), GridBagLayout (`anchor` / `fill`)                                                                                       |
+| **Tight / loose constraints**      | Constraints flow down, sizes flow up; each box answers a `(minW, maxW, minH, maxH)` | [Flutter](flutter.md), Compose                                                                                                                             |
+| **Propose-and-respond**            | Parent proposes an optional `(width?, height?)`; child returns a CGSize             | [SwiftUI](swiftui.md)                                                                                                                                      |
+| **Cursor + auto-advance**          | Layout cursor moves after each widget; explicit `SameLine` for horizontal flow      | [Dear ImGui](dear-imgui.md), [egui](egui.md), [ImTui](../tui-libraries/imtui.md)                                                                           |
+| **Tiling tree**                    | Binary split tree; new windows insert as siblings; resize via proportions           | [i3 / sway](i3-sway.md), [xmonad](xmonad.md)                                                                                                               |
+| **Optimal line breaking**          | Dynamic programming over breakpoints with glue / penalty model                      | [Knuth-Plass](tex-knuth-plass.md)                                                                                                                          |
+
+### By Measure / Arrange Protocol
+
+| Protocol                       | Description                                                                  | Libraries                                                                                                                          |
+| ------------------------------ | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Single-pass top-down**       | Parent passes constraints; child reports size; no second pass                | [Flutter](flutter.md), [Compose](jetpack-compose.md)                                                                               |
+| **Two-pass Measure / Arrange** | Phase 1 collects desired sizes bottom-up; phase 2 distributes space top-down | [WPF / XAML](wpf-xaml.md), [GTK 4](gtk.md), [Qt](qt-layouts.md), [Swing](swing-mig.md), [SwiftUI](swiftui.md) (effectively)        |
+| **Iterative solver**           | Constraint solver runs to a stable solution                                  | [Cassowary](cassowary.md), [Kiwi](kiwi.md), [Auto Layout](auto-layout.md), [Android ConstraintLayout](android-constraintlayout.md) |
+| **Immediate / cursor-based**   | No measure pass; widgets are placed in order they are issued                 | [Dear ImGui](dear-imgui.md), [egui](egui.md)                                                                                       |
+| **Combinator algebra**         | Layout is a pure function from `Rectangle` to placements                     | [xmonad](xmonad.md), [Brick](../tui-libraries/brick.md), [Nottui](../tui-libraries/nottui.md), [FTXUI](../tui-libraries/ftxui.md)  |
+| **Render-command emission**    | Layout pass produces a list of draw commands; renderer agnostic              | [Clay](clay.md)                                                                                                                    |
+
+### By Embedding
+
+| Embedding                                      | Definition                                                                | Examples                                                                                                                                                                                    |
+| ---------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Standalone layout library**                  | Just sizing and positioning; renderer is the application's responsibility | [Clay](clay.md), [Yoga](yoga.md), [Taffy](taffy.md), [Stretch](stretch.md), [Kiwi](kiwi.md)                                                                                                 |
+| **Spec without bundled implementation**        | Definition of behavior; many engines implement it                         | [CSS Flexbox](css-flexbox.md), [CSS Grid](css-grid.md), [CSS Normal Flow](css-normal-flow.md), [Cassowary](cassowary.md), [Knuth-Plass](tex-knuth-plass.md)                                 |
+| **Baked into a GUI framework**                 | Layout types are part of a larger widget system                           | [SwiftUI](swiftui.md), [Compose](jetpack-compose.md), [Flutter](flutter.md), [WPF](wpf-xaml.md), [Qt](qt-layouts.md), [GTK 4](gtk.md), [Swing](swing-mig.md), [Auto Layout](auto-layout.md) |
+| **Baked into a window manager / WM-like tool** | Layout is the product; UI affordances are minimal                         | [i3 / sway](i3-sway.md), [xmonad](xmonad.md)                                                                                                                                                |
+| **Embedded as a TUI sublayer**                 | The layout primitives are wired through a terminal renderer               | All [TUI libraries](../tui-libraries/index.md)                                                                                                                                              |
+
+---
+
+## Detailed Studies
+
+The following entries are analysed in depth.
+
+### Pure layout libraries
+
+- **[Clay][clay]** - single-header C library; sizing primitives `FIT` / `GROW` / `FIXED` / `PERCENT`; render-command emission
+- **[Yoga][yoga]** - Meta's cross-platform Flexbox; the engine behind [Ink](../tui-libraries/ink.md) and React Native
+- **[Taffy][taffy]** - Rust; supports CSS Flexbox + Grid + Block; used by Dioxus, Bevy, Zed
+- **[Stretch][stretch]** - Taffy's archived Flexbox-only predecessor
+- **[Kiwi][kiwi]** - C++ Cassowary implementation; the engine in `kiwisolver`, Matplotlib's `constrained_layout`, enaml
+
+### Foundational algorithms
+
+- **[Cassowary][cassowary]** - linear arithmetic constraint solver (Badros & Borning, 1997); the substrate of iOS Auto Layout
+- **[Knuth-Plass][knuth-plass]** - optimal line breaking via dynamic programming (1981); the algorithm in TeX, SILE, and (selectively) modern browsers
+
+### Web platform layout specs
+
+- **[CSS Normal Flow][normal-flow]** - block / inline formatting contexts, the box model, margin collapsing, floats, position
+- **[CSS Flexbox][flexbox]** - one-axis flex container; main / cross axes; the spec that birthed Yoga
+- **[CSS Grid][grid]** - two-axis grid with tracks, lines, areas, subgrid, `fr` unit, `minmax`, `auto-fill` / `auto-fit`
+
+### Modern declarative GUI framework layouts
+
+- **[SwiftUI][swiftui]** - HStack / VStack / ZStack / Grid; propose-and-respond protocol; `Layout` protocol for custom layouts (iOS 16+)
+- **[Jetpack Compose][compose]** - Row / Column / Box / ConstraintLayout; measure-and-place protocol; `Modifier.layout`; intrinsic measurements
+- **[Flutter][flutter]** - Row / Column / Stack / Wrap / Flex; constraints-down-sizes-up; `RenderBox` protocol
+
+### Traditional desktop GUI layouts
+
+- **[WPF / XAML][wpf]** - Grid (with `*` star sizing) / StackPanel / DockPanel / WrapPanel / Canvas; Measure / Arrange protocol; inherited by Avalonia, UWP, MAUI
+- **[Qt Layouts][qt]** - QHBoxLayout / QVBoxLayout / QGridLayout / QFormLayout / QStackedLayout; QSizePolicy + stretch factor; QML alternatives
+- **[GTK 4][gtk]** - pluggable `GtkLayoutManager`; GtkBoxLayout, GtkGridLayout, GtkConstraintLayout (Cassowary), GtkOverlayLayout
+- **[Swing / MiG Layout][swing-mig]** - AWT `LayoutManager` family; the GridBagLayout case study; GroupLayout; MiG's declarative constraint strings
+- **[Tk geometry managers][tk]** - `pack` (1990), `grid` (1996), `place`; the classical layout API that influenced AWT and many others
+
+### Apple / Android constraint-based
+
+- **[Auto Layout][auto-layout]** - Cassowary in production; NSLayoutConstraint, anchors, intrinsic content size, content hugging / compression resistance
+- **[Android ConstraintLayout][acl]** - flat hierarchy with anchored constraints, guidelines, barriers, chains; the modern Android default
+
+### Immediate-mode layout
+
+- **[Dear ImGui][imgui]** - cursor-based layout; Columns (legacy) and Tables API (since 1.80)
+- **[egui][egui]** - Rust immediate mode with retained sizing memory; horizontal / vertical / columns
+
+### Tiling and structural layout
+
+- **[i3 / sway][i3-sway]** - binary split-container tree; configurable in plain text; the canonical modern tiling WM
+- **[xmonad][xmonad]** - layouts as typeclass values composed with `|||`; pure-Haskell window arrangement
+
+### Comparative
+
+A focused cross-library comparison is in [the TUI Libraries Comparison](../tui-libraries/comparison.md). A follow-up `comparison.md` for layout libraries specifically may be added here as the catalog matures.
+
+---
+
+## References
+
+[clay]: clay.md
+[yoga]: yoga.md
+[taffy]: taffy.md
+[stretch]: stretch.md
+[kiwi]: kiwi.md
+[cassowary]: cassowary.md
+[knuth-plass]: tex-knuth-plass.md
+[normal-flow]: css-normal-flow.md
+[flexbox]: css-flexbox.md
+[grid]: css-grid.md
+[swiftui]: swiftui.md
+[compose]: jetpack-compose.md
+[flutter]: flutter.md
+[wpf]: wpf-xaml.md
+[qt]: qt-layouts.md
+[gtk]: gtk.md
+[swing-mig]: swing-mig.md
+[tk]: tk.md
+[auto-layout]: auto-layout.md
+[acl]: android-constraintlayout.md
+[imgui]: dear-imgui.md
+[egui]: egui.md
+[i3-sway]: i3-sway.md
+[xmonad]: xmonad.md

--- a/docs/research/ui-layout/jetpack-compose.md
+++ b/docs/research/ui-layout/jetpack-compose.md
@@ -1,0 +1,906 @@
+# Jetpack Compose (Kotlin)
+
+Google's declarative UI toolkit for Android, extended via Compose Multiplatform to
+desktop, iOS, web, and -- through Jake Wharton's [Mosaic](../tui-libraries/mosaic.md)
+project -- the terminal. Compose's layout model is built around a **single-pass
+measurement protocol** in which every node receives `Constraints`
+(`minWidth, maxWidth, minHeight, maxHeight`), calls `measure(constraints)` on each
+child to obtain a `Placeable`, then chooses its own size and finally calls
+`place(x, y)` on those placeables. The compiler plugin transforms `@Composable`
+functions into incremental tree-building code, and the runtime observes snapshot
+state to drive minimal recomposition.
+
+| Field            | Value                                                                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Language         | Kotlin (Compose compiler plugin + runtime)                                                                                                                   |
+| License          | Apache 2.0                                                                                                                                                   |
+| Repository       | <https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/compose/>                                                           |
+| GitHub mirror    | <https://github.com/androidx/androidx/tree/androidx-main/compose>                                                                                            |
+| Documentation    | <https://developer.android.com/jetpack/compose> and <https://developer.android.com/develop/ui/compose>                                                       |
+| Version snapshot | Compose UI 1.11.1 (AndroidX, May 2026); Compose Multiplatform releases independently through JetBrains                                                       |
+| Notable adoption | Google Play Store, Twitter/X for Android, Lyft, Airbnb, Pinterest, Square Cash; Compose Multiplatform: JetBrains Toolbox, Toolbox apps; Mosaic for terminal. |
+
+---
+
+## Overview
+
+### What It Solves
+
+Pre-Compose Android UI was written in **XML layouts** combined with imperative `View`
+hierarchies (`LinearLayout`, `RelativeLayout`, `ConstraintLayout`) inflated at runtime
+into Java/Kotlin `View` objects. The model had well-known issues:
+
+- **Two-language split.** Layout shape was in XML; behaviour was in Kotlin/Java. Type
+  safety crossed the boundary via `findViewById` and view binding, both error-prone.
+- **Quadratic measurement on nested layouts.** `LinearLayout` with `weight` measures
+  every child twice; nested weighted layouts compound this multiplicatively. The
+  practical rule was "don't nest weighted layouts" -- a footgun.
+- **Property bag growth.** A `View` had hundreds of attributes shared by every
+  subclass, only a few of which applied to any one widget. State management was
+  imperative and stored on the views themselves.
+- **Animation API mismatch.** `ValueAnimator`, `ObjectAnimator`, and
+  `MotionLayout` all targeted the legacy view system; none composed cleanly with
+  state-driven UI.
+
+Compose replaces all of this with a single-language model (`@Composable` Kotlin
+functions), a runtime that tracks state reactively, and a layout protocol explicitly
+designed to keep measurement O(n) regardless of nesting depth.
+
+### Design Philosophy
+
+Compose's stated design principles, mirrored in its layout machinery:
+
+1. **Composition over inheritance.** A composable is a function, not a class. Building
+   a new container is writing a function that calls `Layout { … }` with a measure
+   policy, not subclassing a `ViewGroup`.
+2. **State is read where it is used.** Snapshot state (`mutableStateOf`,
+   `mutableStateListOf`) automatically registers reads in the currently composing
+   function; a state change invalidates only the composables that read it.
+3. **Single-pass measurement is mandatory by default.** A composable may call
+   `measure()` on each child **exactly once**. This rule eliminates the nested
+   `LinearLayout` problem by construction. Multi-pass measurement is opt-in via
+   `SubcomposeLayout`.
+4. **Modifiers are the configuration channel.** Rather than dozens of constructor
+   parameters, every composable accepts a `Modifier` chain. The chain is a left-to-
+   right list of measure / draw / pointer-input nodes applied in order, with stable
+   identity and predictable composition.
+5. **The compiler plugin does the work.** A bespoke Kotlin compiler plugin (the
+   "Compose compiler") rewrites every `@Composable` function call into bytecode that
+   threads a `Composer` argument and emits `start/end` calls into a `SlotTable`. The
+   runtime uses that slot table to memoise function calls and to skip composables
+   whose inputs are unchanged.
+6. **Multiplatform by construction.** The Compose runtime is platform-agnostic. The
+   `Applier` interface lets non-Android targets (desktop, iOS, web, terminal) emit
+   their own node types. Compose Multiplatform (JetBrains) and [Mosaic](../tui-libraries/mosaic.md)
+   (Jake Wharton, terminal output) both build on this seam.
+
+### History
+
+| Year | Milestone                                                                                                            |
+| ---- | -------------------------------------------------------------------------------------------------------------------- |
+| 2019 | Compose announced at Google I/O. Source goes public in AOSP.                                                         |
+| 2020 | Developer Preview / Alpha. `Layout {}` composable, `Modifier` chain, `mutableStateOf` are present.                   |
+| 2021 | **Compose 1.0** ships (July). Production-ready for Android.                                                          |
+| 2021 | JetBrains releases Compose Multiplatform (desktop) targeting JVM/Skiko.                                              |
+| 2021 | Jake Wharton releases [Mosaic](../tui-libraries/mosaic.md) (June) -- Compose runtime on a custom terminal `Applier`. |
+| 2022 | Compose for Wear OS 1.0. Compose Multiplatform for desktop 1.2.                                                      |
+| 2023 | Compose Multiplatform iOS goes Alpha. Strong skipping mode (compose-compiler 1.5.4).                                 |
+| 2024 | Compose Multiplatform iOS goes Stable. Compose UI 1.7 introduces Lazy*Item* APIs revisions, prefetch tuning.         |
+| 2025 | Mosaic 0.17 ships custom terminal parser, Compose Multiplatform 1.7 expands web support.                             |
+
+---
+
+## Architecture / Layout Model
+
+### Constraints: A Four-Field Box
+
+Every measurement in Compose starts with a [`Constraints`][compose-constraints] value:
+
+```kotlin
+@Immutable
+@kotlin.jvm.JvmInline
+value class Constraints internal constructor(internal val value: Long) {
+    val minWidth: Int
+    val maxWidth: Int    // may be Constraints.Infinity
+    val minHeight: Int
+    val maxHeight: Int   // may be Constraints.Infinity
+
+    val hasBoundedWidth: Boolean
+    val hasBoundedHeight: Boolean
+    val hasFixedWidth: Boolean    // minWidth == maxWidth
+    val hasFixedHeight: Boolean
+
+    fun copy(
+        minWidth: Int = this.minWidth,
+        maxWidth: Int = this.maxWidth,
+        minHeight: Int = this.minHeight,
+        maxHeight: Int = this.maxHeight,
+    ): Constraints
+
+    companion object {
+        const val Infinity: Int = Int.MAX_VALUE
+        fun fixed(width: Int, height: Int): Constraints
+        fun fixedWidth(width: Int): Constraints
+        fun fixedHeight(height: Int): Constraints
+    }
+}
+```
+
+Differences from SwiftUI's [`ProposedViewSize`](./swiftui.md):
+
+- Each axis is a `[min, max]` pair instead of an optional. "Unbounded" is expressed by
+  `maxWidth == Constraints.Infinity`, not by `nil`.
+- The child may not pick a size outside its constraints (in the framework's contract).
+  A child that needs more is expected to return its desired size as a `Placeable` and
+  the parent decides whether to clip.
+- The constraint type is a packed `Long` (`@JvmInline value class`). This avoids
+  per-measure allocation: a constraint is one word.
+
+### Measure / Place Phases
+
+Compose's layout is two-step but **interleaved per node**:
+
+```
+parent.measure(constraints)
+  ├─ inside measure block: each child.measure(childConstraints) -> Placeable
+  ├─ call layout(width, height) { … }
+  └─ inside layout block: each placeable.place(x, y)
+```
+
+The `MeasurePolicy` interface drives this:
+
+```kotlin
+@Stable
+fun interface MeasurePolicy {
+    fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult
+}
+
+interface MeasureResult {
+    val width: Int
+    val height: Int
+    val alignmentLines: Map<AlignmentLine, Int>
+    fun placeChildren()
+}
+```
+
+The `MeasureScope.layout(width, height) { … }` builder constructs a `MeasureResult`;
+the trailing lambda is the `Placeable.PlacementScope` and is where you call
+`place(x, y)`.
+
+### Built-In Containers
+
+| Composable                  | Direction  | Behaviour                                                                                                                                      |
+| --------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Column`                    | vertical   | Top-to-bottom; supports `verticalArrangement`, `horizontalAlignment`, and weighted children.                                                   |
+| `Row`                       | horizontal | Left-to-right; supports `horizontalArrangement`, `verticalAlignment`, weighted children.                                                       |
+| `Box`                       | depth      | Z-stacks children; `contentAlignment` aligns all children, `Modifier.align` overrides per child.                                               |
+| `LazyColumn`                | vertical   | Recycler-backed scroll list. Only visible items composed.                                                                                      |
+| `LazyRow`                   | horizontal | Horizontal recycler.                                                                                                                           |
+| `LazyVerticalGrid`          | 2-D        | Vertical grid; columns described by `GridCells`.                                                                                               |
+| `LazyHorizontalGrid`        | 2-D        | Horizontal counterpart.                                                                                                                        |
+| `LazyVerticalStaggeredGrid` | 2-D        | Pinterest-style staggered grid.                                                                                                                |
+| `FlowRow` / `FlowColumn`    | wrap       | Wrap to next line/column when out of room (Compose 1.4+).                                                                                      |
+| `ConstraintLayout`          | rule-based | Port of Android's `ConstraintLayout`; see [`./android-constraintlayout.md`](./android-constraintlayout.md) for the legacy view-system version. |
+| `Scaffold`                  | slots      | Material Design app shell with slots for `topBar`, `bottomBar`, `floatingActionButton`, etc.                                                   |
+
+#### Column, Row, Box
+
+```kotlin
+@Composable
+inline fun Column(
+    modifier: Modifier = Modifier,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    content: @Composable ColumnScope.() -> Unit
+)
+
+@Composable
+inline fun Row(
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+    verticalAlignment: Alignment.Vertical = Alignment.Top,
+    content: @Composable RowScope.() -> Unit
+)
+
+@Composable
+inline fun Box(
+    modifier: Modifier = Modifier,
+    contentAlignment: Alignment = Alignment.TopStart,
+    propagateMinConstraints: Boolean = false,
+    content: @Composable BoxScope.() -> Unit
+)
+```
+
+The `ColumnScope` / `RowScope` / `BoxScope` receivers expose scope-only modifiers:
+
+```kotlin
+@LayoutScopeMarker
+@Immutable
+interface RowScope {
+    @Stable fun Modifier.weight(weight: Float, fill: Boolean = true): Modifier
+    @Stable fun Modifier.align(alignment: Alignment.Vertical): Modifier
+    @Stable fun Modifier.alignBy(alignmentLine: HorizontalAlignmentLine): Modifier
+    @Stable fun Modifier.alignByBaseline(): Modifier
+}
+```
+
+A canonical example -- a contact row with avatar, name, badge, and a flexible spacer:
+
+```kotlin
+@Composable
+fun ContactRow(contact: Contact) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(contact.avatarUrl),
+            contentDescription = null,
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(contact.name, style = MaterialTheme.typography.titleSmall)
+            Text(
+                contact.statusLine,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (contact.hasUnread) {
+            Badge { Text(contact.unreadCount.toString()) }
+        }
+    }
+}
+```
+
+#### Arrangement and Alignment
+
+Arrangements describe **how leftover main-axis space is distributed**:
+
+```kotlin
+object Arrangement {
+    val Start: Horizontal
+    val End: Horizontal
+    val Top: Vertical
+    val Bottom: Vertical
+    val Center: HorizontalOrVertical
+    val SpaceBetween: HorizontalOrVertical
+    val SpaceAround: HorizontalOrVertical
+    val SpaceEvenly: HorizontalOrVertical
+    fun spacedBy(space: Dp): HorizontalOrVertical
+    fun spacedBy(space: Dp, alignment: Alignment.Horizontal): Horizontal
+    val End: Horizontal
+}
+```
+
+Alignments are the cross-axis story:
+
+```kotlin
+object Alignment {
+    val TopStart: Alignment
+    val TopCenter: Alignment
+    val TopEnd: Alignment
+    val CenterStart: Alignment
+    val Center: Alignment
+    val CenterEnd: Alignment
+    val BottomStart: Alignment
+    val BottomCenter: Alignment
+    val BottomEnd: Alignment
+
+    @Immutable interface Horizontal { fun align(size: Int, space: Int, layoutDirection: LayoutDirection): Int }
+    @Immutable interface Vertical { fun align(size: Int, space: Int): Int }
+
+    val Start: Horizontal
+    val CenterHorizontally: Horizontal
+    val End: Horizontal
+    val Top: Vertical
+    val CenterVertically: Vertical
+    val Bottom: Vertical
+}
+```
+
+#### Modifier Sizing API
+
+The size-related modifiers in `androidx.compose.foundation.layout`:
+
+```kotlin
+fun Modifier.size(size: Dp): Modifier
+fun Modifier.size(width: Dp, height: Dp): Modifier
+fun Modifier.size(size: DpSize): Modifier
+fun Modifier.width(width: Dp): Modifier
+fun Modifier.height(height: Dp): Modifier
+fun Modifier.requiredSize(size: Dp): Modifier          // ignores incoming constraints
+fun Modifier.requiredWidth(width: Dp): Modifier
+fun Modifier.fillMaxSize(fraction: Float = 1f): Modifier
+fun Modifier.fillMaxWidth(fraction: Float = 1f): Modifier
+fun Modifier.fillMaxHeight(fraction: Float = 1f): Modifier
+fun Modifier.wrapContentSize(align: Alignment = Alignment.Center, unbounded: Boolean = false): Modifier
+fun Modifier.wrapContentWidth(align: Alignment.Horizontal = Alignment.CenterHorizontally, unbounded: Boolean = false): Modifier
+fun Modifier.padding(all: Dp): Modifier
+fun Modifier.padding(horizontal: Dp = 0.dp, vertical: Dp = 0.dp): Modifier
+fun Modifier.padding(start: Dp = 0.dp, top: Dp = 0.dp, end: Dp = 0.dp, bottom: Dp = 0.dp): Modifier
+fun Modifier.padding(values: PaddingValues): Modifier
+fun Modifier.offset(x: Dp = 0.dp, y: Dp = 0.dp): Modifier
+fun Modifier.aspectRatio(ratio: Float, matchHeightConstraintsFirst: Boolean = false): Modifier
+
+// In ColumnScope / RowScope:
+fun Modifier.weight(weight: Float, fill: Boolean = true): Modifier
+```
+
+Note `size` versus `requiredSize`: `size` is a _preferred_ value, clamped to the parent's
+`Constraints`. `requiredSize` overrides the parent's constraints (a child that is wider
+than its parent's `maxWidth` can be drawn outside the parent's bounds).
+
+#### LazyColumn, LazyRow, LazyVerticalGrid
+
+```kotlin
+@Composable
+fun LazyColumn(
+    modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    verticalArrangement: Arrangement.Vertical = if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
+    userScrollEnabled: Boolean = true,
+    content: LazyListScope.() -> Unit,
+)
+
+@Composable
+fun LazyVerticalGrid(
+    columns: GridCells,
+    modifier: Modifier = Modifier,
+    state: LazyGridState = rememberLazyGridState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    verticalArrangement: Arrangement.Vertical = if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.Start,
+    flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
+    userScrollEnabled: Boolean = true,
+    content: LazyGridScope.() -> Unit,
+)
+
+sealed class GridCells {
+    class Fixed(val count: Int) : GridCells
+    class Adaptive(val minSize: Dp) : GridCells
+    class FixedSize(val size: Dp) : GridCells
+}
+```
+
+The lazy variants build their item tree via the `LazyListScope` / `LazyGridScope`
+receivers (`item { }`, `items(count) { i -> }`, `items(list) { item -> }`, plus
+`stickyHeader { }`) rather than as a flat `@Composable` block. This is what allows
+them to defer composition of off-screen rows.
+
+#### ConstraintLayout
+
+The Compose port of Android's view-system [`ConstraintLayout`](./android-constraintlayout.md):
+
+```kotlin
+@Composable
+fun ConstraintLayout(
+    modifier: Modifier = Modifier,
+    optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
+    content: @Composable ConstraintLayoutScope.() -> Unit,
+)
+```
+
+Each child gets a reference, and constraints are declared with the DSL:
+
+```kotlin
+ConstraintLayout(Modifier.fillMaxSize()) {
+    val (title, subtitle, button) = createRefs()
+
+    Text(
+        "Hello",
+        modifier = Modifier.constrainAs(title) {
+            top.linkTo(parent.top, margin = 16.dp)
+            start.linkTo(parent.start, margin = 16.dp)
+        },
+    )
+    Text(
+        "World",
+        modifier = Modifier.constrainAs(subtitle) {
+            top.linkTo(title.bottom, margin = 4.dp)
+            start.linkTo(title.start)
+        },
+    )
+    Button(
+        onClick = { },
+        modifier = Modifier.constrainAs(button) {
+            bottom.linkTo(parent.bottom, margin = 16.dp)
+            end.linkTo(parent.end, margin = 16.dp)
+        },
+    ) { Text("OK") }
+}
+```
+
+`ConstraintLayout` runs a Cassowary-style solver and is the recommended container for
+non-trivial 2-D arrangements where simple `Row` / `Column` nesting would obscure
+intent.
+
+### Intrinsic Measurements
+
+Compose's single-pass rule forbids re-measuring a child to discover its preferred
+size. Instead, every `Measurable` exposes four **intrinsic** queries that return what
+the child would prefer **without performing a real measurement**:
+
+```kotlin
+interface IntrinsicMeasurable {
+    val parentData: Any?
+    fun minIntrinsicWidth(height: Int): Int
+    fun maxIntrinsicWidth(height: Int): Int
+    fun minIntrinsicHeight(width: Int): Int
+    fun maxIntrinsicHeight(width: Int): Int
+}
+```
+
+Semantics:
+
+- `minIntrinsicWidth(height)` -- "If you had this height, what is the minimum width
+  below which content would visibly truncate?" For text, this is the longest non-
+  breakable word.
+- `maxIntrinsicWidth(height)` -- "At this height, what width would let you draw all
+  content on one line?"
+- `minIntrinsicHeight(width)` -- "Given this width, what is the smallest height that
+  still shows all content?"
+- `maxIntrinsicHeight(width)` -- "What height do you want if width is this?"
+
+A custom layout that needs `IntrinsicMeasurable` queries implements:
+
+```kotlin
+class TwoColumnMeasurePolicy : MeasurePolicy {
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints
+    ): MeasureResult { /* … */ }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int
+    ): Int = measurables.sumOf { it.minIntrinsicWidth(height) }
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int
+    ): Int = measurables.maxOf { it.maxIntrinsicHeight(width / measurables.size) }
+
+    // …minIntrinsicHeight, maxIntrinsicWidth analogously
+}
+```
+
+The `Modifier.height(IntrinsicSize.Min)` and `Modifier.width(IntrinsicSize.Min/Max)`
+modifiers let you force a parent to query intrinsics on its child instead of
+performing a normal measure:
+
+```kotlin
+Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+    Text("Left", Modifier.weight(1f))
+    Divider(modifier = Modifier.fillMaxHeight().width(1.dp))
+    Text("Right side that may be taller", Modifier.weight(1f))
+}
+```
+
+The divider here fills the height that the tallest of the two `Text`s would request,
+without a separate measurement pass.
+
+---
+
+## Custom Layouts
+
+### The `Layout` Composable
+
+The fundamental building block is the [`Layout`][compose-layout-fn] composable:
+
+```kotlin
+@Composable inline fun Layout(
+    content: @Composable @UiComposable () -> Unit,
+    modifier: Modifier = Modifier,
+    measurePolicy: MeasurePolicy,
+)
+
+@Composable inline fun Layout(
+    contents: List<@Composable @UiComposable () -> Unit>,
+    modifier: Modifier = Modifier,
+    measurePolicy: MultiContentMeasurePolicy,
+)
+```
+
+`MeasurePolicy` is a single-abstract-method interface so a trailing lambda works:
+
+```kotlin
+@Composable
+fun MyColumn(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Layout(content = content, modifier = modifier) { measurables, constraints ->
+        val placeables = measurables.map { it.measure(constraints) }
+
+        val width = placeables.maxOf { it.width }
+        val height = placeables.sumOf { it.height }
+
+        layout(width, height) {
+            var y = 0
+            for (placeable in placeables) {
+                placeable.placeRelative(x = 0, y = y)
+                y += placeable.height
+            }
+        }
+    }
+}
+```
+
+`placeRelative` flips x for right-to-left layout direction; `place` is absolute.
+`placeRelative` should be the default for application code; use `place` only when you
+deliberately want LTR coordinates regardless of locale.
+
+### A Custom Layout Modifier
+
+Instead of writing a new container, you can write a layout-affecting modifier with
+`Modifier.layout`:
+
+```kotlin
+fun Modifier.firstBaselineToTop(firstBaselineToTop: Dp) = this.layout { measurable, constraints ->
+    val placeable = measurable.measure(constraints)
+    check(placeable[FirstBaseline] != AlignmentLine.Unspecified)
+
+    val firstBaseline = placeable[FirstBaseline]
+    val placeableY = firstBaselineToTop.roundToPx() - firstBaseline
+    val height = placeable.height + placeableY
+
+    layout(placeable.width, height) {
+        placeable.placeRelative(0, placeableY)
+    }
+}
+```
+
+This is precisely how Compose's `paddingFromBaseline` is implemented.
+
+### Example: A Flow Layout
+
+Wrap-to-next-line, like CSS `flex-wrap: wrap`:
+
+```kotlin
+@Composable
+fun MyFlowRow(
+    modifier: Modifier = Modifier,
+    horizontalSpacing: Dp = 8.dp,
+    verticalSpacing: Dp = 8.dp,
+    content: @Composable () -> Unit,
+) {
+    Layout(modifier = modifier, content = content) { measurables, constraints ->
+        val hSpacing = horizontalSpacing.roundToPx()
+        val vSpacing = verticalSpacing.roundToPx()
+        val maxWidth = constraints.maxWidth
+
+        data class Row(val placeables: MutableList<Placeable>, var width: Int, var height: Int)
+        val rows = mutableListOf<Row>()
+        var current = Row(mutableListOf(), 0, 0)
+        rows += current
+
+        for (measurable in measurables) {
+            val placeable = measurable.measure(constraints.copy(minWidth = 0))
+            val needed = placeable.width + (if (current.placeables.isEmpty()) 0 else hSpacing)
+            if (current.width + needed > maxWidth && current.placeables.isNotEmpty()) {
+                current = Row(mutableListOf(), 0, 0)
+                rows += current
+            }
+            current.placeables += placeable
+            current.width += needed
+            current.height = maxOf(current.height, placeable.height)
+        }
+
+        val totalWidth = rows.maxOf { it.width }.coerceAtMost(maxWidth)
+        val totalHeight = rows.sumOf { it.height } + vSpacing * (rows.size - 1).coerceAtLeast(0)
+
+        layout(totalWidth, totalHeight) {
+            var y = 0
+            for (row in rows) {
+                var x = 0
+                for (placeable in row.placeables) {
+                    placeable.placeRelative(x, y)
+                    x += placeable.width + hSpacing
+                }
+                y += row.height + vSpacing
+            }
+        }
+    }
+}
+```
+
+### Example: An Equal-Width Distribution
+
+```kotlin
+@Composable
+fun EqualWidthRow(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Layout(modifier = modifier, content = content) { measurables, constraints ->
+        require(measurables.isNotEmpty())
+        val cellWidth = constraints.maxWidth / measurables.size
+        val cellConstraints = constraints.copy(
+            minWidth = cellWidth,
+            maxWidth = cellWidth,
+        )
+        val placeables = measurables.map { it.measure(cellConstraints) }
+        val height = placeables.maxOf { it.height }
+
+        layout(constraints.maxWidth, height) {
+            var x = 0
+            for (placeable in placeables) {
+                placeable.placeRelative(x, 0)
+                x += cellWidth
+            }
+        }
+    }
+}
+```
+
+This is the rough Compose equivalent of the `EqualWidthHStack` SwiftUI example in
+[`swiftui.md`](./swiftui.md). Note the key difference: in SwiftUI we _query_ each
+child for its natural width and then pick the maximum, because the protocol is
+propose-and-respond. In Compose we _impose_ a fixed-width constraint on each child
+and the child measures itself accordingly. The Compose model assumes the parent knows
+what it wants up front; SwiftUI assumes the child does.
+
+### SubcomposeLayout
+
+`Layout` enforces "measure each child once". For genuinely two-pass layouts -- e.g.,
+"size the navigation rail to match the tallest item, then re-lay-out the content
+column to that height" -- Compose offers [`SubcomposeLayout`][compose-subcompose]:
+
+```kotlin
+@Composable
+fun SubcomposeLayout(
+    modifier: Modifier = Modifier,
+    measurePolicy: SubcomposeMeasureScope.(Constraints) -> MeasureResult,
+)
+
+interface SubcomposeMeasureScope : MeasureScope {
+    fun subcompose(slotId: Any?, content: @Composable () -> Unit): List<Measurable>
+}
+```
+
+`subcompose(slotId)` lets you compose a subtree on demand, get back its `Measurable`s,
+and measure them with constraints derived from earlier work in the same pass.
+`BoxWithConstraints` is implemented on top of `SubcomposeLayout`; so is `Scaffold`
+(which must size the body around the actual measured height of the top and bottom
+bars).
+
+A toy example -- a "tab strip that sizes its underline to the active tab's width":
+
+```kotlin
+@Composable
+fun TabsWithUnderline(
+    tabs: List<String>,
+    selectedIndex: Int,
+    onSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SubcomposeLayout(modifier) { constraints ->
+        // First subcomposition: actual tabs
+        val tabMeasurables = subcompose("tabs") {
+            tabs.forEachIndexed { i, label ->
+                Box(
+                    Modifier
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .clickable { onSelected(i) }
+                ) { Text(label) }
+            }
+        }
+        val tabPlaceables = tabMeasurables.map { it.measure(Constraints()) }
+        val widths = tabPlaceables.map { it.width }
+        val totalWidth = widths.sum()
+        val rowHeight = tabPlaceables.maxOf { it.height }
+
+        // Second subcomposition: underline sized to the selected tab
+        val underline = subcompose("underline") {
+            Box(
+                Modifier
+                    .height(2.dp)
+                    .background(MaterialTheme.colorScheme.primary)
+            )
+        }.first().measure(
+            Constraints.fixed(widths[selectedIndex], 2.dp.roundToPx())
+        )
+
+        val underlineX = widths.take(selectedIndex).sum()
+
+        layout(totalWidth, rowHeight + underline.height) {
+            var x = 0
+            for (placeable in tabPlaceables) {
+                placeable.placeRelative(x, 0)
+                x += placeable.width
+            }
+            underline.placeRelative(underlineX, rowHeight)
+        }
+    }
+}
+```
+
+Two-pass layouts are powerful but incur extra composition; the docs explicitly
+recommend `Layout` whenever possible and `SubcomposeLayout` only when intrinsics or
+constraints alone cannot express the relationship.
+
+### Compose Multiplatform and Mosaic
+
+The `Layout` composable, `Modifier`, `Constraints`, and `MeasurePolicy` are all
+defined in `androidx.compose.ui` -- platform-agnostic packages that Compose
+Multiplatform (JetBrains) reuses for desktop, iOS, and web targets without changes.
+The Android-specific bits live in `androidx.compose.ui.platform.android`.
+
+[Mosaic](../tui-libraries/mosaic.md) takes a different route: it does **not** reuse
+`androidx.compose.ui` at all. Instead, Mosaic re-implements an `Applier` against its
+own scene-graph of text-cell nodes, and supplies a minimal layout package (`Row`,
+`Column`, `Box`, `Text`, `Static`) that produces terminal cells rather than pixels. The
+Compose **runtime** (state, recomposition, slot table) is the same; the **layout
+machinery** is bespoke. This is one of the cleanest demonstrations of the
+runtime/UI separation in the Compose architecture: the same compiler plugin and
+slot-table runtime can drive a recycler-view Android grid, a Skiko-on-Linux desktop
+window, an iOS `UIView`, or an ANSI terminal cell buffer.
+
+---
+
+## Strengths and Weaknesses
+
+### For App UIs
+
+**Strengths.**
+
+- **Single-pass measurement is enforced by construction.** Performance-pathological
+  layouts that plagued `LinearLayout` weights are gone unless you opt into
+  `SubcomposeLayout`. Compose's official guidance is that deep nesting is cheap.
+- **Modifiers are a uniform extension point.** A custom property (e.g., a per-child
+  bias for a `ConstraintLayout`, a sticky-header marker, a focus order) lives as a
+  modifier rather than as a one-off constructor parameter.
+- **Snapshot state recomposition.** A `mutableStateOf` write invalidates only the
+  composables that read it. The compiler plugin also adds equality-based skipping,
+  meaning unchanged subtrees are not recomposed even if their parent runs.
+- **Excellent tooling.** Android Studio offers a Compose preview pane (with state
+  hoist support and interactive mode), a layout inspector that maps to source
+  positions, and a recomposition counter overlay.
+- **Multiplatform.** The same Compose source runs on JVM, Android, iOS (Kotlin/Native),
+  desktop (Skiko), web (Kotlin/Wasm), and terminal (Mosaic).
+
+**Weaknesses.**
+
+- **Verbose for trivial UIs.** Every container takes a `modifier`, every text needs
+  a style; what is one HTML line is often four lines of Kotlin.
+- **Recomposition cost is real.** Without `@Stable`/`@Immutable` annotations or
+  `derivedStateOf` for expensive reads, badly written composables recompose far more
+  than they need to. The Compose compiler 1.5.4 "strong skipping" mode mitigates this
+  but does not eliminate it.
+- **Compile times.** The Compose compiler plugin adds noticeable cost to incremental
+  builds. Large Compose projects routinely report multi-minute clean builds.
+- **`SubcomposeLayout` is a footgun.** Multi-pass layouts compose subtrees from
+  scratch each measure call; using `SubcomposeLayout` where intrinsics would suffice
+  can be an order of magnitude more expensive.
+
+### For Static One-Shot Rendering
+
+Compose's runtime model is **persistent**: a `Composer`, slot table, snapshot manager,
+and recomposition scheduler are spun up for any composition, even one rendered exactly
+once. For a single frame, this is overhead -- and for a CLI, it includes a thread
+running the snapshot system whether you want it or not.
+
+Mosaic ([`../tui-libraries/mosaic.md`](../tui-libraries/mosaic.md)) demonstrates that
+the runtime _can_ produce one-shot output: its `renderMosaic` API composes a tree,
+renders it to ANSI once, and exits. But the cost-versus-benefit is a real
+consideration: bringing in the Compose compiler plugin, Kotlin runtime, and snapshot
+machinery just to print a coloured table is heavy. Compose shines when the UI is
+long-lived and state-driven; for batch-style "compose once, emit, exit" workloads, a
+plain string builder or a smaller library is usually faster end-to-end.
+
+### Compared to Alternatives
+
+- **vs. SwiftUI** (see [`swiftui.md`](./swiftui.md)). Compose's `Constraints` is more
+  imperative than SwiftUI's `ProposedViewSize`: the parent dictates a `[min, max]`
+  range on each axis, and the child measures itself once and returns a `Placeable`.
+  SwiftUI's child can ignore the proposal; Compose's child cannot legitimately violate
+  its constraints. Compose is more flexible (you can constrain only one axis, pass
+  through the other) but less expressive at the boundary (no built-in "unspecified" --
+  you must use `Constraints.Infinity` and check `hasBoundedWidth`).
+- **vs. Flutter.** Flutter's `BoxConstraints` and Compose's `Constraints` are nearly
+  isomorphic: both are `(minWidth, maxWidth, minHeight, maxHeight)`. The difference
+  is in scheduling -- Flutter's render tree is mutable and re-laid-out imperatively;
+  Compose's tree is a function of state and re-laid-out reactively.
+- **vs. Android view system.** The Compose `Layout` protocol replaces
+  `View.onMeasure(int, int)` / `View.onLayout(boolean, int, int, int, int)` and the
+  XML attribute soup. Migration is gradual via `AndroidView { … }` and `ComposeView`.
+- **vs. CSS Flexbox (Ink, see [`../tui-libraries/ink.md`](../tui-libraries/ink.md)).**
+  Ink uses Yoga, a C++ Flexbox engine. Yoga's measurement is one-pass; its API is
+  similar in spirit to Compose's `Layout` (children measured then placed) but it
+  exposes only Flexbox primitives. Compose generalises: `Row` and `Column` are
+  ordinary `Layout` instances, not a special-cased Flexbox container.
+- **vs. Ratatui** (see [`../tui-libraries/ratatui.md`](../tui-libraries/ratatui.md)).
+  Ratatui's Cassowary-based area subdivision is closer to ConstraintLayout than to
+  `Row`/`Column`. There is no "intrinsic size" concept for Ratatui widgets because
+  the parent always assigns an area top-down. Compose's intrinsic-measurement protocol
+  matters precisely because most UI elements (text, images) do have an inherent size.
+- **vs. Mosaic** (see [`../tui-libraries/mosaic.md`](../tui-libraries/mosaic.md)).
+  Mosaic _is_ Compose retargeted at the terminal. It reuses the runtime and compiler
+  plugin and ships a small custom layout layer with `Row`, `Column`, `Box`, `Text`,
+  and `Static`. The protocol is the same; only the unit is terminal cells instead of
+  pixels.
+
+### Lessons for Sparkles
+
+For a D-based pretty-printer / CLI layout engine, the Compose model suggests:
+
+1. **A `Constraints`-style packed integer.** A struct
+   `struct Constraints { ushort minW, maxW, minH, maxH; }` fits in 64 bits and is
+   passed by value -- no heap allocation in a `@nogc` layout pass.
+2. **A `Placeable`-style intermediate.** Sparkles' equivalent would be a `Measured`
+   struct with `(width, height)` plus a placement closure. Templates ensure each
+   widget's `measure` is monomorphised at compile time.
+3. **A `MeasurePolicy` analogue via template constraints.** D's design-by-introspection
+   makes this natural:
+   ```d
+   enum hasMeasurePolicy(T) = is(typeof((T t, Measurable[] m, Constraints c) {
+       MeasureResult r = t.measure(m, c);
+   }));
+   ```
+4. **`SubcomposeLayout`-style two-pass on opt-in.** Sparkles can offer a single-pass
+   `layout` for typical use and a multi-pass `relayout` for the few cases (e.g.,
+   table alignment across columns) that require it.
+5. **Modifier chains as compile-time builders.** D's UFCS chains
+   (`text.bold.underline.padding(2)`) can statically thread through a left-to-right
+   `Modifier` analogue, with the same identity-preserving semantics Compose's
+   `Modifier` chain enforces at runtime.
+
+---
+
+## References
+
+- **Compose Layout overview:**
+  <https://developer.android.com/develop/ui/compose/layouts>
+- **Basic layouts:**
+  <https://developer.android.com/develop/ui/compose/layouts/basics>
+- **Custom layouts:**
+  <https://developer.android.com/develop/ui/compose/layouts/custom>
+- **Material `Scaffold`:**
+  <https://developer.android.com/develop/ui/compose/components/scaffold>
+- **`ConstraintLayout` in Compose:**
+  <https://developer.android.com/develop/ui/compose/layouts/constraintlayout>
+- **Layout phases (measure / layout / draw):**
+  <https://developer.android.com/develop/ui/compose/phases>
+- **Compose Multiplatform (JetBrains):**
+  <https://www.jetbrains.com/lp/compose-multiplatform/>
+- **API reference (`androidx.compose.foundation.layout`):**
+  <https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary>
+- **API reference (`androidx.compose.ui.layout`):**
+  <https://developer.android.com/reference/kotlin/androidx/compose/ui/layout/package-summary>
+- **Compose source (`Layout.kt`, `Constraints.kt`, `MeasurePolicy.kt`):**
+  <https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/>
+- **Google I/O 2021 "What's new in Compose":**
+  <https://www.youtube.com/watch?v=PsnNUJUTn4M>
+- **Jake Wharton -- "Bringing Compose to the Terminal" (Droidcon talk on Mosaic):**
+  <https://github.com/JakeWharton/mosaic>
+- **Cross-references inside this catalog:**
+  - [SwiftUI](./swiftui.md) -- the closest peer framework; propose-and-respond.
+  - [Mosaic](../tui-libraries/mosaic.md) -- Compose runtime retargeted at terminal cells.
+  - [Ratatui](../tui-libraries/ratatui.md) -- constraint-solver area subdivision.
+  - [Ink](../tui-libraries/ink.md) -- Flexbox-via-Yoga in JavaScript.
+
+---
+
+## Markdown References
+
+[compose-constraints]: https://developer.android.com/reference/kotlin/androidx/compose/ui/unit/Constraints
+[compose-layout-fn]: https://developer.android.com/reference/kotlin/androidx/compose/ui/layout/package-summary#Layout(kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.ui.layout.MeasurePolicy)
+[compose-subcompose]: https://developer.android.com/reference/kotlin/androidx/compose/ui/layout/SubcomposeLayout
+[compose-measurepolicy]: https://developer.android.com/reference/kotlin/androidx/compose/ui/layout/MeasurePolicy
+[compose-placeable]: https://developer.android.com/reference/kotlin/androidx/compose/ui/layout/Placeable

--- a/docs/research/ui-layout/kiwi.md
+++ b/docs/research/ui-layout/kiwi.md
@@ -1,0 +1,752 @@
+# Kiwi
+
+An efficient C++ reimplementation of the [Cassowary](./cassowary.md) linear arithmetic
+constraint solving algorithm, with hand-rolled Python bindings. Originally written by
+Chris Colbert at Nucleic for the Enaml GUI framework, Kiwi traded the original
+Cassowary's lexicographic strength comparison for floating-point scalar weights —
+sacrificing a corner-case theoretical guarantee in exchange for a 10×–500× speedup. It
+is now the de-facto constraint solver in the Python scientific stack, powering
+**Matplotlib**'s `constrained_layout`, **Enaml**, and a long tail of Python UI work.
+Ports exist for Java, JavaScript, and TypeScript; the JavaScript port underpins
+Apple-Visual-Format-Language layout libraries on the web.
+
+| Field                       | Value                                                                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Domain                      | Incremental linear arithmetic constraint solving for UI layout and scientific plotting                                                            |
+| Authors                     | Chris Colbert (original C++); Nucleic Project maintainers (current); Sébastien Galland and many others                                            |
+| Algorithmic Basis           | [Cassowary](./cassowary.md) (Badros, Borning, Stuckey 2001) — incremental simplex, Phase I / Phase II, dual simplex for edit variables            |
+| First Released              | 2013 (initial C++ release alongside Enaml)                                                                                                        |
+| License                     | BSD 3-Clause                                                                                                                                      |
+| Repository                  | <https://github.com/nucleic/kiwi>                                                                                                                 |
+| Python Package              | `kiwisolver` on PyPI — <https://pypi.org/project/kiwisolver/>                                                                                     |
+| Documentation               | <https://kiwisolver.readthedocs.io/>                                                                                                              |
+| Notable Adoption            | Matplotlib (since 2.0, 2017, for `tight_layout` and `constrained_layout`); Enaml; many downstream Python UI frameworks; autolayout.js via kiwi-js |
+| Reference for the algorithm | See [cassowary.md](./cassowary.md)                                                                                                                |
+
+---
+
+## Overview
+
+### What It Solves
+
+Kiwi solves the same problem as Cassowary: given a system of linear equality and
+inequality constraints — some required, some preferred — find an assignment of values to
+variables that satisfies the required ones exactly and minimizes the weighted violation
+of the preferred ones. The constraint set may be updated incrementally: adding,
+removing, or suggesting a new value for a variable runs in time proportional to the
+local change to the system, not its total size.
+
+Unlike Cassowary, which was conceived in a UI-research context and presented as a
+self-contained algorithm with a paper to read, Kiwi exists as **a production-grade
+library**. The README is short; the documentation is mostly API reference; the C++
+header is the spec. Kiwi is built for embedding into other systems — Enaml, Matplotlib,
+JavaScript layout engines — where the user does not interact with the solver directly,
+but with a domain wrapper (a layout box, a plot axis) that constructs constraints on
+their behalf.
+
+The motivating use case at Nucleic was **Enaml**, a declarative Python/Qt GUI framework
+where every widget's position is expressed as a set of constraints over its container
+and siblings. The original CassowaryJS-style Python solver could not keep up with the
+size and update rate Enaml needed, and rebuilding from scratch in optimized C++ was the
+practical answer.
+
+### Design Philosophy
+
+Kiwi reflects three philosophical choices that diverge from the original Cassowary:
+
+1. **Strengths are floating-point scalars, not symbolic lexicographic vectors.** The
+   TOCHI paper proves that exact strength comparison requires multi-component symbolic
+   weights, because otherwise a sufficiently large number of low-strength constraints
+   can outweigh a single higher-strength one. Kiwi assigns concrete numbers — `required
+= 1000 * (1000² + 1000 + 1) = 1,001,001,000`, `strong = 1000²`, `medium = 1000`,
+   `weak = 1` — and uses ordinary floating-point arithmetic. The numbers are spaced so
+   that several thousand weak constraints can be summed before they outweigh a medium,
+   which is more than enough headroom for any real UI. The simplification is the single
+   biggest source of Kiwi's speedup.
+
+2. **Stay constraints are gone.** Where Cassowary uses weak stays to disambiguate
+   under-constrained systems (every variable gets a weak stay at its current value),
+   Kiwi expects the application to add explicit constraints for variables it wants to
+   pin. The reasoning is twofold: the cost of auto-inserting stays for every variable
+   is non-trivial; and well-designed constraint systems (Enaml's, Matplotlib's)
+   typically constrain every variable explicitly already, making implicit stays
+   redundant.
+
+3. **Performance over theoretical correctness in corner cases.** Several details — the
+   strength scheme, the choice of `AssocVector` (from Andrei Alexandrescu's Loki
+   library) over `std::map` or `std::unordered_map`, the compact symbol representation,
+   the inlined symbol comparisons — sacrifice elegance or formal correctness for cache-
+   friendly hot paths. The documented Kiwi philosophy is _"in some rare corner cases, a
+   large number of weak constraints may outweigh a medium constraint. We believe this
+   trade-off is acceptable for the performance gains it provides."_
+
+### History
+
+Kiwi began in early **2013** when Chris Colbert, lead developer of Enaml at Nucleic
+Project, needed a faster constraint solver. The existing options were:
+
+- The original Cassowary C++ implementation from U. Washington — accurate but slow on
+  modern hardware (the codebase predated modern C++, modern allocators, and modern
+  CPU cache hierarchies by a decade).
+
+- `cassowary.py`, a pure-Python translation — far too slow for an interactive GUI
+  framework.
+
+Colbert rewrote the algorithm from scratch in C++11, applying performance techniques
+learned from his graphics and quant-finance work. The first public release shipped as
+part of Enaml. A standalone PyPI package, `kiwisolver`, followed shortly, distributing
+the C++ core as a binary wheel with thin Python bindings.
+
+The pivotal moment was **2017**: Matplotlib 2.0 introduced `tight_layout` and, later,
+`constrained_layout`, both of which use Kiwi to align subplots, colorbars, titles, and
+suptitles. Matplotlib is one of the most-downloaded Python packages in existence — by
+making `kiwisolver` a transitive dependency, the Matplotlib team gave Kiwi
+distribution into nearly every scientific Python environment.
+
+In parallel, the JavaScript ecosystem produced **kiwi-js**, a TypeScript reimplementation
+of Kiwi by Hein Rutjes (later maintained as part of the lume organization), which
+became the solver underneath **autolayout.js** — a JavaScript implementation of Apple's
+Visual Format Language. Alex Birkett then ported Kiwi line-for-line to Java
+(**kiwi-java**) in January 2015, with later bug fixes from yonsunCN and Sam Twidale.
+
+Kiwi continues to be maintained under the **Nucleic** organization on GitHub. Recent
+work has focused on Python 3.13 / 3.14 wheel support, removing deprecated APIs, and
+fine-tuning the build system for cross-platform reproducibility.
+
+---
+
+## Architecture
+
+This section covers Kiwi's internal architecture: the data structures, the divergences
+from Cassowary, and the optimizations that produce its speedup. For the algorithmic
+foundation, see the [Cassowary doc](./cassowary.md#algorithm); this section assumes
+familiarity with the simplex tableau, basic-feasible-solved form, and edit variables.
+
+### Symbol Encoding
+
+The most idiomatic Kiwi optimization is in how internal variables are represented. Every
+variable in the simplex tableau is encoded as a **`Symbol`**, a wrapper around a single
+`long long`. The low bits encode a discriminator tag and the rest encode a unique
+identifier. The tags are:
+
+- **`v`** (external) — variables created by the application via `Variable(name)`.
+- **`s`** (slack) — variables added when normalizing inequality constraints.
+- **`e`** (error) — variables added for non-required constraints, paired (`eₚ`, `eₙ`).
+- **`d`** (dummy) — added for required equalities; constrained to zero, used to track
+  row provenance for `removeConstraint`.
+- **`i`** (invalid) — sentinel for missing/empty values.
+
+Because a symbol fits in a CPU register, comparing two symbols is one instruction;
+storing a coefficient table indexed by symbol is a flat vector; copying a row of the
+tableau is a `memcpy` over contiguous memory. The whole tableau row often fits in one
+or two cache lines, which is why hot operations like `addConstraint` and
+`suggestValue` are tens of nanoseconds on modern x86.
+
+Compare this to the original Cassowary C++, which used `std::map<Variable*,
+LinearExpression*>` for row coefficients: each access was a tree traversal with three
+or four pointer chases per node, and most coefficients lived in scattered heap
+allocations.
+
+### Internal Classes
+
+The internal C++ structure is small and consistent:
+
+```cpp
+class Variable;       // external variable, holds a name and a current value
+class Term;           // {Variable, coefficient} pair
+class Expression;     // sum of Terms + constant
+class Constraint;     // {Expression, RelationalOperator, strength}
+class Strength;       // floating-point scalar
+class Solver;         // the main interface; owns the tableau
+
+// Internal-only:
+class Symbol;         // {discriminator, id} packed into a long long
+class Row;            // coefficients indexed by Symbol, plus a constant
+class EditInfo;       // tracks an edit variable's marker symbols and current value
+```
+
+The user-facing types overload arithmetic and comparison operators, so a constraint can
+be written naturally in C++:
+
+```cpp
+kiwi::Variable x("x"), y("y");
+kiwi::Constraint c = (x + 2 * y >= 10) | kiwi::strength::strong;
+```
+
+### AssocVector for Hot Tables
+
+Internally, Kiwi maintains a few mappings:
+
+- `rows`: `Symbol -> Row` (the tableau itself, indexed by basic variable)
+- `vars`: `Variable -> Symbol` (which symbol represents each external variable)
+- `edits`: `Variable -> EditInfo` (per-edit-variable metadata)
+- `infeasible_rows`: a list of rows whose basic variable currently has a negative value
+
+These were initially `std::map`s, then `std::unordered_map`s. The current implementation
+uses **`AssocVector`** — a sorted-vector–backed associative container from Andrei
+Alexandrescu's Loki library, which Kiwi vendors. The choice is documented as a "2x
+speedup" over `std::map` in their benchmarks. The reasoning is straightforward: maps
+small enough to fit in L1 cache pay more in pointer chasing than they save in
+asymptotic complexity. For the sizes typical in UI layout (tens to hundreds of
+constraints per panel), a sorted vector wins.
+
+### Simplex Operations
+
+The simplex operations themselves mirror the [Cassowary algorithm](./cassowary.md#algorithm)
+closely. The main entry points on `Solver` are:
+
+- **`addConstraint(Constraint)`** — Phase I for required constraints; Phase II for non-
+  required. Throws `UnsatisfiableConstraint` if a required constraint conflicts.
+- **`removeConstraint(Constraint)`** — Locates the row originating from the constraint
+  (via marker symbols stored at addition time), pivots if needed to make the marker
+  basic, drops the row, then runs Phase II to restore optimality.
+- **`addEditVariable(Variable, Strength)`** — Adds an internal constraint `v = c` at
+  the requested strength and records the variable as editable.
+- **`suggestValue(Variable, double)`** — Updates the constant on the edit constraint,
+  then runs **dual simplex** to restore feasibility. Cheap; designed for interactive
+  mouse-move callbacks.
+- **`updateVariables()`** — Reads the current basic-feasible-solved-form and writes
+  each external variable's value into its `Variable` object. Decoupled from solving so
+  that batches of suggestions can be made before a single value-update sweep.
+
+Internally, the solver also exposes `dump()` / `dumps()` for debugging, which prints
+the current tableau in a human-readable form.
+
+### Constraint Validation: A Deliberate Omission
+
+When a constraint is removed, Kiwi does **not** check whether the variables in the
+constraint are still referenced by other constraints. The user can hold a `Variable`
+object whose name is in the tableau, but if every constraint referencing it has been
+removed, the solver simply forgets about it. Re-adding a constraint with the same
+`Variable` re-introduces it. This is an intentional choice — validating reuse on every
+removal would require a reference-count pass that is expensive relative to the removal
+itself, and the cost of getting it wrong is small.
+
+### Differences from Cassowary, Summary
+
+| Aspect                           | Original Cassowary                             | Kiwi                                                              |
+| -------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------- |
+| Strength representation          | Symbolic 4-tuple (required, strong, med, weak) | Floating-point scalar; values widely spaced                       |
+| Strength comparison              | Lexicographic                                  | Numeric                                                           |
+| Stay constraints                 | First-class operation                          | Removed; application must encode explicitly                       |
+| Tableau row storage              | `std::map<Variable*, ...>` or similar          | `AssocVector` over `Symbol` (sorted vector of pairs)              |
+| Internal variable representation | `Variable*` (pointer per coefficient)          | `Symbol` = `long long` (one register)                             |
+| Edit-variable plumbing           | Manual `addEditVar` / `beginEdit` / `endEdit`  | Single `addEditVariable` + `suggestValue` calls                   |
+| Removal validation               | Validates variable references                  | Does not validate (faster, but mild footgun)                      |
+| Languages                        | C++, Smalltalk, Java + bindings                | C++ core, Python (hand-rolled CPython API), with downstream ports |
+
+The cumulative effect, on the benchmarks Kiwi's authors report, is **10× to 500× speedup
+over original Cassowary**, with typical use cases (Enaml-style GUI constraint systems)
+landing around **40×**. Memory use is similarly improved — Kiwi reports **5× or more**
+reduction in working-set size.
+
+---
+
+## Constraint Language
+
+The constraint language is the same as Cassowary's — equalities and inequalities over
+linear expressions with strengths — and the Python binding lifts it to a natural
+operator-overloaded form. This section concentrates on Kiwi-specific surface details.
+
+### Variables
+
+```python
+from kiwisolver import Variable
+
+x = Variable("x")
+y = Variable("y")
+```
+
+A `Variable` carries a name (for debugging) and an updateable double-precision value.
+The application reads `x.value()` after `solver.updateVariables()` to get the current
+assignment.
+
+### Expressions
+
+Expressions are built using overloaded arithmetic operators:
+
+```python
+expr = 2 * x + 3 * y - 5
+```
+
+The result is an `Expression` — a sum of terms (variable, coefficient) and a constant.
+Multiplication by another variable raises an exception: linearity is enforced at the
+operator-overload level.
+
+### Constraints
+
+Constraints come from comparison operators:
+
+```python
+c1 = x + y == 10       # equality
+c2 = x >= 0            # inequality
+c3 = 2 * x - y <= 100  # inequality on a compound expression
+```
+
+In Python, the `__eq__` / `__le__` / `__ge__` operators on `Variable` and `Expression`
+return `Constraint` objects, not booleans. (This is the standard Cassowary trick; it
+means you cannot use a `Variable` as a dictionary key with `==` semantics without
+care.)
+
+### Strengths
+
+Kiwi exposes four named strength constants plus the ability to construct custom
+strengths from component weights:
+
+```python
+from kiwisolver.strength import required, strong, medium, weak, create
+
+# Built-in:
+#   required ≈ 1.001e9      (overwhelmingly dominant)
+#   strong   ≈ 1.0e6
+#   medium   ≈ 1.0e3
+#   weak     ≈ 1.0
+
+# Custom strength with explicit components:
+custom = create(1.0, 0.5, 2.0)   # strong=1, medium=0.5, weak=2 → 1,000,502
+```
+
+The pipe operator `|` attaches a strength to a constraint:
+
+```python
+soft_constraint = (x == 100) | "weak"
+also_soft = (x == 100) | weak
+multiplied = (x == 100) | (strong * 2)   # strong with weight 2
+```
+
+A constraint without an explicit strength is **required**.
+
+### Edit Variables
+
+The edit-variable workflow:
+
+```python
+solver.addEditVariable(x, "strong")
+solver.suggestValue(x, 42.0)
+solver.updateVariables()
+print(x.value())   # → 42.0 (if no stronger constraint disagrees)
+```
+
+`addEditVariable` may only be called once per variable. `suggestValue` may be called
+any number of times after that. `removeEditVariable` retires the edit.
+
+### Operator Summary
+
+| Operator | On                                  | Produces     | Meaning                      |
+| -------- | ----------------------------------- | ------------ | ---------------------------- |
+| `+`, `-` | `Var`/`Expr`                        | `Expression` | Linear combination           |
+| `*`      | `Var` / scalar                      | `Expression` | Scaling by a constant        |
+| `/`      | `Var` / scalar                      | `Expression` | Scaling by `1/k`             |
+| `==`     | `Expr`/`Expr`                       | `Constraint` | Required-by-default equality |
+| `<=`     | `Expr`/`Expr`                       | `Constraint` | Less-than-or-equal           |
+| `>=`     | `Expr`/`Expr`                       | `Constraint` | Greater-than-or-equal        |
+| `\|`     | `Constraint` / strength             | `Constraint` | Attach strength              |
+| `\|`     | `Constraint` / `(strength, weight)` | `Constraint` | Scaled strength              |
+
+---
+
+## Code Examples
+
+The examples below use the Python binding (`kiwisolver` on PyPI), which is by far the
+most-used surface. Equivalent C++ uses the same API names with `kiwi::` namespace
+prefixes.
+
+### Example 1: Centered Element Inside a Container
+
+A common layout: a child element should be horizontally centered inside its parent
+container, with both edges respecting a minimum margin.
+
+```python
+from kiwisolver import Variable, Solver
+
+solver = Solver()
+
+# Variables
+parent_left  = Variable("parent.left")
+parent_right = Variable("parent.right")
+child_left   = Variable("child.left")
+child_right  = Variable("child.right")
+
+# Required: parent is anchored at 0, with width 200
+solver.addConstraint(parent_left == 0)
+solver.addConstraint(parent_right == 200)
+
+# Required: minimum 10-pixel margin on each side
+solver.addConstraint(child_left  >= parent_left + 10)
+solver.addConstraint(child_right <= parent_right - 10)
+
+# Required: child must have positive width
+solver.addConstraint(child_right >= child_left)
+
+# Strong: child is centered in parent
+solver.addConstraint(
+    (child_left + child_right == parent_left + parent_right) | "strong"
+)
+
+# Medium: child prefers its intrinsic width of 80
+solver.addConstraint((child_right - child_left == 80) | "medium")
+
+solver.updateVariables()
+print(f"child: [{child_left.value()}, {child_right.value()}]")
+# child: [60.0, 140.0]
+```
+
+The interplay of strengths drives the result: the required constraints set up the
+boundary conditions; the strong centering constraint says "if you can center it,
+center it"; the medium intrinsic-width constraint says "and prefer to be 80 wide".
+Both are satisfiable simultaneously here, so both win. If the parent shrank to a width
+of 30, the required margins would force the child to fit in 10 pixels, both `strong`
+and `medium` constraints would yield, and the solver would minimize their combined
+weighted error.
+
+### Example 2: Mid-Point Variable (Classic Cassowary Demo)
+
+A faithful reproduction of the example in Kiwi's own README — three variables on a
+number line, with a midpoint constrained to lie at the average of two endpoints.
+
+```python
+from kiwisolver import Variable, Solver
+
+solver = Solver()
+
+x1 = Variable("x1")
+x2 = Variable("x2")
+xm = Variable("xm")
+
+# Required: x1 stays non-negative; x2 stays bounded; xm sits between
+solver.addConstraint(x1 >= 0)
+solver.addConstraint(x2 <= 100)
+solver.addConstraint(x2 >= x1 + 10)
+solver.addConstraint(xm == (x1 + x2) / 2)
+
+# Weak: prefer x1 to be 40 (a soft hint)
+solver.addConstraint((x1 == 40) | "weak")
+
+# Edit variable: we'll drag xm interactively
+solver.addEditVariable(xm, "strong")
+solver.suggestValue(xm, 60)
+solver.updateVariables()
+
+print(f"x1={x1.value()}, x2={x2.value()}, xm={xm.value()}")
+# x1=40.0, x2=80.0, xm=60.0  (the weak hint succeeds)
+
+# Now drag xm further right; x1 will be pushed away from its weak preference
+solver.suggestValue(xm, 90)
+solver.updateVariables()
+print(f"x1={x1.value()}, x2={x2.value()}, xm={xm.value()}")
+# x1=80.0, x2=100.0, xm=90.0  (x2 hits its ceiling, weak hint yields)
+```
+
+This example shows the canonical "interactive drag with soft preferences" workflow.
+The `weak` constraint on `x1` is a hint that the solver honors when there is room, but
+yields when stronger constraints (the inequality `x2 <= 100`) would otherwise be
+violated. Each `suggestValue` runs a dual-simplex repair, which is cheap regardless of
+tableau size.
+
+### Example 3: Equal-Spacing of a Row of Items
+
+A horizontal toolbar of `n` buttons, evenly distributed across a container width.
+Box-flow systems express this with `space-between`; Cassowary expresses it as a
+constraint.
+
+```python
+from kiwisolver import Variable, Solver, strength
+
+def setup_toolbar(n_buttons, container_width):
+    solver = Solver()
+    container = Variable("container")
+    solver.addConstraint(container == container_width)
+
+    buttons = []
+    for i in range(n_buttons):
+        left  = Variable(f"btn{i}.left")
+        right = Variable(f"btn{i}.right")
+        buttons.append((left, right))
+        # Required: each button has a fixed width of 60
+        solver.addConstraint(right - left == 60)
+
+    # Required: first button against left edge, last against right edge
+    solver.addConstraint(buttons[0][0] == 0)
+    solver.addConstraint(buttons[-1][1] == container)
+
+    # Required: each gap is equal to the previous gap
+    gaps = []
+    for i in range(n_buttons - 1):
+        gap = buttons[i + 1][0] - buttons[i][1]   # left of next minus right of this
+        gaps.append(gap)
+    for i in range(len(gaps) - 1):
+        solver.addConstraint(gaps[i] == gaps[i + 1])
+
+    # Weak: prefer non-negative gaps (helps when over-constrained)
+    for gap in gaps:
+        solver.addConstraint((gap >= 0) | strength.weak)
+
+    solver.updateVariables()
+    return [(l.value(), r.value()) for (l, r) in buttons]
+
+print(setup_toolbar(5, 400))
+# [(0.0, 60.0), (85.0, 145.0), (170.0, 230.0), (255.0, 315.0), (340.0, 400.0)]
+```
+
+With five buttons of width 60 in a 400-wide container, the total button width is 300
+and the remaining 100 splits into four 25-pixel gaps. The constraint system encodes
+"every gap equals every other gap" rather than computing the gap directly. As
+`container` changes, a single `addEditVariable(container, "strong")` plus
+`suggestValue` calls would re-flow the toolbar with one dual-simplex repair per pixel.
+
+### Example 4: Matplotlib-Style Subplot Alignment
+
+A simplified version of what Matplotlib's `constrained_layout` does internally:
+align two subplots so that their inner axes start at the same x-coordinate,
+regardless of how wide their tick labels are.
+
+```python
+from kiwisolver import Variable, Solver, strength
+
+solver = Solver()
+
+# Subplot 1: outer bounding box and inner axes box
+sp1_left  = Variable("sp1.outer.left")
+sp1_axes_left = Variable("sp1.axes.left")
+sp1_tick_label_width = 30  # measured from rendered text
+
+# Subplot 2: same
+sp2_left  = Variable("sp2.outer.left")
+sp2_axes_left = Variable("sp2.axes.left")
+sp2_tick_label_width = 45  # wider y-tick labels
+
+# Required: each axes box is offset from its outer box by the tick label width
+solver.addConstraint(sp1_axes_left == sp1_left + sp1_tick_label_width)
+solver.addConstraint(sp2_axes_left == sp2_left + sp2_tick_label_width)
+
+# Required: subplot 1's outer left is the figure left
+solver.addConstraint(sp1_left == 0)
+
+# Required: subplot 2 sits to the right of subplot 1 with a 50px gap
+sp1_right = Variable("sp1.outer.right")
+solver.addConstraint(sp1_right == 200)
+solver.addConstraint(sp2_left == sp1_right + 50)
+
+# STRONG: prefer the two axes boxes to start at the same offset within their subplot
+# (Equivalent to "align the y-axes")
+solver.addConstraint(
+    (sp1_axes_left - sp1_left == sp2_axes_left - sp2_left) | "strong"
+)
+
+solver.updateVariables()
+
+print(f"sp1: outer.left={sp1_left.value()}, axes.left={sp1_axes_left.value()}")
+print(f"sp2: outer.left={sp2_left.value()}, axes.left={sp2_axes_left.value()}")
+```
+
+In this scenario the **strong** axes-alignment constraint will be **violated**, because
+the tick label widths differ and the required positions of the outer boxes are fixed.
+Kiwi's solver reports the optimal solution — minimum weighted violation — and the
+application can render with the offsets as computed.
+
+If the application wanted the alignment to win at the cost of subplot positioning, the
+strengths would flip: make alignment `required` and the gap-between-subplots `strong`.
+This is how Matplotlib's `constrained_layout` handles the choice: by making layout
+constraints `required` and aesthetic constraints `strong` or `medium`, it gets
+deterministic alignment with graceful degradation under tight space.
+
+---
+
+## Bindings / Implementations
+
+Kiwi proper is **C++ + Python**, distributed as the `kiwisolver` package on PyPI. The
+package ships pre-built wheels for Linux, macOS, and Windows across Python 3.9 through
+3.14, eliminating compilation from the dependency-installation path. This is the
+overwhelming majority of Kiwi installations: pulled in transitively by Matplotlib,
+which itself is on the order of 30+ million monthly downloads.
+
+| Implementation     | Language               | Notes                                                                                                                                                    |
+| ------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Kiwi (core)        | C++ 11                 | <https://github.com/nucleic/kiwi> — header-only, BSD-3-Clause. Embeds in any C++ project.                                                                |
+| `kiwisolver`       | Python via CPython API | <https://pypi.org/project/kiwisolver/> — hand-rolled CPython binding (not `pybind11`/`cython`).                                                          |
+| `kiwi-js`          | TypeScript             | <https://github.com/IjzerenHein/kiwi.js> — TypeScript port; foundation of autolayout.js. Now maintained as `lume/kiwi`.                                  |
+| `autolayout.js`    | JavaScript             | <https://github.com/lume/autolayout> — Apple Visual Format Language on top of kiwi-js. Hein Rutjes.                                                      |
+| `kiwi-java`        | Java                   | <https://github.com/alexbirkett/kiwi-java> — line-for-line Java port. Alex Birkett, with fixes from yonsunCN and Sam Twidale.                            |
+| Various Rust ports | Rust                   | The Rust ecosystem mostly uses `cassowary-rs` / `kasuari` (port of original Cassowary, not Kiwi). [Ratatui](../tui-libraries/ratatui.md) uses `kasuari`. |
+
+The C++ core is **header-only** in the sense that the entire solver compiles as a small
+set of templates and headers; the Python binding adds a thin CPython-extension layer.
+There is no shared library to link against — `#include <kiwi/kiwi.h>` and you have the
+solver.
+
+### Notable Adopters (Python Ecosystem)
+
+- **Matplotlib** (since 2.0, 2017) — uses Kiwi for `tight_layout` and the more general
+  `constrained_layout` to position axes, colorbars, titles, suptitles, and legends.
+  This is the most widely distributed adoption: nearly every scientific Python
+  installation has `kiwisolver` installed transitively.
+
+- **Enaml** — Nucleic's declarative GUI framework. The original motivating use case.
+  Every Enaml widget's geometry is a constraint system; Kiwi solves it on every layout
+  pass.
+
+- **Atom (text editor)** had an Enaml prototype, indirectly using Kiwi.
+
+- **Conda / mamba** ship `kiwisolver` as a dependency of `matplotlib` in the default
+  scientific channel.
+
+### Notable Adopters (JavaScript Ecosystem)
+
+- **autolayout.js / lume/autolayout** — implements Apple's Visual Format Language
+  layout for web/JavaScript, using kiwi-js under the hood. Used by various Famo.us-
+  successor and node-graph UI projects.
+
+- **GSS (Grid Style Sheets)** — historically used CassowaryJS, but later iterations
+  experimented with kiwi-js for performance.
+
+---
+
+## Strengths and Weaknesses
+
+### For UI Layout
+
+**Strengths.**
+
+- **Performance.** The 10×–500× speedup over original Cassowary turns the constraint
+  solver from a measurable cost into invisible plumbing. Matplotlib's
+  `constrained_layout` is fast enough to enable by default; Enaml supports thousands
+  of widgets without layout lag.
+
+- **Production-grade.** Kiwi has been in continuous production at Nucleic since 2013
+  and as a Matplotlib dependency since 2017, debugged across millions of layout
+  scenarios. Edge cases that fresh Cassowary implementations stumble on are well-worn.
+
+- **Predictable.** Same constraint set, same insertion order → same solution. The
+  floating-point strength scheme is _technically_ less robust than symbolic
+  lexicographic comparison, but in practice the strength values are spaced so widely
+  that the documented corner case (thousands of `weak` outweighing one `medium`)
+  occurs only in synthetic stress tests.
+
+- **Easy embedding.** Header-only C++ with no external dependencies. The CPython
+  binding is a single shared library wheel per platform/version, fast to import, no
+  compilation needed for users.
+
+- **BSD license.** Permissive; safe to vendor into proprietary projects.
+
+**Weaknesses.**
+
+- **No stay constraints.** This is the single biggest gotcha for developers porting
+  from Cassowary or Auto Layout. An under-constrained Kiwi system has _no_ preferred
+  resting state; values can land anywhere consistent with the constraints. Applications
+  must add explicit `(v == current_value) | weak` constraints to pin variables, which
+  amounts to reimplementing stays themselves.
+
+- **Floating-point strength corner case.** Mathematically, a `medium` constraint
+  should beat any number of `weak` constraints; in Kiwi, with strength values
+  `medium = 1000` and `weak = 1`, summing ~1000+ weak violations equals one medium.
+  The documentation acknowledges this. Real UI layouts never hit it, but a synthetic
+  benchmark or pathological auto-generated constraint set could.
+
+- **Edit-variable lifecycle is manual.** Forgetting to `addEditVariable` before
+  `suggestValue` raises an exception. Forgetting to `removeEditVariable` when the
+  interactive operation ends leaves the soft constraint in place, possibly subtly
+  distorting future layouts.
+
+- **Removal does not validate variable references.** As described in
+  [Architecture](#architecture), removing a constraint does not check whether other
+  constraints still reference the variables. A removed variable that re-emerges later
+  via a new constraint is treated as a fresh introduction — usually fine, but
+  surprising if you assumed `Variable` identity preserved internal state across
+  removal cycles.
+
+- **No debugging tools beyond `dump()`.** Like Cassowary, Kiwi inherits the
+  "unsatisfiable constraints" debugging problem. The `dump()` method prints the
+  current tableau, which is useful for solver implementers but rarely actionable for
+  layout authors trying to figure out which constraint pair is in conflict. (Auto
+  Layout's runtime debugging messages are themselves famously hard to read; this is a
+  Cassowary-family problem, not a Kiwi-specific one.)
+
+### For Static One-Shot Rendering
+
+For one-shot layouts, Kiwi is **excellent** — possibly even more so than original
+Cassowary. The fixed overhead of building the tableau is small enough that
+`constrained_layout` runs it for every Matplotlib figure render without noticeable
+cost. Matplotlib explicitly uses Kiwi this way: there is no interactive dragging in
+plot rendering; the solver runs once per `savefig` or `draw`.
+
+The incremental machinery is unused in this case, but pays no penalty: the algorithm
+_is_ the incremental algorithm, run once on an empty initial state. There is no
+"batch solve" mode to switch into.
+
+### Compared to Box-Flow Systems
+
+| Aspect                         | Box-flow (CSS / Yoga / [Ratatui](../tui-libraries/ratatui.md))                             | Kiwi                                               |
+| ------------------------------ | ------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| **API surface**                | Layout-specific (`flex`, `align`, `padding`)                                               | Generic (variables, expressions, constraints)      |
+| **Cross-hierarchy alignment**  | Awkward or impossible                                                                      | Single equality constraint                         |
+| **Speed (single layout)**      | O(n) tree pass                                                                             | Few-microseconds simplex on small tableau          |
+| **Speed (incremental update)** | O(touched subtree)                                                                         | O(touched constraints) via dual simplex            |
+| **Footprint**                  | Often zero extra deps (built into [Ink](../tui-libraries/ink.md), Yoga, etc.)              | One `kiwisolver` import                            |
+| **Programming model**          | Declarative widget tree                                                                    | Imperative constraint addition                     |
+| **Best for**                   | Hierarchical layouts: dashboards, lists, forms                                             | Non-hierarchical alignment, plotting, complex DAGs |
+| **Used by**                    | Browsers, [Ink](../tui-libraries/ink.md), [Ratatui (partial)](../tui-libraries/ratatui.md) | Matplotlib, Enaml, autolayout.js                   |
+
+The defining feature of Kiwi-style layout is that **the constraint system is not tied
+to the widget tree**. Two views in different parents can be aligned by adding one
+equality constraint; in a box-flow system, the same effect requires restructuring the
+tree or introducing a coordinating widget. The cost is the imperative API — Kiwi gives
+you a `Solver` to mutate, not a tree to declare.
+
+For terminal UIs where the layout maps naturally onto a tree (header / body / footer;
+sidebar / content), box-flow is the right tool —
+[Ratatui's `Layout`](../tui-libraries/ratatui.md#layout-system) (which itself wraps a
+slimmed-down Cassowary in `kasuari`, never exposing the constraint API) and
+[Ink's Flexbox](../tui-libraries/ink.md#layout-system) suffice. For terminal layouts
+where, say, a status bar item needs to line up with a column header three panels over,
+embedding Kiwi directly is the cleaner answer than weaving alignment-through-the-tree
+helpers.
+
+---
+
+## References
+
+### Project and Source
+
+- Kiwi repository: <https://github.com/nucleic/kiwi>
+- Kiwi documentation: <https://kiwisolver.readthedocs.io/>
+- `kiwisolver` on PyPI: <https://pypi.org/project/kiwisolver/>
+- Nucleic Project umbrella: <https://github.com/nucleic>
+
+### Documentation Pages
+
+- Basic concepts and API: <https://kiwisolver.readthedocs.io/en/latest/basis/basic_systems.html>
+- Solver internals: <https://kiwisolver.readthedocs.io/en/latest/basis/solver_internals.html>
+- Getting started (installation, basics): <https://kiwisolver.readthedocs.io/en/latest/basis/index.html>
+
+### Algorithmic Foundations
+
+- See [cassowary.md](./cassowary.md) for the algorithm Kiwi implements, including the
+  TOCHI paper and related work.
+- Badros, Borning, Stuckey, _"The Cassowary Linear Arithmetic Constraint Solving
+  Algorithm"_, ACM TOCHI Vol. 8 No. 4, 2001:
+  <https://constraints.cs.washington.edu/solvers/cassowary-tochi.pdf>
+
+### Notable Adopters
+
+- Matplotlib: <https://matplotlib.org/>
+  - `constrained_layout` guide: <https://matplotlib.org/stable/users/explain/axes/constrainedlayout_guide.html>
+  - The `tight_layout` and `constrained_layout` code paths in `lib/matplotlib/_constrained_layout.py` exercise Kiwi extensively.
+- Enaml: <https://github.com/nucleic/enaml>
+- autolayout.js: <https://github.com/lume/autolayout>
+
+### Ports
+
+- kiwi-js / TypeScript: <https://github.com/IjzerenHein/kiwi.js>
+- kiwi-java: <https://github.com/alexbirkett/kiwi-java>
+
+### Related Documents in This Catalog
+
+- [Cassowary](./cassowary.md) — the algorithm Kiwi implements, with full algorithmic
+  detail.
+- [Apple Auto Layout](./auto-layout.md) — the production Cassowary at the foundation of
+  iOS / macOS UI; uses a different implementation (Apple's own) but the same algorithm.
+- [Ratatui](../tui-libraries/ratatui.md) — uses `kasuari`, a Cassowary port, for
+  terminal layout; an interesting comparison point for what a slimmed-down Cassowary
+  looks like in a different ecosystem.
+- [Ink](../tui-libraries/ink.md) — uses Flexbox (Yoga) instead, illustrating the
+  box-flow alternative to constraint-based layout.

--- a/docs/research/ui-layout/qt-layouts.md
+++ b/docs/research/ui-layout/qt-layouts.md
@@ -1,0 +1,651 @@
+# Qt Layouts (Qt Widgets and Qt Quick)
+
+A mature, explicit, widget-oriented layout system built around a hierarchy of
+`QLayout` managers, a two-axis `QSizePolicy` per widget, and per-item stretch
+factors. Qt Quick (QML) adds a complementary declarative model with attached
+properties, item positioners, and anchor-based positioning.
+
+| Field            | Value                                                               |
+| ---------------- | ------------------------------------------------------------------- |
+| Language         | C++ (Qt Widgets), QML (Qt Quick)                                    |
+| License          | LGPLv3 / GPL / Commercial                                           |
+| Vendor           | The Qt Company / Qt Project                                         |
+| Documentation    | <https://doc.qt.io/qt-6/layout.html>                                |
+| First Released   | Qt 1.0 (1995); modern `QLayout` hierarchy stabilized in Qt 4 (2005) |
+| Version snapshot | Qt 6 Widgets API; Qt 6.0 shipped in 2020                            |
+| Sub-API          | `QtWidgets`, `QtQuick.Layouts`, `QtQuick` positioners, QML anchors  |
+
+---
+
+## Overview
+
+Qt is one of the longest-lived cross-platform UI toolkits in production. Its
+layout system predates CSS Flexbox by more than a decade and has evolved
+through five major versions while retaining a remarkably stable conceptual
+core. Most desktop and embedded Qt applications still rely on the original
+`QHBoxLayout` / `QVBoxLayout` / `QGridLayout` triad introduced in early Qt and
+modernized in Qt 4.
+
+**What Qt's layout system solves.** Native desktop UIs need to deal with
+several thorny problems at once: localized text of varying length, fonts and
+DPI that differ between platforms, user-driven window resizing, accessibility
+constraints, and (more recently) high-DPI displays and dark/light theme
+switching. Qt's response is a _measure-then-arrange_ protocol where every
+widget reports a `sizeHint()` (preferred), `minimumSizeHint()` (smallest
+sensible), and a `QSizePolicy` (how the widget reacts to extra or insufficient
+space along each axis). Layout managers aggregate those signals from their
+children and produce a geometry assignment.
+
+**Two flavors of layout.** Qt Widgets (`QWidget`-based, C++) and Qt Quick
+(`QtQuick`-based, QML + JavaScript) present the same conceptual model with
+different surfaces. In Qt Widgets, layouts are first-class C++ objects
+(`QLayout` subclasses) installed on a `QWidget` container. In Qt Quick, layout
+managers are QML types (`RowLayout`, `ColumnLayout`, `GridLayout`) that
+participate alongside two older positioning systems: declarative _anchors_
+(`anchors.left: parent.left`) and _item positioners_ (`Row`, `Column`, `Grid`,
+`Flow`) that arrange children without sizing them.
+
+**Design philosophy.** Qt layouts are _explicit_ rather than _implicit_:
+nothing is laid out by default. A bare `QWidget` containing children with no
+`QLayout` attached will leave those children at `(0, 0)`. This was a deliberate
+choice — Qt does not impose a layout model the way HTML does block flow — but
+it means every widget that participates in resizing must opt in through a
+layout. Once installed, a layout _owns_ the geometry of its children: trying
+to set `widget->setGeometry(...)` on a child managed by a layout will simply
+be overwritten on the next resize event.
+
+**Lineage and influence.** Qt's two-pass model (compute hints, then assign
+geometry) closely resembles WPF's measure/arrange pass and predates it by
+roughly a decade. Unlike WPF, however, Qt has no star-sizing (`*` and `Auto`
+in grid columns); instead it uses integer **stretch factors** per item or per
+row/column, plus the `QSizePolicy` enum on each widget. Qt Quick layouts
+introduced attached properties (`Layout.fillWidth`, `Layout.preferredWidth`,
+etc.) that closely echo the WPF / XAML attached-property pattern, and the
+constraint-based `GtkConstraintLayout` in GTK 4 was directly inspired by Qt's
+long-standing flirtation with constraint solvers (the Qt Quick declarative
+binding system has Cassowary-like dataflow semantics).
+
+---
+
+## Layout Model
+
+### The two-pass protocol
+
+Every Qt layout pass works in two phases, propagated up and down the widget
+tree:
+
+1. **Measurement.** Each widget reports three numbers per axis: minimum size,
+   maximum size, and `sizeHint()`. A composite layout (e.g. `QHBoxLayout`)
+   aggregates those values from its children by walking the list of items,
+   applying spacing and contents margins, and producing its own minimum,
+   maximum, and `sizeHint()`. If a child widget overrides `heightForWidth()`
+   (used by word-wrapped labels, for example), the layout participates in a
+   secondary height-for-width measurement.
+
+2. **Allocation.** Once the parent decides on a final geometry, the layout's
+   `setGeometry(QRect)` method is called. The layout walks its items again,
+   assigning each one a rectangle inside the available area. Allocation
+   respects (in order): minimum sizes, then `QSizePolicy::Fixed` items, then
+   stretch factors, then the `QSizePolicy::Expanding` policy, then any leftover
+   space distributed back to non-expanding items.
+
+This protocol mirrors the WPF measure/arrange pass closely. Where WPF uses
+`Auto`, `Pixel`, and `*` (star) for grid sizing, Qt uses a combination of a
+`QSizePolicy` enum on each child widget and an _integer stretch factor_ (per
+child within a box layout, or per row/column within a grid).
+
+### The `QLayout` hierarchy
+
+All Qt Widgets layouts inherit from `QLayout`, which itself inherits from
+`QLayoutItem`. A layout is therefore a layout item — that is what makes
+nesting possible.
+
+```
+QLayoutItem (abstract)
+   |
+   +-- QWidgetItem      (wraps a single QWidget)
+   +-- QSpacerItem      (blank space, fixed or expanding)
+   +-- QLayout (abstract)
+        |
+        +-- QBoxLayout
+        |     +-- QHBoxLayout
+        |     +-- QVBoxLayout
+        +-- QGridLayout
+        +-- QFormLayout
+        +-- QStackedLayout
+```
+
+The five concrete layout classes cover the vast majority of widget UIs. There
+are also third-party flow layouts and grid-bag layouts in the Qt examples,
+but the built-in five are conceptually complete.
+
+### `QHBoxLayout` and `QVBoxLayout`
+
+These are the workhorses: arrange children in a single row (horizontal) or
+column (vertical). Each child has an optional **stretch factor** (an integer,
+default 0) and an optional **alignment**.
+
+```cpp
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QLineEdit>
+
+QWidget* makeToolbar()
+{
+    auto* container = new QWidget;
+    auto* row = new QHBoxLayout(container);
+    row->setContentsMargins(8, 4, 8, 4);
+    row->setSpacing(6);
+
+    auto* search = new QLineEdit;
+    auto* go     = new QPushButton(QObject::tr("Go"));
+    auto* cancel = new QPushButton(QObject::tr("Cancel"));
+
+    // search expands to fill leftover space (stretch=1);
+    // the two buttons stay at their sizeHint.
+    row->addWidget(search, /*stretch=*/1);
+    row->addWidget(go);
+    row->addWidget(cancel);
+
+    return container;
+}
+```
+
+Several conventions are worth noting:
+
+- The `QHBoxLayout(container)` constructor automatically installs the layout
+  on the container widget. There is no separate `setLayout()` call.
+- `addWidget(widget, stretch, alignment)` accepts an optional integer stretch
+  factor and an optional `Qt::Alignment` flag. The signature is overloaded.
+- Inserting `row->addStretch(1)` adds a _spacer_ with `Expanding` policy and
+  the given stretch factor — a common idiom for pushing widgets to one end.
+- Margins are set via `setContentsMargins(left, top, right, bottom)` (with a
+  no-argument convenience getter) and inter-item spacing via `setSpacing`.
+
+### `QGridLayout`
+
+The most flexible 2D layout: place widgets in row/column cells with optional
+spans. Stretch factors are set per row and per column.
+
+```cpp
+auto* grid = new QGridLayout(container);
+grid->setContentsMargins(10, 10, 10, 10);
+grid->setHorizontalSpacing(8);
+grid->setVerticalSpacing(4);
+
+// Place title spanning columns 0..2 on row 0.
+grid->addWidget(title, /*row=*/0, /*col=*/0, /*rowspan=*/1, /*colspan=*/3);
+
+// Two-column form on rows 1..3.
+grid->addWidget(new QLabel("Name:"),    1, 0);
+grid->addWidget(nameEdit,               1, 1);
+grid->addWidget(new QLabel("Email:"),   2, 0);
+grid->addWidget(emailEdit,              2, 1);
+grid->addWidget(new QLabel("Comment:"), 3, 0, Qt::AlignTop);
+grid->addWidget(commentEdit,            3, 1);
+
+// Buttons on the right at row 4.
+auto* buttons = new QHBoxLayout;
+buttons->addStretch(1);
+buttons->addWidget(okButton);
+buttons->addWidget(cancelButton);
+grid->addLayout(buttons, 4, 0, 1, 2);
+
+// Column 1 (the field column) absorbs extra horizontal space.
+grid->setColumnStretch(0, 0);
+grid->setColumnStretch(1, 1);
+
+// The comment row absorbs extra vertical space.
+grid->setRowStretch(3, 1);
+```
+
+Key API:
+
+- `addWidget(widget, fromRow, fromCol, rowSpan, colSpan, alignment)` — the
+  6-argument overload provides span support. A `rowSpan` or `colSpan` of `-1`
+  extends to the bottom/right edge of the grid.
+- `addLayout(...)` nests a sub-layout into a cell.
+- `setColumnStretch(col, stretch)` / `setRowStretch(row, stretch)` are how
+  rows/columns absorb leftover space.
+- `setColumnMinimumWidth(col, px)` / `setRowMinimumHeight(row, px)` force a
+  floor.
+- `setHorizontalSpacing()` / `setVerticalSpacing()` can be different (unlike
+  box layouts which have one `spacing`).
+
+The combination _one expanding column + a final row of stretchy spacer +
+column-stretch on the field column_ handles the layout of about 95% of form
+dialogs.
+
+### `QFormLayout`
+
+A specialization for two-column "label : field" forms. It tracks alignment
+conventions per platform (right-aligned labels on macOS, left-aligned on most
+Linux desktops) and exposes two policies that govern resize behavior.
+
+```cpp
+auto* form = new QFormLayout;
+form->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
+form->setRowWrapPolicy(QFormLayout::WrapLongRows);
+form->setLabelAlignment(Qt::AlignRight);
+
+// Each addRow auto-creates a QLabel and sets it as buddy of the field.
+form->addRow(tr("&Name:"),    nameEdit);
+form->addRow(tr("&Email:"),   emailEdit);
+form->addRow(tr("&Comment:"), commentEdit);
+
+// Spanning row (single widget, no label).
+form->addRow(disclaimerLabel);
+```
+
+The `FieldGrowthPolicy` enum:
+
+| Value                   | Behavior                                                                   |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `FieldsStayAtSizeHint`  | Fields never exceed their `sizeHint()`. macOS default.                     |
+| `ExpandingFieldsGrow`   | Only fields whose `sizePolicy()` is `Expanding` grow. Older Linux default. |
+| `AllNonFixedFieldsGrow` | Any field that can grow does. The de-facto default for new code.           |
+
+The `RowWrapPolicy` enum:
+
+| Value          | Behavior                                                          |
+| -------------- | ----------------------------------------------------------------- |
+| `DontWrapRows` | Labels and fields always share a row.                             |
+| `WrapLongRows` | A field wraps below its label when the label runs out of room.    |
+| `WrapAllRows`  | Fields are always placed below their labels (mobile-style forms). |
+
+`setRowVisible(int, bool)` (added in Qt 6.4) hides a row without deleting it
+— useful for conditional form sections.
+
+### `QStackedLayout`
+
+Holds N children but shows only one at a time. The companion widget
+`QStackedWidget` wraps a `QStackedLayout`. Switching the current index emits
+`currentChanged(int)`. The `StackingMode` enum supports `StackOne` (default,
+hide all but current) and `StackAll` (keep all visible, raise current),
+useful for overlay effects.
+
+```cpp
+auto* stack = new QStackedLayout(container);
+stack->addWidget(welcomePage);   // index 0
+stack->addWidget(editorPage);    // index 1
+stack->addWidget(settingsPage);  // index 2
+stack->setCurrentIndex(1);
+
+QObject::connect(modeCombo, &QComboBox::activated,
+                 stack, &QStackedLayout::setCurrentIndex);
+```
+
+### `QSplitter` (a layout-shaped widget)
+
+Strictly speaking `QSplitter` is _not_ a `QLayout` — it is a `QWidget` that
+contains other widgets directly. But it is the canonical way to do
+_interactively resizable_ splits and so is almost always discussed alongside
+the layout classes.
+
+```cpp
+auto* split = new QSplitter(Qt::Horizontal);
+split->addWidget(fileTree);
+split->addWidget(editor);
+split->addWidget(inspector);
+
+split->setStretchFactor(0, 0);   // file tree: keep its width
+split->setStretchFactor(1, 1);   // editor: absorb growth
+split->setStretchFactor(2, 0);   // inspector: keep its width
+
+split->setHandleWidth(6);
+split->setChildrenCollapsible(true);   // user can drag a pane to width 0
+
+// Persist split positions across sessions.
+QSettings settings;
+settings.setValue("mainSplit", split->saveState());
+// later: split->restoreState(settings.value("mainSplit").toByteArray());
+```
+
+Important constraint: `QSplitter` does _not_ accept a `QLayout` as a child.
+You add widgets via `addWidget()`, and inside each pane you nest your own
+container widget with its own layout.
+
+### `QSizePolicy`: how children react to space
+
+`QSizePolicy` is the per-widget signal that lets the layout manager know how
+the widget wants to behave. It has two axes (horizontal, vertical), each set
+to a value from the `Policy` enum, plus optional stretch factors.
+
+| `QSizePolicy::Policy` | Bit flags              | Behavior                                                         |
+| --------------------- | ---------------------- | ---------------------------------------------------------------- |
+| `Fixed`               | (none)                 | Always `sizeHint()`. Cannot grow, cannot shrink.                 |
+| `Minimum`             | `GrowFlag`             | `sizeHint()` is minimum, can grow but unwilling.                 |
+| `Maximum`             | `ShrinkFlag`           | `sizeHint()` is maximum, can shrink.                             |
+| `Preferred`           | `GrowFlag\|ShrinkFlag` | Default. Can grow or shrink around `sizeHint()`.                 |
+| `Expanding`           | `Grow\|Shrink\|Expand` | Actively wants extra space. Used by text widgets, lists, etc.    |
+| `MinimumExpanding`    | `Grow\|Expand`         | `sizeHint()` is minimum; eager to grow but never shrinks.        |
+| `Ignored`             | `Grow\|Shrink\|Ignore` | Disregards `sizeHint()` entirely; takes whatever space is given. |
+
+The flags above (`GrowFlag`, `ShrinkFlag`, `ExpandFlag`, `IgnoreFlag`) compose
+each policy. The layout reads them when distributing space: `Expand` widgets
+get extra space _before_ `Grow`-only widgets do, and `Ignore` widgets are
+always asked last.
+
+`QSizePolicy` also carries per-axis stretch factors (`horizontalStretch`,
+`verticalStretch`) and an `hasHeightForWidth` flag for word-wrap-like
+widgets. The `ControlType` field is a style hint that lets Qt's per-style
+spacing calculator pick the right inter-widget gap for, say, a `PushButton`
+next to a `ComboBox`.
+
+### `QSpacerItem`
+
+A blank rectangle with its own size policy. Used to push widgets apart inside
+a layout. Two convenience methods on `QBoxLayout` create them inline:
+
+- `addStretch(int factor = 0)` — adds an `Expanding` spacer with the given
+  stretch factor.
+- `addSpacing(int pixels)` — adds a `Fixed` spacer of the given size.
+
+```cpp
+auto* row = new QHBoxLayout;
+row->addWidget(prevButton);
+row->addStretch(1);                  // pushes the next group to the right
+row->addWidget(pageLabel);
+row->addSpacing(20);                 // fixed 20px gap
+row->addWidget(nextButton);
+```
+
+### Alignment
+
+Per-item alignment is set either at the call site
+(`layout->addWidget(w, stretch, Qt::AlignRight)`) or after the fact
+(`layout->setAlignment(w, Qt::AlignRight | Qt::AlignTop)`). Alignment flags
+are bitwise OR-combined `Qt::Alignment` values:
+
+- Horizontal: `Qt::AlignLeft`, `Qt::AlignRight`, `Qt::AlignHCenter`,
+  `Qt::AlignJustify`.
+- Vertical: `Qt::AlignTop`, `Qt::AlignBottom`, `Qt::AlignVCenter`,
+  `Qt::AlignBaseline`.
+- Compound: `Qt::AlignCenter` (== `AlignHCenter | AlignVCenter`).
+
+When alignment is set, the widget is placed at its `sizeHint()` rather than
+filling the cell — alignment and "fill the cell" are mutually exclusive in
+Qt's model. This is one of the surprising-for-beginners behaviors: aligning
+a button to `AlignLeft` makes it stop growing horizontally.
+
+### Margins and spacing
+
+Two distinct concepts:
+
+- **Contents margins** — the padding _between the layout and the surrounding
+  widget_. Set via `setContentsMargins(left, top, right, bottom)`.
+- **Spacing** — the gap _between adjacent items inside the layout_. Set via
+  `setSpacing(int)` on box layouts, or `setHorizontalSpacing/setVerticalSpacing`
+  on grid/form layouts.
+
+Both default to style-dependent values pulled from `QStyle::PM_LayoutLeftMargin`
+and friends, so a Qt app on Windows, macOS, and KDE looks "native" without
+the developer hardcoding pixel values.
+
+### `SizeConstraint`
+
+A `QLayout` can constrain its _parent widget's_ size based on the children:
+
+| `QLayout::SizeConstraint` | Effect                                                      |
+| ------------------------- | ----------------------------------------------------------- |
+| `SetDefaultConstraint`    | Sets the parent's minimum to `minimumSize()`.               |
+| `SetFixedSize`            | Locks the parent to `sizeHint()`. Window cannot be resized. |
+| `SetMinimumSize`          | Floor on the parent.                                        |
+| `SetMaximumSize`          | Ceiling on the parent.                                      |
+| `SetMinAndMaxSize`        | Both floor and ceiling.                                     |
+| `SetNoConstraint`         | Layout does not constrain the parent.                       |
+
+(Qt 6.10 split this into separate horizontal/vertical constraints, accessible
+via `setSizeConstraints(horizontal, vertical)`.)
+
+This is how `QDialog::adjustSize()` makes a dialog snap to its content size,
+and how `setFixedSize()` is implemented when applied to a parent that holds a
+layout.
+
+### Qt Quick layouts (QML)
+
+Qt Quick has _three_ coexisting positioning systems:
+
+1. **Anchors** — declarative attachment of one edge of an item to another:
+
+   ```qml
+   Rectangle {
+       anchors.left: parent.left
+       anchors.right: parent.right
+       anchors.top: header.bottom
+       anchors.margins: 8
+   }
+   ```
+
+   Anchors are computed in a single pass and do not resolve cycles. They are
+   fast and idiomatic for relatively simple compositions.
+
+2. **Item positioners** (`Row`, `Column`, `Grid`, `Flow`) — arrange children
+   _without resizing_ them. The positioner sets only `x` and `y` on each
+   child; the children keep their own intrinsic width/height.
+
+   ```qml
+   Row {
+       spacing: 6
+       Image { source: "icon.png" }
+       Text  { text: "Hello" }
+   }
+   ```
+
+3. **Layouts** (`RowLayout`, `ColumnLayout`, `GridLayout` from
+   `QtQuick.Layouts`) — resize children based on attached properties.
+   Functionally similar to Qt Widgets layouts, but expressed declaratively
+   in QML:
+
+```qml
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+
+ApplicationWindow {
+    width: 640; height: 400
+    visible: true
+    title: qsTr("Layout demo")
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.margins: 8
+        spacing: 6
+
+        // Sidebar: fixed-ish width, full height.
+        Rectangle {
+            Layout.preferredWidth: 180
+            Layout.fillHeight: true
+            color: "#222"
+        }
+
+        // Main content: absorbs all leftover width and height.
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 4
+
+            Label {
+                text: qsTr("Title")
+                Layout.alignment: Qt.AlignHCenter
+            }
+
+            TextArea {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+            }
+
+            RowLayout {
+                Layout.alignment: Qt.AlignRight
+                Button { text: qsTr("OK") }
+                Button { text: qsTr("Cancel") }
+            }
+        }
+    }
+}
+```
+
+The `Layout.*` attached properties echo the Qt Widgets API: `fillWidth`,
+`fillHeight`, `preferredWidth/Height`, `minimumWidth/Height`,
+`maximumWidth/Height`, `alignment`, `row`, `column`, `rowSpan`, `columnSpan`,
+`horizontalStretchFactor`, `verticalStretchFactor`. The `uniformCellSizes`
+property on `GridLayout` (Qt 6.6+) forces all rows/columns to the same size.
+
+The takeaway: Qt Quick deliberately keeps positioners and layouts separate.
+Positioners are cheap and predictable; layouts are flexible but cost more
+per resize. Anchors interoperate with both, but you cannot anchor a child
+_and_ place it in a layout simultaneously — the layout takes ownership of
+geometry, just like in the Widgets world.
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Explicit and predictable.** Every widget participates in layout only
+  when explicitly opted in. Layout boundaries are visible in code.
+- **Mature.** Three decades of polish: rotation handles in `QGraphicsLayout`,
+  RTL support baked into `QHBoxLayout`, per-style spacing via `QStyle::layoutSpacing`,
+  high-DPI scaling at the layout-engine level.
+- **The `QGridLayout` + stretch-factor + spacer combo handles 95% of forms.**
+  Once mastered, the same pattern composes for dialogs, document windows,
+  tool palettes, and side panels.
+- **`QSizePolicy` is verbose but explicit.** Unlike CSS flexbox where space
+  distribution depends on the interaction of `flex-grow`, `flex-shrink`,
+  `flex-basis`, intrinsic content sizes, and minimum size constraints, Qt
+  separates "policy" (what kind of widget is this?) from "stretch" (how
+  greedy is it?). Once you internalize the seven `Policy` values, behavior
+  is deterministic.
+- **Two-axis policy.** Each widget can have completely different behavior
+  horizontally vs. vertically. A multi-line text editor is `Expanding`
+  vertically but `Preferred` horizontally; a button is `Preferred` both
+  ways; a slider is `Expanding` along its axis and `Fixed` across it. There
+  is no single-axis "flex" abstraction to fight.
+- **Layouts are nestable and replaceable.** Swapping a `QHBoxLayout` for a
+  `QVBoxLayout` is a single-line change. The widget tree itself is
+  unaffected.
+- **Three coexisting models in Qt Quick.** Anchors, positioners, and layouts
+  let the developer pick the cheapest tool for each job. A static toolbar
+  uses anchors; a list of equal-sized icons uses `Row`; a resizable
+  document area uses `ColumnLayout`.
+- **Excellent visual designers.** Qt Designer (Widgets) and Qt Design Studio
+  (Quick) both have first-class WYSIWYG support, generating clean code that
+  mirrors what a developer would write by hand.
+- **Save/restore for `QSplitter` and dock layouts.** `saveState()` / `restoreState()`
+  serialize user-adjusted geometry to a `QByteArray` for trivial persistence
+  across sessions.
+- **Localizable.** `QLayout` measures children in logical pixels and respects
+  per-platform spacing; localized strings of different lengths re-layout
+  automatically without app code.
+
+### Weaknesses
+
+- **Implicit cell sizing is awkward.** Qt has no equivalent of WPF's star
+  sizing (`*`, `2*`, `Auto`). Stretch factors approximate `*` weights but
+  require setting `setColumnStretch` separately from cell placement, and
+  there is no direct "shrink to content" mode at the column level — instead
+  you set `QSizePolicy::Fixed` on the child widgets.
+- **No constraint solver in Qt Widgets.** Unlike `GtkConstraintLayout` (Cassowary)
+  or AutoLayout (iOS/macOS), Qt Widgets has no "this edge equals that edge
+  plus 8 pixels" model. You either nest box/grid layouts to approximate the
+  effect, or drop down to `QGraphicsLayout` (more flexible but heavier).
+- **`QSplitter` is not a layout.** Resizable splits require switching to a
+  widget-as-container model; you cannot nest a `QLayout` _inside_ a splitter
+  pane (you must wrap the layout in a `QWidget` first).
+- **`heightForWidth()` is subtle and rarely correct.** Word-wrapped labels
+  and text editors need `hasHeightForWidth()` set on their `QSizePolicy`,
+  plus the containing layout must support it, plus the parent widget must
+  participate. Many third-party widgets break in subtle ways when given a
+  width-constrained vertical layout.
+- **Stretch factor semantics differ from CSS.** Where flex's `flex-grow: 1`
+  shares leftover space evenly, Qt's stretch factor is proportional but
+  _bounded by `QSizePolicy`_. A widget with `Fixed` policy and stretch=1
+  will not grow at all. Newcomers from web backgrounds find this
+  counterintuitive.
+- **Three positioning systems in Qt Quick is two too many.** Anchors,
+  positioners, and layouts have overlapping but non-identical semantics.
+  Mixing them in one parent (e.g., anchoring an item inside a `ColumnLayout`)
+  is a runtime error.
+- **No declarative layout in Qt Widgets.** Layouts are imperatively
+  constructed in C++. Qt Designer generates `.ui` files which are XML, but
+  the runtime API is still imperative `addWidget(...)` calls.
+- **High-DPI quirks.** Qt 5.6+ does most of the right thing for high-DPI,
+  but pixel-perfect alignment of layouts mixed with manually-drawn content
+  (`QPainter`) still requires care. Some apps still ship `Qt::HighDpiScaleFactorRoundingPolicy`
+  configuration to paper over rounding.
+- **Designer-generated code is verbose.** A simple form dialog produces
+  hundreds of lines of `setupUi()` boilerplate, much of it `setObjectName()`
+  calls and translation infrastructure.
+
+### Comparison to other systems
+
+- **WPF.** Both use a measure/arrange pass. WPF has star sizing (`*`, `Auto`);
+  Qt has stretch factors + size policy. WPF has `Grid.Row`, `Grid.Column`
+  attached properties; Qt has them too in QML (`Layout.row`, `Layout.column`)
+  but uses positional arguments in C++. WPF's `Canvas` and `StackPanel` map
+  closely to Qt's `QGraphicsScene` and `QBoxLayout`.
+- **CSS Flexbox.** Conceptually similar (main axis, cross axis, stretch),
+  but Qt's policy/stretch decomposition is more explicit. Flexbox's
+  `flex-basis` has no clean Qt analogue. See also Ink's Yoga-based model in
+  [`../tui-libraries/ink.md`](../tui-libraries/ink.md).
+- **GTK 4.** GTK 4's `GtkLayoutManager` (see [`gtk.md`](gtk.md)) is closer
+  in spirit to Qt's `QLayout` — a swappable algorithm attached to a widget —
+  but ships with fewer built-in layouts and adds a Cassowary-based
+  constraint layout that Qt does not include.
+- **Ratatui constraints.** Ratatui's `Length`/`Fill`/`Min`/`Max`/`Percentage`
+  (see [`../tui-libraries/ratatui.md`](../tui-libraries/ratatui.md)) covers
+  similar ground to Qt's stretch factors + size policy, but is constraint-
+  solver-based (Cassowary via the `kasuari` crate) and is purely 1D per call.
+- **Textual (Python).** Textual's CSS-like layout system (see
+  [`../tui-libraries/textual.md`](../tui-libraries/textual.md)) borrows
+  flexbox grammar; closer to Qt Quick `Layout.*` attached properties than to
+  Qt Widgets' imperative API.
+
+---
+
+## References
+
+- **Qt Widgets Layout Management.**
+  <https://doc.qt.io/qt-6/layout.html>
+- **`QLayout` class reference.**
+  <https://doc.qt.io/qt-6/qlayout.html>
+- **Per-layout references.**
+  - `QHBoxLayout`: <https://doc.qt.io/qt-6/qhboxlayout.html>
+  - `QVBoxLayout`: <https://doc.qt.io/qt-6/qvboxlayout.html>
+  - `QBoxLayout`: <https://doc.qt.io/qt-6/qboxlayout.html>
+  - `QGridLayout`: <https://doc.qt.io/qt-6/qgridlayout.html>
+  - `QFormLayout`: <https://doc.qt.io/qt-6/qformlayout.html>
+  - `QStackedLayout`: <https://doc.qt.io/qt-6/qstackedlayout.html>
+- **Size policies and layout items.**
+  - `QSizePolicy`: <https://doc.qt.io/qt-6/qsizepolicy.html>
+  - `QLayoutItem`: <https://doc.qt.io/qt-6/qlayoutitem.html>
+  - `QSpacerItem`: <https://doc.qt.io/qt-6/qspaceritem.html>
+- **`QSplitter` (interactive split widget).**
+  <https://doc.qt.io/qt-6/qsplitter.html>
+- **Qt Quick Layouts.**
+  - `RowLayout`: <https://doc.qt.io/qt-6/qml-qtquick-layouts-rowlayout.html>
+  - `ColumnLayout`: <https://doc.qt.io/qt-6/qml-qtquick-layouts-columnlayout.html>
+  - `GridLayout`: <https://doc.qt.io/qt-6/qml-qtquick-layouts-gridlayout.html>
+  - `Layout` attached properties:
+    <https://doc.qt.io/qt-6/qml-qtquick-layouts-layout.html>
+  - Overview: <https://doc.qt.io/qt-6/qtquicklayouts-overview.html>
+- **Qt Quick positioners and anchors.**
+  - Item positioners (`Row`, `Column`, `Grid`, `Flow`):
+    <https://doc.qt.io/qt-6/qtquick-positioning-layouts.html>
+  - Anchor-based layout:
+    <https://doc.qt.io/qt-6/qtquick-positioning-anchors.html>
+- **History.**
+  - Qt 1.0 release (1995):
+    <https://en.wikipedia.org/wiki/Qt_(software)#Release_history>
+  - Qt 4 "Layout management" redesign:
+    <https://doc.qt.io/archives/qt-4.8/layout.html>
+- **Cross-references in this catalog.**
+  - Ratatui constraint layouts:
+    [`../tui-libraries/ratatui.md`](../tui-libraries/ratatui.md)
+  - Ink / Flexbox via Yoga:
+    [`../tui-libraries/ink.md`](../tui-libraries/ink.md)
+  - Textual's CSS-like layout:
+    [`../tui-libraries/textual.md`](../tui-libraries/textual.md)
+  - GTK 4 layout managers:
+    [`./gtk.md`](./gtk.md)

--- a/docs/research/ui-layout/stretch.md
+++ b/docs/research/ui-layout/stretch.md
@@ -1,0 +1,610 @@
+# Stretch (Rust)
+
+A Rust implementation of CSS Flexbox built by Visly Inc. as a cross-platform, FFI-friendly
+alternative to Facebook's Yoga. Stretch was the first widely-used Rust Flexbox engine
+and is the direct ancestor of [Taffy](taffy.md); the repository has been archived since
+roughly 2021, but its design --- a tree-owning `Stretch` driver, `Node` handles, and a
+CSS-aligned `Style` struct --- continues to shape every Rust layout engine that came
+after it.
+
+| Field            | Value                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| Language         | Rust                                                                                                |
+| License          | MIT                                                                                                 |
+| Repository       | <https://github.com/vislyhq/stretch> (archived)                                                     |
+| Documentation    | <https://vislyhq.github.io/stretch/> (historical)                                                   |
+| Version snapshot | 0.3.2 (last release ~2020; unmaintained since 2021)                                                 |
+| Notable adoption | Visly design tool; early Servo experiments; embedded UI prototypes; React Native-style mobile demos |
+
+---
+
+## Overview
+
+### What It Solves
+
+In 2018, the only mature, embeddable Flexbox engine in widespread use was Facebook's
+**Yoga** --- a C++ port of the parts of the WebKit layout engine relevant to React
+Native. Yoga was (and remains) excellent, but it carried a C++ codebase, a hand-rolled
+build system, manual memory management across an FFI boundary, and a slightly idiosyncratic
+take on the CSS spec.
+
+Stretch's pitch was: take the same idea --- "Flexbox without a browser" --- and reimplement
+it in modern, safe Rust. The library was intended to be:
+
+- **Embeddable.** A single layout engine that powers iOS, Android, web, desktop, and
+  server-side rendering, with thin FFI shims on each platform.
+- **Cross-platform.** No assumptions about the surrounding runtime; works equally well in
+  a mobile app, a WASM bundle, or a server.
+- **Mobile-first in performance budget.** Small binary size, low allocation pressure,
+  optional multithreaded layout.
+- **Spec-aligned.** Validated against Chrome's layout via headless tests, so behaviour
+  matches what web developers expect.
+
+Stretch was the layout backbone of **Visly**, the design platform from Visly Inc. (now
+defunct). Visly used Stretch to power a "what you see is what you get" UI editor whose
+outputs ran identically on iOS, Android, and the web.
+
+### Design Philosophy
+
+Stretch's design rested on a few core decisions, most of which Taffy inherited.
+
+**A driver-owned tree.** The library's main type is `stretch::node::Stretch`, an arena-like
+container that owns all `Node`s. Nodes are referenced by stable handles, not by pointers
+or `Box`es. This avoided lifetime headaches across FFI: a node's identity is a small
+integer that can live in a Swift `struct` or a Java `long` without borrow-checker drama.
+
+**Style is a plain data struct.** Every CSS-like property is a field on `Style`. No
+inheritance, no cascade, no selectors --- those are problems for whoever builds _on top_ of
+Stretch. The library's job is purely to convert a tree of styles into a tree of
+rectangles.
+
+**Measure functions as escape hatch.** Anything Stretch cannot compute on its own (most
+notably "how wide is this text in this font?") is delegated to a caller-supplied measure
+function, called for leaf nodes whose intrinsic size matters. This is the same pattern
+Yoga uses and Taffy inherited.
+
+**Spec-aligned, browser-validated.** Tests were generated from HTML fixtures rendered in
+headless Chrome, with the expected layout extracted from `getBoundingClientRect()`. If
+Stretch disagreed with Chrome, Stretch was wrong by definition. This kept the library
+honest and is the same testing strategy Taffy uses today.
+
+**Small, focused API.** The full public surface area fit in three modules:
+`stretch::node`, `stretch::style`, `stretch::geometry`. Adding a node, setting children,
+setting a style, computing layout --- there were no other operations.
+
+### History
+
+- **2018 --- Initial release.** Eli Pesso and the Visly team published Stretch as
+  open-source, alongside the Visly design tool. Initial scope was Flexbox only.
+
+- **2019 --- FFI bindings.** Native bindings shipped for Android (Kotlin, via JNI), iOS
+  (Swift, via CocoaPods), and JavaScript/TypeScript (via WebAssembly). This made Stretch
+  one of the first Rust libraries with first-class consumption from mobile platforms.
+
+- **2020 --- 0.3.x maintenance releases.** The final 0.3.2 release added bugfixes and
+  small API polish. The project's stated roadmap mentioned CSS Grid and multithreaded
+  layout, but neither shipped.
+
+- **2021 --- Archived.** Visly Inc. ceased operations, and active maintenance of Stretch
+  stopped. The repository was archived on GitHub. A community fork named `stretch2`
+  attempted to keep the code alive but did not gain momentum.
+
+- **2022 --- Renamed to Taffy.** DioxusLabs picked up `stretch2 0.4.3`, renamed it to
+  `taffy`, cleaned up its dependencies, and committed to long-term maintenance. Taffy
+  later added CSS Grid (0.3), Block (0.4), traitified Style (0.6), and named grid lines
+  (0.9). See [Taffy](taffy.md) for the continuation of this lineage.
+
+Stretch remains historically important even though it is no longer the right tool to
+pick today: it established the shape of the API that every Rust layout engine since
+2018 has converged on.
+
+---
+
+## Layout Model
+
+Stretch is **Flexbox-only**. There is no Grid, no Block formatting context, no absolute
+positioning beyond CSS-style `position: absolute`. Everything is a flex item or a flex
+container, exactly as in CSS Flexbox Level 1.
+
+### The Stretch Driver
+
+The top-level type is `stretch::node::Stretch`:
+
+```rust
+pub struct Stretch { /* internal node storage */ }
+
+impl Stretch {
+    pub fn new() -> Stretch;
+    pub fn new_node(&mut self, style: Style, children: Vec<Node>) -> Result<Node, Error>;
+    pub fn new_leaf(&mut self, style: Style, measure: MeasureFunc) -> Result<Node, Error>;
+    pub fn set_style(&mut self, node: Node, style: Style) -> Result<(), Error>;
+    pub fn set_children(&mut self, parent: Node, children: Vec<Node>) -> Result<(), Error>;
+    pub fn add_child(&mut self, parent: Node, child: Node) -> Result<(), Error>;
+    pub fn remove_child(&mut self, parent: Node, child: Node) -> Result<Node, Error>;
+    pub fn compute_layout(&mut self, node: Node, size: Size<Number>) -> Result<(), Error>;
+    pub fn layout(&self, node: Node) -> Result<&Layout, Error>;
+}
+```
+
+The `Node` handle is a small opaque value (an internal arena index), `Copy`, and safe to
+store in user-side structures.
+
+Layout is a two-step dance:
+
+1. Build the tree by calling `new_node` (containers) and `new_leaf` (terminals).
+2. Call `compute_layout(root, size)` with the available space, then read back per-node
+   `Layout` values.
+
+The `Layout` returned is a simple POD:
+
+```rust
+pub struct Layout {
+    pub order: u32,
+    pub size: Size<f32>,
+    pub location: Point<f32>,
+}
+```
+
+`location` is relative to the node's parent; the caller cumulates parent offsets when
+rendering.
+
+### Sizing Primitives
+
+Stretch's sizing vocabulary is the direct ancestor of Taffy's `Dimension`. It lives in
+`stretch::style`:
+
+```rust
+pub enum Dimension {
+    Undefined,         // explicitly "not set"
+    Auto,              // CSS auto
+    Points(f32),       // absolute length (px-like)
+    Percent(f32),      // 0.0..=1.0 of parent's relevant axis
+}
+
+pub enum Number {
+    Defined(f32),
+    Undefined,
+}
+```
+
+`Number` is the inputs-with-unknowns type: callers pass
+`Size<Number> { width: Defined(800.0), height: Undefined }` to `compute_layout` when
+exactly one axis is known. Taffy later replaced `Number` with the more spec-aligned
+`AvailableSpace` enum (which distinguishes "definite", "min-content", and "max-content"),
+but Stretch's three-way split (`Undefined`, `Auto`, `Defined`) captures the same essential
+information.
+
+### The Style Struct
+
+`Style` is the single source of truth for every layout property. The full field list is
+modest, matching Flexbox Level 1:
+
+```rust
+pub struct Style {
+    pub display: Display,                       // Flex | None
+    pub position_type: PositionType,            // Relative | Absolute
+    pub direction: Direction,                   // Inherit | LTR | RTL
+    pub flex_direction: FlexDirection,          // Row | RowReverse | Column | ColumnReverse
+    pub flex_wrap: FlexWrap,                    // NoWrap | Wrap | WrapReverse
+    pub overflow: Overflow,                     // Visible | Hidden | Scroll
+
+    pub align_items: AlignItems,                // FlexStart | FlexEnd | Center | Baseline | Stretch
+    pub align_self: AlignSelf,                  // Auto | + AlignItems variants
+    pub align_content: AlignContent,            // FlexStart | FlexEnd | Center | Stretch | SpaceBetween | SpaceAround
+    pub justify_content: JustifyContent,        // FlexStart | FlexEnd | Center | SpaceBetween | SpaceAround | SpaceEvenly
+
+    pub position: Rect<Dimension>,              // top/right/bottom/left when position_type == Absolute
+    pub margin:   Rect<Dimension>,
+    pub padding:  Rect<Dimension>,
+    pub border:   Rect<Dimension>,
+
+    pub flex_grow:   f32,                       // default 0.0
+    pub flex_shrink: f32,                       // default 1.0
+    pub flex_basis:  Dimension,                 // default Auto
+
+    pub size:     Size<Dimension>,
+    pub min_size: Size<Dimension>,
+    pub max_size: Size<Dimension>,
+    pub aspect_ratio: Number,
+}
+```
+
+A blank `Style::default()` is a CSS-default Flex item: `flex-grow: 0`, `flex-shrink: 1`,
+`flex-basis: auto`, `align-items: stretch`, `justify-content: flex-start`. This makes it
+straightforward to construct a style by setting only the properties that differ from the
+default:
+
+```rust
+Style {
+    flex_direction: FlexDirection::Column,
+    size: Size { width: Dimension::Percent(1.0), height: Dimension::Auto },
+    ..Default::default()
+}
+```
+
+### Display Modes
+
+`Display` had only two variants in Stretch:
+
+```rust
+pub enum Display {
+    Flex,   // default: children laid out via Flexbox
+    None,   // node and descendants are skipped
+}
+```
+
+There is no `Block` or `Grid` --- Stretch never shipped them. The Visly team mentioned
+Grid as a roadmap item, but it landed only in the Taffy fork (0.3, 2023).
+
+### Position: Relative vs Absolute
+
+```rust
+pub enum PositionType {
+    Relative,   // participates in flex layout (default)
+    Absolute,   // positioned by `position` rect, removed from flex flow
+}
+```
+
+Combined with the `position: Rect<Dimension>` field, Stretch supports CSS absolute
+positioning: an absolute child is removed from its parent's flex flow and positioned by
+its `top`/`right`/`bottom`/`left` offsets relative to the parent's padding edge. This was
+the standard way to build overlays and modals in Stretch-based UIs.
+
+### Padding, Margin, Border
+
+Stretch uses the CSS box model, though with a slightly less complete vocabulary than
+Taffy. Each of margin / padding / border is a `Rect<Dimension>`:
+
+```rust
+pub struct Rect<T> {
+    pub start: T,    // left in LTR
+    pub end:   T,    // right in LTR
+    pub top:   T,
+    pub bottom: T,
+}
+```
+
+The `start` / `end` naming (instead of `left` / `right`) makes RTL trivial: the same style
+declaration produces a mirrored layout when `direction: RTL` is set on the parent. This is
+the same convention CSS uses with `margin-inline-start` etc.
+
+### Alignment
+
+The alignment vocabulary is Flexbox Level 1, no more, no less:
+
+```rust
+pub enum AlignItems    { FlexStart, FlexEnd, Center, Baseline, Stretch }
+pub enum AlignSelf     { Auto, FlexStart, FlexEnd, Center, Baseline, Stretch }
+pub enum AlignContent  { FlexStart, FlexEnd, Center, Stretch, SpaceBetween, SpaceAround }
+pub enum JustifyContent {
+    FlexStart, FlexEnd, Center, SpaceBetween, SpaceAround, SpaceEvenly,
+}
+```
+
+`justify_content` controls the **main axis** (the axis flex items flow along, determined
+by `flex_direction`). `align_items` / `align_self` control the **cross axis** (the
+perpendicular axis). `align_content` controls cross-axis distribution of multiple flex
+_lines_ when `flex_wrap` is enabled. Anyone who has written CSS Flexbox will recognise
+all of this verbatim.
+
+### Measure-Arrange Protocol
+
+Like Taffy and Yoga, Stretch separates **measure** (intrinsic content sizing of leaves)
+from **arrange** (distribution of available space among children). The split is invisible
+to callers --- a single `compute_layout` call runs both --- but it determines how custom
+text and image content fit in.
+
+The measure-function signature reads:
+
+```rust
+pub type MeasureFunc = Box<dyn Fn(Size<Number>) -> Size<f32>>;
+```
+
+The argument is the _constraints_ the algorithm wants the leaf to honour:
+`Number::Defined(w)` means "fit within this width", `Number::Undefined` means "your
+choice". The return value is the natural size the leaf chose. Callers typically close
+over a font + text cache, an image, or a child UI that paints itself.
+
+### Layout Algorithm
+
+`compute_layout` walks the tree twice per pass:
+
+1. **Measure descent.** Visit each node; if it is a leaf with a `MeasureFunc`, invoke
+   the function with whatever constraints are known. Cache the result.
+2. **Layout descent.** Run the Flexbox layout algorithm on each flex container,
+   distributing space according to `flex-grow`, `flex-shrink`, `flex-basis`,
+   `justify-content`, and the rest. Children's `Layout` values are written into the
+   driver's internal storage.
+
+Once `compute_layout` returns, the caller iterates the tree and reads `stretch.layout(node)`
+for each node to get its final size and parent-relative position.
+
+Caching is per-node: each node remembers the input constraints and the computed layout.
+Repeated `compute_layout` calls with the same inputs hit the cache. Mutating a style or
+the child list invalidates the affected subtree.
+
+### Code Example: Basic Flex Row
+
+```rust
+use stretch::geometry::Size;
+use stretch::node::Stretch;
+use stretch::style::{Dimension, FlexDirection, JustifyContent, Style};
+
+let mut stretch = Stretch::new();
+
+let item_a = stretch.new_node(
+    Style {
+        size: Size { width: Dimension::Points(120.0), height: Dimension::Points(40.0) },
+        ..Default::default()
+    },
+    vec![],
+)?;
+
+let item_b = stretch.new_node(
+    Style {
+        size: Size { width: Dimension::Points(120.0), height: Dimension::Points(40.0) },
+        ..Default::default()
+    },
+    vec![],
+)?;
+
+let item_c = stretch.new_node(
+    Style {
+        flex_grow: 1.0,
+        ..Default::default()
+    },
+    vec![],
+)?;
+
+let row = stretch.new_node(
+    Style {
+        flex_direction: FlexDirection::Row,
+        justify_content: JustifyContent::FlexStart,
+        size: Size { width: Dimension::Points(800.0), height: Dimension::Points(40.0) },
+        ..Default::default()
+    },
+    vec![item_a, item_b, item_c],
+)?;
+
+stretch.compute_layout(row, Size::undefined())?;
+
+let c = stretch.layout(item_c)?;
+println!("item_c expands to width {}", c.size.width);
+```
+
+The third item has `flex_grow: 1.0` while the others have the default `flex_grow: 0.0`,
+so it absorbs the remaining 560 units of width.
+
+### Code Example: Column with Text Leaf
+
+```rust
+use stretch::geometry::{Number, Size};
+use stretch::node::{MeasureFunc, Stretch};
+use stretch::style::{AlignItems, Dimension, FlexDirection, Style};
+
+let mut stretch = Stretch::new();
+
+let title_measure: MeasureFunc = Box::new(|constraint: Size<Number>| {
+    // Pretend we shaped "Hello, world" in a 14pt font and got these metrics.
+    let width = match constraint.width {
+        Number::Defined(w) => w.min(120.0),
+        Number::Undefined => 120.0,
+    };
+    Size { width, height: 18.0 }
+});
+
+let title = stretch.new_leaf(Style::default(), title_measure)?;
+
+let body = stretch.new_node(
+    Style {
+        flex_grow: 1.0,
+        ..Default::default()
+    },
+    vec![],
+)?;
+
+let footer = stretch.new_node(
+    Style {
+        size: Size { width: Dimension::Auto, height: Dimension::Points(20.0) },
+        ..Default::default()
+    },
+    vec![],
+)?;
+
+let card = stretch.new_node(
+    Style {
+        flex_direction: FlexDirection::Column,
+        align_items: AlignItems::Stretch,
+        size: Size { width: Dimension::Points(300.0), height: Dimension::Points(200.0) },
+        padding: stretch::geometry::Rect {
+            start: Dimension::Points(8.0),
+            end: Dimension::Points(8.0),
+            top: Dimension::Points(8.0),
+            bottom: Dimension::Points(8.0),
+        },
+        ..Default::default()
+    },
+    vec![title, body, footer],
+)?;
+
+stretch.compute_layout(card, Size::undefined())?;
+```
+
+The measure function closes over whatever font / text-shaping state the application owns;
+Stretch never sees fonts directly.
+
+### Code Example: Absolute Overlay
+
+```rust
+use stretch::geometry::{Rect, Size};
+use stretch::node::Stretch;
+use stretch::style::{Dimension, PositionType, Style};
+
+let mut stretch = Stretch::new();
+
+let overlay = stretch.new_node(
+    Style {
+        position_type: PositionType::Absolute,
+        position: Rect {
+            start: Dimension::Points(20.0),
+            end:   Dimension::Auto,
+            top:   Dimension::Points(20.0),
+            bottom: Dimension::Auto,
+        },
+        size: Size {
+            width:  Dimension::Points(200.0),
+            height: Dimension::Points(100.0),
+        },
+        ..Default::default()
+    },
+    vec![],
+)?;
+
+let underlay = stretch.new_node(
+    Style {
+        flex_grow: 1.0,
+        ..Default::default()
+    },
+    vec![],
+)?;
+
+let scene = stretch.new_node(
+    Style {
+        size: Size {
+            width:  Dimension::Points(800.0),
+            height: Dimension::Points(600.0),
+        },
+        ..Default::default()
+    },
+    vec![underlay, overlay],
+)?;
+
+stretch.compute_layout(scene, Size::undefined())?;
+```
+
+`overlay` is removed from the flex flow of `scene` and pinned to `(20, 20)` with its own
+size. `underlay` fills the full scene independently. This is the standard pattern for
+toasts, modals, and pop-ups in CSS.
+
+---
+
+## Bindings / Language Support
+
+Unlike its successor Taffy, Stretch shipped first-class bindings to several non-Rust
+languages out of the box. This was a deliberate choice: Visly was a cross-platform product
+shipping native iOS, Android, and web apps from a shared layout core.
+
+| Platform              | Binding                         | Distribution |
+| --------------------- | ------------------------------- | ------------ |
+| Rust                  | Native crate                    | crates.io    |
+| Android (Kotlin/Java) | JNI bindings to compiled `.so`  | Maven        |
+| iOS (Swift)           | Swift wrapper over a static lib | CocoaPods    |
+| Web (JS/TS)           | WebAssembly + a thin JS shim    | npm          |
+
+Each binding presented the same conceptual API --- create a `Stretch` driver, add nodes,
+set styles, compute layout --- adapted to the host language's idioms. A Stretch tree
+declared in Kotlin would produce identical layout results to the same tree declared in
+Swift or in raw Rust, because all four paths called the same compiled-Rust core.
+
+The bindings have not been maintained since 2021. The Maven artifacts, CocoaPods, and
+npm package are all frozen at the last release.
+
+For an analogous capability today, the closest equivalents are:
+
+- **Yoga**, which has had supported bindings to virtually every language for years.
+- **[Taffy](taffy.md)**, which leaves binding generation to consumers --- there is no
+  official Swift or Kotlin distribution, though community FFI wrappers exist.
+
+---
+
+## Strengths and Weaknesses
+
+### For the UI-Layout Catalog Domain
+
+**Strengths.**
+
+- **Historically significant.** Stretch was the first Rust Flexbox engine, the first
+  Rust UI-adjacent library with serious mobile bindings, and the direct ancestor of
+  Taffy. Understanding Stretch is genuinely useful for understanding the design of
+  every modern Rust layout engine.
+- **Small, focused API.** The full public surface fits on one page. There is one driver,
+  one style struct, one algorithm. For learning Flexbox in Rust, Stretch's code is far
+  more readable than the larger and more general Taffy or Yoga codebases.
+- **Spec-aligned via headless-Chrome fixtures.** The testing strategy --- diff against a
+  real browser --- is exactly right for a layout engine, and was directly inherited by
+  Taffy.
+- **CSS-aligned vocabulary.** Like Taffy, the `Dimension` / `Points` / `Percent` /
+  `Auto` / `Undefined` quartet maps cleanly to CSS, so developers can transfer mental
+  models from web layout.
+
+**Weaknesses.**
+
+- **Archived and unmaintained.** No bug fixes since 2020-2021. No support for newer Rust
+  editions or recent dependencies. Any production use today is taking on a maintenance
+  cost.
+- **Flexbox only.** No CSS Grid, no block formatting context, no inline flow, no
+  baseline alignment beyond `align-items: baseline`. For real-world UI, this often is not
+  enough; pure-Flex grids of inputs and cards work, but anything that wants two-axis
+  control (rows + columns specified together) requires manual nesting.
+- **`Box<dyn Fn>` measure functions.** Each measure function allocates and dyn-dispatches.
+  Taffy later moved to a generic measure-function shape, removing both costs.
+- **No build for modern Rust workflows.** No `wasm-bindgen` or `tracing` integration,
+  no `no_std` story, no recent `serde` derives. The library predates these conventions.
+- **Roadmap items never shipped.** CSS Grid, multithreaded layout, and incremental
+  re-layout were all listed as future work, none of which Visly ever delivered. Each
+  of these landed in Taffy.
+
+### For Static One-Shot Rendering
+
+For sparkles' static-table use case, Stretch's analysis tracks Taffy's closely, with two
+additional considerations:
+
+- **Smaller, more readable.** A reader curious about "what does Flexbox actually look
+  like, in code?" gets more from reading Stretch's source than Taffy's. Stretch is ~5k
+  LOC of focused algorithm; Taffy is ~30k LOC spanning three algorithms.
+- **But: not a real option.** No serious project should depend on Stretch in 2026.
+  It is on no maintenance schedule, has known bugs that will not be fixed, and its
+  release artifacts have not been updated in five years.
+
+For a working sparkles consumer the practical answer is: **read Stretch to understand
+the shape**, then use Taffy if a real layout engine is needed, or hand-roll a small
+column-sizer if it isn't. The vocabulary worth borrowing --- `Length`, `Percent`,
+`Auto`, `Min`, `Max` --- is identical in both libraries.
+
+### Compared to Alternatives
+
+| Compared with                               | Where Stretch wins                                   | Where Stretch loses                                                                               |
+| ------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [Taffy](taffy.md)                           | Smaller; first-class FFI bindings; easier to read.   | Loses on everything that matters: maintenance, Grid, Block, RTL polish, named lines, modern Rust. |
+| Yoga (C++, by Facebook)                     | Safer (Rust memory model); cleaner build.            | Yoga is maintained, has more language bindings, more battle-tested in mobile.                     |
+| [Ratatui](../tui-libraries/ratatui.md)      | True Flexbox, including baseline alignment and wrap. | Ratatui is terminal-native and shipped; Stretch's `f32`s require rounding policy decisions.       |
+| [Ink](../tui-libraries/ink.md) (Yoga in JS) | Pure Rust; no Node.js dependency.                    | Ink is a full retained-mode TUI framework; Stretch is layout-only and outdated.                   |
+| Manual `int x, y, w, h` arithmetic          | Real Flexbox semantics for free.                     | A heavyweight, unmaintained dep when a couple of `std::cmp::max` calls would do.                  |
+
+The practical summary: **Stretch is primarily historical** --- valuable to study, important
+to Rust layout-engine lineage, but not the right answer for production decisions today.
+Where you would have reached for Stretch in 2020, reach for [Taffy](taffy.md) in 2026.
+
+---
+
+## References
+
+- **Repository:** <https://github.com/vislyhq/stretch> (archived)
+- **API docs (historical):** <https://vislyhq.github.io/stretch/>
+- **Crate:** <https://crates.io/crates/stretch>
+- **stretch2 community fork:** <https://github.com/vislyhq/stretch/network/members>
+- **Successor:** [Taffy](taffy.md) (this catalog)
+- **Conceptual ancestors / siblings:**
+  - Facebook Yoga: <https://github.com/facebook/yoga>
+  - W3C Flexbox spec: <https://www.w3.org/TR/css-flexbox-1/>
+- **Related TUI libraries:**
+  - [Ratatui](../tui-libraries/ratatui.md) --- terminal layout via Cassowary-style
+    constraints; complementary vocabulary.
+  - [Ink](../tui-libraries/ink.md) --- the JavaScript/Yoga analogue of "Flexbox layout
+    powering a non-browser UI framework".
+  - [Textual](../tui-libraries/textual.md) --- Python TUI framework whose CSS layer
+    reaches for similar concepts.
+  - [Bubble Tea](../tui-libraries/bubbletea.md) --- contrasts with Stretch's tree
+    approach: no shared layout engine, all layout by hand in `View`.
+- **Visly Inc.:** The company that funded Stretch's development; ceased operations
+  ~2021.

--- a/docs/research/ui-layout/swiftui.md
+++ b/docs/research/ui-layout/swiftui.md
@@ -1,0 +1,866 @@
+# SwiftUI (Swift)
+
+Apple's declarative UI framework for all Apple platforms. SwiftUI introduces a
+**propose-and-respond** layout protocol where every parent proposes a size to each child
+and the child responds with the size it actually wants -- giving authors per-axis,
+per-subview negotiation that is more flexible than the tight/loose `BoxConstraints`
+model used by Flutter or the single-pass `Constraints` model used by Jetpack Compose.
+Since iOS 16, the same `Layout` protocol that powers built-in stacks is public, so
+applications can write their own containers (flow, radial, equal-width grids) without
+falling back to `GeometryReader` hacks.
+
+| Field            | Value                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Language         | Swift                                                                                                              |
+| License          | Proprietary (Apple SDK)                                                                                            |
+| Repository       | Closed source; ships with Xcode                                                                                    |
+| Documentation    | <https://developer.apple.com/documentation/swiftui>                                                                |
+| Version snapshot | Layout protocol focus: iOS 16+ / macOS 13+; SwiftUI releases are tied to Apple platform SDKs                       |
+| Notable adoption | Apple's own apps (Settings, Weather, Notes, Stocks, App Store, Wallet); third-party: Things 3, Linear macOS, Ivory |
+
+---
+
+## Overview
+
+### What It Solves
+
+Prior to SwiftUI (announced WWDC 2019, iOS 13), Apple-platform UI was written with
+**UIKit** (iOS/tvOS) or **AppKit** (macOS) -- imperative, retained-mode toolkits with
+manual frame computation, Auto Layout constraint solvers, or hand-tuned
+`layoutSubviews()` overrides. Auto Layout in particular was powerful but notoriously
+verbose: every relationship between two views became an `NSLayoutConstraint` object, and
+"intrinsic content size" hooks plus content-hugging and compression-resistance
+priorities had to be tuned per view to make the Cassowary solver produce the desired
+result. Layout bugs typically appeared as ambiguous-constraint console spam rather than
+visibly broken UI, making them hard to diagnose.
+
+SwiftUI replaces this with three coordinated ideas:
+
+1. **A declarative DSL** -- views are immutable value types described by a
+   `@ViewBuilder` result-builder closure. Re-rendering is the framework's job.
+2. **A propose-and-respond layout protocol** -- the parent passes a
+   [`ProposedViewSize`][apple-proposedviewsize] (each axis optional) to each child; the
+   child returns a `CGSize` it would like to occupy. There is no separate "intrinsic
+   content size" API: every view answers the same question with the same protocol.
+3. **A public `Layout` protocol (iOS 16)** -- the very same machinery that backs
+   `HStack`, `VStack`, `Grid`, and `ZStack` is available to user code, so custom
+   containers compose naturally with built-ins, share their alignment-guide machinery,
+   and benefit from the framework's layout caching.
+
+### Design Philosophy
+
+SwiftUI's layout system rests on a small number of orthogonal axioms:
+
+- **A view is a function of state.** The same `body` re-evaluated on the same state
+  produces the same view tree. The framework reconciles successive trees and re-runs
+  layout only where state changed.
+- **Sizing is negotiated, not dictated.** A parent never forces a child to a specific
+  size unless it explicitly wraps the child in a `.frame(...)`. The proposal mechanism
+  expresses "I have this much room available; please tell me what you want." The child
+  may return a smaller or larger size, and the parent then decides how to place it
+  (centred, padded, clipped, etc.).
+- **Composition over configuration.** Where UIKit offered `setNeedsLayout`,
+  `intrinsicContentSize`, content-hugging priorities, and `translatesAutoresizingMaskIntoConstraints`,
+  SwiftUI offers a single protocol with two methods. Behaviour that UIKit modelled with
+  flags becomes a separate view modifier or layout container.
+- **Result builders for shape.** The `@ViewBuilder`, `@SceneBuilder`, and (from iOS 16)
+  `@LayoutValueKey` machinery lets containers consume their children as a
+  result-builder block while still seeing them as a typed sequence at runtime.
+- **Per-platform but not per-toolkit.** The same SwiftUI source compiles for iOS,
+  iPadOS, macOS, tvOS, watchOS, and visionOS. Differences are usually limited to
+  available modifiers (e.g., `.menuBarExtraStyle` only on macOS) rather than to entirely
+  different layout primitives.
+
+### History
+
+| Year | Release              | Layout-relevant additions                                                                                                           |
+| ---- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 2019 | SwiftUI 1.0 / iOS 13 | `HStack`, `VStack`, `ZStack`, `Spacer`, `Divider`, `ScrollView`, `Group`, `GeometryReader`, `.frame`, `.padding`, alignment guides. |
+| 2020 | SwiftUI 2.0 / iOS 14 | `LazyVStack`, `LazyHStack`, `LazyVGrid`, `LazyHGrid`, `GridItem`, `ScrollViewReader`, `Section` pinning.                            |
+| 2021 | SwiftUI 3.0 / iOS 15 | `.safeAreaInset`, `materialBackground`, refined `List` performance, `AsyncImage`.                                                   |
+| 2022 | SwiftUI 4.0 / iOS 16 | **`Layout` protocol becomes public**; `Grid` / `GridRow`; `AnyLayout`; `ViewThatFits`; `gridCellColumns`, `gridColumnAlignment`.    |
+| 2023 | SwiftUI 5.0 / iOS 17 | `ScrollView` content margins, `.scrollTargetBehavior`, `Inspector`, `ContentUnavailableView`.                                       |
+| 2024 | SwiftUI 6.0 / iOS 18 | `@Entry` macro for environment values, `MeshGradient`, refined `Grid` interaction with animations, custom container values.         |
+
+The 2022 release was the most significant for layout: applications previously had to
+choose between Apple's bundled stacks and grids or drop down to `GeometryReader` with
+manual offset math. The `Layout` protocol closed that gap.
+
+---
+
+## Architecture / Layout Model
+
+### The Propose-and-Respond Protocol
+
+Every layout pass walks the view tree twice, conceptually:
+
+1. **Sizing.** The root view is given an unconstrained or window-sized proposal. It
+   forwards a (possibly transformed) proposal to each child via the same protocol. Each
+   child returns its actual size as a `CGSize`. The parent then computes its own size
+   from those responses.
+2. **Placement.** The parent receives a concrete bounds rectangle and decides where each
+   child goes, calling `place(at:anchor:proposal:)` on each subview.
+
+The proposal carries optional axes:
+
+```swift
+@frozen public struct ProposedViewSize {
+    public var width: CGFloat?
+    public var height: CGFloat?
+
+    public static let zero: ProposedViewSize          // (0, 0)
+    public static let infinity: ProposedViewSize      // (∞, ∞)
+    public static let unspecified: ProposedViewSize   // (nil, nil)
+
+    public init(_ size: CGSize)
+    public init(width: CGFloat?, height: CGFloat?)
+    public func replacingUnspecifiedDimensions(by size: CGSize = CGSize(width: 10, height: 10)) -> CGSize
+}
+```
+
+The three sentinel values correspond to three layout queries a parent may want to ask:
+
+- **`.zero`** -- "What is your minimum size?" A child returns the smallest size it can
+  draw at; used by `fixedSize()` and by stacks resolving `minWidth`.
+- **`.infinity`** -- "What is your maximum useful size?" A child returns the largest
+  size it would still benefit from; used to compute `idealWidth` / `idealHeight`.
+- **`.unspecified`** -- "What is your ideal (preferred) size?" A child returns its
+  natural intrinsic size; this is the proposal a top-level container starts with.
+
+A parent typically asks all three. Stacks, for instance, query `.zero` and
+`.infinity` to discover each child's flexibility, then distribute available space
+proportionally to the children with the largest `max - min` range.
+
+A view responds to a proposal by returning a `CGSize`. There is no contract that the
+returned size be _less than or equal to_ the proposal -- a child may legitimately demand
+more space than was offered. The parent then decides whether to clip, scroll, or accept
+the overflow. (`Text`, for example, will lay out wider than its proposal if `lineLimit`
+is `1` and `truncationMode` is `.none`.)
+
+### Built-In Containers
+
+| Container      | Direction  | Behaviour                                                                                                        | Min iOS |
+| -------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- | ------- |
+| `HStack`       | horizontal | Lays children left-to-right, asks each its ideal width, distributes leftover space to flexible children.         | 13      |
+| `VStack`       | vertical   | Top-to-bottom version of `HStack`.                                                                               | 13      |
+| `ZStack`       | depth      | Overlays children in the parent's bounds, aligned via `Alignment`.                                               | 13      |
+| `LazyHStack`   | horizontal | Same API as `HStack` but only materialises children that intersect the visible viewport (inside a `ScrollView`). | 14      |
+| `LazyVStack`   | vertical   | Same as `LazyHStack`, vertical.                                                                                  | 14      |
+| `Grid`         | 2-D        | Two-dimensional layout with aligned columns and rows; rows declared via `GridRow`.                               | 16      |
+| `LazyVGrid`    | vertical   | Vertical-scrolling grid where columns are described by `[GridItem]`.                                             | 14      |
+| `LazyHGrid`    | horizontal | Horizontal-scrolling counterpart.                                                                                | 14      |
+| `ScrollView`   | n/a        | Container that proposes its own size on the scroll axis as unbounded.                                            | 13      |
+| `ViewThatFits` | n/a        | Picks the first child whose ideal size fits the proposal.                                                        | 16      |
+
+#### HStack / VStack / ZStack
+
+```swift
+public struct HStack<Content: View>: View {
+    public init(
+        alignment: VerticalAlignment = .center,
+        spacing: CGFloat? = nil,
+        @ViewBuilder content: () -> Content
+    )
+}
+
+public struct VStack<Content: View>: View {
+    public init(
+        alignment: HorizontalAlignment = .center,
+        spacing: CGFloat? = nil,
+        @ViewBuilder content: () -> Content
+    )
+}
+
+public struct ZStack<Content: View>: View {
+    public init(
+        alignment: Alignment = .center,
+        @ViewBuilder content: () -> Content
+    )
+}
+```
+
+A passed-in `spacing: nil` is **not** zero -- it means "use the system default", which
+varies by platform and by which two views are adjacent. SwiftUI's `ViewSpacing` machinery
+tracks per-edge spacing preferences for each view (text baselines, list rows, etc.) and
+the stack queries that to compute the gap.
+
+The simplest layout example:
+
+```swift
+HStack(alignment: .firstTextBaseline, spacing: 8) {
+    Image(systemName: "exclamationmark.triangle.fill")
+        .foregroundStyle(.yellow)
+    VStack(alignment: .leading, spacing: 2) {
+        Text("Disk almost full")
+            .font(.headline)
+        Text("12.4 GB free of 256 GB")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+    Spacer()
+    Button("Manage…") { /* … */ }
+}
+```
+
+Here the `HStack` proposes its full width to its three children. The image returns
+its intrinsic size; the inner `VStack` returns the natural size of its two `Text`
+labels; the `Spacer` returns `Length(min, max)` with `max = .infinity`. The stack
+then assigns the leftover horizontal space to the spacer.
+
+#### Grid (iOS 16+)
+
+```swift
+public struct Grid<Content: View>: View {
+    public init(
+        alignment: Alignment = .center,
+        horizontalSpacing: CGFloat? = nil,
+        verticalSpacing: CGFloat? = nil,
+        @ViewBuilder content: () -> Content
+    )
+}
+
+public struct GridRow<Content: View>: View {
+    public init(
+        alignment: VerticalAlignment? = nil,
+        @ViewBuilder content: () -> Content
+    )
+}
+```
+
+`Grid` is a real, eager 2-D layout (unlike `LazyVGrid`/`LazyHGrid`): the column
+widths are determined by the widest cell in each column, the row heights by the
+tallest cell in each row, and cells align across both axes. Cells may span multiple
+columns via `.gridCellColumns(_:)`, anchor differently via `.gridCellAnchor(_:)`, or
+override their column alignment with `.gridColumnAlignment(_:)`.
+
+```swift
+Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+    GridRow {
+        Text("Name").bold()
+        Text("Petar Kirov")
+    }
+    GridRow {
+        Text("Email").bold()
+        Text("petar@blocksense.network")
+    }
+    GridRow {
+        Text("Notes").bold()
+        Text("Long multi-line note that should wrap and influence column 2 only.")
+            .gridCellColumns(1)
+    }
+}
+```
+
+#### LazyVGrid / LazyHGrid
+
+```swift
+public struct LazyVGrid<Content: View>: View {
+    public init(
+        columns: [GridItem],
+        alignment: HorizontalAlignment = .center,
+        spacing: CGFloat? = nil,
+        pinnedViews: PinnedScrollableViews = .init(),
+        @ViewBuilder content: () -> Content
+    )
+}
+
+public struct GridItem {
+    public enum Size {
+        case fixed(CGFloat)
+        case flexible(minimum: CGFloat = 10, maximum: CGFloat = .infinity)
+        case adaptive(minimum: CGFloat, maximum: CGFloat = .infinity)
+    }
+    public var size: Size
+    public var spacing: CGFloat?
+    public var alignment: Alignment?
+}
+```
+
+`GridItem` sizing modes:
+
+- **`.fixed(w)`** -- exactly `w` points wide; takes no extra.
+- **`.flexible(min, max)`** -- between `min` and `max`; the number of columns is fixed
+  by the array length.
+- **`.adaptive(min, max)`** -- as many columns of this width as fit in the available
+  axis; this is how SwiftUI builds responsive grids without a media query.
+
+```swift
+let columns = [GridItem(.adaptive(minimum: 120), spacing: 12)]
+
+ScrollView {
+    LazyVGrid(columns: columns, spacing: 12) {
+        ForEach(photos) { photo in
+            AsyncImage(url: photo.thumbnail)
+                .frame(height: 120)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+    .padding()
+}
+```
+
+#### ScrollView
+
+```swift
+public struct ScrollView<Content: View>: View {
+    public init(
+        _ axes: Axis.Set = .vertical,
+        showsIndicators: Bool = true,
+        @ViewBuilder content: () -> Content
+    )
+}
+```
+
+A `ScrollView` proposes `nil` (unspecified) on its scroll axis to its child, meaning
+"you can grow as tall (or as wide) as you want". This is how `LazyVStack`s in a
+`ScrollView` get an unlimited vertical proposal even when their parent window is fixed.
+
+### Sizing Modifiers
+
+```swift
+extension View {
+    public func frame(
+        width: CGFloat? = nil,
+        height: CGFloat? = nil,
+        alignment: Alignment = .center
+    ) -> some View
+
+    public func frame(
+        minWidth: CGFloat? = nil,
+        idealWidth: CGFloat? = nil,
+        maxWidth: CGFloat? = nil,
+        minHeight: CGFloat? = nil,
+        idealHeight: CGFloat? = nil,
+        maxHeight: CGFloat? = nil,
+        alignment: Alignment = .center
+    ) -> some View
+
+    public func fixedSize() -> some View
+    public func fixedSize(horizontal: Bool, vertical: Bool) -> some View
+    public func padding(_ edges: Edge.Set = .all, _ length: CGFloat? = nil) -> some View
+    public func layoutPriority(_ value: Double) -> some View
+}
+```
+
+The `min/ideal/max` variant is the canonical way to make a view _flexible_ -- e.g.,
+`.frame(minWidth: 100, maxWidth: .infinity)` says "I want at least 100 points but I
+will gladly consume any extra width". `fixedSize()` is the opposite: it tells the
+parent "use my ideal size; do not propose a smaller one".
+
+`layoutPriority` modifies how a parent stack distributes _leftover_ space when two
+flexible children compete. Higher-priority children are sized first.
+
+### Safe Area Insets
+
+```swift
+extension View {
+    public func safeAreaInset<V: View>(
+        edge: VerticalEdge,
+        alignment: HorizontalAlignment = .center,
+        spacing: CGFloat? = nil,
+        @ViewBuilder content: () -> V
+    ) -> some View
+
+    public func safeAreaPadding(_ insets: EdgeInsets) -> some View
+}
+```
+
+Adding a `.safeAreaInset(edge: .bottom) { Toolbar() }` extends the safe area: scroll
+content underneath stays scrollable but the toolbar is anchored at the visual bottom
+above the home-indicator inset. This is roughly Compose's `Scaffold` slot pattern
+delivered as a view modifier instead of a top-level container.
+
+### Alignment Guides
+
+Each axis has a typed alignment enum:
+
+```swift
+public struct HorizontalAlignment {
+    public static let leading: HorizontalAlignment
+    public static let center: HorizontalAlignment
+    public static let trailing: HorizontalAlignment
+}
+
+public struct VerticalAlignment {
+    public static let top: VerticalAlignment
+    public static let center: VerticalAlignment
+    public static let bottom: VerticalAlignment
+    public static let firstTextBaseline: VerticalAlignment
+    public static let lastTextBaseline: VerticalAlignment
+}
+
+public struct Alignment {
+    public var horizontal: HorizontalAlignment
+    public var vertical: VerticalAlignment
+    public init(horizontal: HorizontalAlignment, vertical: VerticalAlignment)
+    public static let center: Alignment
+    // … leading, trailing, top, bottom, topLeading, bottomTrailing, …
+}
+```
+
+Custom alignment guides extend the system. The `AlignmentID` protocol takes the
+default offset from the view's natural alignment and adjusts it per view:
+
+```swift
+extension HorizontalAlignment {
+    private enum FormFieldLabelAlignment: AlignmentID {
+        static func defaultValue(in d: ViewDimensions) -> CGFloat {
+            d[.leading]
+        }
+    }
+    static let formFieldLabel = HorizontalAlignment(FormFieldLabelAlignment.self)
+}
+
+VStack(alignment: .formFieldLabel) {
+    HStack {
+        Text("Name:")
+            .alignmentGuide(.formFieldLabel) { d in d[.trailing] }
+        TextField("", text: $name)
+    }
+    HStack {
+        Text("Email:")
+            .alignmentGuide(.formFieldLabel) { d in d[.trailing] }
+        TextField("", text: $email)
+    }
+}
+```
+
+The above aligns the trailing edges of the labels into a single vertical column, even
+though the labels have different widths -- something that would require an explicit
+table layout in most other frameworks.
+
+---
+
+## Custom Layouts -- the `Layout` Protocol (iOS 16+)
+
+Before iOS 16, building a custom container meant building a `GeometryReader` plus
+manual `.offset(...)` modifiers and pre-computed sizes, with no integration into the
+framework's alignment-guide or animation machinery. iOS 16's [`Layout`][apple-layout]
+protocol gave third-party code the same hooks built-in stacks use.
+
+### Protocol Definition
+
+```swift
+public protocol Layout: Animatable {
+    associatedtype Cache = Void
+
+    static var layoutProperties: LayoutProperties { get }
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    ) -> CGSize
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    )
+
+    func spacing(subviews: Subviews, cache: inout Cache) -> ViewSpacing
+
+    func explicitAlignment(
+        of guide: HorizontalAlignment,
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    ) -> CGFloat?
+
+    func explicitAlignment(
+        of guide: VerticalAlignment,
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    ) -> CGFloat?
+
+    func makeCache(subviews: Subviews) -> Cache
+    func updateCache(_ cache: inout Cache, subviews: Subviews)
+}
+```
+
+Only `sizeThatFits` and `placeSubviews` are required (everything else has a default).
+`Subviews` is a typed `RandomAccessCollection` of [`LayoutSubview`][apple-layoutsubview]:
+
+```swift
+public struct LayoutSubview {
+    public func sizeThatFits(_ proposal: ProposedViewSize) -> CGSize
+    public func dimensions(in proposal: ProposedViewSize) -> ViewDimensions
+    public func place(at position: CGPoint, anchor: UnitPoint = .topLeading, proposal: ProposedViewSize)
+    public var spacing: ViewSpacing { get }
+    public var priority: Double { get }
+    public subscript<K: LayoutValueKey>(key: K.Type) -> K.Value { get }
+}
+```
+
+The `cache` parameter is a per-layout-instance scratch space. SwiftUI calls
+`makeCache(subviews:)` once, then `sizeThatFits` and `placeSubviews` zero or more
+times, then `updateCache(_:subviews:)` if the children change. Heavy work (e.g.,
+measuring all children for an equal-width grid) goes into the cache so the place
+phase is O(n).
+
+### Example: A Flow Layout
+
+A wrap-to-next-line layout, like CSS's `flex-wrap: wrap`:
+
+```swift
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    struct Cache {
+        var sizes: [CGSize] = []
+    }
+
+    func makeCache(subviews: Subviews) -> Cache { Cache() }
+
+    func updateCache(_ cache: inout Cache, subviews: Subviews) {
+        cache.sizes.removeAll(keepingCapacity: true)
+    }
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    ) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        cache.sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var widest: CGFloat = 0
+
+        for size in cache.sizes {
+            if x + size.width > maxWidth, x > 0 {
+                y += rowHeight + spacing
+                x = 0
+                rowHeight = 0
+            }
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+            widest = max(widest, x)
+        }
+
+        return CGSize(width: min(widest, maxWidth), height: y + rowHeight)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    ) {
+        let maxWidth = bounds.width
+        var x: CGFloat = bounds.minX
+        var y: CGFloat = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for (subview, size) in zip(subviews, cache.sizes) {
+            if x + size.width > bounds.minX + maxWidth, x > bounds.minX {
+                y += rowHeight + spacing
+                x = bounds.minX
+                rowHeight = 0
+            }
+            subview.place(
+                at: CGPoint(x: x, y: y),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(size)
+            )
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+
+// Usage:
+FlowLayout(spacing: 6) {
+    ForEach(tags, id: \.self) { tag in
+        Text(tag)
+            .padding(.horizontal, 10).padding(.vertical, 4)
+            .background(Capsule().fill(.gray.opacity(0.15)))
+    }
+}
+```
+
+### Example: A Radial Layout
+
+A layout that arranges children evenly around the bounds' centre at a constant radius:
+
+```swift
+struct RadialLayout: Layout {
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        proposal.replacingUnspecifiedDimensions(by: CGSize(width: 300, height: 300))
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let radius = min(bounds.size.width, bounds.size.height) / 3
+        let angleStep = .pi * 2 / Double(subviews.count)
+        let centre = CGPoint(x: bounds.midX, y: bounds.midY)
+
+        for (i, subview) in subviews.enumerated() {
+            let angle = angleStep * Double(i) - .pi / 2
+            let pt = CGPoint(
+                x: centre.x + cos(angle) * radius,
+                y: centre.y + sin(angle) * radius
+            )
+            subview.place(at: pt, anchor: .center, proposal: .unspecified)
+        }
+    }
+}
+```
+
+### Example: An Equal-Width Column Layout
+
+Useful for keyboards or toolbars where every cell should be exactly the widest cell's
+width:
+
+```swift
+struct EqualWidthHStack: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        guard !subviews.isEmpty else { return .zero }
+        let unitSizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        let cellWidth = unitSizes.map(\.width).max() ?? 0
+        let cellHeight = unitSizes.map(\.height).max() ?? 0
+        let totalWidth = cellWidth * CGFloat(subviews.count)
+            + spacing * CGFloat(subviews.count - 1)
+        return CGSize(width: totalWidth, height: cellHeight)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let cellWidth = (bounds.width - spacing * CGFloat(subviews.count - 1))
+            / CGFloat(subviews.count)
+        let cellProposal = ProposedViewSize(width: cellWidth, height: bounds.height)
+        var x = bounds.minX
+        for subview in subviews {
+            subview.place(
+                at: CGPoint(x: x, y: bounds.midY),
+                anchor: .leading,
+                proposal: cellProposal
+            )
+            x += cellWidth + spacing
+        }
+    }
+}
+```
+
+### `AnyLayout` and Layout Switching
+
+`AnyLayout` is a type-erased `Layout` wrapper that allows the layout type itself to be
+animated. This is how SwiftUI achieves the "view morphs from HStack to VStack on
+orientation change" demo:
+
+```swift
+struct AdaptiveStack<Content: View>: View {
+    @Environment(\.horizontalSizeClass) var sizeClass
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        let layout: AnyLayout = sizeClass == .compact
+            ? AnyLayout(VStackLayout())
+            : AnyLayout(HStackLayout())
+
+        layout {
+            content()
+        }
+    }
+}
+```
+
+`VStackLayout` and `HStackLayout` are the `Layout`-conforming structs behind the
+built-in `VStack` / `HStack` containers; they were exposed in iOS 16 to make the
+`AnyLayout` story tractable.
+
+### `LayoutValueKey` -- Passing Data from Subview to Layout
+
+Custom layouts often need per-child metadata (e.g., a span count for a grid, a
+priority weight). The `LayoutValueKey` protocol works like `EnvironmentKey` but flows
+upward:
+
+```swift
+private struct Weight: LayoutValueKey {
+    static let defaultValue: Double = 1
+}
+
+extension View {
+    func weight(_ value: Double) -> some View {
+        self.layoutValue(key: Weight.self, value: value)
+    }
+}
+
+// Inside FlowLayout (or similar):
+let w = subview[Weight.self]
+```
+
+This lets users write `Text("Hello").weight(2)` and have the parent layout read `2`
+from the subview proxy.
+
+---
+
+## Strengths and Weaknesses
+
+### For App UIs
+
+**Strengths.**
+
+- **Sizing protocol is per-axis optional.** Unlike Flutter's `BoxConstraints`, where
+  every constraint is a fixed `[min, max]` pair, SwiftUI's `nil` width/height means
+  "unconstrained" without committing to `0…∞`. This makes it trivial to express "I
+  have unlimited horizontal space but my height is fixed" -- common for scroll-view
+  content.
+- **Result-builder DSL.** `@ViewBuilder` produces a strongly typed tuple of views at
+  compile time. There is no virtual DOM diffing; the framework knows the tree shape
+  statically and can skip large unchanged subtrees with `Equatable` or `@State` hash
+  comparisons.
+- **Built-in animations.** Layout changes (e.g., a stack shrinking when a row is
+  deleted) animate by default; custom layouts get this for free if they conform to
+  `Animatable`.
+- **Alignment guides are first-class.** Built-in cross-stack alignment (the
+  `firstTextBaseline` of a label aligning with the centre of a button) requires no
+  manual offset math.
+- **Live previews.** Xcode's preview canvas renders Swift code with hot-reload, scoped
+  by `#Preview` macros. Iterating on layout is much faster than running a simulator
+  build.
+
+**Weaknesses.**
+
+- **Tooling is opaque when it goes wrong.** When a child returns a size larger than
+  the proposal, the parent silently clips or overflows; the canonical "view too large"
+  diagnostic just prints a warning. Debug-mode tools like `Self._printChanges()` help
+  but are private API.
+- **Slow incremental compilation.** Heavily nested view bodies hit Swift's type
+  inferencer hard. Real-world apps often split complex bodies into small `@ViewBuilder`
+  helpers solely to keep the compiler responsive.
+- **Per-platform quirks accumulate.** A modifier that exists on iOS may be a no-op on
+  watchOS, or behave subtly differently on macOS. Cross-platform code accumulates
+  `#if os(...)` blocks.
+
+### For Static One-Shot Rendering
+
+SwiftUI **can** render off-screen via [`ImageRenderer`][apple-image-renderer] (iOS 16+),
+which composites a SwiftUI view tree into a `CGImage`, `NSImage`/`UIImage`, or PDF
+context. This is the natural fit if you want SwiftUI's layout engine to produce a
+poster, an Open Graph image, or a print-quality PDF.
+
+For terminal-style one-shot rendering, SwiftUI is overkill: the framework spins up a
+fully retained renderer with hit-testing, accessibility, and animations even if you
+only want a single static frame. The Sparkles use case (a CLI emitting a styled report
+once and exiting) maps poorly onto SwiftUI's runtime; the _protocol_ (propose-and-
+respond), however, is exactly what one would want.
+
+### Compared to Alternatives
+
+- **vs. UIKit / AppKit.** SwiftUI replaces an imperative, retained-mode toolkit with a
+  declarative, value-typed one. Auto Layout's constraint-solver complexity is gone; the
+  cost is less direct control over sub-pixel positioning and a harder-to-debug
+  rendering pipeline.
+- **vs. Jetpack Compose** (see [`jetpack-compose.md`](./jetpack-compose.md)). Compose's
+  `Constraints` is a four-field `(minWidth, maxWidth, minHeight, maxHeight)` tuple per
+  axis -- closer to CSS Flexbox or Auto Layout than to SwiftUI's optional proposal.
+  Compose enforces single-pass measurement (each child measured once); SwiftUI permits
+  multiple `sizeThatFits` calls per layout pass, which is why stacks can ask `.zero` /
+  `.infinity` / `.unspecified` to discover flexibility. Compose's separation of
+  `Layout` and `SubcomposeLayout` mirrors SwiftUI's distinction between regular views
+  and `ViewThatFits`, but Compose surfaces it as two different APIs while SwiftUI
+  unifies them.
+- **vs. Flutter.** Flutter's `BoxConstraints` is closer to Compose than to SwiftUI:
+  every axis is `[min, max]`, with no notion of "unspecified". Flutter's render-tree
+  layout is also single-pass with intrinsic-size fallbacks; performance is excellent
+  but expressing "as much as the parent gives me but no more" requires explicit
+  `LayoutBuilder` usage.
+- **vs. CSS Flexbox / Grid (Ink, see [`../tui-libraries/ink.md`](../tui-libraries/ink.md)).**
+  Flexbox solves a similar problem -- distribute available main-axis space among items
+  -- but operates as a constraint solver (via Yoga, in Ink's case) rather than a
+  recursive propose/respond walk. SwiftUI's per-axis `nil` is closer to Flexbox's
+  `auto` than to Compose/Flutter's `[min, max]`.
+- **vs. Ratatui** (see [`../tui-libraries/ratatui.md`](../tui-libraries/ratatui.md)).
+  Ratatui uses a Cassowary-style constraint solver to subdivide a `Rect`. There is no
+  notion of "intrinsic content size" because terminal widgets do not have one --
+  every widget is told its area. SwiftUI's protocol is a strict superset: a Ratatui-
+  like fixed-area subdivision corresponds to "the parent ignores the child's response
+  and forces a frame via `.frame(...)`".
+
+### Lessons for Sparkles
+
+The relevant takeaways for a D-based pretty-printer / CLI layout engine:
+
+1. **Make every axis of a proposal individually optional** rather than `[min, max]`.
+   Terminal output frequently knows its main-axis width (the terminal column count) but
+   has no cross-axis upper bound (you can always print more lines). The SwiftUI model
+   maps onto this cleanly.
+2. **Expose a `Layout`-like protocol** with separate _size_ and _place_ phases. The
+   place phase can write into a target buffer (Sparkles' `SmallBuffer!(Cell, N)`),
+   while the size phase produces a cached layout description usable for tests and for
+   `--width=auto` flow.
+3. **Treat alignment guides as a separate dimension.** When mixing labels, prefixes,
+   and badges in a CLI report, aligning columns by a custom guide (the colon in
+   `key: value`) is exactly the SwiftUI pattern.
+4. **Layout caching keyed on inputs.** SwiftUI's `Cache` type avoids redundant work in
+   `placeSubviews`. The same pattern, with D's CTFE, can pre-bake layouts whose inputs
+   are known at compile time.
+
+---
+
+## References
+
+- **Apple Developer Documentation -- Layout fundamentals:**
+  <https://developer.apple.com/documentation/swiftui/layout-fundamentals>
+- **Apple Developer Documentation -- `Layout` protocol:**
+  <https://developer.apple.com/documentation/swiftui/layout>
+- **Apple Developer Documentation -- `ProposedViewSize`:**
+  <https://developer.apple.com/documentation/swiftui/proposedviewsize>
+- **Apple Developer Documentation -- `LayoutSubview`:**
+  <https://developer.apple.com/documentation/swiftui/layoutsubview>
+- **Apple Developer Documentation -- `AnyLayout`:**
+  <https://developer.apple.com/documentation/swiftui/anylayout>
+- **Apple Developer Documentation -- `AlignmentID`:**
+  <https://developer.apple.com/documentation/swiftui/alignmentid>
+- **Apple Developer Documentation -- `LayoutValueKey`:**
+  <https://developer.apple.com/documentation/swiftui/layoutvaluekey>
+- **Apple Developer Documentation -- `Grid`:**
+  <https://developer.apple.com/documentation/swiftui/grid>
+- **Apple Developer Documentation -- `LazyVGrid`:**
+  <https://developer.apple.com/documentation/swiftui/lazyvgrid>
+- **Apple Developer Documentation -- `ScrollView`:**
+  <https://developer.apple.com/documentation/swiftui/scrollview>
+- **Apple Developer Documentation -- `ImageRenderer`:**
+  <https://developer.apple.com/documentation/swiftui/imagerenderer>
+- **WWDC 2022 session 10056, "Compose custom layouts with SwiftUI":**
+  <https://developer.apple.com/videos/play/wwdc2022/10056/>
+- **WWDC 2019 session 237, "Building Custom Views with SwiftUI":**
+  <https://developer.apple.com/videos/play/wwdc2019/237/>
+- **Cross-references inside this catalog:**
+  - [Jetpack Compose](./jetpack-compose.md) -- the closest peer framework.
+  - [Ratatui](../tui-libraries/ratatui.md) -- constraint-solver style fixed-area subdivision.
+  - [Ink](../tui-libraries/ink.md) -- Flexbox-via-Yoga in the terminal.
+
+---
+
+## Markdown References
+
+[apple-layout]: https://developer.apple.com/documentation/swiftui/layout
+[apple-proposedviewsize]: https://developer.apple.com/documentation/swiftui/proposedviewsize
+[apple-layoutsubview]: https://developer.apple.com/documentation/swiftui/layoutsubview
+[apple-image-renderer]: https://developer.apple.com/documentation/swiftui/imagerenderer

--- a/docs/research/ui-layout/swing-mig.md
+++ b/docs/research/ui-layout/swing-mig.md
@@ -1,0 +1,763 @@
+# Swing AWT Layout Managers and MiG Layout (Java)
+
+A survey of Java's desktop GUI layout heritage: the `LayoutManager`/`LayoutManager2`
+interfaces that AWT introduced in 1995, the built-in managers that Swing inherited
+(BorderLayout, FlowLayout, GridLayout, CardLayout, BoxLayout, GridBagLayout, GroupLayout,
+SpringLayout), and the third-party MiG Layout that became the de-facto default for
+hand-coded layout because the built-ins each have rough edges.
+
+| Field             | Value                                                                   |
+| ----------------- | ----------------------------------------------------------------------- |
+| Language          | Java (Swing/AWT in the JDK; MiG Layout 3rd-party)                       |
+| First Released    | AWT 1.0 (1995), Swing 1.0 (1998), MiG Layout 1.0 (2007)                 |
+| Distribution      | `java.awt`, `javax.swing` (bundled with the JDK); MiG via Maven Central |
+| MiG License       | BSD or GPL (dual)                                                       |
+| MiG Repository    | <https://github.com/mikaelgrev/miglayout>                               |
+| MiG Documentation | <https://www.miglayout.com/>                                            |
+| MiG Latest        | 11.x (2024); also published as `MigPane` for JavaFX                     |
+| MiG Author        | Mikael Grev                                                             |
+
+---
+
+## Overview
+
+Java's Abstract Window Toolkit (AWT) shipped with version 1.0 of the JDK in January 1996.
+Among its design decisions was a deliberate refusal to bake any single layout policy into
+the toolkit. Instead, `java.awt.Container` delegated layout to a pluggable
+[`LayoutManager`][lm] object. Application code, look-and-feel implementations, and IDE
+visual designers could all swap in different managers to get radically different sizing
+behaviour without changing the component tree.
+
+Swing (1998) reused this architecture wholesale. Every `JComponent` is a `Container`, and
+every container has a layout manager (default `FlowLayout` for `JPanel`, `BorderLayout` for
+`JFrame`'s content pane, etc.). Two decades later the contract is unchanged: any class
+implementing `LayoutManager` (or the constraint-aware `LayoutManager2`) can drive Swing.
+
+**The catch.** The built-in managers each solve one slice of the layout problem. A complex
+form needs a combination of nested `BoxLayout`, `BorderLayout`, and the notoriously
+complex `GridBagLayout`. The official tutorial spends entire pages on `GridBagConstraints`
+with its eleven independently-tunable fields. This pain motivated the constraint-string
+DSL approach of MiG Layout: a single manager whose declarative constraint strings subsume
+nearly every built-in.
+
+**Why this matters for a TUI / Sparkles.** Terminals are a constrained layout problem:
+discrete integer cells, no fractional pixels, a small finite grid. Swing's layout
+contracts (preferred / minimum / maximum sizes; vertical and horizontal alignment;
+baselines) map cleanly into terminal cells. The conceptual vocabulary -- "this widget
+hugs its content; this one fills the remaining space; this one has a fixed minimum;
+columns are aligned along baselines" -- is exactly what a polished TUI layout engine
+needs.
+
+**History timeline.**
+
+- **1995** -- AWT 1.0 with `LayoutManager`, `BorderLayout`, `FlowLayout`, `GridLayout`,
+  `CardLayout`, `GridBagLayout`.
+- **1998** -- Swing 1.0 inherits the AWT layout model; adds `BoxLayout` and `OverlayLayout`.
+- **2005** -- `GroupLayout` lands in Java 6, paired with NetBeans' Matisse GUI builder.
+- **2007** -- MiG Layout 3.0 released by Mikael Grev; the constraint-string approach
+  rapidly displaces hand-coded `GridBagLayout` for new Swing code.
+- **2013** -- `MigPane` published for JavaFX, bringing the same syntax to the new
+  scene-graph toolkit.
+- **Today** -- Swing/AWT remain in long-term maintenance; MiG Layout is still maintained
+  and widely used in business desktop applications.
+
+---
+
+## Layout Model
+
+### The LayoutManager Interface
+
+[`java.awt.LayoutManager`][lm] is a five-method interface that every classical AWT layout
+manager implements:
+
+```java
+public interface LayoutManager {
+    void addLayoutComponent(String name, Component comp);
+    void removeLayoutComponent(Component comp);
+    Dimension preferredLayoutSize(Container parent);
+    Dimension minimumLayoutSize(Container parent);
+    void layoutContainer(Container parent);
+}
+```
+
+Semantics of each method:
+
+- **`addLayoutComponent(name, comp)`** -- Invoked when a component is added with a
+  _string_ constraint (e.g. `panel.add(button, "North")` for `BorderLayout`). The manager
+  is free to record this association in its own data structures.
+- **`removeLayoutComponent(comp)`** -- Invoked when a component is removed; the manager
+  drops any stored constraints for it.
+- **`preferredLayoutSize(parent)`** -- The container's _ideal_ size, computed by querying
+  each child's `getPreferredSize()`. The layout manager combines them according to its
+  own rules. Returned `Dimension` is in pixels (width, height).
+- **`minimumLayoutSize(parent)`** -- The smallest size at which the layout can still
+  function. Used when the container is shrunk below its preferred size.
+- **`layoutContainer(parent)`** -- The actual layout pass: read the parent's current
+  bounds, then call `setBounds(x, y, w, h)` on each child to position and size it. This
+  method is the only one that performs side effects.
+
+### LayoutManager2 -- Constraint Objects, Alignment, Maximum Size
+
+[`java.awt.LayoutManager2`][lm2] (introduced in JDK 1.1) extends the interface with
+five more methods:
+
+```java
+public interface LayoutManager2 extends LayoutManager {
+    void addLayoutComponent(Component comp, Object constraints);
+    Dimension maximumLayoutSize(Container target);
+    float getLayoutAlignmentX(Container target);
+    float getLayoutAlignmentY(Container target);
+    void invalidateLayout(Container target);
+}
+```
+
+The headline addition is the _object_-typed constraint. Where the original
+`addLayoutComponent` only accepted a `String` (severely limiting expressiveness),
+`LayoutManager2` accepts any `Object`. `GridBagLayout` uses `GridBagConstraints`,
+`BorderLayout` accepts its `NORTH`/`SOUTH`/`EAST`/`WEST`/`CENTER` string constants (or
+the equivalent constant fields), `BoxLayout` takes nothing, and MiG Layout accepts
+either a `String` constraint or a `CC` (component constraints) object.
+
+`maximumLayoutSize` matters for `BoxLayout`-style alignment: a component with a finite
+maximum is centered within any extra space; a component with `Integer.MAX_VALUE`
+maximum grows to fill it.
+
+`getLayoutAlignmentX/Y` return values in `[0.0f, 1.0f]` indicating where this container
+prefers to be anchored within its allotted space along each axis (0 = left/top,
+0.5 = center, 1 = right/bottom).
+
+`invalidateLayout(target)` is called when something the manager has cached should be
+discarded -- typically when constraints change or components are added/removed.
+
+### Sizing Contract
+
+Every Swing/AWT component participates in a three-tier sizing contract:
+
+```
+component.getMinimumSize()     -> Dimension  // can't go below this without breaking
+component.getPreferredSize()   -> Dimension  // ideal size (e.g. text + insets)
+component.getMaximumSize()     -> Dimension  // can grow no larger
+```
+
+The layout manager calls these and combines results to produce
+`preferredLayoutSize`/`minimumLayoutSize`/`maximumLayoutSize` for the _container_. A
+top-level window typically asks the root pane for its preferred size, then sizes itself
+to match (via `pack()`).
+
+### Built-in Layout Managers
+
+#### FlowLayout
+
+The simplest manager: lay components out left-to-right at their preferred size, wrap to a
+new row when they run past the right edge. Default for `JPanel`. Parameters:
+`alignment` (LEFT/CENTER/RIGHT/LEADING/TRAILING), `hgap`, `vgap`.
+
+#### BorderLayout
+
+Five regions: `NORTH`, `SOUTH`, `EAST`, `WEST`, `CENTER`. Each region holds at most one
+component. NORTH/SOUTH stretch full width and take their preferred height; EAST/WEST take
+their preferred width and stretch full height minus the N/S strips; CENTER fills the
+remaining rectangle. Default for `JFrame`/`JDialog` content panes.
+
+```java
+JFrame frame = new JFrame("Editor");
+frame.setLayout(new BorderLayout());
+frame.add(new JToolBar(), BorderLayout.NORTH);
+frame.add(new JScrollPane(textArea), BorderLayout.CENTER);
+frame.add(statusBar, BorderLayout.SOUTH);
+```
+
+#### GridLayout
+
+Splits the container into a fixed grid of _identical_ cells; every component gets one
+cell. Specified as rows x columns; one dimension can be zero meaning "compute from the
+component count". All cells are the same size, so this manager is appropriate for tiled
+button panels or chessboard-like grids, not free-form forms.
+
+```java
+JPanel keypad = new JPanel(new GridLayout(4, 3, 2, 2)); // 4 rows, 3 cols, 2px gaps
+for (String label : new String[]{"1","2","3","4","5","6","7","8","9","*","0","#"})
+    keypad.add(new JButton(label));
+```
+
+#### CardLayout
+
+Holds multiple components in the same slot; only one is visible at a time. Switched via
+`first()`, `next()`, `previous()`, `last()`, `show(parent, name)`. Effectively a stack:
+useful for wizard pages, tabbed panels (`JTabbedPane` uses a similar idea), or
+state-driven views.
+
+#### BoxLayout
+
+Single-axis arrangement (X_AXIS, Y_AXIS, LINE_AXIS, PAGE_AXIS where the latter two
+respect text orientation). Each component is placed at its preferred size along the main
+axis; perpendicular axis is aligned according to `getAlignmentX/Y`. The Box class
+provides `glue` (expanding empty space) and `struts` (fixed-size spacers):
+
+```java
+JPanel row = new JPanel();
+row.setLayout(new BoxLayout(row, BoxLayout.LINE_AXIS));
+row.add(new JLabel("Name:"));
+row.add(Box.createHorizontalStrut(8));   // 8px fixed gap
+row.add(nameField);
+row.add(Box.createHorizontalGlue());     // expanding spacer
+row.add(saveButton);
+```
+
+#### GridBagLayout -- The Knob-Heavy One
+
+The most flexible of the built-in managers and the running joke of Swing programming.
+Components are added with a [`GridBagConstraints`][gbc] object whose fields independently
+control:
+
+- `gridx`, `gridy` -- The component's cell origin (or `RELATIVE` to mean "next in row").
+- `gridwidth`, `gridheight` -- Cells spanned (or `REMAINDER` to mean "to end of row").
+- `weightx`, `weighty` -- Share of extra space this column/row receives when the
+  container grows beyond its preferred size. A column with weight 0 stays fixed; a column
+  with weight 1.0 takes all the slack (or splits it proportionally with other weighted
+  columns).
+- `fill` -- `NONE`, `HORIZONTAL`, `VERTICAL`, `BOTH`. Whether the component grows to fill
+  its cell.
+- `anchor` -- Where the component anchors when smaller than its cell. Compass directions
+  (`NORTH`, `NORTHEAST`, ...) plus baseline anchors (`BASELINE`, `BASELINE_LEADING`, ...).
+- `insets` -- External padding around the component (top, left, bottom, right).
+- `ipadx`, `ipady` -- Internal padding added to the component's preferred size.
+
+A typical form row in `GridBagLayout`:
+
+```java
+JPanel form = new JPanel(new GridBagLayout());
+GridBagConstraints g = new GridBagConstraints();
+g.insets = new Insets(2, 4, 2, 4);
+
+g.gridx = 0; g.gridy = 0;
+g.anchor = GridBagConstraints.LINE_END;
+form.add(new JLabel("Username:"), g);
+
+g.gridx = 1;
+g.fill = GridBagConstraints.HORIZONTAL;
+g.weightx = 1.0;
+g.anchor = GridBagConstraints.LINE_START;
+form.add(userField, g);
+
+g.gridx = 0; g.gridy = 1;
+g.fill = GridBagConstraints.NONE;
+g.weightx = 0;
+form.add(new JLabel("Password:"), g);
+
+g.gridx = 1;
+g.fill = GridBagConstraints.HORIZONTAL;
+g.weightx = 1.0;
+form.add(passField, g);
+```
+
+That's a lot of mutation of a single constraints object for two label/field pairs. Most
+programmers wrote helper methods to compress the boilerplate; the cottage industry of
+those helpers led to MiG Layout.
+
+#### GroupLayout
+
+Introduced in Java 6, designed primarily as the _output_ of NetBeans' Matisse GUI
+builder, not as a hand-coded layout. Specifies horizontal and vertical layouts
+_independently_ through nested `SequentialGroup` (one after another) and `ParallelGroup`
+(side by side / overlapping) hierarchies. The resulting code is verbose but the model is
+clean -- it ensures every component appears in exactly one horizontal and one vertical
+group, eliminating the contradictions that plague hand-coded `GridBagLayout`.
+
+```java
+GroupLayout layout = new GroupLayout(panel);
+panel.setLayout(layout);
+layout.setAutoCreateGaps(true);
+layout.setAutoCreateContainerGaps(true);
+
+layout.setHorizontalGroup(
+    layout.createSequentialGroup()
+        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
+            .addComponent(userLabel)
+            .addComponent(passLabel))
+        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+            .addComponent(userField)
+            .addComponent(passField))
+);
+
+layout.setVerticalGroup(
+    layout.createSequentialGroup()
+        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+            .addComponent(userLabel)
+            .addComponent(userField))
+        .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+            .addComponent(passLabel)
+            .addComponent(passField))
+);
+```
+
+The baseline-aligned parallel group is the key feature: text in the label and text in the
+field line up on their typographic baseline, not on the component's top edge.
+
+#### SpringLayout
+
+A constraint-based manager that predates iOS Auto Layout by a decade. Each component edge
+(N, S, E, W) is a node in a graph; the graph is connected by `Spring` values that express
+_minimum / preferred / maximum_ offsets between edges. The layout pass solves the spring
+network for equilibrium. Specified by `putConstraint`:
+
+```java
+SpringLayout sl = new SpringLayout();
+JPanel panel = new JPanel(sl);
+panel.add(label); panel.add(field);
+
+// label.west = container.west + 5
+sl.putConstraint(SpringLayout.WEST, label, 5, SpringLayout.WEST, panel);
+// label.north = container.north + 5
+sl.putConstraint(SpringLayout.NORTH, label, 5, SpringLayout.NORTH, panel);
+// field.west = label.east + 5
+sl.putConstraint(SpringLayout.WEST, field, 5, SpringLayout.EAST, label);
+// field.north = label.north
+sl.putConstraint(SpringLayout.NORTH, field, 0, SpringLayout.NORTH, label);
+```
+
+The same edge-relation idea reappears as Auto Layout `NSLayoutConstraint` and again as
+CSS Grid's named lines. SpringLayout was conceptually ahead of its time but the API was
+cumbersome and never developed a community of converts.
+
+### MiG Layout
+
+[MiG Layout][mig] is a single layout manager that subsumes most use cases of the built-ins
+through a declarative _constraint string_ language. The same engine drives Swing
+(`MigLayout` extends `LayoutManager2`), JavaFX (`MigPane` extends `Pane`), and SWT.
+
+Three string slots configure a `MigLayout`:
+
+1. **Layout constraints** -- container-wide options (overall direction, wrapping behaviour,
+   debug visualization, insets, gaps).
+2. **Column constraints** -- one entry per logical column (default width, growth weights,
+   alignment).
+3. **Row constraints** -- one entry per logical row (default height, growth weights,
+   alignment).
+
+Then each component is added with a fourth string of **component constraints**
+(per-component cell, span, alignment, growth, dock).
+
+```java
+import net.miginfocom.swing.MigLayout;
+
+JPanel form = new JPanel(new MigLayout(
+    "wrap 2, insets 10, gapx 8",          // layout constraints
+    "[right][grow,fill]",                  // column constraints
+    "[]10[]10[]"                           // row constraints
+));
+
+form.add(new JLabel("Username:"));
+form.add(userField);
+form.add(new JLabel("Password:"));
+form.add(passField);
+form.add(new JLabel("Notes:"), "top");
+form.add(new JScrollPane(notesArea), "grow, height 100:200:");
+form.add(saveButton, "skip, split 2, tag ok");
+form.add(cancelButton, "tag cancel");
+```
+
+Key syntax elements:
+
+- **`wrap N`** -- After every N components, advance to the next row. Removes the need for
+  manual row tracking.
+- **`[]`** -- A column or row marker. `[100]` sets a fixed width; `[grow]` lets the column
+  take extra space; `[100:200:300]` sets minimum:preferred:maximum; `[fill]` means
+  components fill the column; `[right]` aligns components to the column's right edge.
+- **Numbers between `[]`** -- Gaps in pixels (or units like `8mm`, `2cm`, `2%`).
+- **`grow`, `growx`, `growy`** -- Component grows to fill its cell along the given axis.
+- **`span N`, `spany N`** -- Component spans multiple cells.
+- **`skip N`** -- Leave N empty cells before placing the next component.
+- **`split N`** -- Place the next N components within the _same_ cell as a sub-row.
+- **`dock north`/`south`/`east`/`west`** -- Component attaches to the named edge,
+  consuming the full cross dimension (BorderLayout-style overlay).
+- **`align <h>,<v>`** -- Anchor within the cell.
+- **`gap top|left|right|bottom|push N`** -- Per-side gap, including `push` which is an
+  expanding gap (BoxLayout-glue equivalent).
+- **`hidemode N`** -- Behaviour when the component is hidden: 0 = keep slot, 1 = zero size
+  but keep gaps, 2 = zero size and zero gaps, 3 = skip entirely in size calculations.
+- **`sizegroup name`** -- All components with the same `sizegroup` are sized to the
+  largest in the group. Useful for aligning button widths across a dialog.
+- **`tag ok|cancel|help|apply|...`** -- Standard button roles. MiG knows the platform's
+  conventions (Windows puts OK on the left, macOS on the right) and reorders accordingly.
+- **`debug`** -- A layout-level flag that draws colored overlays showing cells and gaps;
+  invaluable for diagnosing why something isn't where it should be.
+
+A docking example illustrates how MiG subsumes `BorderLayout`:
+
+```java
+JFrame frame = new JFrame("IDE");
+frame.setLayout(new MigLayout("fill, insets 0, gap 0"));
+frame.add(menuBar,     "dock north");
+frame.add(toolBar,     "dock north");
+frame.add(statusBar,   "dock south");
+frame.add(sidePanel,   "dock west, width 200");
+frame.add(propertiesPanel, "dock east, width 250");
+frame.add(editorArea,  "grow, push");      // fills remaining center
+```
+
+The whitepaper at <https://www.miglayout.com/whitepaper.html> describes the design goals:
+one layout manager to learn; cell-grid foundations with first-class docking; constraint
+strings to keep declarations close to the components; an API form (`CC`, `AC`, `LC`
+objects) for programmatic construction. The current implementation lives in
+<https://github.com/mikaelgrev/miglayout>.
+
+#### Component-Form API
+
+Constraint strings are convenient but not type-checked. MiG provides an equivalent
+Java-object API:
+
+```java
+import net.miginfocom.layout.*;
+
+LC layoutConstraints = new LC().wrapAfter(2).insets("10").gridGapX("8");
+AC columnConstraints  = new AC().align("right", 0).grow(1.0f, 1).fill(1);
+AC rowConstraints     = new AC().gap("10");
+
+JPanel form = new JPanel(new MigLayout(layoutConstraints, columnConstraints, rowConstraints));
+
+CC labelCC = new CC().alignX("right");
+CC fieldCC = new CC().growX().pushX();
+form.add(new JLabel("Username:"), labelCC);
+form.add(userField, fieldCC);
+```
+
+Builders are more verbose than strings, but they survive refactorings and IDE rename
+operations.
+
+---
+
+## Code Examples
+
+### Example 1 -- Login Dialog with GridBagLayout
+
+```java
+import java.awt.*;
+import javax.swing.*;
+
+public class GridBagLogin {
+    public static void main(String[] args) {
+        JFrame frame = new JFrame("Sign In");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        JPanel form = new JPanel(new GridBagLayout());
+        GridBagConstraints g = new GridBagConstraints();
+        g.insets = new Insets(4, 6, 4, 6);
+
+        // Row 0: Username
+        g.gridx = 0; g.gridy = 0;
+        g.anchor = GridBagConstraints.LINE_END;
+        g.fill = GridBagConstraints.NONE;
+        g.weightx = 0;
+        form.add(new JLabel("Username:"), g);
+
+        g.gridx = 1;
+        g.anchor = GridBagConstraints.LINE_START;
+        g.fill = GridBagConstraints.HORIZONTAL;
+        g.weightx = 1.0;
+        form.add(new JTextField(20), g);
+
+        // Row 1: Password
+        g.gridx = 0; g.gridy = 1;
+        g.fill = GridBagConstraints.NONE;
+        g.weightx = 0;
+        g.anchor = GridBagConstraints.LINE_END;
+        form.add(new JLabel("Password:"), g);
+
+        g.gridx = 1;
+        g.fill = GridBagConstraints.HORIZONTAL;
+        g.weightx = 1.0;
+        g.anchor = GridBagConstraints.LINE_START;
+        form.add(new JPasswordField(20), g);
+
+        // Row 2: Buttons (spanning both columns, right-anchored)
+        g.gridx = 0; g.gridy = 2;
+        g.gridwidth = 2;
+        g.fill = GridBagConstraints.NONE;
+        g.anchor = GridBagConstraints.LINE_END;
+        g.weightx = 0;
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, 6, 0));
+        buttons.add(new JButton("Cancel"));
+        buttons.add(new JButton("Sign In"));
+        form.add(buttons, g);
+
+        frame.setContentPane(form);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}
+```
+
+Note how the same `GridBagConstraints` object is repeatedly mutated; the order of
+mutations is significant, and forgetting to reset `gridwidth` or `weightx` between rows is
+a common bug source.
+
+### Example 2 -- Same Login Dialog with MiG Layout
+
+```java
+import javax.swing.*;
+import net.miginfocom.swing.MigLayout;
+
+public class MigLogin {
+    public static void main(String[] args) {
+        JFrame frame = new JFrame("Sign In");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        JPanel form = new JPanel(new MigLayout(
+            "wrap 2, insets 10, gapx 6, gapy 4",
+            "[right][grow,fill]",
+            "[][]push[]"
+        ));
+
+        form.add(new JLabel("Username:"));
+        form.add(new JTextField(20));
+
+        form.add(new JLabel("Password:"));
+        form.add(new JPasswordField(20));
+
+        form.add(new JButton("Cancel"), "skip, split 2, tag cancel");
+        form.add(new JButton("Sign In"), "tag ok");
+
+        frame.setContentPane(form);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}
+```
+
+Half as many lines and reads top-to-bottom in the order the form is visually arranged.
+The `tag ok` / `tag cancel` decorations let MiG reorder the buttons to match the host
+platform's convention (Windows: OK then Cancel; macOS: Cancel then OK).
+
+### Example 3 -- IDE-Style Docked Layout (MiG)
+
+```java
+import javax.swing.*;
+import net.miginfocom.swing.MigLayout;
+
+public class MigIDE {
+    public static void main(String[] args) {
+        JFrame frame = new JFrame("MigIDE");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setLayout(new MigLayout("fill, insets 0, gap 0"));
+
+        frame.add(buildMenuBar(),    "dock north");
+        frame.add(buildToolBar(),    "dock north");
+        frame.add(buildStatusBar(),  "dock south");
+        frame.add(buildProjectTree(),"dock west, width 200!");
+        frame.add(buildPropertyPanel(), "dock east, width 250!");
+        frame.add(buildEditorTabs(), "grow, push");
+
+        frame.setSize(1024, 768);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static JComponent buildMenuBar() { return new JMenuBar(); }
+    private static JComponent buildToolBar() {
+        JToolBar tb = new JToolBar();
+        tb.add(new JButton("Open"));
+        tb.add(new JButton("Save"));
+        return tb;
+    }
+    private static JComponent buildStatusBar() {
+        JLabel l = new JLabel(" Ready"); l.setOpaque(true); l.setBackground(java.awt.Color.LIGHT_GRAY);
+        return l;
+    }
+    private static JComponent buildProjectTree() {
+        return new JScrollPane(new JTree());
+    }
+    private static JComponent buildPropertyPanel() {
+        return new JScrollPane(new JTable(5, 2));
+    }
+    private static JComponent buildEditorTabs() {
+        JTabbedPane t = new JTabbedPane();
+        t.addTab("Main.java", new JScrollPane(new JTextArea()));
+        t.addTab("README.md", new JScrollPane(new JTextArea()));
+        return t;
+    }
+}
+```
+
+The `width 200!` syntax is a _strong_ size constraint -- MiG enforces it even at the cost
+of clipping a neighbour, distinguishing it from `width 200` (preferred). The `push`
+keyword on the editor tabs ensures the center component absorbs all remaining slack
+regardless of what the docked panels request.
+
+### Example 4 -- BoxLayout with Struts and Glue
+
+```java
+import java.awt.*;
+import javax.swing.*;
+
+public class BoxButtonRow {
+    public static void main(String[] args) {
+        JFrame frame = new JFrame("Dialog");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        JPanel content = new JPanel(new BorderLayout(0, 10));
+        content.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+        content.add(new JLabel("Are you sure you want to continue?"), BorderLayout.CENTER);
+
+        JPanel buttons = new JPanel();
+        buttons.setLayout(new BoxLayout(buttons, BoxLayout.LINE_AXIS));
+        buttons.add(new JButton("Help"));
+        buttons.add(Box.createHorizontalGlue());           // pushes remaining buttons right
+        buttons.add(new JButton("Cancel"));
+        buttons.add(Box.createHorizontalStrut(6));         // small fixed gap
+        buttons.add(new JButton("OK"));
+        content.add(buttons, BorderLayout.SOUTH);
+
+        frame.setContentPane(content);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}
+```
+
+`Box.createHorizontalGlue()` returns an invisible component with zero preferred width and
+`Integer.MAX_VALUE` maximum width; `BoxLayout` distributes any extra space to it. This is
+the classic "Help on the left, OK/Cancel on the right" dialog footer pattern.
+
+---
+
+## Strengths and Weaknesses
+
+### LayoutManager Interface
+
+**Strengths.**
+
+- **Pluggable contract.** Any class implementing `LayoutManager` can drive any container.
+  Look-and-feel implementations, IDE designers, and third-party libraries all coexist.
+- **Clean sizing model.** The three-tier minimum/preferred/maximum contract is universal
+  across the toolkit and maps cleanly to any sizing problem -- including terminal cells.
+- **30 years of stability.** Code written against the AWT 1.0 LayoutManager API still
+  compiles and runs on modern JVMs.
+- **Reflectively introspectable.** The constraint slots and named regions are
+  string-based, which makes UI builders straightforward to implement.
+
+**Weaknesses.**
+
+- **String-typed constraints in the original interface** were limiting; `LayoutManager2`
+  was a clear retrofit a year later.
+- **Mutable Dimension objects.** `preferredLayoutSize` returns a `Dimension` that callers
+  must treat as immutable by convention; the interface doesn't enforce this.
+- **Pixel-only coordinates.** The contract doesn't accommodate logical units or HiDPI
+  scaling; that has to be handled per-manager.
+- **No baseline support in the original.** Baseline alignment was added later via
+  `Component.getBaseline` (Java 6) and only some managers (`GroupLayout`, `GridBagLayout`)
+  actually use it.
+
+### Built-in Managers
+
+**Strengths.**
+
+- **Cover the common cases.** Most simple UIs can be built from BorderLayout + FlowLayout
+  - occasional GridLayout without ever touching the harder managers.
+- **CardLayout is unique.** No third-party manager improves meaningfully on its
+  one-at-a-time semantics.
+- **GroupLayout's independent H/V groups** are mathematically sound and produce layouts
+  that scale and translate cleanly.
+
+**Weaknesses.**
+
+- **GridBagLayout is the canonical "too many knobs" case study.** Eleven independently
+  tunable fields per component, mutation-based API, no error reporting when constraints
+  conflict.
+- **BoxLayout's reliance on `getMaximumSize`** is fragile; many Swing components
+  return `Integer.MAX_VALUE` by default, making layout decisions unpredictable.
+- **SpringLayout's API never grew a community** despite its useful constraint model.
+- **GroupLayout is verbose** when hand-coded; it's really designed for tools to emit.
+
+### MiG Layout
+
+**Strengths.**
+
+- **One manager subsumes most others.** Forms, grids, docked panels, button rows, tabbed
+  switches -- all expressible without nesting different managers.
+- **Constraint strings are concise and readable** once learned. The syntax is the most
+  popular dialect for Swing UI in the last 15 years.
+- **Built-in platform conventions.** The `tag ok`/`tag cancel`/`tag apply` button roles
+  make MiG dialogs reorder automatically to match host conventions.
+- **Sizegroup makes button rows trivial.** Aligning button widths across a dialog is one
+  property per button, not custom sizing code.
+- **Debug mode** draws colored overlays showing cells, gaps, and constraint failures.
+- **Cross-toolkit.** Same syntax on Swing, JavaFX (`MigPane`), and SWT.
+
+**Weaknesses.**
+
+- **Strings are untyped.** Typos surface only at runtime; misspelled keywords are
+  silently ignored or produce confusing error messages.
+- **Discoverability is poor.** New developers must consult the cheat sheet; the constraint
+  vocabulary is large.
+- **Third-party dependency.** Not in the JDK, has to be brought in via Maven.
+- **JavaFX adoption.** The official JavaFX team prefers their own `GridPane`/`HBox`/`VBox`
+  hierarchy; `MigPane` is a community choice rather than a default.
+- **Same model limits.** Like all rectangle-cell layouts, it can't express overlapping or
+  z-ordered widgets without falling back to manual positioning.
+
+### Mapping to Terminal Layouts
+
+Swing's layout heritage maps surprisingly well onto a terminal:
+
+- **`preferredLayoutSize`/`minimumLayoutSize` -> intrinsic widget sizes in cells.** A
+  paragraph widget has a preferred width (its longest line) and a minimum (some
+  reasonable wrap point). A scrollbar has a fixed 1-cell width.
+- **`maximumLayoutSize` -> "fill" semantics.** A widget with effectively infinite max grows
+  to fill available cells; one with a finite max keeps its preferred size and lets the
+  layout center it.
+- **Baseline alignment is irrelevant** in a fixed-grid terminal -- all text already shares
+  a baseline -- but the _concept_ of aligning label/field rows survives.
+- **`GridBagConstraints.fill` / `anchor` / `weightx` translate directly** to TUI grid
+  systems like Ratatui's `Constraint::Fill(weight)`, gtk-rs's `expand`/`align`, or Ink's
+  `flexGrow`/`alignItems`.
+- **MiG's `dock` keyword** is exactly Ratatui's edge-anchored layout pattern, and matches
+  the BorderLayout regions one-to-one.
+
+For a Sparkles TUI layout module, the lesson is that _one_ small layout DSL based on
+column constraints, row constraints, and per-component cell specifications can subsume
+the most common use cases. MiG demonstrates that the constraint-string approach scales;
+the design-by-introspection approach in D could lift that DSL into compile-time-checked
+templates (so `wrap 2` and `[grow,fill]` become type-checked operations rather than
+string parsing).
+
+---
+
+## References
+
+- **Java SE API documentation:**
+  - [`java.awt.LayoutManager`][lm]
+  - [`java.awt.LayoutManager2`][lm2]
+  - [`java.awt.BorderLayout`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/BorderLayout.html)
+  - [`java.awt.FlowLayout`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/FlowLayout.html)
+  - [`java.awt.GridLayout`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/GridLayout.html)
+  - [`java.awt.CardLayout`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/CardLayout.html)
+  - [`java.awt.GridBagLayout`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/GridBagLayout.html)
+  - [`java.awt.GridBagConstraints`][gbc]
+  - [`javax.swing.BoxLayout`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/javax/swing/BoxLayout.html)
+  - [`javax.swing.GroupLayout`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/javax/swing/GroupLayout.html)
+  - [`javax.swing.SpringLayout`](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/javax/swing/SpringLayout.html)
+- **Official Swing tutorial:**
+  - [A Visual Guide to Layout Managers](https://docs.oracle.com/javase/tutorial/uiswing/layout/visual.html)
+  - [Using Layout Managers](https://docs.oracle.com/javase/tutorial/uiswing/layout/using.html)
+  - [How to Use GridBagLayout](https://docs.oracle.com/javase/tutorial/uiswing/layout/gridbag.html)
+- **MiG Layout:**
+  - Main site: <https://www.miglayout.com/>
+  - White paper: <https://www.miglayout.com/whitepaper.html>
+  - Quick start cheat sheet: <https://www.miglayout.com/QuickStart.pdf>
+  - GitHub repository: <https://github.com/mikaelgrev/miglayout>
+  - `MigPane` for JavaFX: same repository, `miglayout-javafx` module
+- **Related Sparkles research:**
+  - Ratatui's `Constraint` model: `../tui-libraries/ratatui.md`
+  - Ink / Yoga Flexbox: `../tui-libraries/ink.md`
+  - Cassowary constraint solver: `./cassowary.md`
+  - Apple Auto Layout: `./auto-layout.md`
+
+[lm]: https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/LayoutManager.html
+[lm2]: https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/LayoutManager2.html
+[gbc]: https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/GridBagConstraints.html
+[mig]: https://www.miglayout.com/

--- a/docs/research/ui-layout/taffy.md
+++ b/docs/research/ui-layout/taffy.md
@@ -1,0 +1,712 @@
+# Taffy (Rust)
+
+A high-performance, cross-platform UI layout library written in Rust that implements three CSS layout algorithms (Flexbox, Grid, and Block) as a renderer-agnostic engine. Taffy is used as a shared layout dependency by Servo, Bevy, Zed/GPUI, Slint, Floem, Blitz, and other Rust UI frameworks.
+
+| Field            | Value                                                         |
+| ---------------- | ------------------------------------------------------------- |
+| Language         | Rust                                                          |
+| License          | MIT                                                           |
+| Repository       | <https://github.com/DioxusLabs/taffy>                         |
+| Documentation    | <https://docs.rs/taffy/>                                      |
+| Version snapshot | 0.10.1 (2026 release line)                                    |
+| Notable adoption | Servo, Bevy, Zed (GPUI), Slint, Floem, Blitz, iocraft, Takumi |
+
+---
+
+## Overview
+
+### What It Solves
+
+Most UI toolkits eventually need to answer the same question: given a tree of nodes and a
+set of style properties on each one, where does every node end up, and how big is it? In
+the web platform this question is answered by the browser's layout engines (block, inline,
+flex, grid). Outside the browser, the same question is answered repeatedly --- and
+inconsistently --- by every native UI framework, game engine, and embedded UI runtime.
+
+Taffy is an attempt to factor that work out of any particular framework. It provides a
+**pure layout engine**: you describe a tree of nodes with CSS-like styles, you call
+`compute_layout`, and it returns the absolute position and size of every node. It does not
+draw anything, does not handle input, does not own a window, does not assume a particular
+unit. The "pixel" is just a `f32`, which means the same engine works equally well for
+desktop GUIs, terminal cell grids, game-engine HUDs, and PDF or SVG generation.
+
+The library implements three CSS algorithms faithfully enough that you can copy a CSS
+property from MDN and reasonably expect it to behave the same way in Taffy: **Flexbox**
+(`display: flex`), **CSS Grid** (`display: grid`), and **Block** (`display: block`). Each
+is gated behind a Cargo feature flag, so consumers who only need one algorithm pay only for
+that algorithm's compiled code.
+
+### Design Philosophy
+
+Taffy's design rests on a small number of deliberate choices.
+
+**Pure layout, nothing else.** The engine never reads from a font file, never opens a
+window, never asks for a system clock. The only "world" it sees is the style tree and a
+caller-supplied `available_space`. Anything that requires measuring real content (the
+width of a piece of text, the natural dimensions of an image) is delegated back to the
+caller via a _measure function_. This keeps the engine deterministic, testable in
+isolation, and trivially embeddable.
+
+**Web-spec fidelity over invention.** Taffy chooses to implement existing CSS algorithms
+rather than design new ones. The vocabulary (`Length`, `Percent`, `Auto`, `Fr`, `Min`,
+`Max`, `MinMax`, `flex-grow`, `align-self`, `grid-template-rows`, ...) is the vocabulary of
+the W3C specs. The benefit is enormous: every front-end developer already understands the
+mental model, every MDN reference page is also a reference page for Taffy, and the
+correctness of the implementation can be validated against Chromium and Firefox by running
+the same test fixtures.
+
+**Slotmap-backed storage with stable IDs.** Nodes live in a slotmap inside a
+`TaffyTree<Context>`. The caller holds `NodeId` handles, not pointers, which means there
+is no borrow-checker friction when storing IDs in user-side structures, and nodes can be
+freely added and removed without invalidating other IDs. This pattern is shared with most
+slot-arena Rust UI engines (Bevy's `Entity`, GPUI's element keys, slotmap-backed ECS in
+general).
+
+**Cached, incremental computation.** Each node owns a `Cache` that memoises the result of
+layout requests keyed on the available space and the kind of measurement requested
+(content-size vs. final layout). Re-layout of a single subtree only invalidates entries
+whose inputs actually changed, which is what makes Taffy fast enough for retained UI at 60
+or 120 Hz.
+
+**Renderer-agnostic by deliberate omission.** Taffy never tells you what a cell or pixel
+looks like. It hands back floating-point rectangles and lets the caller decide whether to
+draw them, snap them to a character grid, emit them as SVG, or pipe them into a GPU
+command buffer. The same engine is used by Zed (GPU desktop UI), by Bevy (game UI), by
+iocraft (terminal UI), and by Blitz (HTML rendering).
+
+### History
+
+Taffy's history is a chain of forks, each driven by the previous project losing its
+maintainer.
+
+- **2018 -- Stretch.** Visly Inc. released [Stretch][stretch-repo], a Rust Flexbox engine
+  intended as a Yoga-alternative for cross-platform UI. It powered the Visly design tool
+  and ran via FFI bindings on iOS, Android, and the web.
+
+- **2021 -- Stretch archived.** Visly stopped maintaining Stretch. A community fork
+  appeared as `stretch2` to keep the engine alive, but it too went stale within a year.
+
+- **2022 -- Taffy 0.1.** The DioxusLabs maintainers renamed `stretch2 0.4.3` to `taffy`,
+  cleaned up its dependency tree, and committed to long-term maintenance. The initial
+  scope was Stretch's: Flexbox only.
+
+- **0.3 (2023) -- CSS Grid.** The first major algorithm addition. Taffy gained a complete
+  implementation of CSS Grid, including auto-placement, named lines, and `minmax(...)`
+  track sizing.
+
+- **0.4 (2023) -- Block layout and overflow.** Added `display: block`, so Taffy could now
+  serve as a layout backend for HTML rendering (Servo, Blitz). Introduced the `overflow`
+  property and overflow-aware scrollbar sizing.
+
+- **0.6 (2024) -- Traitified style.** The `Style` struct became generic over a trait, so
+  consumers could plug in their own style storage (useful for ECS integration in Bevy).
+  `box-sizing` and computed margin output landed in this release.
+
+- **0.9 (2024-2025) -- Named grid lines and grid template areas.** Generic string support
+  for named lines, matching the CSS Grid spec.
+
+- **0.10 (2026) -- RTL direction, floats, and CSS string parsing.** The `direction`
+  property (LTR/RTL) became supported. Floats landed behind a feature flag. Style values
+  gained `from_str` parsers, so callers can hand-write CSS strings.
+
+The lineage is visible in the API: `Stretch -> Node -> Style` became
+`TaffyTree -> NodeId -> Style`, with the same general shape but a more idiomatic Rust
+slotmap and a much wider style vocabulary.
+
+---
+
+## Layout Model
+
+Taffy is organised around four pieces: a **tree** that owns nodes, a **style** that
+describes each node, an **algorithm** selected by `display`, and a **measure function**
+that callers supply for leaves whose intrinsic size depends on real content.
+
+### The TaffyTree
+
+The top-level type is `TaffyTree<Context>`:
+
+```rust
+pub struct TaffyTree<Context = ()> { /* slotmap of nodes, caches, ... */ }
+```
+
+The optional `Context` type parameter lets callers attach arbitrary user data to each
+leaf node (typically a reference into their own text or asset cache). The headline methods
+are:
+
+| Method                                         | Purpose                                                          |
+| ---------------------------------------------- | ---------------------------------------------------------------- |
+| `new()`                                        | Construct a tree with default capacity (16 nodes).               |
+| `new_leaf(style)`                              | Create an unattached leaf node with the given style.             |
+| `new_leaf_with_context(style, ctx)`            | Same, but attach a `Context` value used by the measure function. |
+| `new_with_children(style, &[NodeId])`          | Create a parent node with an initial set of children.            |
+| `set_style(node, style)`                       | Replace a node's style; invalidates caches.                      |
+| `add_child(parent, child) / remove_child(...)` | Mutate the tree shape.                                           |
+| `set_children(parent, &[NodeId])`              | Replace the entire child list of a node.                         |
+| `compute_layout(root, available_space)`        | Run layout when no leaves need measuring.                        |
+| `compute_layout_with_measure(root, space, fn)` | Run layout, calling `fn` to size leaves.                         |
+| `layout(node) -> Result<&Layout>`              | Read the computed layout for a node relative to its parent.      |
+
+Note the asymmetry: layout is _written_ during `compute_layout` and _read_ via `layout`.
+The `Layout` type is a small POD:
+
+```rust
+pub struct Layout {
+    pub order: u32,
+    pub location: Point<f32>,
+    pub size: Size<f32>,
+    pub content_size: Size<f32>,
+    pub scrollbar_size: Size<f32>,
+    pub border: Rect<f32>,
+    pub padding: Rect<f32>,
+    pub margin: Rect<f32>,
+}
+```
+
+`location` is offset from the parent's content box, so converting to absolute coordinates
+is a simple cumulative sum during a render pass.
+
+### Sizing Primitives
+
+Taffy's most-reused vocabulary lives in `taffy::style::Dimension` and its siblings. These
+are the small types every style field is built from:
+
+```rust
+pub enum Dimension {
+    Length(f32),       // px-equivalent absolute length
+    Percent(f32),      // 0.0..=1.0 of parent's relevant axis
+    Auto,              // CSS auto
+}
+
+pub enum LengthPercentage {
+    Length(f32),
+    Percent(f32),
+}
+
+pub enum LengthPercentageAuto {
+    Length(f32),
+    Percent(f32),
+    Auto,
+}
+```
+
+Different style fields use different variants depending on what CSS allows:
+
+| Property     | Type                         | Why                           |
+| ------------ | ---------------------------- | ----------------------------- |
+| `size`       | `Size<Dimension>`            | `width: auto` is meaningful.  |
+| `min_size`   | `Size<Dimension>`            | Same.                         |
+| `max_size`   | `Size<Dimension>`            | Same.                         |
+| `padding`    | `Rect<LengthPercentage>`     | `padding: auto` is not valid. |
+| `border`     | `Rect<LengthPercentage>`     | Same.                         |
+| `margin`     | `Rect<LengthPercentageAuto>` | `margin: auto` _is_ valid.    |
+| `inset`      | `Rect<LengthPercentageAuto>` | Same.                         |
+| `gap`        | `Size<LengthPercentage>`     | No auto-gap.                  |
+| `flex_basis` | `Dimension`                  | `flex-basis: auto` is valid.  |
+
+For CSS Grid, two additional types appear:
+
+```rust
+pub enum MinTrackSizingFunction {
+    Fixed(LengthPercentage),
+    MinContent, MaxContent, Auto,
+}
+
+pub enum MaxTrackSizingFunction {
+    Fixed(LengthPercentage),
+    MinContent, MaxContent, Auto,
+    FitContent(LengthPercentage),
+    Fraction(f32),    // the `1fr`, `2fr`, ... unit
+}
+```
+
+`Fraction` (the `fr` unit) is the one piece of vocabulary that has no analogue in
+Flexbox: it expresses "share of the remaining track space after fixed and content tracks
+are resolved". This is the same algorithm that makes CSS Grid feel so natural for
+spreadsheet-shaped layouts.
+
+`AvailableSpace` is the input handed into `compute_layout`:
+
+```rust
+pub enum AvailableSpace {
+    Definite(f32),     // I have exactly this many units to fill.
+    MinContent,        // Give me the smallest size that fits.
+    MaxContent,        // Give me the size where nothing wraps.
+}
+```
+
+Callers pass `Size<AvailableSpace>` so the two axes can be specified independently. A
+desktop window typically passes `Definite(width)` and `Definite(height)`. A
+narrow-content-measurement pass (e.g., for shrink-to-fit) passes `MinContent` /
+`MaxContent` on the relevant axis.
+
+### The Style Struct
+
+`Style` is the single source of truth for everything Taffy needs to know about a node.
+Selected fields, grouped:
+
+```rust
+pub struct Style {
+    // ----- algorithm selection -----
+    pub display: Display,                       // Block | Flex | Grid | None
+    pub item_is_table: bool,
+    pub item_is_replaced: bool,
+    pub box_sizing: BoxSizing,
+    pub direction: Direction,                   // LTR | RTL (>=0.10)
+
+    // ----- overflow / scroll -----
+    pub overflow: Point<Overflow>,              // (x, y) Overflow variant
+    pub scrollbar_width: f32,
+
+    // ----- positioning -----
+    pub position: Position,                     // Relative | Absolute
+    pub inset: Rect<LengthPercentageAuto>,
+
+    // ----- box model -----
+    pub size: Size<Dimension>,
+    pub min_size: Size<Dimension>,
+    pub max_size: Size<Dimension>,
+    pub aspect_ratio: Option<f32>,
+    pub margin: Rect<LengthPercentageAuto>,
+    pub padding: Rect<LengthPercentage>,
+    pub border: Rect<LengthPercentage>,
+
+    // ----- gap -----
+    pub gap: Size<LengthPercentage>,
+
+    // ----- alignment (flex & grid) -----
+    pub align_items: Option<AlignItems>,
+    pub align_self: Option<AlignSelf>,
+    pub align_content: Option<AlignContent>,
+    pub justify_items: Option<AlignItems>,
+    pub justify_self: Option<AlignSelf>,
+    pub justify_content: Option<JustifyContent>,
+    pub text_align: TextAlign,
+
+    // ----- flex -----
+    pub flex_direction: FlexDirection,          // Row | RowReverse | Column | ColumnReverse
+    pub flex_wrap: FlexWrap,                    // NoWrap | Wrap | WrapReverse
+    pub flex_basis: Dimension,
+    pub flex_grow: f32,                         // default 0.0
+    pub flex_shrink: f32,                       // default 1.0
+
+    // ----- grid -----
+    pub grid_template_rows: Vec<GridTemplateComponent<S>>,
+    pub grid_template_columns: Vec<GridTemplateComponent<S>>,
+    pub grid_auto_rows: Vec<TrackSizingFunction>,
+    pub grid_auto_columns: Vec<TrackSizingFunction>,
+    pub grid_auto_flow: GridAutoFlow,
+    pub grid_template_areas: Vec<GridTemplateArea<S>>,
+    pub grid_template_row_names: Vec<Vec<S>>,
+    pub grid_template_column_names: Vec<Vec<S>>,
+    pub grid_row: Line<GridPlacement<S>>,
+    pub grid_column: Line<GridPlacement<S>>,
+
+    // ----- floats (>=0.10, feature = "float_layout") -----
+    pub float: Float,
+    pub clear: Clear,
+}
+```
+
+Most consumers never touch most of these fields. The idiomatic constructor is
+`Style { ..Default::default() }`, in which everything is set to the CSS default. The
+defaults are chosen so that an unstyled tree behaves the same as an unstyled CSS document
+under the chosen `Display`.
+
+### Display Modes
+
+`Display` selects which algorithm runs on a node's children:
+
+```rust
+pub enum Display {
+    Block,   // CSS block formatting context
+    Flex,    // CSS Flexbox
+    Grid,    // CSS Grid
+    None,    // node and descendants are skipped
+}
+```
+
+The default is `Flex` (assuming the `flexbox` feature is enabled), which matches the
+preference of most Taffy-consuming UI frameworks. Switching modes is per-node: a flex
+container can contain a grid container, which can contain a block container, exactly as in
+HTML.
+
+### Padding, Margin, Border, Gap
+
+Taffy uses the CSS box model verbatim. Every node has, from outside in:
+
+1. **Margin** -- space _outside_ the border; collapses in block flow, never in flex/grid.
+2. **Border** -- visible (or not) edge; Taffy reserves the space, but does not paint it.
+3. **Padding** -- space _inside_ the border, before content.
+4. **Content** -- the area children flow into.
+
+`box_sizing` toggles between `ContentBox` (the size set on `size` is the content box) and
+`BorderBox` (the size includes border + padding).
+
+`gap` controls space between flex items in a line, between flex lines when wrapping, and
+between grid tracks. It is `Size<LengthPercentage>`, allowing different row-gap and
+column-gap values.
+
+### Alignment
+
+The alignment vocabulary is the union of Flexbox's and Grid's:
+
+```rust
+pub enum AlignItems {
+    Start, End, FlexStart, FlexEnd,
+    Center, Baseline, Stretch,
+}
+pub type AlignSelf = AlignItems;
+
+pub enum AlignContent {
+    Start, End, FlexStart, FlexEnd,
+    Center, Stretch, SpaceBetween, SpaceEvenly, SpaceAround,
+}
+pub type JustifyContent = AlignContent;
+```
+
+For Flexbox: `justify_content` controls main-axis alignment, `align_items`/`align_self`
+control cross-axis alignment of single items, `align_content` controls the cross-axis
+alignment of _lines_ when wrapping. For Grid: `justify_*` runs on the inline axis,
+`align_*` on the block axis, and the same vocabulary is reused.
+
+### Measure-Arrange Protocol
+
+Taffy implements a two-phase **measure / arrange** protocol, although it does not expose
+the phases separately. From the caller's perspective, a single call to `compute_layout`
+runs both. Internally, layout proceeds as follows:
+
+1. **Style cascade is skipped.** Taffy does not implement CSS inheritance; every node's
+   style is independent. Callers do their own inheritance up-front.
+
+2. **Measure pass.** For each leaf, Taffy asks "how big are you?" If a measure function
+   was supplied, it is called with the known dimensions, available space, node ID, optional
+   context, and the node's `Style`. If no measure function is supplied (or this node is
+   not a leaf), the node's intrinsic size is `Size::ZERO`.
+
+3. **Layout pass.** For each container, Taffy runs the algorithm selected by `display`:
+   block, flex, or grid. Each algorithm distributes the available space among children
+   according to the appropriate spec.
+
+4. **Cache writeback.** Each node's `Layout` is written into a slotmap-backed cache,
+   keyed on the `(NodeId, AvailableSpace, MeasureMode)` triple. Subsequent
+   `compute_layout` calls with the same inputs are O(1).
+
+The measure-function signature reads:
+
+```rust
+FnMut(
+    known_dimensions: Size<Option<f32>>,
+    available_space:  Size<AvailableSpace>,
+    node_id:          NodeId,
+    node_context:     Option<&mut Context>,
+    style:            &Style,
+) -> Size<f32>
+```
+
+This shape is the single seam between Taffy and the rest of the world. For text, the
+measure function calls into a text-shaping library (cosmic-text, parley, swash, ...). For
+images, it returns the intrinsic image size. For terminal cells, it returns
+`Size { width: cells_wide as f32, height: lines_tall as f32 }`.
+
+### Code Example: Flexbox Column
+
+```rust
+use taffy::prelude::*;
+
+let mut tree: TaffyTree<()> = TaffyTree::new();
+
+let header = tree.new_leaf(Style {
+    size: Size { width: length(800.0), height: length(100.0) },
+    ..Default::default()
+}).unwrap();
+
+let body = tree.new_leaf(Style {
+    size: Size { width: length(800.0), height: auto() },
+    flex_grow: 1.0,
+    ..Default::default()
+}).unwrap();
+
+let footer = tree.new_leaf(Style {
+    size: Size { width: length(800.0), height: length(40.0) },
+    ..Default::default()
+}).unwrap();
+
+let root = tree.new_with_children(Style {
+    flex_direction: FlexDirection::Column,
+    size: Size { width: length(800.0), height: length(600.0) },
+    gap: Size { width: length(0.0), height: length(8.0) },
+    ..Default::default()
+}, &[header, body, footer]).unwrap();
+
+tree.compute_layout(root, Size::MAX_CONTENT).unwrap();
+
+let body_layout = tree.layout(body).unwrap();
+println!("body @ {:?} size {:?}", body_layout.location, body_layout.size);
+```
+
+The `prelude` re-exports the helper functions `length(x)`, `percent(x)`, `auto()`, and
+`fr(x)`, which produce the right enum variant for whichever style field they are passed
+into.
+
+### Code Example: CSS Grid
+
+```rust
+use taffy::prelude::*;
+
+let mut tree: TaffyTree<()> = TaffyTree::new();
+
+let cell = |t: &mut TaffyTree<()>| t.new_leaf(Style::default()).unwrap();
+
+let a = cell(&mut tree);
+let b = cell(&mut tree);
+let c = cell(&mut tree);
+let d = cell(&mut tree);
+
+let root = tree.new_with_children(Style {
+    display: Display::Grid,
+    size: Size { width: length(600.0), height: length(400.0) },
+    grid_template_columns: vec![
+        TrackSizingFunction::from_length(120.0),  // sidebar
+        TrackSizingFunction::fr(1.0),             // main, takes leftover
+        TrackSizingFunction::fr(1.0),             // detail, equal share
+    ],
+    grid_template_rows: vec![
+        TrackSizingFunction::from_length(40.0),   // header
+        TrackSizingFunction::fr(1.0),             // body
+    ],
+    gap: Size { width: length(8.0), height: length(8.0) },
+    ..Default::default()
+}, &[a, b, c, d]).unwrap();
+
+tree.compute_layout(root, Size::MAX_CONTENT).unwrap();
+```
+
+Without `grid_row` / `grid_column` placement, items auto-flow into the grid in
+declaration order according to `grid_auto_flow` (defaults to `Row`).
+
+### Code Example: Custom Measure Function
+
+```rust
+use taffy::prelude::*;
+
+#[derive(Clone, Copy)]
+enum LeafKind { Text(&'static str), Image(f32, f32) }
+
+let mut tree: TaffyTree<LeafKind> = TaffyTree::new();
+
+let title = tree.new_leaf_with_context(
+    Style::default(),
+    LeafKind::Text("Hello, world"),
+).unwrap();
+
+let avatar = tree.new_leaf_with_context(
+    Style::default(),
+    LeafKind::Image(64.0, 64.0),
+).unwrap();
+
+let root = tree.new_with_children(Style {
+    flex_direction: FlexDirection::Row,
+    gap: Size { width: length(12.0), height: length(0.0) },
+    ..Default::default()
+}, &[avatar, title]).unwrap();
+
+tree.compute_layout_with_measure(
+    root,
+    Size { width: AvailableSpace::Definite(400.0), height: AvailableSpace::MaxContent },
+    |known, avail, _id, ctx, _style| {
+        match ctx.copied() {
+            Some(LeafKind::Image(w, h)) => Size { width: w, height: h },
+            Some(LeafKind::Text(s)) => {
+                let max_w = match avail.width {
+                    AvailableSpace::Definite(w) => w,
+                    _ => f32::INFINITY,
+                };
+                // Pretend we shaped text and got these dimensions back.
+                let natural = s.chars().count() as f32 * 7.0;
+                let width = known.width.unwrap_or(natural.min(max_w));
+                let lines = ((natural / width).ceil()).max(1.0);
+                Size { width, height: lines * 16.0 }
+            }
+            None => Size::ZERO,
+        }
+    },
+).unwrap();
+```
+
+This is the canonical shape of integrating Taffy with a text shaper: the measure function
+closes over the application's font and asset caches, and decides per-leaf how to compute
+intrinsic dimensions.
+
+### Code Example: Block + Flex Composition
+
+```rust
+use taffy::prelude::*;
+
+let mut tree: TaffyTree<()> = TaffyTree::new();
+
+let para_a = tree.new_leaf(Style::default()).unwrap();
+let para_b = tree.new_leaf(Style::default()).unwrap();
+
+let article = tree.new_with_children(Style {
+    display: Display::Block,
+    padding: Rect::length(16.0),
+    ..Default::default()
+}, &[para_a, para_b]).unwrap();
+
+let sidebar = tree.new_leaf(Style {
+    size: Size { width: length(220.0), height: auto() },
+    ..Default::default()
+}).unwrap();
+
+let page = tree.new_with_children(Style {
+    display: Display::Flex,
+    flex_direction: FlexDirection::Row,
+    size: Size { width: length(960.0), height: auto() },
+    gap: Size { width: length(24.0), height: length(0.0) },
+    ..Default::default()
+}, &[sidebar, article]).unwrap();
+
+tree.compute_layout(page, Size::MAX_CONTENT).unwrap();
+```
+
+The outer container uses Flex to lay out sidebar + article side by side; the inner
+`article` switches to `Block` so its paragraph children stack vertically with margin
+collapsing, exactly like HTML.
+
+---
+
+## Bindings / Language Support
+
+Taffy itself is a Rust crate. Unlike Stretch, which shipped first-class FFI bindings,
+Taffy leaves binding generation to downstream consumers. In practice:
+
+- **C FFI** is provided by community crates such as `taffy_ffi`. Because the API is small
+  (mostly `compute_layout`, `set_style`, `add_child`), wrapping it by hand is also a
+  reasonable approach.
+- **WebAssembly.** Taffy compiles cleanly to `wasm32-unknown-unknown` and is used inside
+  WASM browsers (Servo's WASM build, Blitz). Downstream wrappers expose it to JavaScript
+  via `wasm-bindgen`.
+- **Bevy** vendors Taffy as an internal dependency for its UI plugin; Bevy users never
+  call Taffy directly.
+- **Slint** uses Taffy via a private interface for items that opt into CSS-like layout.
+- **GPUI / Zed** uses Taffy for its element layout, with GPUI-specific element traits as
+  the public API.
+
+The pattern is consistent: Taffy is treated as a _library that frameworks use_, not as a
+library that applications use. The vocabulary of `Style` and `Dimension` shows up in
+those frameworks, sometimes 1-to-1 (Floem), sometimes wrapped in framework-specific
+helpers (Bevy's `Node`, GPUI's `Style`).
+
+---
+
+## Strengths and Weaknesses
+
+### For the UI-Layout Catalog Domain
+
+**Strengths.**
+
+- **Three algorithms in one engine.** Most layout libraries (Yoga, Stretch, classic
+  Cassowary solvers) implement only one model. Taffy is the only widely-used Rust engine
+  that ships Flexbox, Grid, _and_ Block under a single API. For a sparkles-style catalog
+  this matters because the choice between algorithms is per-page: a CLI dashboard's outer
+  shell might be a 3-row Grid, an inner toolbar a Flex row, and a help section a Block of
+  paragraphs.
+- **Spec fidelity.** Taffy is tested against the WPT (Web Platform Tests) suite where
+  applicable, and against fixtures generated by headless Chrome for the rest. The
+  practical consequence: if a layout works in a browser, it almost certainly works in
+  Taffy, and if it does not, that is a bug Taffy is interested in fixing.
+- **Renderer-agnostic.** Nothing about Taffy assumes pixels; the `f32` "unit" is whatever
+  the caller decides it is. For a terminal layout it can be character cells, and the
+  Cassowary-like distribution behaviour falls out naturally.
+- **Active maintenance.** DioxusLabs has shipped Taffy releases continuously since 2022,
+  with a steady cadence of bugfixes and feature additions. It is the de-facto choice for
+  any Rust UI framework that does not want to write its own layout engine.
+
+**Weaknesses.**
+
+- **Heavyweight vocabulary.** The `Style` struct has thirty-plus fields, including
+  fifteen that are only meaningful for CSS Grid. For a simple Flexbox-only consumer this
+  is a lot of irrelevant surface area. Feature flags reduce _compiled_ code, but not the
+  size of the public API.
+- **No styling, no events, no rendering.** Taffy is pure layout. Consumers must supply
+  their own text shaper, their own colour and font model, their own input system. For a
+  catalog comparing against, e.g., [Ratatui](../tui-libraries/ratatui.md) (which bundles
+  layout + widgets + buffering) or [Textual](../tui-libraries/textual.md) (full TUI
+  framework), Taffy is at a much lower abstraction level.
+- **`f32` units are awkward for terminals.** Terminals are integer grids. Mixing `f32`
+  layout with character cells means rounding policy becomes a real concern: do you floor,
+  ceil, round-to-nearest? Taffy lets the caller decide, but that decision is non-trivial
+  and easy to get wrong (off-by-one cells on resize is a common Taffy-in-terminal bug).
+- **No incremental tree diffing.** The cache invalidates on `set_style`, but there is no
+  "this subtree did not change, skip it" hook beyond cache hits. Frameworks like GPUI add
+  their own layer on top.
+
+### For Static One-Shot Rendering
+
+Sparkles' main near-term consumer is the `drawTable` helper, which renders a single
+non-interactive table once and exits. For that use case, Taffy is overkill in some ways
+and underwhelming in others.
+
+- **Overkill.** A table draw needs roughly two things: figure out per-column widths from
+  content, then stamp the cells. Taffy can do that --- it amounts to a one-row Flex
+  container with shrink-to-fit columns, or equivalently a one-row Grid with
+  `auto`-sized columns. But pulling in a 30k-LOC layout engine to compute four column
+  widths is the kind of dependency cost that is hard to justify.
+- **Underwhelming.** Conversely, Taffy does not solve the _actual_ hard parts of static
+  rendering: ANSI escape generation, Unicode width tables, grapheme-cluster handling,
+  styled-text composition. All of these are _upstream_ of measurement (the measure
+  function needs to know the width of a piece of text) and _downstream_ of layout (the
+  arranged rects need to be rendered with ANSI escapes). A consumer would still need to
+  write or import all of that.
+- **What is genuinely useful.** The _vocabulary_ of `Length`, `Percent`, `Auto`, `Fr`,
+  `Min`/`Max`/`MinMax` is excellent. It cleanly expresses the column-sizing problem ("two
+  fixed columns, one auto, one taking the rest") that every drawTable consumer eventually
+  hits. Even without using Taffy itself, copying this vocabulary into a sparkles-internal
+  layout API would be a substantial usability win over ad-hoc `int width / int weight`
+  pairs.
+
+### Compared to Alternatives
+
+| Compared with                                 | Where Taffy wins                                                | Where Taffy loses                                                                      |
+| --------------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [Stretch](stretch.md)                         | Maintained; adds Grid, Block, RTL, named lines, floats.         | Larger API surface; loses Stretch's official FFI bindings.                             |
+| Yoga (Facebook, used by Ink/Reaqct Native)    | Pure Rust; Grid + Block in addition to Flex; no C++ dependency. | Yoga has a larger ecosystem in mobile UI and is the runtime behind React Native + Ink. |
+| [Ratatui](../tui-libraries/ratatui.md) layout | Generic algorithms (Flex, Grid, Block) not just kasuari-driven. | Ratatui's `Constraint` is purpose-built for terminals and integrates with widgets.     |
+| [Ink](../tui-libraries/ink.md) / Yoga in JS   | Native Rust; embeds in any framework.                           | Ink offers a full retained-mode CLI framework; Taffy is layout-only.                   |
+| Kasuari / Cassowary constraint solvers        | Algorithmic familiarity (CSS); incremental cache.               | Cassowary expresses arbitrary linear constraints; Taffy is limited to CSS algorithms.  |
+| Manual `int x, y, w, h` arithmetic            | Handles wrapping, alignment, grid, baseline, ...                | Pulls in a ~30k-LOC dependency for cases where two `min`/`max`/`sum` calls suffice.    |
+
+The honest summary: **Taffy is the right answer when "this looks like CSS layout" is
+true** --- multi-pane dashboards, resizable splits, intrinsic-content sizing across many
+elements, grid-shaped UIs. For one-shot terminal output of a known shape (a single table,
+a single tree, a single status line), the dependency cost is hard to justify, but the
+_vocabulary_ (`Length`/`Percent`/`Auto`/`Fr`) is worth borrowing wholesale.
+
+---
+
+## References
+
+- **Repository:** <https://github.com/DioxusLabs/taffy>
+- **Crate:** <https://crates.io/crates/taffy>
+- **API docs (current):** <https://docs.rs/taffy/>
+  - `TaffyTree`: <https://docs.rs/taffy/latest/taffy/tree/struct.TaffyTree.html>
+  - `Style`: <https://docs.rs/taffy/latest/taffy/style/struct.Style.html>
+  - `Display`: <https://docs.rs/taffy/latest/taffy/style/enum.Display.html>
+  - `Dimension`, `LengthPercentage`, `LengthPercentageAuto`: see `taffy::style`
+- **Release notes / changelog:** <https://github.com/DioxusLabs/taffy/blob/main/CHANGELOG.md>
+- **Notable adopters:**
+  - Bevy UI: <https://github.com/bevyengine/bevy>
+  - Zed editor (via GPUI): <https://github.com/zed-industries/zed>
+  - Servo browser engine: <https://github.com/servo/servo>
+  - Blitz: <https://github.com/DioxusLabs/blitz>
+  - Slint: <https://github.com/slint-ui/slint>
+  - Floem (Lapce editor): <https://github.com/lapce/floem>
+- **Predecessor:** [Stretch](stretch.md) (this catalog)
+- **Related TUI libraries:**
+  - [Ratatui](../tui-libraries/ratatui.md) --- its `Constraint` enum is a single-axis
+    cousin of Taffy's track-sizing vocabulary.
+  - [Ink](../tui-libraries/ink.md) --- the JS-side equivalent of Taffy-embedded-in-a-framework.
+  - [Textual](../tui-libraries/textual.md) --- ships its own CSS-driven layout, conceptually similar.
+  - [Bubble Tea](../tui-libraries/bubbletea.md) --- contrasts with Taffy: no layout engine, all layout is by hand.
+
+[stretch-repo]: https://github.com/vislyhq/stretch

--- a/docs/research/ui-layout/tex-knuth-plass.md
+++ b/docs/research/ui-layout/tex-knuth-plass.md
@@ -1,0 +1,628 @@
+# TeX / Knuth-Plass Line-Breaking
+
+The line-breaking algorithm described in Donald E. Knuth and Michael F. Plass's
+1981 paper _Breaking Paragraphs into Lines_ (Software: Practice & Experience,
+volume 11, number 11) and shipped with TeX since 1978. The algorithm replaces the
+near-universal "fit as many words on each line as possible" greedy heuristic with
+a **global** dynamic-programming optimisation over an entire paragraph, treating
+text as a stream of _boxes_, _glue_, and _penalties_ and selecting the set of
+break-points that minimises a sum of squared _demerits_. The result -- visible in
+any TeX document -- is paragraphs noticeably more uniform in spacing than those
+produced by browsers or word processors.
+
+| Field                  | Value                                                                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Original paper         | D. E. Knuth, M. F. Plass, _Breaking Paragraphs into Lines_, Software: Practice & Experience 11 (1981), pp. 1119--1184 |
+| Reprint                | Chapter 3 of D. E. Knuth, _Digital Typography_, CSLI Publications, 1999, ISBN 1-57586-010-4                           |
+| First shipped in       | TeX (Knuth, 1978; rewritten in WEB 1982)                                                                              |
+| Complexity             | O(n) amortised with passive-node pruning; O(n\*L) worst case where L is the look-back window                          |
+| Algorithm class        | Single-source shortest path / dynamic programming over a DAG of feasible break-points                                 |
+| Reference impl.        | TeX `\linebreak` machinery, modules 813--880 of `tex.web`                                                             |
+| Modern implementations | TeX, eTeX, pdfTeX, LuaTeX, XeTeX, ConTeXt, SILE; standalone JS port `knuthplass`; CSS `text-wrap: pretty`             |
+| Authors                | Donald E. Knuth (Stanford), Michael F. Plass (Xerox PARC, later)                                                      |
+
+---
+
+## Overview
+
+### What It Solves
+
+Given a paragraph of text and a line width (or sequence of line widths), produce
+a sequence of line breaks. The naive solution -- the "first-fit" or "greedy"
+algorithm -- walks left to right, accumulating words until the next word would
+overflow, then breaks. The greedy algorithm is local, fast, and produces lines
+that match a human reading "this fits, this doesn't". It is also the algorithm
+implemented by ([virtually every browser at the time of writing][css-normal-flow]
+for normal flow), every classic word processor, every CLI `fold(1)` utility, and
+every TUI library that paragraph-wraps text without further qualification.
+
+Greedy line-breaking has two characteristic failure modes that the Knuth-Plass
+paper documents at length:
+
+1. **Last-line problems.** A greedy algorithm makes no attempt to leave a
+   reasonable amount of text on the final line. The final line of a paragraph
+   under greedy breaking is frequently a single word -- a "widow" of the
+   paragraph, not the page -- because the previous lines were each packed as
+   tightly as possible.
+2. **Inter-line spacing variance.** Each greedy line is packed to "just under
+   the maximum"; when the algorithm finally breaks, the surplus space falls on
+   that single line. Justified output therefore has lines whose stretch varies
+   widely: one line is comfortably set, the next stretches by 30%. Knuth and
+   Plass's central observation is that _a slightly worse fit early in the
+   paragraph can produce a strictly better overall fit_, but a greedy
+   algorithm cannot see this.
+
+Knuth-Plass formulates line-breaking as an optimisation over the entire
+paragraph: choose the set of break-points that minimises the sum of a
+per-line _demerit_ function. Because demerits grow quadratically with how far a
+line stretches or shrinks from its natural width, the optimal solution
+distributes the stretch _evenly_ across lines.
+
+### Design Philosophy
+
+The paper articulates four design constraints:
+
+1. **The model must be data-driven**, not algorithm-driven. Different scripts,
+   different font metrics, different break-point conventions
+   (hyphenation/no-hyphenation, em-dash kerning, ...) are encoded in the
+   _input_ sequence of boxes/glue/penalties, not by special-casing the
+   algorithm.
+2. **The optimisation function must respect human typographic judgement.**
+   Demerits include not only "how stretched is this line" but "how different is
+   the stretch from the previous line" (a _fitness class_ penalty), "did we
+   hyphenate two lines in a row" (a _flagged-penalty_ penalty), and "did we
+   leave a widow on the last line".
+3. **The algorithm must run in linear time on real input.** Knuth and Plass
+   demonstrate that with a bounded active-set (typically 8--10 active nodes per
+   break-point), the algorithm runs in time linear in the paragraph length on
+   practical input.
+4. **There must be an escape hatch.** When the optimisation finds no feasible
+   layout (because no set of breaks can fit the text), the algorithm relaxes
+   constraints in well-defined stages: first allow over-full lines (returning
+   the famous TeX warning "Overfull \hbox..."), then allow hyphenation, then
+   re-run with a tolerance parameter raised.
+
+### History
+
+- **~1977.** Knuth begins TeX as a typesetting system for _The Art of Computer
+  Programming_. An unpublished memo dated 1977 sketches the dynamic-programming
+  approach to line-breaking; Plass, then a PhD student at Stanford, joins to
+  formalise it.
+- **1978.** First version of TeX (TeX78) ships with an early form of the
+  algorithm.
+- **1981.** Knuth and Plass publish _Breaking Paragraphs into Lines_ in
+  _Software: Practice & Experience_. The paper presents the algorithm, the
+  badness/demerits formulae, and the analyses of greedy vs. global breaking
+  using paragraphs from _The Art of Computer Programming_ and works by Lewis
+  Carroll and others as examples.
+- **1982.** TeX82, rewritten in Knuth's WEB literate-programming system,
+  contains the canonical implementation that almost every later port descends
+  from.
+- **1999.** Knuth republishes the paper as Chapter 3 of _Digital Typography_
+  with a retrospective addendum.
+- **2003 onwards.** pdfTeX, LuaTeX, XeTeX extend TeX while keeping the
+  line-breaking core. Hans Hagen's ConTeXt, Simon Cozens's SILE, and Bram
+  Stein's `typeset` rebuild the algorithm in modern languages
+  (C, Lua, JavaScript).
+- **2010s onwards.** Brian Tingley's [`knuthplass`][knuthplass-js] JS library is
+  used in web typography demos. Bram Stein's [`typeset`][typeset-js]
+  generalises it to SVG/canvas.
+- **2023.** Chromium and WebKit ship `text-wrap: balance` and `text-wrap:
+pretty` (CSS Text Level 4), the latter using a Knuth-Plass-like algorithm for
+  paragraph balancing in normal flow. See
+  ([css-normal-flow.md][css-normal-flow]) for the browser-wrapping comparison.
+- **2010s--2020s.** A few CLI/terminal projects experiment with optimal
+  line-breaking. Andrew Kelley (author of the Zig programming language) has
+  publicly discussed applying Knuth-Plass to terminal text. The pattern is
+  uncommon enough that the question "why doesn't `fold` use Knuth-Plass?"
+  recurs on Stack Overflow every few years.
+
+---
+
+## Layout Model
+
+### The Box/Glue/Penalty Stream
+
+Input to the algorithm is a _horizontal list_ -- a sequence of three kinds of
+items:
+
+```
+data Item = Box      { width :: Double, content :: Content }
+          | Glue     { width :: Double, stretch :: Double, shrink :: Double }
+          | Penalty  { width :: Double, cost :: Int, flagged :: Bool }
+```
+
+- A **Box** is an atomic, unbreakable unit -- typically a character or a
+  pre-shaped word. Its `width` is the typeset width on the page. Boxes are
+  never split.
+- **Glue** is a stretchable, shrinkable space. Each glue item carries a
+  _natural width_ (the width when no adjustment is needed), a _stretchability_
+  (how far it can grow before the algorithm gives up), and a _shrinkability_
+  (how far it can be compressed; never below `width - shrink`).
+- A **Penalty** is a point in the stream where a line break may or may not
+  occur. Its `cost` is an integer in `[-infinity, +infinity]`: `-infinity`
+  forces a break (e.g. end of paragraph), `+infinity` forbids one (e.g.
+  between a number and its units). A `flagged` penalty is one that, when used
+  consecutively, accrues an additional aesthetic penalty -- this is how TeX
+  discourages hyphenating two lines in a row.
+
+A break may occur at a `Glue` item _immediately preceded by a `Box`_ (so that
+white space between words is a valid break candidate, but white space at the
+start of a paragraph is not), or at any `Penalty` whose cost is less than
+`+infinity`.
+
+This three-element vocabulary is enough to describe paragraphs, lists,
+mathematical formulae, displayed equations, justified vs. ragged text, French
+spacing, and a hundred other typographic phenomena -- the algorithm itself
+never changes; only the input stream does.
+
+### Badness
+
+For each candidate line spanning items `i .. j`, the algorithm computes an
+_adjustment ratio_ `r`:
+
+```
+let W = sum of widths of items (i..j)
+let X = target line width
+let Y = sum of stretchability of glue items in (i..j)
+let Z = sum of shrinkability of glue items in (i..j)
+
+r = (X - W) / Y   if X >= W   (line needs to stretch)
+  = (X - W) / Z   if X <  W   (line needs to shrink)
+```
+
+When `r = 0` the line fits exactly. Positive `r` means glue stretches; negative
+`r` means glue shrinks. `r = -1` is the maximum shrink (every shrinkable glue
+fully compressed); `r < -1` is infeasible.
+
+The **badness** of a line is then:
+
+```
+badness = 10000              if r < -1 or r > tolerance (infeasible)
+        = 100 * |r|^3        otherwise
+```
+
+The cubic term penalises stretches and shrinks superlinearly: a line stretched
+by 50% is 8x worse than one stretched by 25%, not 2x. This is the formal
+expression of the typographic intuition that _very_ stretched lines are visibly
+ugly while moderately stretched ones are tolerable.
+
+### Demerits
+
+Each feasible line's _demerits_ combine its badness with break-point penalties
+and inter-line aesthetic costs:
+
+```
+let bad = badness of the line
+let pen = penalty cost at the break-point (0 for glue breaks)
+let linep = a global "line penalty" constant (e.g. 10 in plain TeX)
+let hyph = 3000 if both this line and the previous one ended with a flagged
+                  penalty (consecutive hyphenations), else 0
+
+demerits = (linep + bad)^2 + sign(pen) * pen^2 + hyph
+
+   where sign(pen) * pen^2 means:
+     +pen^2   if pen >= 0
+     -pen^2   if -infinity < pen < 0   (reward for explicit good breaks)
+     not added at all if pen = -infinity (forced break)
+```
+
+The squaring of `(linep + bad)` is the key non-linearity. It means a paragraph
+with three lines of badness 10 (total `3 * (10+10)^2 = 1200`) beats one with two
+lines of badness 0 and one of badness 30 (total `(10)^2 + (10)^2 + (10+30)^2 =
+1800`). Smoothing wins over packing.
+
+A **fitness class** is also tracked: each feasible line is classified by its
+adjustment ratio into one of four buckets (`< -0.5`, `[-0.5, 0.5]`, `[0.5, 1]`,
+`> 1`). When two adjacent lines fall in non-adjacent classes, an extra
+_adjacent-line_ demerit is added. This penalises "tight then loose" transitions
+even when each line in isolation is fine.
+
+### The Dynamic Programming Algorithm
+
+Knuth and Plass cast the problem as a single-source shortest-path search in a
+DAG. Vertices are _active break-points_; edges are feasible lines; edge weights
+are demerits. The shortest path from the paragraph start to the paragraph end
+is the optimal layout.
+
+Pseudocode (transcribed from §3 of the paper, simplified):
+
+```
+ACTIVE := { (start, line=0, fitness=class_2, demerits=0) }
+
+for b in 1 .. n:                          -- each candidate break-point
+    feasible := []
+    for a in ACTIVE:
+        r := adjustment_ratio(a.position, b)
+        if r < -1:                        -- this line shrinks too much
+            ACTIVE.remove(a)              -- (and all later breaks from a
+                                          --  are also infeasible: prune)
+        else if -1 <= r <= rho:           -- rho = tolerance, default 200
+            d := demerits(a, b, r)
+            feasible.append( (predecessor=a, total=a.demerits+d) )
+    if not empty(feasible):
+        best := argmin(feasible, key=total)
+        ACTIVE.add( BreakNode(position=b,
+                              line=best.predecessor.line + 1,
+                              fitness=fitness_class(r),
+                              demerits=best.total,
+                              prev=best.predecessor) )
+
+best_final := argmin(ACTIVE where position is end-of-paragraph, key=demerits)
+return reconstruct(best_final)
+```
+
+The crucial efficiency observation is that an `ACTIVE` node becomes "passive"
+(removable) the moment it is too far back for any _future_ break-point to reach
+without violating the shrink limit (`r < -1`). Because line widths are
+typically a small multiple of average word width, the active set stays around
+8--10 entries at steady state, giving amortised linear behaviour on real text.
+
+When the algorithm finishes with an empty `ACTIVE` and never reached the end,
+TeX falls back: it raises tolerance from 200 to 10000 (i.e. accepts almost any
+stretch) and re-runs. If that also fails, it accepts an overfull box and
+reports "Overfull \hbox by Xpt".
+
+### Three Passes in Practice
+
+TeX's actual line-breaker runs up to three passes:
+
+1. **Pass 1: tolerance 200, no hyphenation.** Find an optimum using only
+   already-broken words. Most well-set paragraphs succeed here.
+2. **Pass 2: tolerance 200, hyphenation.** Introduce hyphenation points (using
+   Liang's hyphenation algorithm) and try again. This is where flagged
+   penalties earn their demerits.
+3. **Pass 3: tolerance 9999, hyphenation, allow overfull.** Accept whatever fit
+   is least bad; report.
+
+Each pass shares the same algorithm; only the input stream's penalties change.
+
+### A Worked Example
+
+Consider the input stream (simplified) for the text "the quick brown fox":
+
+```
+Box "the"      width 18
+Glue           width  3  stretch  2  shrink  1
+Box "quick"    width 30
+Glue           width  3  stretch  2  shrink  1
+Box "brown"    width 28
+Glue           width  3  stretch  2  shrink  1
+Box "fox"      width 18
+Penalty        cost -10000  (end of paragraph)
+```
+
+For a line width of 50, the candidate break-points after each glue produce:
+
+| Break after | Line text         | Width | Adj. ratio    | Badness                        |
+| ----------- | ----------------- | ----- | ------------- | ------------------------------ |
+| "the"       | "the"             | 18    | (50-18)/2=16  | ~infeasible (stretch too high) |
+| "quick"     | "the quick"       | 51    | (50-51)/1=-1  | 100\*1^3=100                   |
+| "brown"     | "the quick brown" | 82    | (50-82)/2=-16 | infeasible (shrink too high)   |
+
+For 26-wide lines, the algorithm explores three- and four-line layouts and
+picks the one minimising squared demerits. With cubic badness, a layout with
+three moderately stretched lines beats one with two perfect lines and one
+heavily stretched line.
+
+### Reference Implementation Sketch (Haskell)
+
+A concise Haskell implementation, adapted from Knuth/Plass §6:
+
+```haskell
+data Item = Box Double | Glue Double Double Double | Penalty Double Int Bool
+
+type Position = Int      -- index into the item stream
+data Node = Node { pos      :: !Position
+                 , line     :: !Int
+                 , fitness  :: !Fitness
+                 , width    :: !Double      -- cumulative width up to pos
+                 , stretch  :: !Double
+                 , shrink   :: !Double
+                 , demerits :: !Double
+                 , prev     :: Maybe Node
+                 }
+
+knuthPlass :: [Item] -> Double -> Double -> [Position]
+knuthPlass items lineWidth tolerance =
+    reconstruct $ minimumBy (comparing demerits) finalNodes
+  where
+    items'      = zip [0..] items
+    initial     = Node 0 0 Class2 0 0 0 0 Nothing
+    finalNodes  = foldl' step [initial] items'
+
+    step active (b, item)
+        | isBreakable item =
+            let candidates = mapMaybe (tryBreak b item) active
+                best       = bestByLineCount candidates
+                pruned     = prune b active
+            in pruned ++ best
+        | otherwise = active
+
+    tryBreak b item a =
+        let r = adjustmentRatio a b lineWidth
+        in if r < -1 || r > tolerance
+             then Nothing
+             else Just $ Node b (line a + 1) (fitClass r)
+                              (cumWidth b) (cumStretch b) (cumShrink b)
+                              (demerits a + lineDemerits a r item) (Just a)
+
+    reconstruct n = case prev n of
+                      Nothing -> [pos n]
+                      Just p  -> reconstruct p ++ [pos n]
+```
+
+This omits the cumulative-width book-keeping (which in a production
+implementation is done with running sums to make `adjustmentRatio` O(1)) but
+captures the structural shape: a fold over the item stream that maintains an
+active set, computing feasible predecessors at each break candidate.
+
+### Reference Implementation Sketch (Python-like)
+
+The same algorithm, in a more procedural style closer to TeX's WEB source
+(modules 829--862 of `tex.web`):
+
+```python
+def knuth_plass(items, line_width, tolerance=200, line_penalty=10):
+    active = [Node(position=0, line=0, fitness=1, demerits=0, prev=None)]
+    cumW = cumY = cumZ = 0.0     # cumulative width, stretch, shrink
+
+    for b, item in enumerate(items):
+        if isinstance(item, Box):
+            cumW += item.width
+            continue
+        if isinstance(item, Glue):
+            if b > 0 and isinstance(items[b-1], Box):
+                # candidate break-point at this glue
+                explore_break(active, b, cumW, cumY, cumZ,
+                              line_width, tolerance, line_penalty)
+            cumW += item.width
+            cumY += item.stretch
+            cumZ += item.shrink
+            continue
+        if isinstance(item, Penalty) and item.cost < INF:
+            explore_break(active, b, cumW, cumY, cumZ,
+                          line_width, tolerance, line_penalty,
+                          penalty=item.cost, flagged=item.flagged)
+
+    end = min((a for a in active if a.position == len(items) - 1),
+              key=lambda a: a.demerits)
+    return reconstruct(end)
+```
+
+`explore_break` is the inner loop: for each `a in active`, compute the
+adjustment ratio of a hypothetical line from `a` to `b`, drop `a` if it can
+never feasibly reach `b` (prune), and if the line is feasible insert a new
+active node at `b` recording `a` as predecessor.
+
+### Adapting to Terminal Output
+
+Translating the algorithm to terminal/CLI prose wrapping requires only that
+"widths" become "columns":
+
+- A `Box` is a _grapheme cluster_ (or, more practically, a word's width
+  measured by Unicode display-width tables like `wcwidth(3)` -- East Asian
+  wide characters count as 2, combining marks as 0).
+- The natural width of a `Glue` is 1 (one space). Most terminal renderers do
+  not have access to true stretchable glue: a column is either occupied or
+  not. The closest approximation is to model glue stretchability as the
+  _maximum_ extra spaces the renderer is willing to insert (e.g. up to 3
+  extra), or to set stretch to 0 and shrink to 0 and use the algorithm only
+  for ragged-right (unjustified) prose -- in which case it still wins by
+  balancing line lengths.
+- Penalties can be assigned at sentence boundaries (`-100`, "prefer to break
+  here"), after dashes and slashes (`-50`), inside hyphenated compounds
+  (positive penalty discouraging breaks unless necessary), and at clause
+  punctuation.
+- For ragged-right CLI output, the natural metric is "minimise the sum of
+  squared trailing white-space columns" -- the simplification of Knuth-Plass
+  to the case where all glue is rigid. Even this simplified case
+  produces visibly better `--help` and `man`-page wrapping than greedy:
+
+  ```
+  Greedy wrap, width 50:
+    The quick brown fox jumps over the lazy dog and
+    then runs.
+  Knuth-Plass wrap, width 50:
+    The quick brown fox jumps over the lazy
+    dog and then runs.
+  ```
+
+  The greedy output's first line is full and the second contains only two
+  words; the optimal output spreads two words from line one to line two,
+  producing more balanced lines.
+
+### Modern Implementations
+
+| Implementation                        | Language               | Notes                                                                      |
+| ------------------------------------- | ---------------------- | -------------------------------------------------------------------------- |
+| TeX                                   | WEB / Pascal / C       | The canonical implementation; tex.web modules 813--880                     |
+| pdfTeX                                | C                      | Adds protrusion and font expansion (extension)                             |
+| LuaTeX                                | C + Lua                | Exposes line-breaking via the `linebreak_filter` callback                  |
+| XeTeX                                 | C++                    | Same algorithm, Unicode + OpenType                                         |
+| ConTeXt                               | TeX + Lua              | Layered on top of LuaTeX; tweaks the demerit constants                     |
+| SILE                                  | Lua                    | Modern reimplementation by Simon Cozens and Caleb Maclennan; clean Lua API |
+| `knuthplass` (Tingley)                | JavaScript             | Standalone JS port; powers web demos                                       |
+| `typeset` (Stein)                     | JavaScript             | SVG/canvas paragraph setter using Knuth-Plass                              |
+| Microsoft Word's "Optimise paragraph" | C++                    | A balance algorithm shipped in Word 2003+ for justified text               |
+| CSS `text-wrap: pretty`               | C++ (Chromium, WebKit) | Knuth-Plass-style balancing for normal-flow text                           |
+
+For a comparison with the simpler greedy/first-fit algorithm dominant on the
+web, see ([css-normal-flow.md][css-normal-flow]).
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Visibly better paragraphs.** The most cited demonstration is the
+  side-by-side comparison in the original paper of a paragraph from _The Art
+  of Computer Programming_: greedy breaking leaves wildly varying inter-word
+  spacing, Knuth-Plass equalises it. Every TeX document one has ever read is
+  evidence.
+- **Linear time on real input.** Despite formulating the problem as
+  optimisation over a DAG of `O(n^2)` candidate lines, the active-set pruning
+  keeps the practical complexity linear with a small constant.
+- **Composable extensions.** Because the algorithm operates on a stream of
+  boxes/glue/penalties, new typographic features (hyphenation, French spacing,
+  inhibited breaks around URLs, math display) integrate by emitting different
+  items, not by patching the algorithm.
+- **Principled escape hatches.** Three-pass fallback ensures the algorithm
+  always returns _something_: progressively relaxed tolerances and an explicit
+  "overfull" report mean no paragraph is left unset.
+- **Well-studied.** Forty-five years of literature exist. The algorithm is
+  taught in every typography text and analysed extensively in computer-science
+  literature (Plass's own thesis on the NP-hardness of the more general
+  two-dimensional layout problem grew out of this work).
+
+### Weaknesses
+
+- **Integration cost.** A caller must supply the glue/penalty stream. For a
+  CLI program that wants to wrap a string, this means first lexing the string
+  into atoms with width and stretchability information. That is mechanical but
+  not zero work, and rules out simply replacing `printf "%s\n"` with a
+  Knuth-Plass call.
+- **Look-back memory.** The algorithm holds active nodes back to the
+  furthest-feasible predecessor. For pathological input (very narrow columns,
+  long words) the active set can grow; TeX caps it in practice but the bound
+  is empirical.
+- **Two-dimensional layout is out of scope.** Knuth-Plass solves _paragraph_
+  line-breaking. It does not solve page-breaking (which TeX handles with a
+  separate, simpler algorithm), column balancing, or float placement. Plass's
+  PhD thesis showed the two-dimensional version is NP-hard, which is why
+  TeX uses heuristics there.
+- **Table cells are not paragraphs.** Most CLI table output (Sparkles
+  `drawTable`, `column(1)`, `awk` tabular output, ...) wraps each cell to a
+  width that is small relative to the words it contains. With cells of, say,
+  20 columns and words of 8--10 columns, the active set never has more than
+  one or two entries; the algorithm degenerates to greedy. Knuth-Plass shines
+  in long-line prose, not narrow columns.
+- **The terminal lacks stretchable glue.** A monospace grid cannot truly
+  _stretch_ spaces; it can only insert or omit them. Justified output via
+  Knuth-Plass on a monospace terminal therefore looks worse than on a
+  proportional-font page, because the only way to widen a line is to add
+  whole-column spaces. Ragged-right is the natural mode, and there
+  Knuth-Plass is still useful.
+- **Tolerance is a magic number.** TeX's default `tolerance = 200` and
+  `linepenalty = 10` were chosen by Knuth empirically. They work well for
+  English prose at typical book widths. Other scripts (German with its long
+  compounds, Thai with no inter-word spacing, CJK with character-grid
+  breaking) need different defaults, and Knuth-Plass on its own does not
+  guide you.
+- **Implementation complexity.** TeX's line-breaker in `tex.web` runs to
+  ~70 WEB modules and ~1500 lines of Pascal-with-macros. The algorithm is
+  compact, but the production code has a lot of accidental complexity (cursor
+  positions, font expansion, alignment with display math, list
+  reconstruction).
+
+### Lessons for Sparkles
+
+For Sparkles specifically, the relevance is partial but clear:
+
+- **For `drawTable` cells: not directly applicable.** Table cells are too
+  narrow for the global optimisation to outperform greedy. A greedy
+  word-wrapper (already what most CLI table libraries use) is the right
+  choice.
+- **For `--help`, `--man`, and long-form prose output: highly relevant.**
+  Sparkles `core-cli` already pretty-prints structured values; it does not
+  currently pretty-print _prose_. If a future Sparkles feature wraps user-
+  facing prose (`Usage: ...` text, error descriptions, multi-paragraph
+  documentation), a Knuth-Plass-style optimiser would be visible win for
+  paragraphs longer than a few lines.
+- **The box/glue/penalty stream is a natural fit for D.** Sparkles already
+  uses output ranges and `SmallBuffer` for `@nogc` text production. A
+  Knuth-Plass implementation can be entirely `@nogc`: the item stream is a
+  `SmallBuffer!(Item, 256)`, the active set is another `SmallBuffer!(Node,
+16)`, and the demerit arithmetic is pure floating-point.
+- **The simplified ragged-right case is cheap to ship first.** Setting all
+  glue to non-stretchable (`stretch = shrink = 0`) reduces the algorithm to
+  minimising `sum of squared (lineWidth - lineFilled)` over feasible
+  break-point sets -- the _Plass-balancing_ problem. This drops all the
+  hyphenation-passes complexity, runs in true `O(n*w/avgWord)` time, and
+  already gives the bulk of the visible quality improvement over greedy.
+  This is what we would recommend implementing first.
+- **Stop-the-world hyphenation is optional.** Knuth-Plass without hyphenation
+  works fine; one just turns off the second pass. Sparkles does not need to
+  ship a hyphenation dictionary to ship Knuth-Plass wrapping.
+- **A sketch of the API.** A future `sparkles.core_cli.wrap` module could expose:
+
+  ```d
+  @safe pure nothrow @nogc
+  void wrapParagraph(Writer)(
+      scope const(char)[] text,
+      int lineWidth,
+      ref Writer w,
+      WrapOptions opt = WrapOptions.init);
+
+  struct WrapOptions {
+      WrapAlgorithm algorithm = WrapAlgorithm.knuthPlass;
+      int tolerance = 200;       // KP only
+      int linePenalty = 10;      // KP only
+      bool justify = false;      // ragged-right is the default
+  }
+
+  enum WrapAlgorithm { greedy, knuthPlass }
+  ```
+
+  `WrapAlgorithm.greedy` keeps the existing fast path; `WrapAlgorithm.knuthPlass`
+  delivers the better wrap for long-form prose. Both share the same surface
+  API and both can be `@nogc`.
+
+- **Comparison context.** For the contrast with greedy line-breaking dominant
+  in CSS normal flow and almost every CLI text wrapper, see
+  ([css-normal-flow.md][css-normal-flow]). For the wrap-rendering layer of a
+  TUI library that gets this right via paragraph widgets, see
+  ([../tui-libraries/brick.md][brick]) (Brick's `strWrap`/`txtWrap` and the
+  `Paragraph` widget) and ([../tui-libraries/ratatui.md][ratatui]) (Ratatui's
+  `Paragraph::wrap`, which is greedy first-fit).
+
+---
+
+## References
+
+- **Primary paper**: D. E. Knuth, M. F. Plass. _Breaking Paragraphs into
+  Lines_. Software: Practice and Experience, **11**(11):1119--1184,
+  November 1981.
+  PDF mirrors:
+  - <https://www.eprg.org/G53DOC/pdfs/knuth-plass-breaking.pdf>
+  - <http://defoe.sourceforge.net/folio/knuth-plass.html> (analysis + Java reimplementation)
+- **Reprint**: Chapter 3 of D. E. Knuth, _Digital Typography_. CSLI
+  Publications, Stanford, 1999. ISBN 1-57586-010-4.
+- **TeX source**: D. E. Knuth, _TeX: The Program_. Computers & Typesetting
+  Volume B. Addison-Wesley, 1986. ISBN 0-201-13437-3. Modules 813--880 contain
+  the line-breaking machinery in WEB.
+- **Plass's thesis**: M. F. Plass. _Optimal Pagination Techniques for
+  Automatic Typesetting Systems_. PhD thesis, Stanford University, 1981.
+  (Proves NP-hardness of the two-dimensional generalisation.)
+- **Wikipedia overview**: <https://en.wikipedia.org/wiki/Line_wrap_and_word_wrap#Optimal_line-breaking_algorithm>
+- **Liang's hyphenation algorithm** (used by TeX in pass 2):
+  F. M. Liang. _Word Hy-phen-a-tion by Com-pu-ter_. PhD thesis, Stanford, 1983.
+- **LuaTeX `linebreak_filter` documentation**:
+  <https://www.luatex.org/svn/trunk/manual/luatex-nodes.tex>
+- **SILE typesetter**: <https://sile-typesetter.org/> (Simon Cozens, Caleb
+  Maclennan; written in Lua; reimplements Knuth-Plass line-breaking).
+- **`knuthplass` (JavaScript)**: Brian Tingley.
+  <https://github.com/bramstein/typeset> ports the algorithm to JS.
+- **Bram Stein, _The State of Web Type_**: <https://stateofwebtype.com/> --
+  discusses CSS `text-wrap: pretty` and its relationship to Knuth-Plass.
+- **CSS Text Module Level 4**: <https://www.w3.org/TR/css-text-4/> -- defines
+  `text-wrap: balance | pretty`.
+- **Andrew Kelley on terminal text rendering**: see
+  <https://andrewkelley.me/> and the Zig issue tracker for discussions of
+  optimal paragraph layout in CLI contexts.
+- **Sparkles cross-links**:
+  - Greedy / fit-first line-breaking: ([css-normal-flow.md][css-normal-flow])
+  - Paragraph widgets in TUI libraries:
+    ([../tui-libraries/brick.md][brick]),
+    ([../tui-libraries/ratatui.md][ratatui]),
+    ([../tui-libraries/ink.md][ink])
+  - Flexbox-style space distribution (a related but orthogonal problem):
+    ([css-flexbox.md](./css-flexbox.md))
+
+[css-normal-flow]: ./css-normal-flow.md
+[brick]: ../tui-libraries/brick.md
+[ratatui]: ../tui-libraries/ratatui.md
+[ink]: ../tui-libraries/ink.md
+[knuthplass-js]: https://github.com/robertknight/tex-linebreak
+[typeset-js]: https://github.com/bramstein/typeset

--- a/docs/research/ui-layout/tk.md
+++ b/docs/research/ui-layout/tk.md
@@ -1,0 +1,755 @@
+# Tk Geometry Managers (pack / grid / place)
+
+The trio of geometry managers — `pack`, `grid`, and `place` — that ship with
+the Tk widget toolkit (the X11 / Windows / macOS GUI toolkit created by John
+Ousterhout in 1990 alongside Tcl). `pack` was the original; it predates CSS
+Flexbox by nineteen years and is the conceptual ancestor of nearly every
+"box-with-direction-and-fill" layout system that followed. `grid` arrived in
+1996 and pioneered the row/column/sticky model that re-emerged in CSS Grid
+two decades later. `place` covers the absolute-positioning escape hatch.
+Together they form a coherent, three-tier approach to GUI layout that is
+unusually concise — `pack {.toolbar} -side top -fill x` is a complete
+"sticky horizontal toolbar" in one line.
+
+| Field            | Value                                                                                                                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Language         | Tcl (with first-class bindings for Python (`tkinter`), Perl (`Tk` / `Tkx`), Ruby (`ruby-tk`), Common Lisp (`Lisp-Tk`), Haskell, more)                                                                                  |
+| License          | Tcl/Tk License (BSD-style, permissive)                                                                                                                                                                                 |
+| Repository       | <https://core.tcl-lang.org/tk/timeline> (Fossil); GitHub mirror <https://github.com/tcltk/tk>                                                                                                                          |
+| Documentation    | <https://www.tcl-lang.org/man/> (man pages), <https://tkdocs.com/> (tutorial)                                                                                                                                          |
+| Version snapshot | Tk 9.0.2 (July 2025); long-lived 8.6 series still common                                                                                                                                                               |
+| Notable adoption | Python's standard-library `tkinter`; IDLE (Python's reference IDE); `pgAdmin` (PostgreSQL admin); historically the AOLserver admin UI; Moneydance, Eagle Mode, many engineering and scientific GUIs across Linux / BSD |
+
+---
+
+## Overview
+
+### What It Solves
+
+Tk's geometry managers solve the fundamental GUI layout problem: given a
+container (in Tk terminology, a _master_ or, since Tk 8.5, a _parent_) and a
+set of child widgets (_slaves_ / _children_) with intrinsic "natural" sizes,
+position and size each child within the container so that:
+
+- The container's size accommodates its contents (or imposes a fixed size).
+- Resizing the container redistributes available space sensibly.
+- The layout adjusts when children appear, disappear, or change size.
+
+The Tk approach is to _separate widget creation from widget placement_.
+Creating a button does not display it; it only allocates the widget object.
+Display happens only when one of the three geometry managers takes ownership
+of the widget and assigns it space in a parent. This separation is enforced
+by the API: `Button .ok` creates the button, `pack .ok` places it.
+
+Three managers cover three distinct mental models:
+
+- **`pack`** — sequential placement. "Cram this widget onto the top edge of
+  whatever space is left." The model is _cavity_-based: each placement
+  subtracts a strip from the remaining cavity.
+
+- **`grid`** — row/column placement. "Put this widget in cell (row 2,
+  column 3). When the window grows, give the extra space to columns with
+  weight." The conceptual ancestor of CSS Grid.
+
+- **`place`** — absolute placement. "Put this widget at (x, y), or at
+  (relx, rely) as a fraction of the parent." Used rarely, for special cases.
+
+### Design Philosophy
+
+The geometry managers embody several decisions that have aged well:
+
+- **Each child is managed by exactly one geometry manager at a time, in one
+  parent at a time.** Switching managers (calling `grid .x` after `pack .x`)
+  transfers ownership. The constraint is enforced per-parent: a single
+  parent should be managed entirely by one of `pack`, `grid`, or `place`.
+  Folklore says "never mix `pack` and `grid` in the same container" — see the
+  [Mixing Managers](#mixing-managers-the-pack-vs-grid-folklore) section
+  below.
+
+- **Layout is _relational_, not absolute.** `pack` expresses "put this above
+  that" and "this fills the remaining horizontal space." `grid` expresses
+  "this is in column 1 and stretches with `-sticky we`." Neither requires
+  the author to compute pixel coordinates. (`place` is the explicit exception
+  for the rare case where pixel coordinates are wanted.)
+
+- **Natural size first, fitting second.** Each widget reports a _requested_
+  size (its natural size, computed from its content and configuration). The
+  geometry manager respects that as the floor, then applies fill / expand /
+  sticky rules to decide whether to stretch beyond it. A `Label "Quit"`
+  remains a small button-sized box unless explicitly asked to grow.
+
+- **Container shrinks to fit children, by default.** A frame with no explicit
+  size adopts the bounding box of its packed/gridded contents. This is the
+  inverse of CSS, where most blocks default to filling their containing
+  block's width.
+
+- **Geometry options are _configuration_, not code.** All options
+  (`-side`, `-fill`, `-sticky`, `-padx`, `-weight`) are passed as
+  `-name value` pairs to the manager command. There is no separate
+  "layout DSL" — the same Tcl command syntax that creates widgets configures
+  their layout.
+
+### History
+
+- **1988–1990: Tcl is born.** John Ousterhout, then at UC Berkeley, creates
+  Tcl as an embeddable command language for the design-automation tools his
+  group is building.
+
+- **1990: Tk emerges.** Ousterhout begins work on Tk as a Tcl extension for
+  building GUIs on the X Window System. The original geometry manager,
+  `placer` (the ancestor of `place`), is joined by `packer` (the ancestor of
+  `pack`). The `pack` model — "shove this widget toward the top/bottom/left/
+  right edge of the remaining space" — proves vastly more usable than
+  pixel-coordinate placement.
+
+- **1991: First public Tk release.** Tk 1.0 ships, packaged with Tcl. The
+  combination becomes wildly popular as a rapid-prototyping toolkit on Unix,
+  partly because it was substantially easier than Motif / Athena Widgets /
+  Xaw.
+
+- **1994: Python's Tkinter.** Steen Lumholt and Guido van Rossum bind Tk into
+  Python's standard library as `Tkinter` (later `tkinter`). To this day, Tk
+  is the GUI toolkit Python ships with by default. Perl/Tk (Nick Ing-Simmons)
+  follows soon after.
+
+- **1996: `grid` is introduced.** Tk 4.1 adds the `grid` geometry manager,
+  designed for the alignment-based form layouts (aligned labels, aligned
+  entries, stretchy cells) that `pack` could only express awkwardly. `grid`
+  introduces the _sticky_ model (`n s e w` and combinations), _row/column
+  configure_ for weights, and _spanning_.
+
+- **1997: ACM Software System Award.** Ousterhout receives the ACM Software
+  System Award for "creating a simple mechanism for creating graphical user
+  interfaces."
+
+- **1997: Tk 8.0.** Native look-and-feel arrives on Windows and Macintosh.
+  Tk transitions from a Unix-only toolkit to a true cross-platform one.
+
+- **2007: Tk 8.5.** A major revival: themed widgets (`ttk`), the new
+  geometry-aware `panedwindow`, and improvements to font and Unicode handling.
+
+- **2013: Tk 8.6.** PNG support, angled-text, and other modernizations.
+
+- **2024–2025: Tk 9.0.** UTF-32 internals (full Unicode 15 support), 64-bit
+  size limits, and modernization of the C API. Tk's design — including the
+  geometry managers — is preserved essentially intact across the entire
+  three-decade history.
+
+The influence of `pack` and `grid` is hard to overstate. AWT's `BorderLayout`
+and `FlowLayout`, Java Swing's `BoxLayout` and `GridBagLayout`, GTK's
+`GtkBox` and `GtkGrid`, Qt's `QHBoxLayout` / `QVBoxLayout` / `QGridLayout`,
+WPF's `StackPanel` and `Grid` — every one of these owes a direct conceptual
+debt to Tk's geometry managers. CSS Flexbox arrived in 2012 with semantics
+that, on inspection, look like `pack` with prettier names (`flex-direction:
+row` ↔ `pack ... -side left`, `align-self` ↔ `-anchor`, `flex-grow` ↔
+`-expand`).
+
+---
+
+## Layout Model
+
+Tk has three geometry managers, summarized:
+
+| Manager | Mental model                           | Best for                                                      | Year added         |
+| ------- | -------------------------------------- | ------------------------------------------------------------- | ------------------ |
+| `pack`  | Pack widgets into a cavity             | Toolbars, status bars, simple side-by-side / stacked layouts. | 1990               |
+| `grid`  | Row / column table                     | Form layouts, aligned grids, two-dimensional UIs.             | 1996               |
+| `place` | Absolute or relative pixel coordinates | Splash screens, draggable overlays, edge-anchored widgets.    | 1990 (as `placer`) |
+
+### `pack`: The Cavity Algorithm
+
+The conceptual model: the parent has a rectangular _cavity_. Each call to
+`pack` claims a strip from one edge of the cavity (the side specified by
+`-side`), reducing the cavity for subsequent packs. The widget receives a
+_parcel_ — the strip it just claimed — and its placement within that parcel
+depends on `-fill` (whether to expand into the parcel) and `-anchor` (where
+to sit within an unfilled parcel).
+
+**Command syntax.**
+
+```tcl
+pack widget ?widget ...? ?options?
+pack configure widget ?widget ...? ?options?
+pack forget widget ?widget ...?
+pack info widget
+pack propagate parent ?boolean?
+pack slaves parent
+```
+
+`pack widget` is shorthand for `pack configure widget`. All forms accept the
+following per-widget options:
+
+| Option              | Default  | Meaning                                                                                         |
+| ------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `-side`             | `top`    | Which edge of the _remaining cavity_ to attach the widget to: `top`, `bottom`, `left`, `right`. |
+| `-fill`             | `none`   | Stretch the widget within its parcel: `none`, `x`, `y`, `both`.                                 |
+| `-expand`           | `0`      | Whether the _parcel itself_ grows to claim unused cavity space. Boolean.                        |
+| `-anchor`           | `center` | Position the widget within its parcel: `n`, `ne`, `e`, `se`, `s`, `sw`, `w`, `nw`, `center`.    |
+| `-padx`, `-pady`    | `0`      | External padding (outside the widget, inside the parcel).                                       |
+| `-ipadx`, `-ipady`  | `0`      | Internal padding (added to the widget's natural size before placement).                         |
+| `-before`, `-after` | --       | Insert this widget in the packing order before / after another packed widget.                   |
+| `-in`               | parent   | Pack this widget into a different parent than its logical parent.                               |
+
+**The algorithm.** Given a parent with cavity `C` (initially the parent's
+content area) and a list of packed children in order:
+
+1. Take the next child `w`.
+2. Allocate a _parcel_ from the cavity along the side specified by `w`'s
+   `-side`:
+   - For `-side top` or `-side bottom`: the parcel spans the full _width_ of
+     the cavity. Its _height_ is `w`'s natural height (plus padding), or
+     more if `-expand 1`.
+   - For `-side left` or `-side right`: the parcel spans the full _height_
+     of the cavity. Its _width_ is `w`'s natural width (plus padding), or
+     more if `-expand 1`.
+3. Subtract the parcel from the cavity.
+4. Place `w` inside its parcel according to `-fill` and `-anchor`.
+5. Repeat for the next child.
+
+Crucially, `-side top` claims a parcel spanning the _current_ cavity's full
+width — not the parent's full width. If you `pack .a -side left` first, then
+`pack .b -side top`, `.b`'s parcel is only as wide as the cavity _minus_ the
+strip `.a` took on the left.
+
+This is what gives `pack` its characteristic conciseness for "edge plus
+center" layouts but also its surprises: the order of `pack` calls matters,
+and inserting a new packed widget in the middle of a layout can reshape
+everything that follows.
+
+**A canonical example: a window with a toolbar, status bar, and main area.**
+
+```tcl
+# Frames for the regions
+frame .toolbar -bg lightgray -height 30
+frame .status  -bg gray80    -height 20
+frame .main    -bg white
+
+# Pack the toolbar at the top, full width
+pack .toolbar -side top -fill x
+
+# Pack the status bar at the bottom, full width
+pack .status  -side bottom -fill x
+
+# Pack the main area to fill all remaining space
+pack .main    -side top -fill both -expand 1
+```
+
+The cavity walk:
+
+1. `.toolbar`: claims a 30-px strip across the top. Cavity is now
+   "everything except the top 30 px".
+2. `.status`: claims a 20-px strip across the bottom of the _remaining
+   cavity_ (i.e. across the full width again). Cavity is now "middle
+   region between toolbar and status bar".
+3. `.main`: with `-fill both -expand 1`, it fills the entire remaining
+   cavity and the parcel grows on resize.
+
+This is a complete, idiomatic Tk toolbar-and-status-bar layout in three
+lines. The CSS-Flexbox equivalent — `display: flex; flex-direction: column`
+with the body as `flex: 1` — takes more markup and CSS but expresses the
+same idea.
+
+**A side-by-side example: a tree view next to a detail pane.**
+
+```tcl
+frame .left  -width 200
+frame .right
+
+pack .left  -side left  -fill y
+pack .right -side left  -fill both -expand 1
+```
+
+Both children pack to the left, claiming vertical strips. The first claims a
+200-px-wide strip from the cavity's left edge; the second claims the entire
+remaining cavity because of `-expand 1`.
+
+**`-fill` versus `-expand`** is a frequent source of confusion. The parcel
+is what `pack` _gave_ the widget; `-expand 1` lets the parcel grow to claim
+unused cavity space, while `-fill` controls how the widget fills its parcel:
+
+```tcl
+# A button centered in a stretchy parcel
+pack .button -side top -expand 1
+# (parcel is large; button sits in the middle of it, unstretched)
+
+# A button stretching across a stretchy parcel
+pack .button -side top -expand 1 -fill x
+# (parcel is large; button stretches horizontally to fill it)
+
+# A button against the top edge, parcel only as tall as the button
+pack .button -side top
+# (parcel = natural size; widget = natural size)
+```
+
+**`-anchor`** positions the widget within its parcel when neither `-fill`
+(in the relevant direction) nor `-expand` is enough to fill it. Compass-point
+values: `n`, `ne`, `e`, `se`, `s`, `sw`, `w`, `nw`, `center`. The default is
+`center`.
+
+**`-padx`, `-pady`** add external padding _outside_ the widget but _inside_
+the parcel; `-ipadx`, `-ipady` add internal padding to the widget's natural
+size. Either single integers or two-element lists (`{left right}` or
+`{top bottom}`):
+
+```tcl
+pack .ok     -side right -padx 8 -pady 8
+pack .cancel -side right -padx {0 8} -pady 8
+```
+
+**Re-ordering with `-before` / `-after`.**
+
+```tcl
+pack .new_button -before .ok
+```
+
+inserts `.new_button` into the packing order before `.ok`, then re-runs the
+cavity algorithm.
+
+**`-in`** allows packing a widget into a non-default parent — useful for
+re-parenting in special cases. Most code does not need this.
+
+**`pack propagate`** controls whether a parent shrinks/grows to fit its
+packed contents. Default is `true` — a frame with packed children adopts
+their bounding-box size. `pack propagate .myframe false` keeps the frame at
+its configured `-width`/`-height` regardless of its contents.
+
+### `grid`: Row / Column / Sticky
+
+Added in Tk 4.1 (1996), `grid` is a flat row-and-column model. Each managed
+widget is assigned to a cell (or a rectangular block of cells via `-rowspan`
+and `-columnspan`). Rows and columns are sized to fit their largest cell's
+natural size by default; configurable per-row and per-column weights
+distribute extra space when the container is larger than the natural size.
+
+**Command syntax.**
+
+```tcl
+grid widget ?widget ...? ?options?
+grid configure widget ?widget ...? ?options?
+grid forget widget ?widget ...?
+grid info widget
+grid slaves parent ?-row r? ?-column c?
+grid size parent
+grid bbox parent ?column row? ?column2 row2?
+grid rowconfigure    parent index ?-option value ...?
+grid columnconfigure parent index ?-option value ...?
+grid propagate parent ?boolean?
+grid anchor parent ?anchor?
+grid remove widget ?widget ...?
+```
+
+**Per-widget options.**
+
+| Option                    | Default | Meaning                                                                                                                |
+| ------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `-row`, `-column`         | --      | Cell coordinates. Non-negative integers, need not be contiguous.                                                       |
+| `-rowspan`, `-columnspan` | `1`     | Number of cells (rows or columns) the widget occupies.                                                                 |
+| `-sticky`                 | `""`    | Compass-direction string controlling how the widget sticks to the edges of its cell. Any subset of `n`, `s`, `e`, `w`. |
+| `-padx`, `-pady`          | `0`     | External padding around the cell.                                                                                      |
+| `-ipadx`, `-ipady`        | `0`     | Internal padding added to the widget's natural size.                                                                   |
+| `-in`                     | parent  | Grid this widget into a non-default parent.                                                                            |
+
+**`-sticky` semantics.** The most distinctive feature of `grid`. The value
+is a string composed of zero or more of the letters `n`, `s`, `e`, `w`,
+indicating which edges of the cell the widget should stick to:
+
+- `""` _(default)_ — the widget is placed at its natural size, centered in
+  the cell. Extra space is around it.
+- `"n"` — the widget is at its natural size, jammed against the top edge.
+- `"nw"` — the widget is at its natural size, in the top-left corner.
+- `"we"` (or `"ew"`) — the widget _stretches_ horizontally to fill the cell;
+  vertical placement is centered.
+- `"ns"` — the widget _stretches_ vertically; horizontal placement is
+  centered.
+- `"nsew"` (or any equivalent permutation) — the widget fills the cell in
+  both directions.
+
+The rule: when opposite directions both appear in `-sticky`, the widget
+stretches along that axis; otherwise the widget keeps its natural size and is
+positioned according to the present directions.
+
+**`grid rowconfigure` and `grid columnconfigure`.** Per-row and per-column
+configuration:
+
+| Option     | Default | Meaning                                                                                    |
+| ---------- | ------- | ------------------------------------------------------------------------------------------ |
+| `-weight`  | `0`     | Share of extra space when the parent grows. Weight `0` means the row/column does not grow. |
+| `-minsize` | `0`     | Minimum row/column size in pixels.                                                         |
+| `-pad`     | `0`     | Extra padding added to the row/column.                                                     |
+| `-uniform` | --      | A group name. Rows or columns in the same uniform group are forced to be the same size.    |
+
+`-uniform` is particularly useful for equally-sized columns regardless of
+content:
+
+```tcl
+grid columnconfigure . 0 -weight 1 -uniform col
+grid columnconfigure . 1 -weight 1 -uniform col
+grid columnconfigure . 2 -weight 1 -uniform col
+```
+
+makes columns 0, 1, 2 always the same width, even if column 1 contains
+wider content than column 0.
+
+**A canonical example: a labelled form.**
+
+```tcl
+ttk::label .lblName    -text "Name:"
+ttk::entry .entName    -textvariable name
+ttk::label .lblEmail   -text "Email:"
+ttk::entry .entEmail   -textvariable email
+ttk::label .lblNotes   -text "Notes:"
+ttk::text  .txtNotes   -height 4
+ttk::button .btnOK     -text "OK"     -command submit
+ttk::button .btnCancel -text "Cancel" -command cancel
+
+# Labels on the left, entry fields on the right
+grid .lblName    -row 0 -column 0 -sticky e  -padx 8 -pady 4
+grid .entName    -row 0 -column 1 -sticky we -padx 8 -pady 4
+
+grid .lblEmail   -row 1 -column 0 -sticky e  -padx 8 -pady 4
+grid .entEmail   -row 1 -column 1 -sticky we -padx 8 -pady 4
+
+grid .lblNotes   -row 2 -column 0 -sticky ne -padx 8 -pady 4
+grid .txtNotes   -row 2 -column 1 -sticky nsew -padx 8 -pady 4
+
+# Buttons spanning both columns, right-aligned
+grid .btnCancel  -row 3 -column 0 -sticky e -padx 8 -pady 8
+grid .btnOK      -row 3 -column 1 -sticky w -padx 8 -pady 8
+
+# Column 1 (entries) takes all extra horizontal space; row 2 (notes) all extra vertical
+grid columnconfigure . 1 -weight 1
+grid rowconfigure    . 2 -weight 1
+```
+
+Three things to notice:
+
+- Labels use `-sticky e` so they right-align next to their entry fields,
+  producing a clean colon-aligned column.
+- The notes label uses `-sticky ne` (top-right) because the multi-line text
+  area is taller; aligning the label to the top keeps it visually paired
+  with the entry's first line.
+- `columnconfigure 1 -weight 1` + `rowconfigure 2 -weight 1` means: when the
+  window grows, the entry column and the notes row absorb all the new space;
+  the label column and the button row stay at their natural sizes.
+
+**Introspection.**
+
+- `grid info .entName` returns the current grid configuration of `.entName`.
+- `grid slaves .` (without args) returns all gridded children of `.`,
+  optionally filtered by row or column.
+- `grid size .` returns `{columns rows}`, the dimensions of the grid.
+- `grid bbox . col row` returns the pixel bounding box `{x y w h}` of the
+  cell, or `{x1 y1 x2 y2 w h}` for a range.
+
+**`grid remove` vs `grid forget`.** `forget` strips the widget of its grid
+options. `remove` hides it but preserves the options, so a subsequent plain
+`grid .widget` re-displays it in its original cell. Useful for show/hide
+toggles.
+
+**`grid anchor`** controls where the grid as a whole is placed inside the
+parent when the grid is smaller than the parent. Default `nw` (top-left).
+`center` centers the grid; `e` right-aligns it; etc.
+
+### `place`: Absolute and Relative Placement
+
+The escape hatch. `place` lets the programmer specify pixel coordinates
+(`-x`, `-y`) or _relative_ coordinates as a fraction of the parent's size
+(`-relx`, `-rely`), as well as absolute or relative sizes (`-width`,
+`-height`, `-relwidth`, `-relheight`). It is the only geometry manager that
+permits overlapping siblings and the only one with a notion of "fraction of
+parent."
+
+**Command syntax.**
+
+```tcl
+place widget ?options?
+place configure widget ?options?
+place forget widget
+place info widget
+place slaves parent
+```
+
+**Options.**
+
+| Option                    | Default  | Meaning                                                                                          |
+| ------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `-x`, `-y`                | `0`      | Absolute pixel position of the widget's anchor point within the parent.                          |
+| `-relx`, `-rely`          | `0.0`    | Relative position as a fraction of the parent's width / height.                                  |
+| `-width`, `-height`       | --       | Absolute pixel size, overriding the widget's natural size.                                       |
+| `-relwidth`, `-relheight` | --       | Size as a fraction of the parent's size. Use `1.0` to make the widget fill the parent.           |
+| `-anchor`                 | `nw`     | Which point of the widget the `-x`/`-y`/`-relx`/`-rely` coordinates refer to.                    |
+| `-bordermode`             | `inside` | Whether the parent's border is included in the coordinate system: `inside`, `outside`, `ignore`. |
+| `-in`                     | parent   | Place into a different parent.                                                                   |
+
+The `-x`/`-relx` (and `-y`/`-rely`) values _add together_ to give the final
+position. This is genuinely useful: "centered, but offset 10 pixels right"
+is `-relx 0.5 -x 10 -anchor center`.
+
+**A centered, fixed-size dialog inside its parent.**
+
+```tcl
+place .dialog -relx 0.5 -rely 0.5 -anchor center -width 320 -height 200
+```
+
+**An overlay covering 80% of the parent.**
+
+```tcl
+place .overlay -relx 0.1 -rely 0.1 -relwidth 0.8 -relheight 0.8
+```
+
+**A widget anchored to the parent's bottom-right corner with 10-px padding.**
+
+```tcl
+place .corner -relx 1.0 -rely 1.0 -x -10 -y -10 -anchor se
+```
+
+`place` is rarely used for _primary_ layout — its outputs do not adapt
+well to fonts, content changes, or DPI scaling. It excels for:
+
+- Overlay widgets (loading spinners over a main content area).
+- Edge-anchored controls (a small status indicator pinned to a corner).
+- Drag-to-reposition UI elements (a `bind <B1-Motion>` handler updates
+  `-x`/`-y`).
+- Layered effects (a banner over a background image).
+
+### Mixing Managers: The `pack`-vs-`grid` Folklore
+
+A long-running piece of Tk folklore says **"never mix `pack` and `grid` in
+the same parent."** The technical reason is that each geometry manager
+_reads_ its children's requested sizes and _writes_ their actual positions
+and sizes; when two managers manage children of the same parent, they fight
+over the parent's size and may loop indefinitely (each manager re-reads
+sizes that the other just wrote).
+
+The constraint is per-parent, not global. The same window may use `pack`
+for the outer layout (toolbar / main / status) and `grid` _inside_ the main
+frame (for a form). This is the recommended idiom:
+
+```tcl
+# Outer layout uses pack
+frame .toolbar
+frame .main
+frame .status
+pack .toolbar -side top    -fill x
+pack .status  -side bottom -fill x
+pack .main    -side top    -fill both -expand 1
+
+# The .main frame, internally, uses grid
+ttk::label  .main.lblName -text "Name:"
+ttk::entry  .main.entName
+grid .main.lblName -row 0 -column 0 -sticky e
+grid .main.entName -row 0 -column 1 -sticky we
+grid columnconfigure .main 1 -weight 1
+```
+
+The two managers do not interfere because they manage different _parents_.
+`place` does not have this issue (it does not require fitting the parent),
+so a `place`d overlay can coexist with packed or gridded siblings — it is
+often used precisely for floating overlays atop a packed primary layout.
+
+### Two Computation Phases
+
+Conceptually, each geometry manager runs in two phases:
+
+1. **Up phase.** Recursively ask each child its requested size. Compose them
+   to compute the parent's natural size.
+2. **Down phase.** Given the parent's actual (resized) size, distribute it
+   to children according to the manager's rules (cavity for `pack`,
+   row/column weights for `grid`, relative fractions for `place`).
+
+The result is a single coherent layout pass. There is no constraint solver,
+no iterative settling — the entire layout is computed in two tree walks.
+This is one reason Tk has historically been so responsive: layouts that
+would require hundreds of milliseconds of solver time in modern web stacks
+complete in microseconds in Tk.
+
+`grid` and `pack` honor a parent's `propagate` setting: by default, the
+parent's requested size grows or shrinks to match its packed/gridded
+contents, but `pack propagate $f 0` (or `grid propagate $f 0`) decouples the
+two so the parent retains an explicit `-width`/`-height`.
+
+---
+
+## Strengths and Weaknesses
+
+### For GUI Application Layout (target domain)
+
+**Strengths.**
+
+- **Conciseness.** Three lines for a "toolbar / main / status" layout that
+  takes 8 – 15 lines in CSS / Flexbox markup. The Tk maxim "type less than
+  you would in a config file" is unusually true for layout code.
+- **Direct expression.** The manager command names describe what they do:
+  `pack -side top -fill x` reads as "pack to the top, filling x." Authors
+  rarely need to translate intent into a layout DSL.
+- **Predictable resize behavior.** `-expand` (for `pack`) and `-weight`
+  (for `grid` rows / columns) give explicit control over which children
+  absorb extra space. The behavior is deterministic; there are no surprises
+  from min-content / max-content fluctuations as in some CSS contexts.
+- **Decoupled creation and placement.** Widgets can be created (and have
+  their content set, event bindings attached, etc.) before any decision
+  about layout is made. This is good for code organization: a "create
+  widgets" function is independent of a "lay out widgets" function.
+- **`-sticky` is uniquely expressive.** A single short string controls four
+  axes of alignment and stretching, in a way that compares favorably to the
+  combination of `align-self`, `justify-self`, and `width: 100%` it takes
+  to express the equivalent in CSS Grid.
+
+**Weaknesses.**
+
+- **The cavity model has nonlocal effects.** Inserting a new packed widget
+  changes the cavity for all subsequent widgets. Refactoring a `pack` layout
+  is often nonlocal — moving widget A may shift widget B's parcel.
+- **No content-based row heights with mixed cell types.** `grid` rows size
+  to the tallest cell content, but there is no way to say "row 2 is tall
+  enough for a 4-line text widget" without setting `-height` on the text
+  widget itself.
+- **No equivalent of `flex-wrap`.** A `pack` row that exceeds the parent's
+  width does not wrap to the next line; it simply overflows or clips. Wrap-
+  to-next-line behavior must be coded manually (e.g. with a `text` widget
+  embedding child widgets, or with `grid` and explicit row management).
+- **No baseline alignment.** Items align by their bounding boxes, not by
+  their text baselines. A button next to an entry next to a label do not
+  share a baseline unless their box heights happen to match.
+- **`place` is the only option for "absolute coordinates"** — and it does
+  not interact well with content-sized siblings. A `place`d widget shares
+  its parent's content area with `pack`'ed or `grid`'ed siblings, but the
+  cavity / cell computation ignores the placed widget's space.
+- **No animation primitives.** Layout transitions on container resize are
+  instantaneous; smooth animation must be implemented manually.
+
+### For Static One-Shot Rendering
+
+Tk is fundamentally a _live_, _retained-mode_, _interactive_ toolkit. Its
+geometry managers were designed for live windows that respond to user
+resize, font change, and theme switches. "Render once and exit" is not a
+target use case for Tk.
+
+Nevertheless, the _layout vocabulary_ Tk pioneered is highly relevant to
+static rendering, including terminal output:
+
+- The `pack` _cavity_ model maps cleanly to "claim a strip from the
+  remaining vertical space" — exactly what a terminal-cell renderer does
+  when writing a report's header, footer, and body.
+- The `grid` _row/column/sticky_ model is the most concise way to describe
+  aligned tabular output, including bordered tables.
+- The `place` _relative-coordinate_ model is the only one where a static
+  renderer needs _no_ knowledge of children's natural sizes — the position
+  is given directly. Useful when you know "this widget covers the bottom
+  20% of the screen."
+
+For Sparkles, the directly applicable lesson is that `pack`'s API is _short_
+in a way modern layout APIs are not. A two-line "header on top, body fills
+rest" specification:
+
+```tcl
+pack .header -side top -fill x
+pack .body   -side top -fill both -expand 1
+```
+
+is the conceptual shape of a CLI-rendering layout function that takes
+positional arguments rather than a builder pattern with many `.setX().setY()`
+calls. The D translation would look something like:
+
+```d
+auto report = Layout()
+    .pack(header, side: Side.top, fill: Fill.x)
+    .pack(body,   side: Side.top, fill: Fill.both, expand: 1);
+```
+
+— and CTFE could specialize the result for a known output width.
+
+### Compared to Alternatives
+
+| Aspect                   | Tk `pack`                       | Tk `grid`                       | CSS Flexbox                            | CSS Grid                                     | Ratatui constraints             |
+| ------------------------ | ------------------------------- | ------------------------------- | -------------------------------------- | -------------------------------------------- | ------------------------------- |
+| Primary axis             | One (cavity-claimed)            | Two (rows × columns)            | One                                    | Two                                          | One (Horizontal / Vertical)     |
+| Year introduced          | 1990                            | 1996                            | 2012 (CR)                              | 2017 (Rec)                                   | 2018 (tui-rs) / 2023 (ratatui)  |
+| API verbosity            | Very low (1 – 4 options/widget) | Low (5 – 8 options/widget)      | Medium (CSS verbose)                   | High (CSS verbose)                           | Medium (Rust verbose)           |
+| Ordering matters?        | Yes (cavity is order-dependent) | No (cells are coordinate-keyed) | Source order (with `order` opt-out)    | No (placement is coordinate-keyed)           | Yes (list order = layout order) |
+| Sticky / fill alignment  | `-anchor`, `-fill`              | `-sticky NSEW`                  | `align-self`, `justify-self`           | `align-self`, `justify-self`                 | `Constraint::Length` / `Fill`   |
+| Spans                    | Not supported                   | `-rowspan`, `-columnspan`       | Not native (use `flex-basis`)          | `grid-row: span n`                           | Not native                      |
+| Wrapping                 | Not supported                   | Not supported                   | `flex-wrap: wrap`                      | `grid-template-rows: repeat(auto-fill, ...)` | Not native                      |
+| "Fill remaining space"   | `-expand 1`                     | `rowconfigure -weight 1`        | `flex: 1`                              | `1fr`                                        | `Constraint::Fill(n)`           |
+| Constraint-solver based? | No (cavity walk + two-pass)     | No (two-pass)                   | No (algorithmic, single-pass-per-axis) | No (algorithmic)                             | Yes (Cassowary via `kasuari`)   |
+
+The most important observation: **Tk's geometry managers shipped the core
+ideas that modern layout systems still use.** `flex-direction: row` is
+`-side left`. `align-self: stretch` is `-sticky we`. `flex-grow: 1` is
+`-expand 1`. `grid-template-columns: 1fr 2fr` is `grid columnconfigure 0
+-weight 1; grid columnconfigure 1 -weight 2`. The CSS specifications use
+different vocabulary and add expressive features (named grid areas, line
+naming, item ordering) — but the conceptual debt to `pack` and `grid` is
+unmistakable.
+
+### When Tk Geometry Managers Win
+
+- **Quick prototypes.** A scientist who needs a parameter-sweep GUI in 30
+  lines of Python uses `tkinter.pack` and is done.
+- **Cross-platform GUIs without web tech.** Tk runs natively on Linux,
+  macOS, and Windows without a browser. The geometry managers are part of
+  why Tk apps start in milliseconds where Electron apps take seconds.
+- **Resizable forms with weight-driven elasticity.** `grid columnconfigure`
+  with `-weight` and `-uniform` matches the typical "this column grows, this
+  one stays fixed" UI very directly.
+- **Embedded Tcl in instrument and design-automation tools.** Tk's original
+  domain. Reliability and minimal dependencies matter more than visual
+  polish.
+
+### When Tk Geometry Managers Lose
+
+- **Modern web-style responsive design** with wrapping flex rows, media-
+  query-driven re-layout, and animation. Use Flexbox / Grid.
+- **Pixel-perfect graphic-design layouts.** Use a canvas / drawing API or a
+  layout system built for graphic design.
+- **Layouts with many constraints that interact** (e.g. an IDE's split
+  panes with min sizes and proportional resizing). A constraint solver
+  (Cassowary, kasuari) handles these more gracefully than `pack` /`grid`.
+- **High-frequency layout changes** where each change should animate
+  smoothly. Tk's geometry managers re-layout instantaneously; smooth
+  animation must be hand-rolled.
+
+---
+
+## References
+
+### Primary Documentation
+
+- **Tk `pack` manual.** <https://www.tcl-lang.org/man/tcl9.0/TkCmd/pack.htm>
+- **Tk `grid` manual.** <https://www.tcl-lang.org/man/tcl9.0/TkCmd/grid.htm>
+- **Tk `place` manual.** <https://www.tcl-lang.org/man/tcl9.0/TkCmd/place.htm>
+- **TkDocs Tutorial — Concepts (geometry managers overview).** <https://tkdocs.com/tutorial/concepts.html>
+- **TkDocs Tutorial — Grid.** <https://tkdocs.com/tutorial/grid.html>
+- **Python `tkinter` documentation.** <https://docs.python.org/3/library/tkinter.html>
+
+### Historical and Background
+
+- **John Ousterhout, "Tcl and the Tk Toolkit"** (Addison-Wesley, 1994). The
+  original book describing Tk's design philosophy, including the geometry
+  managers. ISBN 0-201-63337-X.
+- **Wikipedia — Tk (software).** <https://en.wikipedia.org/wiki/Tk_(software)>
+- **ACM Software System Award 1997 citation.**
+  <https://awards.acm.org/award_winners/ousterhout_2009295>
+- **Tcler's Wiki — pack.** <https://wiki.tcl-lang.org/page/pack>
+- **Tcler's Wiki — grid.** <https://wiki.tcl-lang.org/page/grid>
+- **Tcler's Wiki — place.** <https://wiki.tcl-lang.org/page/place>
+
+### Source
+
+- **Tk source code (Fossil repository).** <https://core.tcl-lang.org/tk/timeline>
+- **Tk source code (GitHub mirror).** <https://github.com/tcltk/tk>
+- **The geometry manager implementations live in `generic/tkPack.c`,
+  `generic/tkGrid.c`, and `generic/tkPlace.c`.**
+
+### Adjacent Sparkles Research
+
+- **CSS normal flow (the "blocks stack, inlines flow" model that predates
+  every CSS layout module):** [css-normal-flow.md](./css-normal-flow.md)
+- **CSS Flexbox (Tk `pack`'s direct descendant in spirit, 19 years later):**
+  [css-flexbox.md](./css-flexbox.md)
+- **CSS Grid (Tk `grid`'s direct descendant in spirit, 21 years later):**
+  [css-grid.md](./css-grid.md)
+- **Constraint-based TUI layout (a different, solver-driven approach
+  contemporaneous with Ratatui):** [../tui-libraries/ratatui.md](../tui-libraries/ratatui.md)
+- **Yoga / Flexbox-driven TUI (the closest TUI analogue of Tk's `pack`
+  layered with Flex semantics):** [../tui-libraries/ink.md](../tui-libraries/ink.md)

--- a/docs/research/ui-layout/wpf-xaml.md
+++ b/docs/research/ui-layout/wpf-xaml.md
@@ -1,0 +1,1011 @@
+# WPF / XAML (.NET)
+
+Windows Presentation Foundation's two-pass _Measure / Arrange_ layout protocol,
+expressed declaratively in XAML markup. The same protocol underpins Silverlight, UWP,
+.NET MAUI, Uno Platform, and Avalonia -- making it the most-replicated layout model
+of any GUI framework.
+
+| Field            | Value                                                               |
+| ---------------- | ------------------------------------------------------------------- |
+| Language         | C# / VB.NET / F# (any CLR language); XAML for markup                |
+| License          | MIT (open source since 2018)                                        |
+| Repository       | <https://github.com/dotnet/wpf>                                     |
+| Documentation    | <https://learn.microsoft.com/en-us/dotnet/desktop/wpf/>             |
+| First Release    | WPF 3.0 (November 2006, with .NET Framework 3.0)                    |
+| Version snapshot | Open-source WPF in the modern .NET line; active maintenance         |
+| Layout Protocol  | Two-pass: MeasureOverride -> ArrangeOverride                        |
+| Notable Lineage  | Silverlight (2007), WinRT/UWP (2015), MAUI (2022), Avalonia (2016+) |
+
+---
+
+## Overview
+
+### What It Is
+
+WPF is Microsoft's retained-mode desktop UI framework. It pairs a C#/CLR object model
+of `DependencyObject` / `UIElement` / `FrameworkElement` with an XML-based declarative
+markup language called XAML. Layout is performed by a two-pass recursive protocol
+where every element first reports how much space it _wants_ (Measure), then is told
+how much space it _gets_ (Arrange).
+
+### What It Solves
+
+When WPF was designed, Windows Forms was the dominant .NET UI framework. WinForms
+used absolute pixel positioning -- a button at (10, 20) was at (10, 20), period. This
+made resolution-independent UI, multi-monitor DPI handling, and resizable layouts
+painful. WPF replaced absolute coordinates with a layout-system-managed protocol:
+the developer describes the _structure_ of the UI (a grid with three rows, two
+columns, stretched buttons in the cells), and the layout system computes the actual
+pixel coordinates based on the window size, font metrics, content sizes, and DPI.
+
+The Measure/Arrange protocol decouples _what content needs_ from _what container
+allocates_. A `TextBlock` measures the width of its text and reports a desired size;
+a `Grid` arranges columns according to its `*` / `Auto` / fixed-pixel rules; the
+two negotiate until every element has a final rectangle. This is the same idea as
+Flutter's constraint protocol (see [flutter.md](./flutter.md)) but with two passes
+instead of one, and with per-element attached properties instead of widget wrappers.
+
+### Design Philosophy
+
+Three principles drive WPF's layout design:
+
+1. **Declarative over imperative.** UI structure is described in XAML markup, with
+   code-behind only for behaviour. The markup is the source of truth; a designer
+   tool (Visual Studio, Blend, or third-party) can manipulate the markup directly.
+2. **Composition through panels.** Layout containers (called _panels_, all deriving
+   from the `Panel` base class) provide specific arrangement strategies: `Grid`,
+   `StackPanel`, `DockPanel`, `WrapPanel`, `Canvas`, `UniformGrid`. A layout is built
+   by nesting panels.
+3. **Per-element layout properties via attached properties.** Where a child sits inside
+   a `Grid` is encoded on the child itself via attached properties:
+   `Grid.Row="2" Grid.Column="1"`. The parent doesn't have to know about its children
+   ahead of time; the children declare where they want to be.
+
+### History
+
+- **November 2006 -- WPF 3.0.** Shipped with .NET Framework 3.0 as "Avalon". The
+  Measure/Arrange protocol, XAML markup, `Grid` / `StackPanel` / `DockPanel`, data
+  binding, and the DependencyObject system were all there at launch.
+- **April 2007 -- Silverlight 1.0.** Plug-in version of WPF for the web; 2.0 added
+  the full XAML toolkit.
+- **2015 -- UWP.** Windows 10's app platform inherits the XAML layout system.
+- **2016 -- Avalonia.** An open-source rewrite of WPF/XAML targeting Windows, macOS,
+  Linux, iOS, Android, and WebAssembly via Skia. Shares the Measure/Arrange protocol
+  and `Grid` star sizing with WPF.
+- **December 2018 -- WPF open-sourced** on GitHub under MIT; ported to .NET Core.
+- **2020 -- Uno Platform.** Another cross-platform WPF/UWP-compatible runtime.
+- **May 2022 -- .NET MAUI.** Successor to Xamarin.Forms; same Measure/Arrange model.
+- **2024 -- WPF in .NET 9.** Active maintenance for long-tail enterprise apps.
+
+WPF's biggest legacy is its _layout protocol_, which has propagated unchanged into
+every framework Microsoft has built or inspired since. Anyone who has learned `Grid`
+star sizing in WPF can use it identically in UWP, MAUI, Avalonia, and Uno.
+
+### Comparison to Other Layout Models
+
+For terminal-UI comparators see [Ratatui](../tui-libraries/ratatui.md) (immediate-mode
+constraint solving via Cassowary) and [Ink](../tui-libraries/ink.md) (Flexbox via
+Yoga). For an alternative single-pass model, see [Flutter](./flutter.md). Contrasts:
+
+| Property              | WPF / XAML            | Flutter         | Ratatui           | Ink             |
+| --------------------- | --------------------- | --------------- | ----------------- | --------------- |
+| Passes per frame      | 2 (Measure + Arrange) | 1               | 1                 | 1               |
+| Markup language       | XAML (XML)            | Dart            | Rust              | JSX             |
+| Per-child positioning | Attached properties   | Widget wrappers | `Constraint` enum | Flexbox cascade |
+| Star (`*`) sizing     | Built into Grid       | `Expanded` flex | `Fill(n)`         | `flexGrow: n`   |
+| Auto sizing           | `Auto` in Grid        | Intrinsics      | `Min`/`Max`       | `flexShrink`    |
+
+WPF's distinctive contribution is _star sizing_ -- the idea that columns and rows can
+declare proportional sizes like `*`, `2*`, `Auto`, `200`, with the layout system
+distributing leftover space among star-sized tracks. This is the most-copied feature
+in the lineage.
+
+---
+
+## Layout Model
+
+### The Two-Pass Protocol
+
+Every element in a WPF UI participates in a two-pass layout cycle, driven by the
+parent panel. The interface lives on `UIElement` and `FrameworkElement`:
+
+```csharp
+// UIElement methods invoked by the layout system:
+public void Measure(Size availableSize);
+public void Arrange(Rect finalRect);
+
+// Read-back after Measure:
+public Size DesiredSize { get; }
+
+// Read-back after Arrange:
+public Size RenderSize { get; }
+public double ActualWidth { get; }
+public double ActualHeight { get; }
+```
+
+A subclass overrides two protected methods to customise layout behaviour:
+
+```csharp
+// FrameworkElement (and Panel) extension points:
+protected virtual Size MeasureOverride(Size availableSize);
+protected virtual Size ArrangeOverride(Size finalSize);
+```
+
+### Pass 1: Measure
+
+The Measure pass asks every element, "given this much space, how much do you _want_?"
+
+```
+Parent calls: child.Measure(availableSize)
+  child computes its DesiredSize:
+    - subtracts Margin from availableSize -> constraintSize
+    - calls MeasureOverride(constraintSize) -> rawDesiredSize
+    - clamps rawDesiredSize against Width/MinWidth/MaxWidth
+    - adds Margin back
+    - stores result in child.DesiredSize
+```
+
+`MeasureOverride` is where a panel measures its own children and aggregates their
+desired sizes:
+
+```csharp
+protected override Size MeasureOverride(Size availableSize)
+{
+    double maxWidth = 0;
+    double totalHeight = 0;
+    foreach (UIElement child in InternalChildren)
+    {
+        child.Measure(availableSize);  // Recurse.
+        maxWidth = Math.Max(maxWidth, child.DesiredSize.Width);
+        totalHeight += child.DesiredSize.Height;
+    }
+    return new Size(maxWidth, totalHeight);  // What I want.
+}
+```
+
+The Measure pass result is `DesiredSize` -- a hint to the parent. The parent is free
+to ignore it (a `Canvas` ignores child desired sizes entirely; a `StackPanel` respects
+them on the stacking axis and stretches them on the perpendicular axis).
+
+### Pass 2: Arrange
+
+After every descendant has reported its desired size, the parent decides how to
+actually distribute the available space:
+
+```
+Parent calls: child.Arrange(finalRect)
+  child computes its render rectangle:
+    - subtracts Margin from finalRect -> arrangeSize
+    - calls ArrangeOverride(arrangeSize) -> renderedSize
+    - applies HorizontalAlignment / VerticalAlignment
+    - sets RenderSize = renderedSize
+    - stores final offset in the visual tree
+```
+
+`ArrangeOverride` positions children within the panel's final rectangle:
+
+```csharp
+protected override Size ArrangeOverride(Size finalSize)
+{
+    double y = 0;
+    foreach (UIElement child in InternalChildren)
+    {
+        double h = child.DesiredSize.Height;
+        child.Arrange(new Rect(0, y, finalSize.Width, h));
+        y += h;
+    }
+    return finalSize;
+}
+```
+
+Notice that Arrange receives `finalSize` -- the actual rectangle allocated by the
+grandparent -- not the desired size. The element may have asked for 200x150 in
+Measure and been allocated only 180x140 in Arrange. The element's `ArrangeOverride`
+is responsible for handling this gracefully (typically by clipping or alignment).
+
+### Why Two Passes?
+
+The two passes solve a problem the one-pass protocol cannot: collaborative sizing.
+A `Grid` with three star-sized columns (`*`, `2*`, `*`) must know all children's
+desired widths in `Auto`-sized columns _before_ it can distribute the leftover space
+among the star columns. With a single pass, you would either need backtracking or
+multiple recursive layout calls per child.
+
+In Measure, each `Auto`-column child reports its desired width; the Grid sums those,
+subtracts from the available width, and divides the remainder among the star
+columns according to their proportions. In Arrange, each child gets its final cell
+rectangle.
+
+The cost is roughly 2x layout time compared to Flutter's single-pass model. The
+benefit is that constructs like star sizing and DockPanel's `LastChildFill` are
+trivial to express -- you just need both passes.
+
+### When Layout Runs
+
+The layout system is invoked when:
+
+- The root window is sized (first time or resize).
+- `InvalidateMeasure()` is called on an element (queues a Measure pass).
+- `InvalidateArrange()` is called on an element (queues an Arrange pass).
+- A dependency property marked `AffectsMeasure` or `AffectsArrange` changes.
+- `UpdateLayout()` is called explicitly (synchronous full layout pass).
+- A new child is added to a panel's `Children` collection.
+- A `LayoutTransform` is applied (forces a layout update; unlike `RenderTransform`,
+  which only affects painting).
+
+Each dependency property declares whether it affects measure or arrange via
+`FrameworkPropertyMetadata`:
+
+```csharp
+public static readonly DependencyProperty WidthProperty =
+    DependencyProperty.Register(
+        nameof(Width),
+        typeof(double),
+        typeof(FrameworkElement),
+        new FrameworkPropertyMetadata(
+            double.NaN,
+            FrameworkPropertyMetadataOptions.AffectsMeasure));
+```
+
+When `Width` changes, the layout system marks the element for Measure and propagates
+the invalidation up the visual tree until it hits a layout boundary.
+
+### Per-Element Layout Properties
+
+Every `FrameworkElement` carries a fixed set of layout-influencing properties:
+
+| Property                                                 | Purpose                                           |
+| -------------------------------------------------------- | ------------------------------------------------- |
+| `Width` / `Height` (`double` or `NaN`)                   | Desired size; `NaN` means "sized to content".     |
+| `MinWidth` / `MaxWidth`, `MinHeight` / `MaxHeight`       | Clamp ranges.                                     |
+| `Margin` (`Thickness`)                                   | Outer space; reduces available size.              |
+| `Padding` (`Thickness`)                                  | Inner space (only on `Control`-derived elements). |
+| `HorizontalAlignment`: `Left`/`Center`/`Right`/`Stretch` | How element fills its cell horizontally.          |
+| `VerticalAlignment`: `Top`/`Center`/`Bottom`/`Stretch`   | Same, vertically.                                 |
+| `Visibility`: `Visible`/`Collapsed`/`Hidden`             | See below.                                        |
+| `ClipToBounds` (`bool`)                                  | Whether descendants outside bounds are clipped.   |
+| `LayoutTransform` / `RenderTransform`                    | Affects layout / paint-only respectively.         |
+
+`HorizontalAlignment` / `VerticalAlignment` interact with `Width`/`Height`. If
+`Width` is set, alignment controls positioning within the cell. If `Width` is `NaN`
+and alignment is `Stretch`, the element fills the cell. If alignment is `Center` and
+`Width` is `NaN`, the element sizes to content and is centred.
+
+### Margin and Padding
+
+`Thickness` is a 4-tuple: `Margin="left,top,right,bottom"`. Shorthand
+`Margin="10"` is uniform; `Margin="10,5"` is horizontal-then-vertical. Margin is
+applied _outside_ the element's render bounds -- it reduces the available size
+passed to children. Padding is applied _inside_ controls (between the control's
+border and its content) and is only available on `Control`, not on every
+`FrameworkElement`.
+
+### Visibility
+
+The `Visibility` property has three values, two of which differ in layout impact:
+
+- `Visible`: Element is rendered and participates in layout.
+- `Hidden`: Element is _not_ rendered but _still occupies layout space_. The next
+  Measure/Arrange pass returns its normal `DesiredSize` and reserves the space.
+- `Collapsed`: Element is not rendered and is removed from layout. Its
+  `DesiredSize` is `(0, 0)` and the layout shifts as if the element were not there.
+
+This three-state visibility is one of WPF's most-replicated features -- web CSS has
+`display: none` (collapsed) and `visibility: hidden`, mirroring the same distinction.
+
+### Clipping
+
+`ClipToBounds="True"` causes a panel to clip any descendants that try to draw
+outside its bounds. The default depends on the panel: `Canvas` does not clip by
+default (children may overflow), most others do not need to clip because their
+arrange contracts already bound children.
+
+### Logical vs Visual Tree
+
+WPF maintains two parallel trees:
+
+- **Logical tree.** The tree as expressed in XAML markup: a `Window` contains a
+  `Grid`, which contains a `Button`, which contains a `TextBlock`.
+- **Visual tree.** The expanded tree including template internals: the `Button`'s
+  `Style` and `Template` introduce a `Border`, a `ContentPresenter`, and so on, all
+  of which are visual children of the button.
+
+Layout traverses the _visual_ tree, not the logical tree. This is important for
+custom panels: when you override `MeasureOverride`, you walk `InternalChildren`,
+which gives you the visual children including any data-bound items.
+
+### Data Binding and Layout
+
+WPF's data binding system feeds into layout. A `Width="{Binding ColumnWidth}"`
+triggers a Measure invalidation when the bound property changes. An
+`ItemsControl.ItemsSource="{Binding Records}"` triggers a full child-collection
+update when the source collection changes. The binding pipeline calls into the
+dependency-property system, which calls into the layout system, which schedules a
+Measure pass on the dispatcher thread.
+
+---
+
+## Panels
+
+`Panel` is the abstract base class of all layout containers. It exposes:
+
+- `Children` -- the `UIElementCollection` of child elements (the logical children).
+- `InternalChildren` -- includes data-bound items.
+- `Background` -- a `Brush` to fill the panel's area.
+- `Panel.ZIndex` -- attached property for z-ordering siblings.
+
+The built-in panel set:
+
+### Grid
+
+The most powerful and most-used panel. Defines columns and rows with three sizing
+modes:
+
+- **Fixed pixel.** `Width="200"` -- the column is exactly 200 device-independent
+  pixels.
+- **Auto.** `Width="Auto"` -- the column sizes to fit its widest child's
+  `DesiredSize`.
+- **Star.** `Width="*"`, `Width="2*"` -- after fixed and auto columns are sized,
+  the leftover width is divided among star columns proportional to their stars.
+
+```xaml
+<Grid>
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto"/>  <!-- Sized to the widest child   -->
+        <ColumnDefinition Width="*"/>     <!-- Gets 1 share of leftover     -->
+        <ColumnDefinition Width="2*"/>    <!-- Gets 2 shares of leftover    -->
+        <ColumnDefinition Width="100"/>   <!-- Exactly 100 pixels           -->
+    </Grid.ColumnDefinitions>
+    <Grid.RowDefinitions>
+        <RowDefinition Height="40"/>
+        <RowDefinition Height="*"/>
+        <RowDefinition Height="Auto"/>
+    </Grid.RowDefinitions>
+
+    <TextBlock Grid.Row="0" Grid.Column="0" Text="Label:"/>
+    <TextBox   Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3"/>
+    <ListBox   Grid.Row="1" Grid.ColumnSpan="4"/>
+    <Button    Grid.Row="2" Grid.Column="3" Content="OK"/>
+</Grid>
+```
+
+The star algorithm:
+
+```
+totalAvailable    = Grid's available width
+totalFixed        = sum of fixed-pixel column widths
+totalAuto         = sum of Auto-column children's max DesiredSize.Width
+totalStars        = sum of star weights (e.g. 1 + 2 = 3)
+leftover          = max(0, totalAvailable - totalFixed - totalAuto)
+oneStarWidth      = leftover / totalStars
+
+For each column:
+  if fixed:  width = its pixel value
+  if Auto:   width = max child DesiredSize.Width
+  if star:   width = stars * oneStarWidth
+```
+
+Star sizing is what makes Grid uniquely good for forms: declare three columns as
+`Auto, *, Auto` and you have label / stretchy-input / trailing-button -- the input
+absorbs all extra space, the label and button hug their content. No imperative
+math, no event handlers, just markup.
+
+`Grid.RowSpan` and `Grid.ColumnSpan` extend a child across multiple cells.
+`SharedSizeGroup` lets multiple Grids share `Auto`-column widths (so multiple stacked
+forms align). `ShowGridLines="True"` is a debug aid that draws cell borders.
+
+### StackPanel
+
+Stacks children in a single line:
+
+```xaml
+<StackPanel Orientation="Vertical">
+    <Button Content="One"/>
+    <Button Content="Two"/>
+    <Button Content="Three"/>
+</StackPanel>
+```
+
+- `Orientation="Horizontal"` or `"Vertical"`.
+- On the stacking axis, the panel is _constrained to content_ -- its size is the sum
+  of children's desired sizes.
+- On the perpendicular axis, the panel is _constrained_ to its parent and children
+  stretch by default.
+- StackPanel does not virtualise. For 10,000 items use `VirtualizingStackPanel`.
+
+### DockPanel
+
+Docks children to the edges of a container in declaration order:
+
+```xaml
+<DockPanel LastChildFill="True">
+    <Menu       DockPanel.Dock="Top"/>
+    <ToolBar    DockPanel.Dock="Top"/>
+    <StatusBar  DockPanel.Dock="Bottom"/>
+    <TreeView   DockPanel.Dock="Left" Width="200"/>
+    <Border>    <!-- LastChildFill="True" -> fills remaining space. -->
+        <ContentControl Content="{Binding CurrentView}"/>
+    </Border>
+</DockPanel>
+```
+
+The first child sized at top takes the full width and a strip of height equal to its
+desired height. The next child occupies the space below it, and so on. The last
+child fills whatever rectangle remains if `LastChildFill="True"` (the default).
+
+This is the easiest way to express an Outlook-style "menu / toolbar / sidebar / main
+content / status bar" shell layout.
+
+### Canvas
+
+Absolute positioning. Children declare their pixel offsets:
+
+```xaml
+<Canvas Width="400" Height="400">
+    <Rectangle Canvas.Left="0"   Canvas.Top="0"   Width="100" Height="100" Fill="Red"/>
+    <Rectangle Canvas.Left="100" Canvas.Top="100" Width="100" Height="100" Fill="Green"/>
+    <Rectangle Canvas.Left="50"  Canvas.Top="50"  Width="100" Height="100" Fill="Blue"/>
+</Canvas>
+```
+
+`Canvas.Left`, `Canvas.Top`, `Canvas.Right`, `Canvas.Bottom` are attached properties.
+Canvas does no constraint propagation: it asks every child to measure with `Infinity`
+in both dimensions and places them at their declared offsets. Useful for
+draw-style applications, custom diagram editors, animation playgrounds.
+
+By default Canvas does _not_ clip its children -- a Canvas with `Width="100"
+Height="100"` will happily display a child at `Canvas.Left="500"`. Set
+`ClipToBounds="True"` to change this.
+
+### WrapPanel
+
+A `StackPanel` that wraps to a new line when it runs out of room:
+
+```xaml
+<WrapPanel Orientation="Horizontal">
+    <Button Content="Apple"/>
+    <Button Content="Banana"/>
+    <Button Content="Cherry"/>
+    <Button Content="Damson"/>
+    <Button Content="Elderberry"/>
+</WrapPanel>
+```
+
+Each child takes its desired width; when the next child would overflow, the panel
+moves to a new line. Useful for tag clouds, photo galleries, dynamic toolbar
+overflow.
+
+### UniformGrid
+
+A grid where all cells are the same size:
+
+```xaml
+<UniformGrid Rows="2" Columns="3">
+    <Button Content="1"/>
+    <Button Content="2"/>
+    <Button Content="3"/>
+    <Button Content="4"/>
+    <Button Content="5"/>
+    <Button Content="6"/>
+</UniformGrid>
+```
+
+No cell-by-cell sizing rules; every cell is `availableWidth / Columns` wide and
+`availableHeight / Rows` tall. Children are placed in row-major order. Setting only
+one of `Rows` or `Columns` lets the other dimension auto-compute.
+
+### VirtualizingStackPanel
+
+A `StackPanel` that only materialises children currently in the viewport. Used as
+the default `ItemsPanel` for `ListBox`, `DataGrid`, `ComboBox`. Critical for any
+list with more than a few hundred items.
+
+### Custom Panels
+
+To write a custom panel, inherit from `Panel` and override `MeasureOverride` and
+`ArrangeOverride`. A custom panel can also expose its own attached properties to
+control child behaviour, mirroring the `Grid.Row` / `DockPanel.Dock` pattern. See
+Example 3 below for a full implementation.
+
+---
+
+## Code Examples
+
+### Example 1: A Three-Pane Application Shell
+
+Outlook-style "menu / sidebar / main content / status bar" layout:
+
+```xaml
+<Window x:Class="MyApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        Title="My App" Height="600" Width="900">
+    <DockPanel LastChildFill="True">
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="_New"/>
+                <MenuItem Header="_Open..."/>
+                <Separator/>
+                <MenuItem Header="E_xit"/>
+            </MenuItem>
+            <MenuItem Header="_Edit"/>
+        </Menu>
+
+        <StatusBar DockPanel.Dock="Bottom">
+            <StatusBarItem><TextBlock Text="Ready"/></StatusBarItem>
+            <Separator/>
+            <StatusBarItem HorizontalAlignment="Right">
+                <TextBlock Text="{Binding LineCount, StringFormat='Lines: {0}'}"/>
+            </StatusBarItem>
+        </StatusBar>
+
+        <Border DockPanel.Dock="Left" Width="200" Background="#F0F0F0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Margin="8"
+                           FontWeight="Bold" Text="Navigation"/>
+                <TreeView Grid.Row="1" Margin="4"
+                          ItemsSource="{Binding NavigationItems}"/>
+            </Grid>
+        </Border>
+
+        <!-- Main content area (LastChildFill -> fills remaining space) -->
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Border Grid.Row="0" BorderBrush="Gray" BorderThickness="1" Margin="4">
+                <TextBox Text="{Binding DocumentText}"
+                         AcceptsReturn="True" AcceptsTab="True"
+                         VerticalScrollBarVisibility="Auto"/>
+            </Border>
+            <StackPanel Grid.Row="1" Orientation="Horizontal"
+                        HorizontalAlignment="Right" Margin="4">
+                <Button Content="Cancel" Width="80" Margin="4,0"/>
+                <Button Content="Save"   Width="80" Margin="4,0" IsDefault="True"/>
+            </StackPanel>
+        </Grid>
+    </DockPanel>
+</Window>
+```
+
+This example shows:
+
+- DockPanel for the outer chrome: menu top, status bar bottom, sidebar left, body
+  fills.
+- Grid inside the sidebar for "title row above, content row stretches" pattern.
+- Grid inside the body with `*` and `Auto` rows: the editor stretches, the button
+  bar hugs.
+- StackPanel for the right-aligned button row.
+- Data binding for `LineCount`, `NavigationItems`, `DocumentText`.
+
+### Example 2: A Form With Star Sizing
+
+A login form that demonstrates the canonical `Auto, *` Grid pattern:
+
+```xaml
+<Grid Margin="20" MaxWidth="400">
+    <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto" SharedSizeGroup="Labels"/>
+        <ColumnDefinition Width="*"/>
+    </Grid.ColumnDefinitions>
+    <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="*"/>
+        <RowDefinition Height="Auto"/>
+    </Grid.RowDefinitions>
+
+    <TextBlock Grid.Row="0" Grid.Column="0" Margin="4"
+               Text="Username:" VerticalAlignment="Center"/>
+    <TextBox   Grid.Row="0" Grid.Column="1" Margin="4"
+               Text="{Binding Username}"/>
+
+    <TextBlock Grid.Row="1" Grid.Column="0" Margin="4"
+               Text="Password:" VerticalAlignment="Center"/>
+    <PasswordBox Grid.Row="1" Grid.Column="1" Margin="4"/>
+
+    <CheckBox Grid.Row="2" Grid.Column="1" Margin="4"
+              Content="Remember me" IsChecked="{Binding RememberMe}"/>
+
+    <!-- Row 3 is `*`: a spacer that absorbs leftover vertical space -->
+
+    <StackPanel Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                Orientation="Horizontal"
+                HorizontalAlignment="Right" Margin="4">
+        <Button Content="Cancel" Width="80" Margin="4,0" IsCancel="True"/>
+        <Button Content="Log In" Width="80" Margin="4,0"
+                IsDefault="True" Command="{Binding LogInCommand}"/>
+    </StackPanel>
+</Grid>
+```
+
+The structural points:
+
+- Column 0 is `Auto` -- the column width equals the longest label.
+- Column 1 is `*` -- the input column absorbs all remaining horizontal space.
+- Rows 0-3 are `Auto` -- each row is the height of its content.
+- Row 4 is `*` -- a vertical spacer that pushes the button bar to the bottom.
+- Row 5 is `Auto` -- the button bar hugs its content.
+- `SharedSizeGroup="Labels"` on column 0 lets you nest this Grid inside an outer
+  `Grid.IsSharedSizeScope="True"` and have its `Auto` column width match other
+  forms in the same scope.
+
+### Example 3: A Custom Panel With Attached Properties
+
+A `RadialPanel` that lays out children around a circle, controlled by per-child
+angle attached properties:
+
+```csharp
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+public class RadialPanel : Panel
+{
+    // Attached property: angle in degrees from north (0 = top, 90 = right).
+    public static readonly DependencyProperty AngleProperty =
+        DependencyProperty.RegisterAttached(
+            "Angle", typeof(double), typeof(RadialPanel),
+            new FrameworkPropertyMetadata(
+                0.0, FrameworkPropertyMetadataOptions.AffectsParentArrange));
+
+    public static void SetAngle(UIElement e, double v) => e.SetValue(AngleProperty, v);
+    public static double GetAngle(UIElement e) => (double)e.GetValue(AngleProperty);
+
+    public double Radius
+    {
+        get => (double)GetValue(RadiusProperty);
+        set => SetValue(RadiusProperty, value);
+    }
+
+    public static readonly DependencyProperty RadiusProperty =
+        DependencyProperty.Register(
+            nameof(Radius), typeof(double), typeof(RadialPanel),
+            new FrameworkPropertyMetadata(
+                100.0, FrameworkPropertyMetadataOptions.AffectsArrange));
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var unlimited = new Size(
+            double.PositiveInfinity, double.PositiveInfinity);
+        foreach (UIElement child in InternalChildren)
+            child.Measure(unlimited);
+        double diameter = Radius * 2;
+        return new Size(diameter, diameter);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        double cx = finalSize.Width / 2, cy = finalSize.Height / 2;
+        foreach (UIElement child in InternalChildren)
+        {
+            double rad = (GetAngle(child) - 90) * Math.PI / 180;
+            double x = cx + Radius * Math.Cos(rad) - child.DesiredSize.Width / 2;
+            double y = cy + Radius * Math.Sin(rad) - child.DesiredSize.Height / 2;
+            child.Arrange(new Rect(
+                x, y, child.DesiredSize.Width, child.DesiredSize.Height));
+        }
+        return finalSize;
+    }
+}
+```
+
+Used in XAML:
+
+```xaml
+<local:RadialPanel Radius="120">
+    <Ellipse Width="40" Height="40" Fill="Red"
+             local:RadialPanel.Angle="0"/>
+    <Ellipse Width="40" Height="40" Fill="Green"
+             local:RadialPanel.Angle="90"/>
+    <Ellipse Width="40" Height="40" Fill="Blue"
+             local:RadialPanel.Angle="180"/>
+    <Ellipse Width="40" Height="40" Fill="Yellow"
+             local:RadialPanel.Angle="270"/>
+</local:RadialPanel>
+```
+
+The example demonstrates the full panel-extension surface:
+
+- An attached property (`Angle`) the child sets on itself; the panel reads it during
+  `ArrangeOverride`.
+- A regular dependency property on the panel (`Radius`) that affects arrange when
+  changed.
+- The `FrameworkPropertyMetadataOptions.AffectsParentArrange` flag on `Angle`: when
+  a child changes its angle, the panel's arrange pass is invalidated automatically.
+
+### Example 4: Visibility and Layout
+
+Demonstrating the layout difference between `Collapsed` and `Hidden`:
+
+```xaml
+<Grid>
+    <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+
+    <Button Grid.Row="0" Content="Always visible"/>
+    <Button Grid.Row="1" Content="Hidden (reserves space)"
+            Visibility="Hidden"/>
+    <Button Grid.Row="2" Content="Collapsed (no space)"
+            Visibility="Collapsed"/>
+
+    <TextBlock Grid.Row="3" VerticalAlignment="Top"
+               Text="The first button is at the top.
+                     The second is invisible but its row is the button's height.
+                     The third is gone; no row for it.
+                     This text starts directly below the (invisible) second button."/>
+</Grid>
+```
+
+Use `Collapsed` for "I want this element to entirely disappear from the layout"
+(default for `if`-style toggles bound to view-model state). Use `Hidden` for "I want
+to make this invisible but keep my layout from jumping when it appears" (helpful for
+tab content placeholders).
+
+---
+
+## Common Gotchas
+
+### Auto-Sized Children Inside a `*` Column That's Too Small
+
+If a Grid is given less available width than the sum of its `Auto` columns' desired
+widths, the `Auto` columns shrink to whatever is available, then the star columns
+get zero. Content may overflow visibly. Fix: set `MinWidth` on the auto column or
+the child.
+
+### StackPanel Inside a `*` Row
+
+A `StackPanel` inside a Grid row sized `*` always sizes to content -- it will not
+distribute the row's extra space among its children. Empty space appears at the
+bottom. Fix: replace the outer StackPanel with another Grid.
+
+### `Auto` in a ScrollViewer
+
+A ScrollViewer passes `double.PositiveInfinity` on its scroll axis during Measure to
+discover total content size. A `*` row or column inside a ScrollViewer collapses to
+zero. Always use `Auto` or fixed sizes inside a ScrollViewer on the scroll axis.
+
+### LayoutTransform vs RenderTransform
+
+`RenderTransform` applies during paint and does not affect layout (rotated content
+may overlap neighbours). `LayoutTransform` applies during measure and arrange and
+does reflow the layout, at the cost of an extra layout pass. Use `RenderTransform`
+for animations; `LayoutTransform` when you want layout to reflow.
+
+### Sub-Pixel Edges
+
+WPF uses 1/96-inch device-independent units. Pixel-perfect 1-pixel hairlines require
+`UseLayoutRounding="True"` -- without it, sub-pixel positioning blurs edges.
+
+### Performance Sinks
+
+- Deeply nested `Grid`s with `Auto` columns trigger many recursive measure passes.
+- `LayoutTransform` re-lays the entire subtree.
+- `InvalidateMeasure` on every mouse-move destroys frame rate.
+- Non-virtualising panels with thousands of children allocate visuals for everything.
+
+---
+
+## The XAML Lineage
+
+WPF's layout model has been inherited, with minor variations, by every framework
+Microsoft has built or sponsored since: Silverlight (2007), WinRT XAML (2012), UWP
+(2015), Xamarin.Forms (2014), Avalonia (2016+), Uno Platform (2018+), WinUI 3
+(2021), and .NET MAUI (2022). All share the two-pass Measure/Arrange protocol,
+`Grid` with `Auto`/`*`/fixed sizing, `StackPanel` / `WrapPanel` / `Canvas`, attached
+properties (`Grid.Row`, `Canvas.Left`, `DockPanel.Dock`), and the
+`HorizontalAlignment` / `VerticalAlignment` / `Margin` / `Padding` quartet on every
+element.
+
+The most interesting member for cross-platform purposes is **Avalonia**, which has
+demonstrated that the WPF layout protocol works equally well on macOS, Linux, iOS,
+Android, and WebAssembly. In principle Avalonia could target a terminal backend,
+treating each cell as a 1x1 device-independent pixel.
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Star sizing is uniquely ergonomic for forms.** The `Auto, *, Auto` Grid pattern
+  expresses "label / stretchy input / trailing widget" in three column definitions,
+  no event handlers, no calculations. Every other framework has copied this idea.
+- **The Measure/Arrange protocol is clean and well-documented.** Microsoft's docs
+  on the protocol are thorough; the conceptual model is small enough to fit on one
+  page; the same protocol underpins six different frameworks.
+- **Attached properties keep panels decoupled from children.** A `Grid` does not need
+  to know what kinds of children it has; children carry their layout intent
+  (`Grid.Row="2"`) on themselves. This makes `Grid` reusable across arbitrary content.
+- **Excellent declarative markup.** XAML is verbose but readable; designer tools can
+  round-trip it; data binding integrates directly. A complex shell layout can be
+  expressed in a few hundred lines of markup.
+- **Strong cross-framework portability.** The same layout knowledge works in WPF,
+  Silverlight, UWP, MAUI, Avalonia, and Uno -- six frameworks that span Windows,
+  macOS, Linux, iOS, Android, browser, and embedded targets.
+- **Dependency property system integrates with layout.** Marking a property
+  `AffectsMeasure` is all it takes to trigger correct invalidation. The framework
+  guarantees that dirty propagation reaches the right elements.
+- **Visibility tri-state.** `Visible` / `Hidden` / `Collapsed` is more expressive
+  than CSS's two-state and avoids many layout-jump bugs.
+- **Comprehensive built-in panel set.** Grid, StackPanel, DockPanel, WrapPanel,
+  Canvas, UniformGrid, VirtualizingStackPanel cover essentially every desktop UI
+  scenario without needing a custom panel.
+
+---
+
+### Weaknesses
+
+- **XAML is verbose.** The same UI in Flutter Dart code can be half the size of the
+  equivalent XAML. Closing tags, namespace declarations, attribute syntax, and
+  property-element syntax all bloat the file.
+- **Two passes cost roughly 2x layout time.** Flutter's single-pass protocol is
+  measurably faster on cold layout. For thousands of elements, this matters.
+- **Attached properties can be confusing.** `Grid.Row="2"` on a button works only
+  inside a Grid; the property has no meaning elsewhere. Tooling helps, but it's
+  unintuitive for newcomers.
+- **LayoutTransform is expensive.** Any transform that affects the bounding box
+  forces a layout pass; this is correct but easy to abuse.
+- **Auto-sizing inside ScrollViewer is treacherous.** The most common WPF beginner
+  bug is putting an `Auto` height inside a vertically-scrolling ScrollViewer and
+  getting nothing.
+- **Performance pitfalls scale with depth.** Deeply nested Grids with `Auto`
+  columns/rows produce O(depth) measure passes; star sizing requires a second
+  iteration. Recurring measure invalidations on every frame are catastrophic.
+- **Static one-shot rendering is awkward.** Like Flutter, WPF assumes a continuous
+  event loop. Rendering one frame to an offscreen surface and then exiting is
+  possible but goes against the grain.
+- **No first-class flex / wrap models.** Star sizing is great for grids; WrapPanel
+  works for simple flows; but CSS Flexbox's `flex-grow` / `flex-shrink` /
+  `flex-basis` triple, or grid-template-areas, have no direct analogue without
+  combining multiple panels.
+
+---
+
+## Lessons for D / Sparkles
+
+The WPF layout protocol translates well to terminal UIs, with one twist: the second
+pass is largely free in a terminal context because the tree is small.
+
+### Measure / Arrange Maps Cleanly to Static Terminal Layouts
+
+A two-pass protocol is conceptually simple to implement in D:
+
+```d
+struct Size { ushort width, height; }
+struct Rect { ushort x, y, width, height; }
+
+interface IPanel {
+    Size measure(Size available);   // Returns DesiredSize.
+    void arrange(Rect finalRect);   // Positions self and children.
+    Size desiredSize() const;
+}
+```
+
+For a terminal table, the Measure pass walks every cell to find its desired width
+and height (e.g., the length of its longest line); the Arrange pass distributes
+leftover width among star columns and places each cell at its final coordinates.
+For a small tree (dozens of cells), the cost of two passes is negligible.
+
+### Star Sizing Is Just Constraint Arithmetic
+
+Ratatui already has `Constraint::Fill(n)`, which is functionally identical to WPF's
+`Width="n*"`. A D implementation could lift this into a richer DSL:
+
+```d
+enum ColumnWidth {
+    auto_,           // Sized to widest content.
+    fixed(ushort n), // n cells.
+    star(double w),  // w shares of leftover.
+}
+
+struct Grid {
+    ColumnWidth[] columns;
+    ColumnWidth[] rows;
+    Cell[][] cells;
+}
+```
+
+The measure pass computes each `auto` column's max desired width; the arrange pass
+distributes leftover among star columns.
+
+### Attached Properties as UDAs
+
+D's UDAs (User-Defined Attributes) could serve a similar role to WPF's attached
+properties for static layout description:
+
+```d
+struct Row { ushort r; }
+struct Column { ushort c; }
+
+@Grid([1, "*", 1])
+struct LoginForm {
+    @Row(0) @Column(0) Label usernameLabel;
+    @Row(0) @Column(1) TextBox username;
+    @Row(1) @Column(0) Label passwordLabel;
+    @Row(1) @Column(1) TextBox password;
+}
+```
+
+A template-based renderer can introspect these UDAs at compile time, eliminating
+all runtime indirection. Compile-time errors catch mistakes like out-of-bounds row
+indices.
+
+### CTFE Pre-Computes Static Layouts
+
+For static dashboards where the layout is known at compile time, D's CTFE can
+collapse the entire Measure/Arrange protocol into compile-time constants:
+
+```d
+enum dashboardLayout = grid([
+    columnDef!Auto,
+    columnDef!"*",
+    columnDef!(40),
+], [
+    rowDef!"Auto",
+    rowDef!"*",
+    rowDef!"Auto",
+]).measure(Size(80, 24)).arrange(Rect(0, 0, 80, 24));
+```
+
+This is something WPF cannot do because everything depends on runtime DPI, font
+metrics, and window size. For terminals, none of that matters.
+
+### Avalonia-Inspired Cross-Backend Strategy
+
+Avalonia proved the Measure/Arrange protocol works on every platform. A Sparkles
+layout sub-package could target multiple backends (terminal, SDL, in-memory test)
+because the protocol itself is backend-agnostic -- only the paint phase differs.
+
+---
+
+## References
+
+- **WPF Layout (the foundational article):**
+  <https://learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/layout>
+- **Panels Overview:**
+  <https://learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/panel>
+- **Alignment, Margins, and Padding:**
+  <https://learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/alignment-margins-and-padding-overview>
+- **API Reference:**
+  - `FrameworkElement.MeasureOverride`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.measureoverride>
+  - `FrameworkElement.ArrangeOverride`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.arrangeoverride>
+  - `UIElement.Measure`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.uielement.measure>
+  - `UIElement.Arrange`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.uielement.arrange>
+  - `Panel`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.panel>
+  - `Grid`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.grid>
+  - `DockPanel`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.dockpanel>
+  - `StackPanel`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.stackpanel>
+  - `WrapPanel`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.wrappanel>
+  - `Canvas`:
+    <https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.canvas>
+- **The XAML lineage:**
+  - WPF source: <https://github.com/dotnet/wpf>
+  - Avalonia: <https://avaloniaui.net/>
+  - Uno Platform: <https://platform.uno/>
+  - .NET MAUI: <https://learn.microsoft.com/en-us/dotnet/maui/>
+- **Cross-reference:**
+  - Flutter (single-pass constraint protocol):
+    [./flutter.md](./flutter.md)
+  - Ratatui (Rust TUI, immediate-mode constraint solver):
+    [../tui-libraries/ratatui.md](../tui-libraries/ratatui.md)
+  - Ink (JS TUI, retained-mode Flexbox):
+    [../tui-libraries/ink.md](../tui-libraries/ink.md)

--- a/docs/research/ui-layout/xmonad.md
+++ b/docs/research/ui-layout/xmonad.md
@@ -1,0 +1,640 @@
+# xmonad (Haskell)
+
+A dynamically tiling X11 window manager written and configured in Haskell. Although
+xmonad targets full desktop windows rather than terminal cells, its **layout
+architecture** is one of the cleanest published examples of a typeclass-as-strategy
+pattern for arranging rectangles. The same ideas -- layouts as first-class values,
+combinators that compose them, messages that mutate them -- transfer naturally to any
+extensible UI-layout system, including a terminal renderer like Sparkles.
+
+| Field            | Value                                                              |
+| ---------------- | ------------------------------------------------------------------ |
+| Language         | Haskell (GHC)                                                      |
+| License          | BSD-3-Clause                                                       |
+| Repository       | <https://github.com/xmonad/xmonad>                                 |
+| Contrib          | <https://github.com/xmonad/xmonad-contrib>                         |
+| Documentation    | <https://xmonad.org/>                                              |
+| Version snapshot | xmonad 0.18.1; xmonad-contrib 0.18.2 (March 2026)                  |
+| First Release    | March 2007                                                         |
+| Core size        | ~2,000 lines of Haskell (StackSet + Layout + main loop)            |
+| Authors          | Don Stewart, Spencer Janssen, Jason Creighton (original 2007 team) |
+
+---
+
+## Overview
+
+### What It Is
+
+xmonad is a [dynamically tiling][xmonad-home] X11 window manager. "Dynamically tiling"
+means it does not require the user to pre-specify a layout; instead it automatically
+arranges windows in a workspace according to a _layout algorithm_ (typically a master
+pane plus a column of stack windows), and the user reshapes the layout by spawning
+new windows, resizing the master area, or switching to an entirely different layout
+with a keystroke. Floating windows are supported as an opt-in, second-class citizen.
+
+What makes xmonad interesting outside its application domain is that **every layout
+algorithm is a Haskell value of a known typeclass**, and combinators (`Mirror`,
+`|||`, `Choose`, layout modifiers like gaps and smart borders) compose those values
+into more elaborate layouts the way `std.algorithm` composes ranges. The set of
+available layouts is open and extensible by third parties without forking the core,
+and the open-set is enforced by the typeclass system rather than by a configuration
+language.
+
+### Design Philosophy
+
+The xmonad README and home page emphasise four properties:
+
+1. **Minimalism.** No titlebars, no taskbar, no icon dock. The window manager's job
+   is to arrange windows; everything else is delegated to dedicated programs
+   (xmobar, dzen2, trayer, ...).
+2. **Stability.** The core uses Haskell's type system aggressively. The central
+   data structure, `StackSet`, is a purely functional zipper over workspaces and
+   windows; its invariants are tested with QuickCheck. Crash-resistance was a major
+   marketing point in xmonad's early years.
+3. **Efficiency.** The tiling core is around 500 lines of Haskell. The full
+   distribution (StackSet + Layout + main loop + X11 plumbing) is around 2,000.
+4. **Keyboard-driven extensibility.** All user configuration is a Haskell program
+   (`xmonad.hs`) that imports the library and overrides defaults. Reconfiguration
+   compiles a new binary and execs it.
+
+The phrase often associated with xmonad is "exemplary Haskell" -- the project was
+publicly held up by the Haskell community as proof that real systems software could
+be built in a pure functional language with negligible overhead.
+
+### History
+
+- **2007.** Don Stewart, Spencer Janssen, and Jason Creighton announce xmonad as a
+  reimplementation, in Haskell, of the ideas behind `dwm` (Anselm R. Garbe's
+  C-based suckless tiling window manager). Initial release 0.1 lands in March.
+- **2007--2008.** QuickCheck properties for `StackSet`. The published paper
+  "xmonad in Coq" by Spencer Janssen, Andy Gill, and others demonstrates a
+  mechanically verified port of the core data structure.
+- **2009 onwards.** The `xmonad-contrib` package becomes the home for dozens of
+  third-party layouts, layout modifiers, key bindings, and prompts. Today
+  `xmonad-contrib` is roughly an order of magnitude larger than `xmonad` proper.
+- **2017--2024.** Long maintenance era under new maintainers (Brent Yorgey, Tony
+  Zorman, slotThe). Core API is mostly frozen; most innovation happens in contrib.
+- **0.18.x (2024--2026).** GHC 9.x compatibility, Wayland-adjacent discussions,
+  small contrib additions.
+
+---
+
+## Layout Model
+
+### The `LayoutClass` Typeclass
+
+At the centre of xmonad's layout architecture is the [`LayoutClass`][xmonad-layout]
+typeclass, defined (slightly abridged) in `XMonad.Core`:
+
+```haskell
+class (Show (layout a), Typeable layout) => LayoutClass layout a where
+
+    -- | Compute the actual layout: given the screen rectangle and the
+    --   non-empty 'Stack' of visible windows, return the per-window
+    --   rectangles plus optionally a new layout state.
+    runLayout :: Workspace WorkspaceId (layout a) a
+              -> Rectangle
+              -> X ([(a, Rectangle)], Maybe (layout a))
+    runLayout (Workspace _ l ms) r = maybe (emptyLayout l r)
+                                           (doLayout l r) ms
+
+    -- | A simpler variant of runLayout for the common case of a
+    --   non-empty stack. Default implementation defers to pureLayout.
+    doLayout :: layout a
+             -> Rectangle
+             -> Stack a
+             -> X ([(a, Rectangle)], Maybe (layout a))
+    doLayout l r s = return (pureLayout l r s, Nothing)
+
+    -- | Pure layout function for layouts that have no state and need
+    --   no access to the X monad.
+    pureLayout :: layout a -> Rectangle -> Stack a -> [(a, Rectangle)]
+    pureLayout _ r s = [(focus s, r)]
+
+    -- | What to do when the stack is empty (default: nothing).
+    emptyLayout :: layout a -> Rectangle
+                -> X ([(a, Rectangle)], Maybe (layout a))
+    emptyLayout _ _ = return ([], Nothing)
+
+    -- | React to a 'Message' (resize, layout change, ...). Returning
+    --   Nothing means "no change"; Just l' replaces the layout state.
+    handleMessage :: layout a -> SomeMessage -> X (Maybe (layout a))
+    handleMessage l = return . pureMessage l
+
+    -- | Pure version of handleMessage for stateless reactions.
+    pureMessage :: layout a -> SomeMessage -> Maybe (layout a)
+    pureMessage _ _ = Nothing
+
+    -- | A human-readable description shown in status bars.
+    description :: layout a -> String
+    description = show
+```
+
+The signature `doLayout :: l a -> Rectangle -> Stack a -> X ([(a, Rectangle)], Maybe (l a))`
+captures the entire problem statement in one type:
+
+- **Input**: the layout's own state `l a`, the screen rectangle `Rectangle`, and
+  a non-empty zipper `Stack a` of windows with a distinguished focus.
+- **Output**: a list of `(window, rectangle)` pairs (the assignment) and
+  optionally a new layout state (e.g. an updated master/slave ratio).
+- **Effects**: the `X` monad (a reader/state monad over `XConf`/`XState`)
+  allows IO when needed; most layouts never use it and default to `pureLayout`.
+
+This is precisely a strategy interface. Each layout chooses how clever it wants to
+be: stateless tilings (`Full`, `Tall`) define `pureLayout`; stateful ones
+(`ResizableTall`, `MosaicAlt`) override `doLayout` and emit a `Just l'` when their
+internal state changes; layouts that need to query X (e.g. fetch a window title for
+a tab bar) reach for `X` directly.
+
+### The `Message` System
+
+Layouts react to user input via the [`Message`][xmonad-core] system, an open-set
+extension mechanism built on `Data.Typeable`:
+
+```haskell
+class Typeable a => Message a
+
+data SomeMessage = forall a. Message a => SomeMessage a
+
+fromMessage :: Message m => SomeMessage -> Maybe m
+fromMessage (SomeMessage m) = cast m
+
+-- Built-in messages
+data ChangeLayout = NextLayout | FirstLayout deriving (Eq, Show, Typeable)
+data Resize       = Shrink | Expand          deriving (Eq, Show, Typeable)
+data IncMasterN   = IncMasterN !Int          deriving (Eq, Show, Typeable)
+instance Message ChangeLayout
+instance Message Resize
+instance Message IncMasterN
+```
+
+A key binding like `mod-h` sends `SomeMessage Shrink` to the current layout via
+`sendMessage`. The layout's `handleMessage` implementation pattern-matches on
+`fromMessage msg :: Maybe Resize` and decides what to do; if the message is not
+relevant it returns `Nothing` and the framework leaves the layout untouched. This
+is essentially Smalltalk's `doesNotUnderstand:` but type-safe: any value of any
+type can be a message as long as it implements `Message`, and the layout only
+catches the messages whose types it cares about.
+
+### Core Layouts
+
+`XMonad.Layout` defines the small set of layouts shipped with the core:
+
+```haskell
+-- | Master area on the left, stack of remaining windows on the right.
+data Tall a = Tall { tallNMaster      :: !Int       -- windows in master pane
+                   , tallRatioIncrement :: !Rational -- resize step
+                   , tallRatio        :: !Rational  -- master area fraction
+                   } deriving (Show, Read)
+
+instance LayoutClass Tall a where
+    pureLayout (Tall nmaster _ frac) r s = zip ws rs
+        where ws = W.integrate s
+              rs = tile frac r nmaster (length ws)
+
+    pureMessage (Tall nmaster delta frac) m =
+        msum [fmap resize     (fromMessage m)
+             ,fmap incmastern (fromMessage m)]
+        where resize Shrink             = Tall nmaster delta (max 0 $ frac-delta)
+              resize Expand             = Tall nmaster delta (min 1 $ frac+delta)
+              incmastern (IncMasterN d) = Tall (max 0 (nmaster+d)) delta frac
+
+    description _ = "Tall"
+
+-- | Render a single window fullscreen.
+data Full a = Full deriving (Show, Read)
+instance LayoutClass Full a
+
+-- | Rotate any layout 90 degrees.
+data Mirror l a = Mirror (l a) deriving (Show, Read)
+
+instance LayoutClass l a => LayoutClass (Mirror l) a where
+    runLayout (W.Workspace i (Mirror l) ms) r =
+        (fmap (map $ second mirrorRect) *** fmap Mirror)
+        <$> runLayout (W.Workspace i l ms) (mirrorRect r)
+    handleMessage (Mirror l) = fmap (fmap Mirror) . handleMessage l
+    description (Mirror l) = "Mirror " ++ description l
+  where
+    mirrorRect (Rectangle rx ry rw rh) = Rectangle ry rx rh rw
+```
+
+Note how `Mirror` is a true _combinator_: it takes any `LayoutClass l a` and produces
+another `LayoutClass (Mirror l) a`. It does not need to know what `l` does -- it
+swaps the input rectangle into "mirrored" coordinates, defers to `l`, and swaps the
+output back. This pattern -- "transform the input, delegate, transform the output" --
+is repeated dozens of times across xmonad-contrib's layout modifiers (`Gaps`,
+`Spacing`, `SmartBorder`, `Reflect`, `NoBorders`, `Magnifier`, ...).
+
+### The `|||` Combinator
+
+The most commonly used layout combinator is [`Choose`][xmonad-layout], pronounced
+"or" and written `|||`:
+
+```haskell
+data Choose l r a = Choose CLR (l a) (r a) deriving (Show, Read)
+data CLR = CL | CR  -- which side is currently active
+
+(|||) :: l a -> r a -> Choose l r a
+(|||) = Choose CL
+infixr 5 |||
+
+instance (LayoutClass l a, LayoutClass r a) => LayoutClass (Choose l r) a where
+    runLayout (W.Workspace i (Choose CL l r) ms) rect =
+        fmap (fmap (flip (Choose CL) r)) <$> runLayout (W.Workspace i l ms) rect
+    runLayout (W.Workspace i (Choose CR l r) ms) rect =
+        fmap (fmap (Choose CR l)) <$> runLayout (W.Workspace i r ms) rect
+
+    handleMessage c m | Just NextLayout <- fromMessage m = ...
+                     | otherwise                         = ...
+    description (Choose CL l _) = description l
+    description (Choose CR _ r) = description r
+```
+
+Because `|||` is right-associative with low precedence, this just works:
+
+```haskell
+myLayout = Tall 1 (3/100) (1/2)
+       ||| Mirror (Tall 1 (3/100) (1/2))
+       ||| Full
+       ||| ThreeColMid 1 (3/100) (1/2)
+```
+
+Each `|||` builds a `Choose`-tree; sending `NextLayout` walks the tree, flipping
+the `CLR` tag from `CL` to `CR` at the appropriate level. The result is that
+`myLayout` is, statically, a single Haskell value of some concrete type
+`Choose Tall (Choose (Mirror Tall) (Choose Full ThreeColMid))`, with the union of
+all message-handling behaviour of its constituents.
+
+`XMonad.Layout.LayoutCombinators` extends this with more specialised
+combinators ([`xmonad-layout-combinators`][xmonad-layout-combinators]):
+
+- `|||` itself (re-exported, with a non-deprecated implementation that supports
+  `JumpToLayout`).
+- `JumpToLayout name` -- a `Message` that jumps to the _named_ layout (matched
+  against `description`), without cycling through intermediates.
+- A family of geometric splitters: `*||*` (one-half left), `**||*` (two-thirds
+  left), `*//*` (one-half top), `**//*` (two-thirds top), etc. -- these split
+  the screen at a fixed ratio and run a different sub-layout in each half.
+
+### `xmonad-contrib` Layout Catalogue
+
+The contrib package ships dozens of additional layouts. A representative sample:
+
+| Module                               | Layout          | Sketch                                       |
+| ------------------------------------ | --------------- | -------------------------------------------- |
+| `XMonad.Layout.ThreeColumns`         | `ThreeColMid`   | Master in centre, stack columns left + right |
+| `XMonad.Layout.Grid`                 | `Grid`          | Regular `sqrt n` grid                        |
+| `XMonad.Layout.Spiral`               | `spiral`        | Fibonacci spiral subdivision                 |
+| `XMonad.Layout.Circle`               | `Circle`        | Master in centre, others on a circle         |
+| `XMonad.Layout.Roledex`              | `Roledex`       | Stack of cascading windows                   |
+| `XMonad.Layout.Accordion`            | `Accordion`     | Focused window expanded, others collapsed    |
+| `XMonad.Layout.Tabbed`               | `tabbed`        | One window visible, tab bar at top           |
+| `XMonad.Layout.MosaicAlt`            | `MosaicAlt`     | User-adjustable mosaic of sizes              |
+| `XMonad.Layout.ResizableTile`        | `ResizableTall` | Tall with per-stack-row resize               |
+| `XMonad.Layout.BinarySpacePartition` | `emptyBSP`      | Tree of recursive vertical/horizontal splits |
+| `XMonad.Layout.IM`                   | `withIM`        | Reserve a strip for an IM roster             |
+
+Each of them is a `LayoutClass` instance. Each one composes with `Mirror`, `|||`,
+and the layout modifiers without modification.
+
+### Layout Modifiers (`LayoutModifier`)
+
+A second layer of extensibility comes from `XMonad.Layout.LayoutModifier`:
+
+```haskell
+class (Show (m a), Read (m a)) => LayoutModifier m a where
+    modifyLayout    :: m a -> Workspace WorkspaceId (l a) a -> Rectangle
+                    -> X ([(a, Rectangle)], Maybe (l a))
+    handleMess      :: m a -> SomeMessage -> X (Maybe (m a))
+    pureMess        :: m a -> SomeMessage -> Maybe (m a)
+    redoLayout      :: m a -> Rectangle -> Maybe (Stack a)
+                    -> [(a, Rectangle)]
+                    -> X ([(a, Rectangle)], Maybe (m a))
+    pureModifier    :: m a -> Rectangle -> Maybe (Stack a)
+                    -> [(a, Rectangle)]
+                    -> ([(a, Rectangle)], Maybe (m a))
+    modifierDescription :: m a -> String
+
+data ModifiedLayout m l a = ModifiedLayout (m a) (l a) deriving (Show, Read)
+
+instance (LayoutModifier m a, LayoutClass l a) =>
+         LayoutClass (ModifiedLayout m l) a where ...
+```
+
+A `LayoutModifier` is a "small" version of a layout that only adjusts the output of
+some inner layout. `Spacing` (per-window gaps), `Gaps` (screen-edge gaps),
+`SmartBorders` (suppress borders when only one window), `NoBorders`,
+`WindowNavigation` (record adjacency for directional focus), `Renamed` (rename for
+the status bar), and many others are implemented this way. The same modifier wraps
+arbitrarily many layouts:
+
+```haskell
+import XMonad.Layout.Spacing  (spacingRaw, Border(..))
+import XMonad.Layout.NoBorders (smartBorders)
+
+myLayout = smartBorders
+         $ spacingRaw False (Border 4 4 4 4) True (Border 4 4 4 4) True
+         $ Tall 1 (3/100) (1/2) ||| Full ||| ThreeColMid 1 (3/100) (1/2)
+```
+
+The Haskell type checker statically _proves_ that the composed layout still
+implements `LayoutClass`. There is no possibility of dispatching a message that
+some part of the stack cannot handle: the typeclass instances for `ModifiedLayout`,
+`Mirror`, and `Choose` collectively delegate message handling along the same
+structure as `runLayout`.
+
+### `StackSet`: The Pure Workspace State
+
+xmonad's other contribution to the design space is `Data.StackSet`, the pure data
+structure that holds the workspaces, screens, and focus state:
+
+```haskell
+data StackSet i l a sid sd = StackSet
+    { current  :: !(Screen i l a sid sd)   -- focused screen
+    , visible  :: [Screen i l a sid sd]    -- non-focused but mapped
+    , hidden   :: [Workspace i l a]        -- non-mapped workspaces
+    , floating :: Map a RationalRect       -- floating window positions
+    }
+
+data Screen    i l a sid sd = Screen { workspace :: !(Workspace i l a), ... }
+data Workspace i l a        = Workspace { tag :: !i, layout :: l, stack :: Maybe (Stack a) }
+data Stack a                = Stack { focus :: !a, up :: [a], down :: [a] }
+```
+
+A `Stack a` is a _zipper_: the focused element plus the lists of elements above
+and below it. All workspace operations (`focusUp`, `focusDown`, `swapMaster`,
+`shiftWin`, ...) are pure functions on `StackSet`, exhaustively tested with
+QuickCheck properties (e.g. "after focus up then focus down, the set is
+unchanged"). Layouts live _inside_ a `Workspace`, parameterised on the type `l`,
+so each workspace can have its own layout state independently.
+
+### Putting It Together: An Example Configuration
+
+A representative `xmonad.hs` showing layouts, combinators, and modifiers:
+
+```haskell
+import XMonad
+import XMonad.Layout.NoBorders          (smartBorders)
+import XMonad.Layout.Spacing            (spacingRaw, Border(..))
+import XMonad.Layout.ThreeColumns       (ThreeCol(..))
+import XMonad.Layout.Tabbed             (tabbed, shrinkText, def)
+import XMonad.Layout.LayoutCombinators  ((|||), JumpToLayout(..))
+import XMonad.Layout.Renamed            (renamed, Rename(..))
+import XMonad.Util.EZConfig             (additionalKeysP)
+
+myLayout = smartBorders
+         . spacingRaw True (Border 0 8 8 8) True (Border 8 8 8 8) True
+         $ renamed [Replace "tall"]  (Tall 1 (3/100) (1/2))
+       ||| renamed [Replace "wide"]  (Mirror (Tall 1 (3/100) (1/2)))
+       ||| renamed [Replace "3col"]  (ThreeColMid 1 (3/100) (1/2))
+       ||| renamed [Replace "full"]  Full
+       ||| renamed [Replace "tabs"]  (tabbed shrinkText def)
+
+main = xmonad $ def
+    { layoutHook = myLayout
+    , terminal   = "alacritty"
+    } `additionalKeysP`
+    [ ("M-S-f", sendMessage $ JumpToLayout "full")
+    , ("M-S-t", sendMessage $ JumpToLayout "tall")
+    , ("M-S-w", sendMessage $ JumpToLayout "wide")
+    ]
+```
+
+The `myLayout` value is, statically, a single layout of some elaborate Haskell
+type. Adding a new layout means importing a module and inserting another `|||`.
+Adding a new _kind_ of modifier (e.g. one that paints debug rectangles) means
+writing a `LayoutModifier` instance -- no patches to `xmonad-core`, no
+plugin-loader, no configuration DSL.
+
+---
+
+## Strengths and Weaknesses
+
+### Strengths
+
+- **Layouts are first-class values.** A layout is a Haskell expression that can
+  be named, passed around, and combined like any other value. There is no second
+  language (configuration, DSL, JSON schema) interposed between the user and
+  the layout algorithm.
+- **Combinators compose cleanly.** `Mirror`, `|||`, and the `LayoutModifier`
+  framework allow non-trivial compositions (`smartBorders $ spacing 4 $
+Tall ||| Full`) without any layout knowing about the others. The typeclass
+  obligation is the only contract.
+- **Type-safe open extensibility.** The `Message`/`SomeMessage` system lets
+  layouts declare arbitrary new commands without coordinating with the core. A
+  layout that does not understand a message returns `Nothing`; one that does
+  pattern-matches via `fromMessage`. This is open in the
+  ["expression problem"][expr-problem] sense: both new layouts and new messages
+  can be added without modifying existing code.
+- **Pure functional core.** `StackSet` and `pureLayout`/`pureMessage` are total
+  functions over immutable data. QuickCheck-tested invariants give the project a
+  reputation for stability that few window managers can match.
+- **Tiny core.** ~500 lines for the tiling logic and ~2,000 lines for the whole
+  WM. A reader can grasp the entire data model in an afternoon.
+- **Configuration is a real program.** A user's `xmonad.hs` is recompiled and
+  re-exec'd on change. The configuration has access to the full Haskell language
+  and the full xmonad library; there is no expressivity ceiling.
+
+### Weaknesses
+
+- **Configuration learning curve is steep for non-Haskell users.** Editing
+  `xmonad.hs` requires reading Haskell type errors. Newcomers routinely report
+  that the type signatures in `XMonad.Layout.*` modules are intimidating, even
+  though the _usage_ is usually one line. The community has partly mitigated
+  this with `XMonad.Util.EZConfig` (string-based key specs) and quickstart
+  templates, but the bar remains higher than i3's INI-like config.
+- **GHC dependency.** Reconfiguring xmonad recompiles a fresh binary. On systems
+  without GHC pre-installed, this is a non-trivial setup cost; on slow hardware
+  the rebuild takes seconds.
+- **X11-only.** xmonad targets the X protocol. There is no native Wayland
+  port; users who want a Wayland tiling compositor look at `sway`, `river`,
+  `niri`, or `Hyprland`. The xmonad-on-Wayland question has been periodically
+  discussed but no production implementation exists.
+- **The type system can rebel.** Composing many `LayoutModifier`s yields
+  exotic types like `ModifiedLayout SmartBorder (ModifiedLayout Spacing
+(Choose (Mirror Tall) (Choose Full (ModifiedLayout WindowNavigation
+ThreeCol))))`. Most users never look at these types, but the moment a
+  `JumpToLayout` message or a function signature needs to mention the layout
+  type, GHC's error messages become a learning opportunity.
+- **No mouse-first workflow.** xmonad expects keyboard-driven navigation.
+  Floating windows can be dragged, but the tiling story is keyboard-only.
+- **Layout state is opaque to the rest of the system.** Because layout state is
+  hidden inside `l a`, status bars that want to display "current master ratio"
+  or "BSP tree shape" have to define a custom `Message` and have the layout
+  publish state through it.
+
+### Lessons for Sparkles
+
+xmonad is _not_ a TUI library, but for a layout subsystem in a CLI/TUI toolkit a
+few patterns are directly applicable:
+
+- **Layout-as-type / strategy-as-value.** A D `interface Layout` or
+  Design-by-Introspection trait `isLayout!T` enforcing
+  `Rect[] doLayout(Rect screen, Window[] windows)` maps onto `LayoutClass`
+  almost mechanically. Combinators like a `Mirror!Layout` wrapping any inner
+  layout, or a `Choose!(L, R)` selecting between two, can be implemented as
+  templated structs that delegate at compile time without virtual dispatch.
+- **Open-set messages.** The `SomeMessage`/`fromMessage` pattern can be realised
+  in D with `std.variant.Variant`, with a typeclass-style introspection check
+  ("does this layout's `handleMessage` accept a `Resize`?"). For a
+  more zero-cost variant, a CTFE-built dispatch table keyed on `TypeInfo`
+  achieves the same flexibility without `Variant`'s allocations.
+- **Pure layout functions.** xmonad's `pureLayout :: l a -> Rect -> Stack a ->
+[(a, Rect)]` is a `@safe pure nothrow @nogc` function in D terms: takes
+  layout state and screen, returns a finite list of placed rectangles. Sparkles
+  could declare a `pureLayout` primitive of this exact shape and require
+  layouts that opt into it.
+- **Composable wrappers (`LayoutModifier`).** A "modifier" pattern -- a struct
+  that wraps another layout and post-processes its output -- maps onto D
+  template wrappers very directly:
+
+  ```d
+  struct Spacing(Inner)
+  if (isLayout!Inner)
+  {
+      Inner inner;
+      int padding;
+
+      Rect[] doLayout(in Rect screen, in Window[] ws) {
+          auto inset = screen.inset(padding);
+          auto rs = inner.doLayout(inset, ws);
+          foreach (ref r; rs) r = r.inset(padding);
+          return rs;
+      }
+  }
+  ```
+
+  The compile-time wiring is identical to xmonad's `ModifiedLayout`.
+
+For comparison with a _configuration-language_ approach to the same problem,
+see [i3-sway.md](./i3-sway.md): i3/Sway expresses layout choices through a
+small INI-flavoured DSL, but the set of available layouts is closed and the
+extension story is "fork i3 or write an IPC client". xmonad's layouts are open
+because they are values of an open typeclass; i3's are closed because they are
+keywords in a parser.
+
+### Concrete D Sketch
+
+A first-cut translation of `LayoutClass` into idiomatic D, suitable for a
+hypothetical `sparkles.core_cli.layout` module:
+
+```d
+module sparkles.core_cli.layout;
+
+@safe pure nothrow:
+
+/// Capability trait: any T is a Layout if it supplies the three primitives.
+enum isLayout(T) = is(typeof((T t, Rect r, Pane[] ps) {
+    Pane[] placed = t.doLayout(r, ps);
+    static assert(is(typeof(placed) == Pane[]));
+}));
+
+/// Optional capability: a layout that reacts to messages.
+enum handlesMessage(T, M) = is(typeof((T t, M m) {
+    auto next = t.handleMessage(m); // returns T (new state) or void
+}));
+
+struct Rect { int x, y, w, h; }
+struct Pane { uint id; Rect rect; }
+
+/// The canonical xmonad-Tall analogue.
+struct Tall {
+    int nMaster   = 1;
+    float ratio   = 0.5f;
+    float delta   = 0.03f;
+
+    Pane[] doLayout(in Rect r, Pane[] ps) const {
+        if (ps.length == 0) return ps;
+        // master pane fills `ratio * r.w`; remaining stack split vertically.
+        // (Body elided.)
+        return ps;
+    }
+
+    Tall handleMessage(Resize m) const {
+        final switch (m) with (Resize) {
+            case shrink: return Tall(nMaster, ratio - delta, delta);
+            case expand: return Tall(nMaster, ratio + delta, delta);
+        }
+    }
+}
+
+enum Resize { shrink, expand }
+
+/// `Mirror` works for any Layout. Compile-time delegation: zero virtual cost.
+struct Mirror(Inner) if (isLayout!Inner)
+{
+    Inner inner;
+    Pane[] doLayout(in Rect r, Pane[] ps) {
+        auto mirrored = Rect(r.y, r.x, r.h, r.w);
+        auto out_ = inner.doLayout(mirrored, ps);
+        foreach (ref p; out_)
+            p.rect = Rect(p.rect.y, p.rect.x, p.rect.h, p.rect.w);
+        return out_;
+    }
+}
+
+/// `Choose!(L, R)` is `|||`: cycle between two layouts at compile time.
+struct Choose(L, R) if (isLayout!L && isLayout!R)
+{
+    L left;
+    R right;
+    bool useLeft = true;
+
+    Pane[] doLayout(in Rect r, Pane[] ps) {
+        return useLeft ? left.doLayout(r, ps)
+                       : right.doLayout(r, ps);
+    }
+}
+```
+
+Note how `Mirror` and `Choose` are generic over their inner layouts: D's
+template system gives the same compile-time guarantee as Haskell's type-class
+constraint that the inner type is a layout. Sending a message to a
+`Choose!(Mirror!Tall, Full)` works without virtual dispatch -- the compiler
+generates direct calls to each delegated `handleMessage`. The resulting binary
+shape mirrors xmonad's Haskell types exactly.
+
+### Notes on Wayland Compositors
+
+While xmonad itself is X11-only, the _layout-as-strategy_ pattern has been
+re-implemented in several Wayland compositors:
+
+- **`river`** (Zig) -- separates "layout" into an external process spoken to
+  over a custom Wayland protocol. Any executable that speaks the protocol
+  becomes a layout. Layouts are open in the same sense as xmonad's typeclass,
+  but the boundary is a UNIX socket rather than a Haskell module.
+- **`niri`** (Rust) -- ships a small enumerated set of layouts; closer to the
+  i3 model.
+- **`Hyprland`** (C++) -- plugin-loadable layouts; closer to xmonad's
+  contrib model but via shared libraries rather than recompilation.
+
+For a TUI library, "process boundary" is overkill; the in-process,
+typeclass/template approach used by xmonad is the right comparable.
+
+---
+
+## References
+
+- **Home page**: <https://xmonad.org/>
+- **Source (core)**: <https://github.com/xmonad/xmonad>
+- **Source (contrib)**: <https://github.com/xmonad/xmonad-contrib>
+- **Hackage (core)**: <https://hackage.haskell.org/package/xmonad>
+- **Hackage (contrib)**: <https://hackage.haskell.org/package/xmonad-contrib>
+- **`XMonad.Layout`**: <https://hackage.haskell.org/package/xmonad/docs/XMonad-Layout.html>
+- **`XMonad.Layout.LayoutCombinators`**: <https://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Layout-LayoutCombinators.html>
+- **`XMonad.Layout.LayoutModifier`**: <https://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Layout-LayoutModifier.html>
+- **Original announcement (haskell-cafe, 2007)**: <https://mail.haskell.org/pipermail/haskell-cafe/2007-March/023253.html>
+- **"xmonad in Coq"** (Janssen, Gill, et al., 2008): a Coq port of the
+  `StackSet` data structure, illustrating the small-pure-core philosophy.
+- **`dwm` (the C precursor)**: <https://dwm.suckless.org/>
+- **Comparison docs**: [i3-sway.md](./i3-sway.md) (config-DSL approach),
+  [css-flexbox.md](./css-flexbox.md) (declarative grow/shrink),
+  [taffy.md](./taffy.md) (Rust layout engine),
+  [../tui-libraries/brick.md](../tui-libraries/brick.md) (Haskell TUI
+  combinators in the same ecosystem).
+
+[xmonad-home]: https://xmonad.org/
+[xmonad-layout]: https://hackage.haskell.org/package/xmonad/docs/XMonad-Layout.html
+[xmonad-core]: https://hackage.haskell.org/package/xmonad/docs/XMonad-Core.html
+[xmonad-layout-combinators]: https://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Layout-LayoutCombinators.html
+[expr-problem]: https://en.wikipedia.org/wiki/Expression_problem

--- a/docs/research/ui-layout/yoga.md
+++ b/docs/research/ui-layout/yoga.md
@@ -1,0 +1,712 @@
+# Yoga (C++)
+
+Meta's portable, embeddable layout engine that implements a faithful subset
+of the CSS Flexbox specification, exposes a consistent API across more than
+half a dozen host languages, and powers layout in React Native, Litho,
+ComponentKit, Ink, and a number of in-house Meta surfaces. Where Clay
+optimises for raw speed and a tight C-macro DSL, Yoga optimises for
+behavioural fidelity to CSS and cross-platform consistency.
+
+| Field            | Value                                                                        |
+| ---------------- | ---------------------------------------------------------------------------- |
+| Language         | C++20 core, with bindings for Java, Kotlin, Obj-C, JS, C                     |
+| License          | MIT                                                                          |
+| Repository       | <https://github.com/facebook/yoga>                                           |
+| Documentation    | <https://www.yogalayout.dev/>                                                |
+| Version snapshot | 3.2.1 (December 13, 2024); 3.2.0 introduced `box-sizing`                     |
+| Notable adoption | React Native, Litho, ComponentKit, [Ink](../tui-libraries/ink.md), Bloomberg |
+
+---
+
+## Overview
+
+### What It Solves
+
+Cross-platform UI frameworks face a recurring quandary: web developers
+expect Flexbox; native platforms (iOS, Android, terminal, embedded) have
+their own native layout engines (Auto Layout, ConstraintLayout, ad-hoc
+column math). Implementing the same UI three times for three layout
+engines, with three slightly-different bugs and three slightly-different
+edge-case behaviours, is expensive and tedious. Yoga's pitch is: write
+one Flexbox tree, get pixel-identical layout on every host where Yoga
+runs.
+
+Concretely, Yoga is an **embeddable layout system** -- you create a
+tree of `YGNode`s, set Flexbox properties on each node, call
+`YGNodeCalculateLayout(root, availableWidth, availableHeight,
+ownerDirection)`, and Yoga annotates each node with its computed
+`(left, top, width, height)`. The host then walks the tree and draws
+the nodes using whatever rendering primitives it has -- pixels for
+React Native and ComponentKit, virtual DOM operations for ReactDOM
+ports, terminal cells for Ink. Yoga itself never draws anything.
+
+### Design Philosophy
+
+Yoga's design choices are all in service of CSS fidelity and portability:
+
+- **CSS Flexbox is the source of truth.** Where the spec has a defined
+  behaviour for a corner case, Yoga matches it -- including some
+  intentionally inconsistent spec behaviours, on the grounds that
+  divergence would surprise users more than the inconsistency.
+- **One algorithm, many bindings.** The layout algorithm lives in C++
+  in `yoga/`, and the bindings (Java, JavaScript, Obj-C, Kotlin) call
+  into it through thin FFI layers. There is no per-binding fork of the
+  layout logic, so behaviour is identical across hosts.
+- **Conformance is verified, not asserted.** Yoga ships an extensive
+  set of generated test fixtures that capture the layout that a real
+  browser produces for a particular DOM tree, and the same fixtures run
+  against Yoga to ensure it matches. New corner-case bugs are typically
+  reproduced first as a browser fixture, then fixed in Yoga.
+- **Embeddability is non-negotiable.** No global state, no thread
+  affinity, no implicit allocation behind your back, no required event
+  loop. You allocate a `YGNode`, set properties on it, drop it when
+  you are done. The whole engine is a couple of dozen kilobytes of
+  compiled code.
+- **Custom measurement is a first-class extension point.** Leaves (text,
+  images, native widgets) register a `YGMeasureFunc` that Yoga calls
+  during layout to get the intrinsic size of the leaf at a given
+  constraint. Everything else is delegated to a host-defined notion
+  of "what does this node measure to?"
+
+### History
+
+Yoga's pedigree predates the Yoga name. The earliest ancestor was
+`css-layout` (sometimes written `CSSLayout`), a small JavaScript
+implementation of the Flexbox spec that Facebook open-sourced around
+**2014-2015** to power layout in React Native. The JS implementation was
+then ported to C for performance and the result was renamed **Yoga**
+around **2017** -- by then it was already in use by React Native,
+ComponentKit (Facebook's Obj-C UI framework for iOS), and Litho
+(Facebook's Android UI framework on top of ComponentKit's ideas). The
+key fact for terminal-CLI watchers is that the same C codebase is what
+Ink compiles into WebAssembly and ships in `node_modules` to compute
+Flexbox layout for terminal output.
+
+Major milestones since:
+
+- **Yoga 2.0.0 (June 30, 2023)** -- the first major release since 2018.
+  Introduced full Flexbox `gap` support (`gap`, `rowGap`, `columnGap`),
+  modernised the toolchain (CMake-based builds, C++20), and improved
+  conformance against newer Flexbox spec revisions.
+- **Yoga 2.0.1 (November 1, 2023)** -- maintenance.
+- **Yoga 3.0.0 (March 14, 2024)** -- introduced `position: static` (CSS
+  `position` value, distinct from default `relative`), added
+  `align-content: space-evenly`, switched the JavaScript bindings to
+  ES Modules, and shipped alongside React Native 0.74. Some legacy APIs
+  were removed.
+- **Yoga 3.0.3 / 3.0.4 (April 2024)** -- maintenance.
+- **Yoga 3.1.0 (June 26, 2024)** -- additional CSS conformance fixes.
+- **Yoga 3.2.0 (December 3, 2024)** -- introduced `box-sizing` (so
+  `border-box` is finally supported, matching CSS), added `display:
+contents`, used by React Native 0.77.
+- **Yoga 3.2.1 (December 13, 2024)** -- maintenance.
+
+The cadence has been steady but unflashy: incremental conformance
+improvements driven by React Native's release train, with the
+occasional new CSS property added when a major React Native version
+needs it.
+
+---
+
+## Architecture / Layout Model
+
+### The Flexbox Subset Yoga Implements
+
+Yoga's documentation puts it plainly: Yoga "supports a familiar subset
+of CSS, mostly focused on Flexbox." What is in:
+
+- **Container axis & direction**: `flexDirection` (`row`, `row-reverse`,
+  `column`, `column-reverse`), and the `direction` property for
+  `ltr`/`rtl` writing direction.
+- **Main-axis distribution**: `justifyContent` with all six values
+  (`flex-start`, `center`, `flex-end`, `space-between`, `space-around`,
+  `space-evenly`).
+- **Cross-axis alignment of items**: `alignItems`, with values
+  `flex-start`, `center`, `flex-end`, `stretch`, `baseline`.
+- **Per-item cross-axis override**: `alignSelf`, same value set as
+  `alignItems` plus `auto`.
+- **Cross-axis line packing for wrapped containers**: `alignContent`,
+  with values `flex-start`, `center`, `flex-end`, `stretch`,
+  `space-between`, `space-around`, and (since 3.0) `space-evenly`.
+- **Wrapping**: `flexWrap` (`nowrap`, `wrap`, `wrap-reverse`).
+- **Flex item sizing**: `flex` (the CSS shorthand), `flexGrow`,
+  `flexShrink`, `flexBasis`.
+- **Gaps**: `gap`, `rowGap`, `columnGap` (since Yoga 2.0).
+- **Spacing**: `padding` and `margin` on all four sides plus logical
+  edges (`paddingStart`/`paddingEnd` for RTL).
+- **Positioning**: `position: relative` (default), `absolute`, and
+  (since 3.0) `static`.
+- **Aspect ratio**: `aspectRatio`.
+- **Dimensions**: `width`, `height`, `minWidth`, `minHeight`,
+  `maxWidth`, `maxHeight`, all in points, percentages, or `auto`.
+- **Display**: `display: flex` (default), `display: none`, and (since
+  3.2) `display: contents`.
+- **Box model**: `box-sizing: content-box` (default) or `border-box`
+  (since 3.2.0).
+
+What is **not** in (as of 3.2.1):
+
+- **CSS Grid**. Yoga has no Grid implementation. If you need
+  two-dimensional grid layout, you build it on top of nested Flexbox
+  rows, or you use a different engine.
+- **Floats** (`float: left`, `clear: both`). Pre-Flexbox layout
+  primitives that Yoga has no use for.
+- **Tables**. CSS table layout is a separate algorithm; Yoga does not
+  implement it.
+- **Multi-column layout** (`column-count`, `column-gap` in the
+  multicol sense, not the Flexbox sense).
+- **Text shaping or line-breaking**. Yoga measures text only through
+  the host-provided `YGMeasureFunc` callback; it has no built-in
+  understanding of text content.
+
+For terminal CLI purposes the missing pieces are mostly irrelevant
+(no one wants CSS floats in a CLI), but the absence of Grid is
+significant: many CLI layouts -- a help table with fixed-width
+columns, a dashboard with a fixed grid of cells -- read more
+naturally as Grid than as Flexbox. Ink users routinely express
+these as nested Flexbox containers, which works but feels indirect.
+
+### Sizing Primitives
+
+The three knobs you have for sizing on each axis are:
+
+| Property                 | Type              | Meaning                                                   |
+| ------------------------ | ----------------- | --------------------------------------------------------- |
+| `width` / `height`       | points, %, `auto` | Preferred dimension. `auto` means "use intrinsic / flex". |
+| `minWidth` / `minHeight` | points, %         | Minimum dimension; node will not shrink below this.       |
+| `maxWidth` / `maxHeight` | points, %         | Maximum dimension; node will not grow past this.          |
+
+For flex items there are three additional knobs:
+
+| Property     | Type              | Default | Meaning                                                                                                                                                                            |
+| ------------ | ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flexGrow`   | number            | `0`     | If there is leftover space on the main axis after positioning all items, distribute it among grow-enabled items in proportion to their `flexGrow` value.                           |
+| `flexShrink` | number            | `0`     | If items overflow the main axis, shrink shrink-enabled items in proportion to `flexShrink` \* `flexBasis`. With `UseWebDefaults`, Yoga switches this default to the CSS value `1`. |
+| `flexBasis`  | points, %, `auto` | `auto`  | The starting size on the main axis before grow/shrink applies. `auto` means "use the item's `width`/`height` if set, otherwise content size".                                      |
+
+The `flex` shorthand combines all three (`flex: 1` is roughly
+`flexGrow: 1, flexShrink: 1, flexBasis: 0`). Yoga's JavaScript bindings expose
+object-style setters; the C API exposes the three setters individually.
+
+The default `flexShrink` value is one of Yoga's known divergences from
+the CSS Flexbox spec: CSS specifies a default of `1` (items shrink to
+fit), Yoga's C API defaults to `0` (items do not shrink), the JS
+binding patches this back to `1` to match web expectations. This is the
+single most-asked support question in Yoga's history.
+
+### Padding, Margin, and Gap
+
+`padding` and `margin` each have per-side setters:
+
+```cpp
+YGNodeStyleSetPadding(node, YGEdgeLeft,   8);
+YGNodeStyleSetPadding(node, YGEdgeRight,  8);
+YGNodeStyleSetPadding(node, YGEdgeTop,    4);
+YGNodeStyleSetPadding(node, YGEdgeBottom, 4);
+```
+
+`YGEdge` values include `Left`, `Right`, `Top`, `Bottom`, `Start`,
+`End`, `Horizontal` (sets left+right), `Vertical` (sets top+bottom),
+and `All`. `Start`/`End` are the RTL-aware variants that flip with
+`direction: rtl`.
+
+`gap` (since Yoga 2.0) is a single setter for both row and column,
+with `rowGap` and `columnGap` for asymmetric values:
+
+```cpp
+YGNodeStyleSetGap(node, YGGutterAll,    8);   // 8 on both axes
+YGNodeStyleSetGap(node, YGGutterRow,    4);   // 4 between rows
+YGNodeStyleSetGap(node, YGGutterColumn, 8);   // 8 between columns
+```
+
+This matches CSS Flexbox's `gap` / `row-gap` / `column-gap`. Before
+Yoga 2.0 you had to fake gaps with margin, which is fiddly because
+margins on the outermost children produce edge bleed.
+
+### Alignment
+
+Alignment in Yoga is honest CSS Flexbox alignment, not Clay's collapsed
+single-value-per-axis model. The four properties are:
+
+| Property         | Axis       | Notes                                                                  |
+| ---------------- | ---------- | ---------------------------------------------------------------------- |
+| `justifyContent` | Main axis  | Packs the items as a group along the main axis (or distributes them).  |
+| `alignItems`     | Cross axis | Default cross-axis alignment for all children.                         |
+| `alignSelf`      | Cross axis | Override for a specific child.                                         |
+| `alignContent`   | Cross axis | When `flexWrap: wrap`, controls how multiple lines pack on cross axis. |
+
+`alignContent` only matters when wrapping is enabled and there are
+multiple lines of items. If wrapping is off (or there is only one
+line), `alignContent` is ignored.
+
+### Position
+
+`position: relative` (default) makes the node participate in normal
+Flexbox flow. `position: absolute` takes the node out of flow and
+positions it relative to the _padding edge_ of the nearest ancestor
+that has `position` set to anything other than `static` -- by default
+that is the immediate parent. `position: static` (since Yoga 3.0)
+matches CSS: the node participates in flow and ignores `top`/`left`/
+etc. settings.
+
+```cpp
+YGNodeStyleSetPositionType(node, YGPositionTypeAbsolute);
+YGNodeStyleSetPosition(node, YGEdgeTop,  8);
+YGNodeStyleSetPosition(node, YGEdgeLeft, 8);
+```
+
+### Aspect Ratio
+
+`aspectRatio` is `width / height`. When set, Yoga uses it to derive the
+unknown dimension from the known one. This is the easiest way to keep
+an image or video element from distorting under flex pressure.
+
+### Measure-Arrange Protocol
+
+Like Clay, Yoga delegates text measurement to a host callback:
+
+```cpp
+typedef YGSize (*YGMeasureFunc)(
+    YGNodeRef node,
+    float width,
+    YGMeasureMode widthMode,
+    float height,
+    YGMeasureMode heightMode
+);
+```
+
+The host registers a `YGMeasureFunc` on leaf nodes (typically text or
+image nodes). During layout, Yoga calls it with the available width and
+height plus a _measure mode_:
+
+- `YGMeasureModeUndefined` -- "no constraint, return intrinsic size".
+- `YGMeasureModeExactly` -- "you must be exactly this size".
+- `YGMeasureModeAtMost` -- "you may be up to this size".
+
+The callback returns a `YGSize { width, height }` that Yoga then uses
+in the parent's flex calculations. This is the extension hook for
+terminal-cell-width measurement, monospaced or otherwise, and it is
+exactly what [../tui-libraries/ink.md](../tui-libraries/ink.md) uses
+for its text-wrapping logic.
+
+The arrangement pass is internal to Yoga. After
+`YGNodeCalculateLayout(root, availableWidth, availableHeight,
+ownerDirection)` returns, you read computed values off each node:
+
+```cpp
+float x = YGNodeLayoutGetLeft(child);
+float y = YGNodeLayoutGetTop(child);
+float w = YGNodeLayoutGetWidth(child);
+float h = YGNodeLayoutGetHeight(child);
+```
+
+Unlike Clay, Yoga does _not_ emit a render-command stream. The host is
+expected to walk the layout tree itself, reading the computed
+properties and producing whatever rendering primitives are appropriate.
+This is a meaningful architectural difference: Yoga is a "compute
+layout, write back to tree" engine; Clay is a "compute layout, emit
+flat commands" engine. Yoga's model is more flexible (you can attach
+arbitrary state to each node and walk it any way you like), Clay's is
+more decoupled (you can hand the command array to a renderer that has
+never heard of Clay's tree types).
+
+### Code Example 1: Native C API
+
+```cpp
+#include <yoga/Yoga.h>
+
+int main(void) {
+    // Root: 500x300, horizontal flex.
+    YGNodeRef root = YGNodeNew();
+    YGNodeStyleSetWidth(root, 500);
+    YGNodeStyleSetHeight(root, 300);
+    YGNodeStyleSetFlexDirection(root, YGFlexDirectionRow);
+    YGNodeStyleSetPadding(root, YGEdgeAll, 16);
+    YGNodeStyleSetGap(root, YGGutterAll, 16);
+
+    // Sidebar: fixed width, full height.
+    YGNodeRef sidebar = YGNodeNew();
+    YGNodeStyleSetWidth(sidebar, 120);
+    YGNodeStyleSetFlexGrow(sidebar, 0);
+    YGNodeStyleSetFlexShrink(sidebar, 0);
+    YGNodeInsertChild(root, sidebar, 0);
+
+    // Content: grows to fill remaining width.
+    YGNodeRef content = YGNodeNew();
+    YGNodeStyleSetFlexGrow(content, 1);
+    YGNodeInsertChild(root, content, 1);
+
+    YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+
+    // Read computed layout.
+    printf("sidebar: x=%g y=%g w=%g h=%g\n",
+        YGNodeLayoutGetLeft(sidebar),
+        YGNodeLayoutGetTop(sidebar),
+        YGNodeLayoutGetWidth(sidebar),
+        YGNodeLayoutGetHeight(sidebar));
+    printf("content: x=%g y=%g w=%g h=%g\n",
+        YGNodeLayoutGetLeft(content),
+        YGNodeLayoutGetTop(content),
+        YGNodeLayoutGetWidth(content),
+        YGNodeLayoutGetHeight(content));
+
+    YGNodeFreeRecursive(root);
+}
+```
+
+Things to notice:
+
+- Every property is set through a `YGNodeStyleSet*` setter. The C API
+  is verbose by design -- there is no fluent builder, no constructor
+  taking a struct of properties. Every property is one function call.
+- The root's `width` and `height` are set explicitly, but the call to
+  `YGNodeCalculateLayout` passes `YGUndefined` for the available
+  width/height. This is the contract: the values you pass to
+  `YGNodeCalculateLayout` are _additional_ constraints from outside
+  the tree; if you have already pinned the root with explicit
+  dimensions, you do not need to re-supply them.
+- Memory ownership is explicit. `YGNodeFreeRecursive` walks the tree
+  freeing all descendants; if you have shared ownership of some node,
+  use `YGNodeFree` and free children individually.
+
+### Code Example 2: JavaScript Bindings (the Path Ink Uses)
+
+The JS bindings wrap the C++ core through Emscripten-compiled WASM,
+producing a `yoga-layout` npm package. The API maps the C functions
+onto a Node-style object:
+
+```js
+import { Yoga, FlexDirection, Edge, Gutter } from 'yoga-layout';
+
+const root = Yoga.Node.create();
+root.setWidth(80);
+root.setHeight(24);
+root.setFlexDirection(FlexDirection.Column);
+root.setPadding(Edge.All, 1);
+root.setGap(Gutter.All, 1);
+
+const header = Yoga.Node.create();
+header.setHeight(3);
+header.setFlexGrow(0);
+header.setFlexShrink(0);
+root.insertChild(header, 0);
+
+const body = Yoga.Node.create();
+body.setFlexGrow(1);
+root.insertChild(body, 1);
+
+const footer = Yoga.Node.create();
+footer.setHeight(1);
+footer.setFlexGrow(0);
+root.insertChild(footer, 2);
+
+root.calculateLayout(80, 24, /* direction */ 0);
+
+console.log('header:', header.getComputedLayout());
+console.log('body:', body.getComputedLayout());
+console.log('footer:', footer.getComputedLayout());
+
+root.freeRecursive();
+```
+
+`getComputedLayout()` returns `{ left, top, width, height }`. This is
+the API surface Ink calls through after JSX is reconciled into a
+node tree -- see [../tui-libraries/ink.md](../tui-libraries/ink.md) for
+the full pipeline from `<Box>` to `Yoga.Node.create()` to ANSI string
+output.
+
+Critically, in the terminal-CLI use case, one Yoga "point" maps to
+**one character cell**. Ink chooses this scaling: when Yoga reports
+`width: 80`, that is 80 columns. The cell-scale assumption is what
+makes Yoga's float-typed `setWidth`/`setHeight`/`flexGrow` API usable
+for terminal output without further projection.
+
+### Code Example 3: Measure Function for Text
+
+```cpp
+typedef struct {
+    const char *text;
+    int         fontHeight;  // cells, for terminal use
+} TextLeaf;
+
+YGSize MeasureText(
+    YGNodeRef node,
+    float width, YGMeasureMode widthMode,
+    float height, YGMeasureMode heightMode
+) {
+    TextLeaf *leaf = (TextLeaf *) YGNodeGetContext(node);
+    size_t len = strlen(leaf->text);
+
+    YGSize result = { .width = (float) len, .height = (float) leaf->fontHeight };
+
+    if (widthMode == YGMeasureModeExactly) {
+        result.width = width;
+    } else if (widthMode == YGMeasureModeAtMost && result.width > width) {
+        // Naive word-wrap: split on the last space before `width`.
+        size_t lines = (size_t) ceilf(result.width / width);
+        result.width  = width;
+        result.height = (float) (leaf->fontHeight * lines);
+    }
+    return result;
+}
+
+YGNodeRef text = YGNodeNew();
+YGNodeSetContext(text, &myLeaf);
+YGNodeSetMeasureFunc(text, MeasureText);
+```
+
+This is essentially what Ink's measure function does, but elaborated
+with proper grapheme width handling for emoji, CJK double-width
+characters, and ANSI escape sequences (which take terminal-cell width
+0).
+
+### Code Example 4: Composing a Centered Card
+
+```cpp
+// Root: column-direction, items centered on both axes.
+YGNodeRef root = YGNodeNew();
+YGNodeStyleSetFlexDirection(root, YGFlexDirectionColumn);
+YGNodeStyleSetJustifyContent(root, YGJustifyCenter);
+YGNodeStyleSetAlignItems(root, YGAlignCenter);
+YGNodeStyleSetWidth(root, 80);
+YGNodeStyleSetHeight(root, 24);
+
+// Card: column-direction, fits content, with padding and a min width.
+YGNodeRef card = YGNodeNew();
+YGNodeStyleSetFlexDirection(card, YGFlexDirectionColumn);
+YGNodeStyleSetMinWidth(card, 30);
+YGNodeStyleSetMaxWidth(card, 60);
+YGNodeStyleSetPadding(card, YGEdgeAll, 2);
+YGNodeStyleSetGap(card, YGGutterAll, 1);
+YGNodeStyleSetAlignItems(card, YGAlignCenter);
+YGNodeInsertChild(root, card, 0);
+
+// Two text children inside the card.
+YGNodeRef title = YGNodeNew();
+YGNodeSetContext(title, /* leaf with "Confirm" */ ...);
+YGNodeSetMeasureFunc(title, MeasureText);
+YGNodeInsertChild(card, title, 0);
+
+YGNodeRef body = YGNodeNew();
+YGNodeSetContext(body, /* leaf with "Are you sure?" */ ...);
+YGNodeSetMeasureFunc(body, MeasureText);
+YGNodeInsertChild(card, body, 1);
+
+YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+```
+
+The card has `minWidth: 30` / `maxWidth: 60`, so it grows or shrinks
+within that band as its text content varies. The combination
+`justifyContent: center` + `alignItems: center` on the root produces
+true center-of-screen placement on both axes.
+
+---
+
+## Bindings and Language Support
+
+Yoga's value proposition is that the layout algorithm is identical
+across hosts, so the binding catalog is the API:
+
+| Language                | Binding                                   | Notes                                                                                           |
+| ----------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| C++                     | Core (in-tree)                            | The reference implementation. C++20.                                                            |
+| C                       | `yoga/Yoga.h`                             | A thin C facade over the C++ core, used by all non-C++ bindings.                                |
+| Java                    | `yoga/javatests`                          | Used by Litho (Facebook's Android UI framework). JNI to the C core.                             |
+| Kotlin                  | (Android)                                 | Calls the Java bindings.                                                                        |
+| Objective-C             | `YogaKit`                                 | Used by ComponentKit (Facebook's iOS UI framework). Categories on `UIView`.                     |
+| Swift                   | via `YogaKit`                             | Mostly imports the Obj-C surface; Swift Package Manager support is available.                   |
+| JavaScript / TypeScript | `yoga-layout` (npm)                       | Emscripten-compiled WASM. This is what [Ink](../tui-libraries/ink.md) uses for terminal layout. |
+| .NET / C#               | Community ports                           | Several wrappers exist; no official Meta-maintained binding.                                    |
+| Rust                    | `yoga` (crates.io), maintained externally | Wraps the C facade via `bindgen`.                                                               |
+
+The dominant deployments:
+
+- **React Native** uses Yoga to compute layout for native iOS and
+  Android views. This is by far the biggest user, and it is why React
+  Native's release cycle drives Yoga's release cycle (a new Yoga
+  version typically ships in advance of a corresponding React Native
+  release that needs the new properties).
+- **Litho** (Facebook's Android UI) uses Yoga for declarative,
+  Flexbox-driven view layout, mostly to avoid `View` allocation in
+  list-heavy screens.
+- **ComponentKit** (Facebook's iOS UI) uses Yoga via `YogaKit` for the
+  same reason.
+- **Ink** ([../tui-libraries/ink.md](../tui-libraries/ink.md)) uses
+  `yoga-layout` (the WASM build) to compute Flexbox layout for
+  terminal text output. Every `<Box>` in Ink is a `YGNode`; every
+  `<Text>` is a leaf with a `YGMeasureFunc` that returns string width
+  in cells.
+- **Bloomberg** has been a long-running Yoga user for terminal UI,
+  predating Ink.
+
+### WASM Footprint
+
+Because Ink ships Yoga's WASM build with every Ink CLI, the WASM
+artifact size is worth noting. The current `yoga-layout` package
+bundles a roughly 100-200 KB WASM binary (compressed) plus its JS
+shim. Loading is asynchronous and adds a small fixed cost to every
+Ink program's startup. This is one of the reasons Ink's startup time
+is heavier than native CLI alternatives.
+
+---
+
+## Strengths and Weaknesses
+
+### For Cross-Platform Component Layout (its target)
+
+Yoga is the best-in-class choice for cross-platform Flexbox:
+
+- **CSS-spec fidelity**. If you know what a browser would do, you know
+  what Yoga will do (modulo a few documented divergences, mostly
+  around `flexShrink` defaults). Web developers can sketch a UI in
+  the browser and port it to React Native or Ink without surprises.
+- **Identical behaviour across hosts**. A `<Box flexDirection="row">`
+  in Ink lays out exactly like a `View` with the same style in React
+  Native. This is the whole point of Yoga.
+- **Mature and stable**. Ten years of production use at Meta, with
+  ongoing investment driven by the React Native release train. Bugs
+  are tracked via browser-fixture regression tests.
+- **Good extensibility hook**. `YGMeasureFunc` is enough to integrate
+  text shaping engines (HarfBuzz for native), terminal cell-width
+  calculators (Ink's wide-character handling), or image natural
+  sizes (React Native's `<Image>` measurement).
+- **Predictable performance**. Yoga's layout pass is linear in node
+  count for typical UIs. The hot path is well-optimised C++, with
+  cached intrinsic measurements and a layout-dirty-flag system.
+
+### For Static One-Shot Terminal Rendering
+
+For a one-shot terminal renderer (a CLI table, a help screen, a log
+line), Yoga is overkill in much the same way Clay is, but for slightly
+different reasons:
+
+- **The engine is sized for many frames per second of layout, not for
+  one frame.** Allocating a tree of `YGNode`s for a one-shot render,
+  setting properties one function call at a time, and then walking
+  the tree to read computed values is a lot of ceremony for a static
+  output. The amortised cost is fine for a long-running TUI; for a
+  CLI tool that prints a table and exits, the layout-engine overhead
+  is larger than the actual rendering work.
+- **You are forced to think in Flexbox terms**. If your goal is "two
+  columns, the left one fits its content, the right one fills the
+  rest, with a one-cell gap," the Flexbox encoding is
+  `flexDirection: row; gap: 1; left.flexShrink: 0;
+right.flexGrow: 1`. That works, but for simple layouts a direct
+  `(col1_width, col2_width = total - col1 - gap)` calculation is two
+  lines of arithmetic. The conceptual overhead of "what does
+  `flexShrink: 0` mean here?" is not zero, and a simpler library
+  (Ratatui-style constraint splitting, or just D's
+  `std.algorithm.sum` on column widths) is often clearer.
+- **There is no built-in renderer.** Yoga gives you a tree of
+  computed `(left, top, width, height)` values. You still have to
+  walk the tree and emit cells. For a one-shot output, that walk is
+  often as much code as a direct layout computation would have been.
+- **The dependency is heavy.** For Ink, the Yoga WASM is justified by
+  the cross-platform component model. For a small CLI, the same
+  dependency is a hundred kilobytes of WASM plus a JS shim, all to
+  align two columns.
+- **Float coordinates have to be rounded.** Yoga's API is all `float`,
+  so even when you are deliberately using one-point-equals-one-cell
+  scaling, the values you read out can be `3.0000002` or `3.9999998`
+  depending on the arithmetic. A terminal renderer has to round
+  carefully (Ink uses `Math.round` on every dimension) to avoid
+  off-by-one artefacts. Native point-based renderers do not have
+  this problem because their hosts treat fractional points correctly;
+  terminal renderers have to manage it.
+
+The shape of the problem here is the same as the Clay critique: a
+layout engine designed for a streaming UI imposes its mental model on
+a static renderer, where a much smaller, less general primitive would
+do. The Sparkles `core-cli` `prettyPrint` module solves a similar
+problem with direct integer arithmetic over an output range, with no
+intermediate tree and no allocation; that style of code is awkward to
+reach for once Yoga is in the dependency graph.
+
+### Compared to Alternatives
+
+- **[Clay](./clay.md)**. Clay's pitch is "much faster, single-header,
+  zero dependencies, simplified flex model." Yoga's counter-pitch is
+  "faithful CSS, ten years of production hardening, identical across
+  ten hosts." For a single-host project Clay's speed advantage is
+  real but rarely matters in absolute terms; for a multi-host project
+  Yoga's fidelity advantage is decisive. Clay produces a flat
+  render-command array; Yoga annotates the input tree and the host
+  walks it.
+- **Ratatui's `Constraint` system** ([../tui-libraries/ratatui.md](../tui-libraries/ratatui.md)).
+  Not a comparable layout _engine_ -- Ratatui's constraint solver is
+  a one-shot rectangle splitter, not a tree-aware Flexbox
+  implementation. But for the terminal-rendering use case it is the
+  honest comparison: Yoga gives you a Flexbox subset, Ratatui gives
+  you `Length(n) | Fill(weight) | Percentage(p) | Min(n) | Max(n)`
+  and resolves it in linear time without any tree-building.
+- **`stretch` (Rust) / `taffy` (Rust)**. Two third-party Rust ports
+  of the Yoga algorithm. `taffy` (the active fork of `stretch`) is
+  the canonical Rust Flexbox engine and is used by Bevy's UI and
+  Dioxus. API-wise it is very close to Yoga's C++ API, with Rust
+  idioms.
+- **Native toolkit engines (Auto Layout, ConstraintLayout)**.
+  Platform-bound, much more powerful for arbitrary constraint
+  problems (the Cassowary system underneath Auto Layout can express
+  arbitrary linear inequalities), but not portable. Yoga's pitch is
+  "a subset that is identical everywhere."
+
+---
+
+## References
+
+### Primary
+
+- **Repository**: <https://github.com/facebook/yoga>
+- **Documentation site**: <https://www.yogalayout.dev/>
+- **Interactive playground**: <https://www.yogalayout.dev/playground>
+- **API docs (per binding)**: <https://www.yogalayout.dev/docs/about-yoga>
+- **Release notes / changelog**: <https://github.com/facebook/yoga/releases>
+
+### Spec / Algorithm
+
+- **CSS Flexible Box Layout Module Level 1 (W3C)**: <https://www.w3.org/TR/css-flexbox-1/>
+- **Yoga's documented Flexbox differences**: <https://github.com/facebook/yoga/blob/main/README.md>
+
+### Bindings
+
+- **Native C / C++** (in-tree): `yoga/Yoga.h`, `yoga/Yoga.cpp`
+- **Java** (in-tree, for Litho/Android): `java/`
+- **Kotlin** (Android): wraps the Java surface
+- **`YogaKit`** (Obj-C, for ComponentKit/iOS): `YogaKit/`
+- **`yoga-layout`** (npm, JS/TS, used by Ink): <https://www.npmjs.com/package/yoga-layout>
+- **`taffy`** (Rust port, used by Bevy/Dioxus): <https://github.com/DioxusLabs/taffy>
+
+### Notable Adopters
+
+- **React Native**: <https://reactnative.dev/> -- Yoga's flagship use case.
+- **Litho**: <https://fblitho.com/> -- Facebook's Android UI framework.
+- **ComponentKit**: <https://componentkit.org/> -- Facebook's iOS UI framework.
+- **Ink** ([../tui-libraries/ink.md](../tui-libraries/ink.md)) -- React for CLIs, with Yoga doing the terminal layout.
+
+### History
+
+- **Original `css-layout` repository (archived)**: predecessor JS implementation, ca. 2014-2015.
+- **Yoga 2.0 announcement (June 2023)**: <https://github.com/facebook/yoga/releases/tag/v2.0.0>
+- **Yoga 3.0 announcement (March 2024)**: <https://github.com/facebook/yoga/releases/tag/v3.0.0>
+- **Yoga 3.2 announcement (December 2024)**: <https://github.com/facebook/yoga/releases/tag/v3.2.0>
+
+### Cross-References
+
+- [clay.md](./clay.md) -- the other Flexbox-style layout engine in this
+  catalog, comparing favourably on raw speed and macro-DSL ergonomics
+  but with a simplified flex model and a renderer-emit-commands
+  philosophy where Yoga annotates an input tree.
+- [../tui-libraries/ink.md](../tui-libraries/ink.md) -- the production
+  case study for Yoga in a terminal-CLI context. Every `<Box>` is a
+  `YGNode`; every `<Text>` is a Yoga leaf with a custom
+  `YGMeasureFunc` for cell-aware widths.
+- [../tui-libraries/ratatui.md](../tui-libraries/ratatui.md) -- the
+  natural contrast: a constraint-based one-shot box splitter rather
+  than a tree-walking Flexbox engine. For static terminal output,
+  Ratatui's model is much closer to the natural shape of the problem.
+- [../tui-libraries/textual.md](../tui-libraries/textual.md) -- a
+  Python TUI framework that builds its own CSS-subset layout engine
+  rather than reusing Yoga; useful as a third design point.
+- [../tui-libraries/ftxui.md](../tui-libraries/ftxui.md) -- C++ TUI
+  with `hbox`/`vbox`/`flex` primitives that occupy a similar design
+  space to Yoga's Flexbox subset but with a much smaller surface.

--- a/lychee.ci.exclude
+++ b/lychee.ci.exclude
@@ -5,3 +5,4 @@
 ^https://www\.happycoders\.eu/java/scoped-values/?$
 ^https://journal\.stuffwithstuff\.com/2015/02/01/what-color-is-your-function/?$
 ^http://www\.fm2gp\.com/?$
+^https?://hyprland\.org/

--- a/lychee.exclude
+++ b/lychee.exclude
@@ -14,3 +14,16 @@
 ^https://developers\.redhat\.com/articles/
 ^https://zigistry\.dev/
 ^https://en.cppreference.com
+# UI-layout catalog: hosts that reject lychee's UA or have broken TLS/DNS
+^https?://en\.wikipedia\.org/
+^https?://developer\.mozilla\.org/
+^https?://www\.npmjs\.com/
+^https?://www\.youtube\.com/
+^https?://awards\.acm\.org/
+^https?://android\.googlesource\.com/
+^https?://developer\.android\.com/reference/kotlin/
+^https?://www\.miglayout\.com
+^https?://overconstrained\.io/
+^https?://www\.eprg\.org/
+^https?://www\.tcl-lang\.org/man/
+^https?://www\.luatex\.org/svn/


### PR DESCRIPTION
Survey of major UI layout systems complementing the existing TUI Libraries
catalog: renderer-agnostic libraries (Clay, Yoga, Taffy, Stretch, Kiwi),
foundational algorithms (Cassowary, Knuth-Plass), CSS specs (Flexbox, Grid,
Normal Flow), modern declarative GUIs (SwiftUI, Jetpack Compose, Flutter),
traditional desktop GUIs (WPF/XAML, Qt, GTK 4, Swing/MiG, Tk), constraint-based
systems (Auto Layout, Android ConstraintLayout), immediate-mode (Dear ImGui,
egui), and tiling/structural layouts (i3/sway, xmonad).

Each entry follows the tui-libraries doc skeleton (lead, metadata table,
overview, layout model with code examples, strengths/weaknesses, references)
and cross-links into the TUI catalog where relevant. The new index.md adds
taxonomy tables by sizing vocabulary, measure/arrange protocol, and embedding
style.

VitePress sidebar updated under Research with a collapsible UI Layout section.

Also expands lychee.exclude with hosts that reject the link-checker's UA or
have broken TLS/DNS (Wikipedia, MDN, npm, YouTube, ACM, googlesource,
miglayout.com, overconstrained.io, eprg.org, tcl-lang.org/man, luatex.org/svn,
developer.android.com/reference/kotlin) so docs that reference them don't
break pre-commit and CI.
