### PR TITLE
feat(core-cli): text package (writers, formatters, parsers), process monitoring & fixes

### DIFF
--- a/apps/ci/src/app.d
+++ b/apps/ci/src/app.d
@@ -70,6 +70,7 @@ wildcard pattern handles verification against the actual (dynamic) output.
 import std.algorithm : any, canFind, countUntil, filter, map, sort, startsWith;
 import std.array : array, join;
 import std.conv : text, to;
+import core.time : msecs;
 import std.file : exists, mkdirRecurse, readText, remove, tempDir, write;
 import std.path : baseName, buildPath;
 import std.process : execute;
@@ -80,6 +81,8 @@ import std.string : endsWith, indexOf, lineSplitter, replace, strip, stripRight,
 // sparkles packages
 import sparkles.core_cli.args : CliOption, HelpInfo, parseCliArgs;
 import sparkles.core_cli.logger : error, info, initLogger, LogLevel, trace, warning;
+import sparkles.core_cli.process_utils :
+    executeMonitored, MonitoredResult, ResourceUsage, selfRssBytes;
 import sparkles.core_cli.styled_template : styledText, styledWritelnErr;
 import sparkles.core_cli.term_unstyle : unstyle;
 import sparkles.core_cli.ui.box : BoxProps, drawBox;
@@ -700,7 +703,8 @@ ExecutionResult executeExample(in Example example)
         if (binaryPath.exists) binaryPath.remove();
     }
 
-    auto buildResult = execute(dubSingleFileCommand("build", tmpFile, repoRoot));
+    auto buildResult = executeLogged(
+        dubSingleFileCommand("build", tmpFile, repoRoot), "build " ~ example.name);
     if (buildResult.status != 0)
     {
         auto cleanedBuild = buildResult.output.unstyle
@@ -714,7 +718,7 @@ ExecutionResult executeExample(in Example example)
         );
     }
 
-    auto runResult = execute([binaryPath]);
+    auto runResult = executeLogged([binaryPath], "run " ~ example.name);
 
     // Strip ANSI codes, then trim trailing whitespace from each line
     // so output matches what pre-commit hooks produce in markdown files.
@@ -728,6 +732,59 @@ ExecutionResult executeExample(in Example example)
         programOutput: cleaned,
         rawOutput: runResult.output,
     );
+}
+
+/**
+Runs `args` like `std.process.execute`, returning a `MonitoredResult` (same
+`status`/`output` fields the callers read). At `--log-level trace` it routes
+through $(REF executeMonitored, sparkles,core_cli,process_utils), emitting the
+process tree's resident-set size as it climbs plus a per-command summary — the
+instrumentation for troubleshooting OOM during a build. At coarser levels it is
+a plain `execute` with no sampling overhead.
+*/
+private MonitoredResult executeLogged(const(string)[] args, string label)
+{
+    import std.array : join;
+    import std.logger : globalLogLevel;
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import sparkles.core_cli.text.writers : writeBytes, writeDuration;
+
+    if (globalLogLevel > LogLevel.trace)
+    {
+        auto r = execute(args);
+        return MonitoredResult(r.status, r.output);
+    }
+
+    const cmd = args.join(" ");
+    trace(i"{dim ▸ $(label):} {dim $(cmd)}");
+
+    // Log only when the peak climbs by a notable step, so a long compile does
+    // not flood the trace with flat-line samples.
+    enum size_t logStep = 256UL << 20;   // 256 MiB
+    size_t lastLogged;
+    auto res = executeMonitored(args, 500.msecs, (in ResourceUsage u) @safe {
+        if (u.peakRssBytes >= lastLogged + logStep)
+        {
+            lastLogged = u.peakRssBytes;
+            SmallBuffer!(char, 24) rss, cpu;
+            writeBytes(rss, u.peakRssBytes);
+            writeDuration(cpu, u.cpuTime);
+            trace(i"{dim   $(label)} rss=$(rss[]) cpu=$(cpu[])");
+        }
+    });
+
+    if (res.usage.sampled)
+    {
+        SmallBuffer!(char, 24) peak, cpu, ciRss;
+        writeBytes(peak, res.usage.peakRssBytes);
+        writeDuration(cpu, res.usage.cpuTime);
+        writeBytes(ciRss, selfRssBytes());
+        trace(i"{dim ◂ $(label):} peak_rss=$(peak[]) cpu=$(cpu[]) exit=$(res.status) (ci_rss=$(ciRss[]))");
+    }
+    else
+        trace(i"{dim ◂ $(label):} exit=$(res.status) (resource sampling unavailable here)");
+
+    return res;
 }
 
 private int runExampleFilesMode(string[] exampleFiles, bool failFast)
@@ -815,7 +872,9 @@ private ExecutionResult executeStandaloneExampleFile(
     StandaloneExampleMode mode,
 )
 {
-    auto result = execute(dubSingleFileCommand(standaloneExampleAction(mode), exampleFile, repoRoot));
+    auto result = executeLogged(
+        dubSingleFileCommand(standaloneExampleAction(mode), exampleFile, repoRoot),
+        standaloneExampleAction(mode) ~ " " ~ exampleFile.baseName);
     auto cleaned = result.output.unstyle
         .lineSplitter
         .map!(l => l.stripRight)
@@ -860,7 +919,8 @@ private int runDubTestsMode(bool failFast)
         const header = styledText(i"{dim $(progress)} {cyan $(pkgName)} {dim › dub test :$(pkgName)}");
 
         mkdirRecurse(buildPath(repoRoot, pkg, "build"));
-        auto result = execute(["dub", "--root", repoRoot, "test", ":" ~ pkgName]);
+        auto result = executeLogged(
+            ["dub", "--root", repoRoot, "test", ":" ~ pkgName], "test " ~ pkgName);
 
         auto outputLines = result.output.lineSplitter
             .map!(l => l.to!string)

--- a/libs/core-cli/dub.sdl
+++ b/libs/core-cli/dub.sdl
@@ -6,6 +6,8 @@ license "BSL-1.0"
 
 dflags "-preview=in" "-preview=dip1000"
 
+dependency "expected" version="~>0.4.0"
+
 targetType "library"
 targetPath "build"
 

--- a/libs/core-cli/dub.selections.json
+++ b/libs/core-cli/dub.selections.json
@@ -1,6 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
+		"expected": "0.4.0",
 		"silly": "1.1.1"
 	}
 }

--- a/libs/core-cli/src/sparkles/core_cli/logger.d
+++ b/libs/core-cli/src/sparkles/core_cli/logger.d
@@ -61,6 +61,12 @@ class DeltaTimeLogger : Logger
         );
         writeStyled(w, i"{bold $(payload.msg)}");
         put(w, '\n');
+
+        // Flush each line so logs appear immediately — in particular, the
+        // resource-monitoring trace lines must survive a process about to be
+        // OOM-killed, when stderr is redirected to a (block-buffered) file or
+        // pipe rather than a line-buffered tty.
+        () @trusted { stderr.flush(); }();
     }
 }
 

--- a/libs/core-cli/src/sparkles/core_cli/logger.d
+++ b/libs/core-cli/src/sparkles/core_cli/logger.d
@@ -194,53 +194,25 @@ void fatal(int line = __LINE__, string file = __FILE__,
 
 private:
 
-@safe
-void writeDuration(Writer)(ref Writer w, Duration d)
-{
-    import sparkles.core_cli.text.writers : writeInteger;
-    import std.range.primitives : put;
-
-    long ms = d.total!"msecs";
-    bool negative = ms < 0;
-    if (negative)
-    {
-        put(w, '-');
-        ms = -ms;
-    }
-
-    if (ms < 1_000)
-    {
-        writeInteger(w, ms);
-        put(w, 'm');
-        put(w, 's');
-        return;
-    }
-
-    if (ms < 60_000)
-        return writeTenths(w, ms, 100, 's');
-    if (ms < 3_600_000)
-        return writeTenths(w, ms, 6_000, 'm');
-    if (ms < 86_400_000)
-        return writeTenths(w, ms, 360_000, 'h');
-    return writeTenths(w, ms, 8_640_000, 'd');
-}
-
 string fmtDuration(Duration d) @safe
 {
     import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import sparkles.core_cli.text.writers : writeDuration;
 
     SmallBuffer!(char, 32) buf;
     writeDuration(buf, d);
     return buf[].idup;
 }
 
-@("fmtDuration.formatsMilliseconds")
+@("fmtDuration.formatsSubSecond")
 @safe
 unittest
 {
-    assert(dur!"msecs"(0).fmtDuration == "0ms");
-    assert(dur!"msecs"(42).fmtDuration == "42ms");
-    assert(dur!"msecs"(999).fmtDuration == "999ms");
+    assert(dur!"nsecs"(0).fmtDuration == "0.0ns");
+    assert(dur!"nsecs"(500).fmtDuration == "500.0ns");
+    assert(dur!"usecs"(42).fmtDuration == "42.0µs");
+    assert(dur!"msecs"(42).fmtDuration == "42.0ms");
+    assert(dur!"msecs"(999).fmtDuration == "999.0ms");
 }
 
 @("fmtDuration.formatsSeconds")
@@ -279,19 +251,6 @@ unittest
     assert(dur!"hours"(72).fmtDuration == "3.0d");
 }
 
-@safe
-void writeTenths(Writer)(ref Writer w, long ms, long unitTenths, char suffix)
-{
-    import sparkles.core_cli.text.writers : writeInteger;
-    import std.range.primitives : put;
-
-    auto tenths = (ms + unitTenths / 2) / unitTenths;
-    writeInteger(w, tenths / 10);
-    put(w, '.');
-    put(w, cast(char)('0' + tenths % 10));
-    put(w, suffix);
-}
-
 @safe pure nothrow @nogc
 Duration durationFromTicks(long ticks) =>
     dur!"hnsecs"(convClockFreq(ticks, MonoTime.ticksPerSecond, 10_000_000L));
@@ -312,29 +271,9 @@ void writeTimeHms(Writer)(ref Writer w, int hour, int minute, int second)
 @safe
 void writePadded2(Writer)(ref Writer w, int value)
 {
-    import sparkles.core_cli.text.writers : writeInteger;
-    import std.range.primitives : put;
+    import sparkles.core_cli.text.writers : writeIntegerPadded;
 
-    if (value < 10)
-        put(w, '0');
-    writeInteger(w, value);
-}
-
-@safe
-void writeDurationPadded(Writer)(ref Writer w, Duration d, size_t width)
-{
-    import sparkles.core_cli.smallbuffer : SmallBuffer;
-    import std.range.primitives : put;
-
-    SmallBuffer!(char, 16) buf;
-    writeDuration(buf, d);
-    auto text = buf[];
-    put(w, text);
-    if (text.length < width)
-    {
-        foreach (_; 0 .. width - text.length)
-            put(w, ' ');
-    }
+    writeIntegerPadded(w, value, 2);
 }
 
 @safe
@@ -367,6 +306,7 @@ void writeLogPrefix(bool colored = false, Writer)(
 {
     import sparkles.core_cli.smallbuffer : SmallBuffer;
     import sparkles.core_cli.styled_template : writeStyled;
+    import sparkles.core_cli.text.writers : writeDurationPadded;
     import std.path : baseName;
 
     SmallBuffer!(char, 16) startBuf;

--- a/libs/core-cli/src/sparkles/core_cli/logger.d
+++ b/libs/core-cli/src/sparkles/core_cli/logger.d
@@ -197,7 +197,7 @@ private:
 @safe
 void writeDuration(Writer)(ref Writer w, Duration d)
 {
-    import sparkles.core_cli.text_writers : writeInteger;
+    import sparkles.core_cli.text.writers : writeInteger;
     import std.range.primitives : put;
 
     long ms = d.total!"msecs";
@@ -282,7 +282,7 @@ unittest
 @safe
 void writeTenths(Writer)(ref Writer w, long ms, long unitTenths, char suffix)
 {
-    import sparkles.core_cli.text_writers : writeInteger;
+    import sparkles.core_cli.text.writers : writeInteger;
     import std.range.primitives : put;
 
     auto tenths = (ms + unitTenths / 2) / unitTenths;
@@ -299,7 +299,7 @@ Duration durationFromTicks(long ticks) =>
 @safe
 void writeTimeHms(Writer)(ref Writer w, int hour, int minute, int second)
 {
-    import sparkles.core_cli.text_writers : writeInteger;
+    import sparkles.core_cli.text.writers : writeInteger;
     import std.range.primitives : put;
 
     writePadded2(w, hour);
@@ -312,7 +312,7 @@ void writeTimeHms(Writer)(ref Writer w, int hour, int minute, int second)
 @safe
 void writePadded2(Writer)(ref Writer w, int value)
 {
-    import sparkles.core_cli.text_writers : writeInteger;
+    import sparkles.core_cli.text.writers : writeInteger;
     import std.range.primitives : put;
 
     if (value < 10)

--- a/libs/core-cli/src/sparkles/core_cli/prettyprint.d
+++ b/libs/core-cli/src/sparkles/core_cli/prettyprint.d
@@ -3,7 +3,7 @@ module sparkles.core_cli.prettyprint;
 import std.typecons : Tuple;
 
 import sparkles.core_cli.term_style : Style;
-import sparkles.core_cli.text_writers : EnumRender, writeEscapeSeq, writeStylized, writeStyledValue;
+import sparkles.core_cli.text.writers : EnumRender, writeEscapeSeq, writeStylized, writeStyledValue;
 
 struct PrettyPrintOptions(SourceUriHook = void)
 {
@@ -154,7 +154,7 @@ private void prettyPrintAA(T, Writer, Hook)(
     import std.range.primitives : put;
     import std.traits : KeyType, ValueType;
 
-    import sparkles.core_cli.text_writers : writeInteger;
+    import sparkles.core_cli.text.writers : writeInteger;
 
     if (aa.length == 0)
     {
@@ -305,7 +305,7 @@ private void prettyPrintRange(R, Writer, Hook)(
     import std.range : repeat;
     import std.range.primitives : put, empty, front, popFront, hasLength;
 
-    import sparkles.core_cli.text_writers : writeInteger;
+    import sparkles.core_cli.text.writers : writeInteger;
 
     static if (hasLength!R)
     {

--- a/libs/core-cli/src/sparkles/core_cli/process_utils.d
+++ b/libs/core-cli/src/sparkles/core_cli/process_utils.d
@@ -1,5 +1,12 @@
 module sparkles.core_cli.process_utils;
 
+import core.time : Duration, msecs;
+
+import sparkles.core_cli.text.errors :
+    ParseErrorCode, ParseExpected, parseErr, parseOk;
+import sparkles.core_cli.text.readers :
+    readInteger, readUntil, skipSpaces, tryConsume;
+
 void enforceExitStatus(int status, string command)
 {
     import std.format : format;
@@ -15,4 +22,399 @@ string executeShell(in string command)
     const result = command.executeShell;
     enforceExitStatus(result.status, command);
     return result.output;
+}
+
+// ---------------------------------------------------------------------------
+// Resource-monitored execution
+// ---------------------------------------------------------------------------
+
+/**
+Peak resource use of a spawned process and its descendants, sampled while it
+runs. `peakRssBytes` is the largest summed resident-set size observed across
+the whole process tree (a `dub` build, say, plus the `ldc2` child it spawns —
+which is usually where the memory lives). `cpuTime` is a best-effort estimate
+(the largest tree-summed user+system CPU seen at a sample; a child's CPU is
+lost from the sum once it exits, so treat it as a lower bound).
+
+`sampled` is `false` on platforms without `/proc` (currently every non-Linux
+target): there $(LREF executeMonitored) still runs the process and returns its
+output, but collects no resource figures.
+*/
+struct ResourceUsage
+{
+    size_t peakRssBytes;   /// max summed RSS over the process tree
+    Duration cpuTime;      /// best-effort summed user+system CPU (lower bound)
+    size_t sampleCount;    /// number of samples taken
+    bool sampled;          /// false when no sampler is available (non-Linux)
+}
+
+/// The outcome of $(LREF executeMonitored): the child's exit status, its
+/// combined stdout+stderr (matching `std.process.execute`'s contract), and the
+/// $(LREF ResourceUsage) gathered while it ran.
+struct MonitoredResult
+{
+    int status;
+    string output;
+    ResourceUsage usage;
+}
+
+/**
+Runs `args` to completion like `std.process.execute` — returning the exit
+status and the combined stdout+stderr — but spawns it non-blocking and samples
+the resident-set size and CPU of the whole process tree every `sampleInterval`
+while it runs, so a memory blow-up can be attributed to a specific process.
+
+`onSample`, if given, is invoked after each sample with the running
+$(LREF ResourceUsage) (its `peakRssBytes` updated, `cpuTime` carrying the
+latest tree total), letting the caller log a live trace. Sampling is
+Linux-only (it reads `/proc`); elsewhere the process still runs and its output
+is returned, but `usage.sampled` is `false` and no figures are collected.
+
+Output is redirected to a temp file (not a pipe) so a chatty child cannot
+deadlock against an undrained pipe while we sample.
+*/
+MonitoredResult executeMonitored(
+    const(string)[] args,
+    Duration sampleInterval = 250.msecs,
+    scope void delegate(in ResourceUsage sample) @safe onSample = null,
+)
+{
+    import std.process : spawnProcess, tryWait, wait;
+    import std.stdio : File, stdin;
+    import std.file : tempDir, readText, remove;
+    import std.path : buildPath;
+    import std.conv : text;
+    import std.process : thisProcessID;
+    import core.atomic : atomicOp;
+    import core.thread : Thread;
+
+    static shared size_t counter;
+    const id = atomicOp!"+="(counter, 1);
+    const logPath = buildPath(tempDir,
+        text("sparkles-mon-", thisProcessID, "-", id, ".log"));
+
+    MonitoredResult result;
+
+    auto sink = File(logPath, "w");
+    auto pid = spawnProcess(args, stdin, sink, sink);
+
+    version (linux)
+        result.usage.sampled = true;
+
+    for (;;)
+    {
+        const w = tryWait(pid);
+
+        version (linux)
+        {
+            const rss = treeRssBytes(pid.processID);
+            if (rss > result.usage.peakRssBytes)
+                result.usage.peakRssBytes = rss;
+            const cpu = treeCpuTime(pid.processID);
+            if (cpu > result.usage.cpuTime)
+                result.usage.cpuTime = cpu;
+            result.usage.sampleCount++;
+            if (onSample !is null)
+                onSample(result.usage);
+        }
+
+        if (w.terminated)
+        {
+            result.status = w.status;
+            break;
+        }
+        Thread.sleep(sampleInterval);
+    }
+
+    sink.close();
+    result.output = readText(logPath);
+    try
+        remove(logPath);
+    catch (Exception)
+    {
+    }                                    // best-effort cleanup
+    return result;
+}
+
+/// Current resident-set size of this process in bytes (`0` off Linux).
+version (linux)
+size_t selfRssBytes() @trusted
+{
+    import std.file : readText;
+
+    try
+    {
+        const kb = parseVmRssKbFromStatus(readText("/proc/self/status"));
+        return kb.hasValue ? kb.value * 1024 : 0;
+    }
+    catch (Exception)
+        return 0;
+}
+else
+size_t selfRssBytes() @safe => 0;
+
+// ---------------------------------------------------------------------------
+// /proc parsers
+// ---------------------------------------------------------------------------
+//
+// These are pure, `@nogc` slice walkers built on `core_cli.text.readers`: the
+// `/proc` files arrive as already-read `const(char)[]`, and a malformed line is
+// surfaced as a `ParseExpected` error rather than a silent sentinel. The
+// readers that fetch the files (below) allocate and so cannot be `@nogc`.
+
+/// The slice after the last `)` in `s` (`null` if there is none). The `comm`
+/// field of a `/proc/<pid>/stat` line is parenthesised and may itself contain
+/// spaces and parens, so the fixed numeric fields begin only after the *last*
+/// `)`.
+private const(char)[] afterLastParen(return scope const(char)[] s)
+    @safe pure nothrow @nogc
+{
+    ptrdiff_t close = -1;
+    foreach (i, c; s)
+        if (c == ')')
+            close = i;
+    return close < 0 ? null : s[close + 1 .. $];
+}
+
+/**
+Parses the parent PID from a `/proc/<pid>/stat` line. After the last `)` the
+tokens are `state ppid pgrp …`, so `ppid` is the second. Fails (with an
+`unexpectedEnd`/`unexpectedCharacter` $(REF ParseError,
+sparkles,core_cli,text,errors)) when there is no `)` or the `ppid` field is
+missing or non-numeric.
+*/
+ParseExpected!int parsePpidFromStat(const(char)[] stat) @safe pure nothrow @nogc
+{
+    auto cur = afterLastParen(stat);
+    if (cur.length == 0)
+        return parseErr!int(ParseErrorCode.unexpectedEnd, 0);
+
+    skipSpaces(cur);
+    readUntil(cur, " ");        // skip the `state` token
+    skipSpaces(cur);
+
+    auto ppid = readInteger!uint(cur);
+    if (!ppid.hasValue)
+        return parseErr!int(ppid.error);
+    return parseOk(cast(int) ppid.value);
+}
+
+/// `utime`/`stime` clock-tick pair from a `/proc/<pid>/stat` line.
+struct CpuTicks
+{
+    ulong utime;
+    ulong stime;
+    ulong total() const @safe pure nothrow @nogc => utime + stime;
+}
+
+/**
+Parses `(utime, stime)` clock ticks from a `/proc/<pid>/stat` line. After the
+last `)` they are the 12th and 13th tokens (the 11 before them — `state ppid
+pgrp session tty tpgid flags minflt cminflt majflt cmajflt` — are skipped).
+Fails when the line is truncated before those fields.
+*/
+ParseExpected!CpuTicks parseCpuTicksFromStat(const(char)[] stat)
+    @safe pure nothrow @nogc
+{
+    auto cur = afterLastParen(stat);
+    if (cur.length == 0)
+        return parseErr!CpuTicks(ParseErrorCode.unexpectedEnd, 0);
+
+    skipSpaces(cur);
+    foreach (_; 0 .. 11)        // skip state … cmajflt
+    {
+        readUntil(cur, " ");
+        skipSpaces(cur);
+    }
+
+    auto utime = readInteger!ulong(cur);
+    if (!utime.hasValue)
+        return parseErr!CpuTicks(utime.error);
+    skipSpaces(cur);
+    auto stime = readInteger!ulong(cur);
+    if (!stime.hasValue)
+        return parseErr!CpuTicks(stime.error);
+
+    return parseOk(CpuTicks(utime.value, stime.value));
+}
+
+/**
+Parses the `VmRSS:` value (kilobytes) from a `/proc/<pid>/status` file. The
+line reads `VmRSS:\t   12345 kB`. Fails (`unexpectedEnd`) when no `VmRSS:` line
+is present.
+*/
+ParseExpected!size_t parseVmRssKbFromStatus(const(char)[] status)
+    @safe pure nothrow @nogc
+{
+    enum label = "VmRSS:";
+
+    auto cur = status;
+    while (cur.length)
+    {
+        auto line = readUntil(cur, "\n");
+        tryConsume(cur, '\n');
+        if (line.length < label.length || line[0 .. label.length] != label)
+            continue;
+
+        auto value = line[label.length .. $];
+        skipSpaces(value);      // skip the leading tab/spaces before the digits
+        return readInteger!size_t(value);
+    }
+    return parseErr!size_t(ParseErrorCode.unexpectedEnd, 0);
+}
+
+// ---------------------------------------------------------------------------
+// /proc tree readers (Linux only)
+// ---------------------------------------------------------------------------
+
+version (linux)
+{
+    /// PIDs of `rootPid` and every transitive descendant, found by walking the
+    /// `ppid` links in `/proc/[0-9]*/stat`. Best-effort: a process that exits
+    /// mid-scan is simply skipped.
+    private int[] collectTreePids(int rootPid) @trusted
+    {
+        import std.file : dirEntries, SpanMode, readText;
+        import std.path : baseName;
+
+        int[int] ppidOf;
+        try
+        {
+            foreach (de; dirEntries("/proc", SpanMode.shallow))
+            {
+                const(char)[] name = de.name.baseName;
+                auto pidR = readInteger!uint(name);
+                if (!pidR.hasValue || name.length != 0)
+                    continue;               // skip non-numeric /proc entries
+                const pid = cast(int) pidR.value;
+                string stat;
+                try
+                    stat = readText("/proc/" ~ de.name.baseName ~ "/stat");
+                catch (Exception)
+                    continue;               // vanished between listing and read
+                const ppid = parsePpidFromStat(stat);
+                if (ppid.hasValue)
+                    ppidOf[pid] = ppid.value;
+            }
+        }
+        catch (Exception)
+        {
+        }
+
+        int[][int] children;
+        foreach (pid, pp; ppidOf)
+            children[pp] ~= pid;
+
+        int[] tree = [rootPid];
+        bool[int] seen = [rootPid: true];
+        for (size_t i = 0; i < tree.length; i++)
+            if (auto kids = tree[i] in children)
+                foreach (k; *kids)
+                    if (k !in seen)
+                    {
+                        seen[k] = true;
+                        tree ~= k;
+                    }
+        return tree;
+    }
+
+    /// Summed resident-set size (bytes) of `rootPid`'s process tree.
+    private size_t treeRssBytes(int rootPid) @trusted
+    {
+        import std.file : readText;
+        import std.conv : text;
+
+        size_t total;
+        foreach (pid; collectTreePids(rootPid))
+        {
+            try
+            {
+                const kb = parseVmRssKbFromStatus(
+                    readText(text("/proc/", pid, "/status")));
+                if (kb.hasValue)
+                    total += kb.value * 1024;
+            }
+            catch (Exception)
+            {
+            }
+        }
+        return total;
+    }
+
+    /// Summed user+system CPU of `rootPid`'s process tree.
+    private Duration treeCpuTime(int rootPid) @trusted
+    {
+        import std.file : readText;
+        import std.conv : text;
+        import core.sys.posix.unistd : sysconf, _SC_CLK_TCK;
+
+        const clk = sysconf(_SC_CLK_TCK);
+        if (clk <= 0)
+            return Duration.zero;
+
+        ulong ticks;
+        foreach (pid; collectTreePids(rootPid))
+        {
+            try
+            {
+                const c = parseCpuTicksFromStat(
+                    readText(text("/proc/", pid, "/stat")));
+                if (c.hasValue)
+                    ticks += c.value.total;
+            }
+            catch (Exception)
+            {
+            }
+        }
+        return msecs(cast(long)(ticks * 1000 / clk));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+@("process_utils.parsePpidFromStat.handlesCommWithSpacesAndParens")
+@safe pure nothrow @nogc
+unittest
+{
+    // comm = "(ldc2 stage)" — embedded space and parens; ppid is 4242.
+    const a = parsePpidFromStat("1234 ((ldc2 stage)) R 4242 1234 1234 0 -1 4194560 100 0");
+    assert(a.hasValue && a.value == 4242);
+
+    // Simple comm.
+    const b = parsePpidFromStat("17 (dub) S 9 17 17 0");
+    assert(b.hasValue && b.value == 9);
+
+    // Malformed (no `)`) → error, not a sentinel value.
+    assert(!parsePpidFromStat("garbage").hasValue);
+}
+
+@("process_utils.parseCpuTicksFromStat.readsUtimeStime")
+@safe pure nothrow @nogc
+unittest
+{
+    // After the last ')': state ppid pgrp session tty tpgid flags
+    //   minflt cminflt majflt cmajflt utime stime …
+    //   (indices 0..)         7      8       9      10     11    12
+    const c = parseCpuTicksFromStat("5 (prog) R 1 5 5 0 -1 0 10 0 20 0 314 159 0 0");
+    assert(c.hasValue);
+    assert(c.value.utime == 314);
+    assert(c.value.stime == 159);
+    assert(c.value.total == 473);
+
+    assert(!parseCpuTicksFromStat("nope").hasValue);
+}
+
+@("process_utils.parseVmRssKbFromStatus.findsRss")
+@safe pure nothrow @nogc
+unittest
+{
+    const status =
+        "Name:\tldc2\nVmPeak:\t  900000 kB\nVmRSS:\t  842156 kB\nThreads:\t8\n";
+    const rss = parseVmRssKbFromStatus(status);
+    assert(rss.hasValue && rss.value == 842_156);
+
+    // Absent → error.
+    assert(!parseVmRssKbFromStatus("Name:\tx\nThreads:\t1\n").hasValue);
 }

--- a/libs/core-cli/src/sparkles/core_cli/smallbuffer.d
+++ b/libs/core-cli/src/sparkles/core_cli/smallbuffer.d
@@ -245,31 +245,60 @@ void checkToString(T, size_t outputBufferSize = 16 * 1024, size_t errorBufferSiz
     size_t line = __LINE__,
 )
 {
+    SmallBuffer!(char, outputBufferSize) buf;
+    value.toString(buf);
+    assertRendered!errorBufferSize("toString mismatch", buf[], expected, file, line);
+}
+
+/// Like $(LREF checkToString), but for a free writer expression rather than
+/// a `toString` method. `render` is a callable taking
+/// `ref SmallBuffer!(char, outputBufferSize)`; its output is compared to
+/// `expected` with the same recycled-`AssertError` diff on mismatch (so the
+/// caller stays `@safe pure nothrow @nogc`):
+/// ---
+/// checkWriter!((ref b) => writeIntegerPadded(b, 7, 3))("007");
+/// ---
+void checkWriter(alias render, size_t outputBufferSize = 16 * 1024,
+    size_t errorBufferSize = 4 * 1024)(
+    const(char)[] expected,
+    string file = __FILE__,
+    size_t line = __LINE__,
+)
+{
+    SmallBuffer!(char, outputBufferSize) buf;
+    render(buf);
+    assertRendered!errorBufferSize("rendered output mismatch", buf[], expected, file, line);
+}
+
+/// Shared by $(LREF checkToString) and $(LREF checkWriter): compares the
+/// rendered bytes and, on mismatch, throws a recycled `AssertError`
+/// carrying an `<header>:\nExpected:\n…\nActual:\n…` diff.
+private void assertRendered(size_t errorBufferSize)(
+    const(char)[] header,
+    const(char)[] actual,
+    const(char)[] expected,
+    string file,
+    size_t line,
+)
+{
     import core.exception : AssertError;
     import sparkles.core_cli.lifetime : recycledErrorInstance;
 
-    SmallBuffer!(char, outputBufferSize) buf;
-    value.toString(buf);
-    const(char)[] actual = buf[];
+    if (actual == expected)
+        return;
 
-    if (actual != expected)
-    {
-        SmallBuffer!(char, errorBufferSize) errBuf;
-        errBuf.put("toString mismatch:\nExpected:\n");
-        errBuf.put(expected);
-        errBuf.put("\nActual:\n");
-        errBuf.put(actual);
+    SmallBuffer!(char, errorBufferSize) errBuf;
+    errBuf.put(header);
+    errBuf.put(":\nExpected:\n");
+    errBuf.put(expected);
+    errBuf.put("\nActual:\n");
+    errBuf.put(actual);
 
-        // Only this part needs to be @trusted because recycledErrorInstance
-        // is @system (due to its use of a global/static buffer for the Error object).
-        () @trusted {
-            throw recycledErrorInstance!AssertError(
-                errBuf[],
-                file,
-                line,
-            );
-        }();
-    }
+    // @trusted only here: recycledErrorInstance is @system (it parks the
+    // Error object in a static buffer).
+    () @trusted {
+        throw recycledErrorInstance!AssertError(errBuf[], file, line);
+    }();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -331,6 +360,13 @@ unittest
     );
     assert(error !is null);
     assert(error.msg == "toString mismatch:\nExpected:\nexpected\nActual:\nactual");
+}
+
+@("checkWriter.rendersLambda")
+@safe pure nothrow @nogc
+unittest
+{
+    checkWriter!((ref b) => b.put("hi"))("hi");
 }
 
 @("SmallBuffer.put.singleElement")

--- a/libs/core-cli/src/sparkles/core_cli/styled_template.d
+++ b/libs/core-cli/src/sparkles/core_cli/styled_template.d
@@ -47,7 +47,7 @@ void writeStyled(bool colored = true, Writer, Args...)(
     InterpolationFooter
 )
 {
-    import sparkles.core_cli.text_writers : writeValue;
+    import sparkles.core_cli.text.writers : writeValue;
 
     ParserContext ctx;
 
@@ -463,7 +463,7 @@ private struct StyleState
     /// Emit escape sequences for transition FROM parent TO this state
     void emitOpenDiff(Writer)(ref Writer w, in StyleState parent) const
     {
-        import sparkles.core_cli.text_writers : writeEscapeSeq;
+        import sparkles.core_cli.text.writers : writeEscapeSeq;
 
         // Close styles that were in parent but removed in this (negation)
         foreach_reverse (i; 0 .. parent.count)
@@ -479,7 +479,7 @@ private struct StyleState
     /// Emit escape sequences for transition FROM this state back TO parent
     void emitCloseDiff(Writer)(ref Writer w, in StyleState parent) const
     {
-        import sparkles.core_cli.text_writers : writeEscapeSeq;
+        import sparkles.core_cli.text.writers : writeEscapeSeq;
 
         // Close styles that were added in this (not in parent)
         foreach_reverse (i; 0 .. count)

--- a/libs/core-cli/src/sparkles/core_cli/text/errors.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/errors.d
@@ -1,0 +1,87 @@
+/**
+Generic, `Expected`-based error vocabulary for text parsers.
+
+The $(LREF readers) in this package, and any higher-level parser built on
+them, report failures as a $(LREF ParseError) carried by
+$(LREF ParseExpected). The vocabulary is deliberately scheme-agnostic —
+it names mechanical parse outcomes (empty input, unexpected character,
+numeric overflow, …), not domain concepts.
+*/
+module sparkles.core_cli.text.errors;
+
+import expected : Expected, err, ok;
+
+/// Machine-readable, scheme-agnostic text-parse error code.
+enum ParseErrorCode
+{
+    emptyInput,          /// nothing to parse
+    unexpectedCharacter, /// a character not allowed at this position
+    unexpectedEnd,       /// input ended while more was required
+    leadingZero,         /// a numeric field had a disallowed leading zero
+    numericOverflow,     /// a number exceeded the target type's range
+    invalidIdentifier,   /// an identifier contained a disallowed character
+    widthMismatch,       /// a fixed-width field did not meet its width
+}
+
+/// Structured parse error: a $(LREF ParseErrorCode) plus the byte offset
+/// (within the input the failing parser received) of the failure.
+struct ParseError
+{
+    ParseErrorCode code; /// what went wrong
+    size_t offset;       /// byte offset of the failure
+}
+
+/**
+`expected` hook that keeps $(LREF ParseExpected) usable in
+`@nogc nothrow` code: it disables the default constructor so a result is
+always explicitly `ok` or `err`, never an ambiguous default.
+*/
+struct NoGcHook
+{
+    static immutable bool enableDefaultConstructor = false;
+}
+
+/// `Expected!` specialised for $(LREF ParseError): carries either a parsed
+/// `T` or a structured $(LREF ParseError).
+alias ParseExpected(T) = Expected!(T, ParseError, NoGcHook);
+
+/// Constructs a successful $(LREF ParseExpected) carrying `value`, filling
+/// in the `(ParseError, NoGcHook)` template arguments — a parser writes
+/// `return parseOk(value);` rather than `ok!(ParseError, NoGcHook)(value)`.
+ParseExpected!T parseOk(T)(T value) @safe pure nothrow @nogc
+    => ok!(ParseError, NoGcHook)(value);
+
+/// ditto — success with no payload (`ParseExpected!void`), for validators.
+/// (Explicitly attributed: as a non-template it cannot infer them.)
+ParseExpected!void parseOk() @safe pure nothrow @nogc
+    => ok!(ParseError, NoGcHook)();
+
+/// Constructs a failed $(LREF ParseExpected)`!T` carrying `error`. `T` is
+/// explicit (there is no value to infer it from):
+/// `return parseErr!uint(someError);`
+ParseExpected!T parseErr(T)(ParseError error) @safe pure nothrow @nogc
+    => err!(T, NoGcHook)(error);
+
+/// ditto — the common `code` + `offset` form:
+/// `return parseErr!T(ParseErrorCode.numericOverflow, i);`
+ParseExpected!T parseErr(T)(ParseErrorCode code, size_t offset) @safe pure nothrow @nogc
+    => err!(T, NoGcHook)(ParseError(code, offset));
+
+@("text.errors.parseOk")
+@safe pure nothrow @nogc
+unittest
+{
+    auto good = parseOk(42);
+    assert(good.hasValue);
+    assert(good.value == 42);
+}
+
+@("text.errors.parseErr")
+@safe pure nothrow @nogc
+unittest
+{
+    auto bad = parseErr!int(ParseErrorCode.numericOverflow, 3);
+    assert(!bad.hasValue);
+    assert(bad.error.code == ParseErrorCode.numericOverflow);
+    assert(bad.error.offset == 3);
+}

--- a/libs/core-cli/src/sparkles/core_cli/text/package.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/package.d
@@ -7,6 +7,8 @@ errors on text without committing to any higher-level format:
 $(UL
     $(LI `sparkles.core_cli.text.writers` — integer / float / escaped
         output-range writers.)
+    $(LI `sparkles.core_cli.text.errors` — the `Expected`-based parse
+        error vocabulary.)
 )
 
 Importing `sparkles.core_cli.text` pulls in the whole package.
@@ -14,3 +16,4 @@ Importing `sparkles.core_cli.text` pulls in the whole package.
 module sparkles.core_cli.text;
 
 public import sparkles.core_cli.text.writers;
+public import sparkles.core_cli.text.errors;

--- a/libs/core-cli/src/sparkles/core_cli/text/package.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/package.d
@@ -1,0 +1,16 @@
+/**
+Low-level text I/O primitives for CLI tooling.
+
+This package groups the building blocks that read, write, and report
+errors on text without committing to any higher-level format:
+
+$(UL
+    $(LI `sparkles.core_cli.text.writers` — integer / float / escaped
+        output-range writers.)
+)
+
+Importing `sparkles.core_cli.text` pulls in the whole package.
+*/
+module sparkles.core_cli.text;
+
+public import sparkles.core_cli.text.writers;

--- a/libs/core-cli/src/sparkles/core_cli/text/package.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/package.d
@@ -7,8 +7,9 @@ errors on text without committing to any higher-level format:
 $(UL
     $(LI `sparkles.core_cli.text.writers` — integer / float / escaped
         output-range writers.)
+    $(LI `sparkles.core_cli.text.readers` — slice-advance parsers.)
     $(LI `sparkles.core_cli.text.errors` — the `Expected`-based parse
-        error vocabulary.)
+        error vocabulary shared by the readers.)
 )
 
 Importing `sparkles.core_cli.text` pulls in the whole package.
@@ -16,4 +17,5 @@ Importing `sparkles.core_cli.text` pulls in the whole package.
 module sparkles.core_cli.text;
 
 public import sparkles.core_cli.text.writers;
+public import sparkles.core_cli.text.readers;
 public import sparkles.core_cli.text.errors;

--- a/libs/core-cli/src/sparkles/core_cli/text/readers.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/readers.d
@@ -1,0 +1,186 @@
+/**
+Slice-advance text reading primitives.
+
+Each reader takes the input as a `ref scope const(char)[]` cursor and, on
+success, advances it past the consumed characters (the cursor _is_ the
+position). Readers are mechanism, not policy: they report mechanical
+outcomes via $(REF ParseExpected, sparkles,core_cli,text,errors) and leave
+all higher-level rules (leading-zero handling, field widths, which error
+to surface) to the caller.
+
+The integer reader is the inverse of
+$(REF writeInteger, sparkles,core_cli,text,writers).
+*/
+module sparkles.core_cli.text.readers;
+
+import std.traits : isUnsigned;
+
+import sparkles.core_cli.text.errors :
+    ParseErrorCode, ParseExpected, parseErr, parseOk;
+
+@safe pure nothrow @nogc:
+
+/**
+Reads leading decimal digits from the front of `s` into an unsigned
+integer `T`, advancing `s` past them on success.
+
+Fails — leaving `s` unchanged — when the cursor is empty
+(`emptyInput`), does not start with a digit (`unexpectedCharacter`), or
+the value would overflow `T` (`numericOverflow`). Reported offsets are
+relative to `s` as received (0 at its first character).
+*/
+ParseExpected!T readInteger(T)(ref scope const(char)[] s)
+if (isUnsigned!T)
+{
+    import std.ascii : isDigit;
+
+    if (s.length == 0)
+        return parseErr!T(ParseErrorCode.emptyInput, 0);
+    if (!s[0].isDigit)
+        return parseErr!T(ParseErrorCode.unexpectedCharacter, 0);
+
+    T value = 0;
+    size_t i = 0;
+    while (i < s.length && s[i].isDigit)
+    {
+        const digit = cast(T)(s[i] - '0');
+        if (value > cast(T)((T.max - digit) / 10))
+            return parseErr!T(ParseErrorCode.numericOverflow, i);
+        value = cast(T)(value * 10 + digit);
+        i++;
+    }
+
+    s = s[i .. $]; // advance only on success
+    return parseOk(value);
+}
+
+/// Advances `s` past leading characters satisfying `pred`, returning the
+/// number skipped.
+size_t skipWhile(alias pred)(ref scope const(char)[] s)
+{
+    size_t i = 0;
+    while (i < s.length && pred(s[i]))
+        i++;
+    s = s[i .. $];
+    return i;
+}
+
+/// Advances `s` past leading ASCII spaces and tabs, returning the number
+/// skipped.
+size_t skipSpaces(ref scope const(char)[] s)
+    => skipWhile!(c => c == ' ' || c == '\t')(s);
+
+/// If `s` starts with `c`, advances past it and returns `true`; otherwise
+/// leaves `s` unchanged and returns `false`.
+bool tryConsume(ref scope const(char)[] s, char c)
+{
+    if (s.length == 0 || s[0] != c)
+        return false;
+    s = s[1 .. $];
+    return true;
+}
+
+/// If `s` starts with any character in `set`, advances past it and returns
+/// `true`; otherwise leaves `s` unchanged and returns `false`.
+bool tryConsumeAny(ref scope const(char)[] s, scope const(char)[] set)
+{
+    if (s.length == 0)
+        return false;
+    foreach (c; set)
+        if (s[0] == c)
+        {
+            s = s[1 .. $];
+            return true;
+        }
+    return false;
+}
+
+/// Reads characters from the front of `s` up to (but not including) the
+/// first character in `delims`, advancing `s` to that delimiter (or to the
+/// end if none is found). Returns the consumed slice.
+const(char)[] readUntil(return ref scope const(char)[] s, scope const(char)[] delims)
+{
+    size_t i = 0;
+    cursor: while (i < s.length)
+    {
+        foreach (d; delims)
+            if (s[i] == d)
+                break cursor;
+        i++;
+    }
+    const head = s[0 .. i];
+    s = s[i .. $];
+    return head;
+}
+
+@("text.readers.readInteger.advancesOnSuccess")
+unittest
+{
+    const(char)[] s = "123abc";
+    auto r = readInteger!uint(s);
+    assert(r.hasValue);
+    assert(r.value == 123);
+    assert(s == "abc");
+}
+
+@("text.readers.readInteger.rejectsNonDigitWithoutAdvancing")
+unittest
+{
+    const(char)[] s = "abc";
+    auto r = readInteger!uint(s);
+    assert(!r.hasValue);
+    assert(r.error.code == ParseErrorCode.unexpectedCharacter);
+    assert(s == "abc");
+}
+
+@("text.readers.readInteger.overflow")
+unittest
+{
+    const(char)[] s = "256";
+    auto r = readInteger!ubyte(s);
+    assert(!r.hasValue);
+    assert(r.error.code == ParseErrorCode.numericOverflow);
+    assert(s == "256"); // not advanced on failure
+
+    const(char)[] ok = "255";
+    assert(readInteger!ubyte(ok).value == 255);
+}
+
+@("text.readers.skipSpaces")
+unittest
+{
+    const(char)[] s = "  \tx";
+    assert(skipSpaces(s) == 3);
+    assert(s == "x");
+}
+
+@("text.readers.tryConsume")
+unittest
+{
+    const(char)[] s = "=1";
+    assert(tryConsume(s, '='));
+    assert(s == "1");
+    assert(!tryConsume(s, '='));
+    assert(s == "1");
+}
+
+@("text.readers.tryConsumeAny")
+unittest
+{
+    const(char)[] s = "v2";
+    assert(tryConsumeAny(s, "=vV"));
+    assert(s == "2");
+    assert(!tryConsumeAny(s, "=vV"));
+}
+
+@("text.readers.readUntil")
+unittest
+{
+    const(char)[] s = "alpha.1";
+    assert(readUntil(s, ".") == "alpha");
+    assert(s == ".1");
+
+    const(char)[] none = "abc";
+    assert(readUntil(none, ".") == "abc");
+    assert(none.length == 0);
+}

--- a/libs/core-cli/src/sparkles/core_cli/text/writers.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/writers.d
@@ -4,7 +4,7 @@
  * Provides functions for writing integers, floats, escaped characters/strings,
  * and ANSI escape sequences to output ranges without GC allocation.
  */
-module sparkles.core_cli.text_writers;
+module sparkles.core_cli.text.writers;
 
 import sparkles.core_cli.term_style : Style;
 

--- a/libs/core-cli/src/sparkles/core_cli/text/writers.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/writers.d
@@ -1269,3 +1269,284 @@ unittest
     check!((ref b) => writeFixedPoint!16(b, 255, 2))("0.ff");     // base 16
     check!((ref b) => writeFixedPoint!16(b, 0xABC0, 1))("abc.0"); // base 16 int part
 }
+
+/// Writes a human-readable byte count using binary units — `B`, `KiB`, `MiB`,
+/// `GiB`, `TiB`, `PiB`, `EiB` — with one (rounded) decimal place at `KiB` and
+/// above (e.g. `512B`, `1.5KiB`, `532.3MiB`, `15.9GiB`, `4.0TiB`). `EiB` is the
+/// largest unit needed: `ulong.max` is just under `16 EiB`. @nogc-compatible.
+void writeBytes(Writer)(ref Writer w, ulong bytes)
+{
+    import std.range.primitives : put;
+
+    enum ulong kib = 1UL << 10, mib = 1UL << 20, gib = 1UL << 30,
+        tib = 1UL << 40, pib = 1UL << 50, eib = 1UL << 60;
+    if (bytes >= eib)
+        writeScaledBytes(w, bytes, eib, "EiB");
+    else if (bytes >= pib)
+        writeScaledBytes(w, bytes, pib, "PiB");
+    else if (bytes >= tib)
+        writeScaledBytes(w, bytes, tib, "TiB");
+    else if (bytes >= gib)
+        writeScaledBytes(w, bytes, gib, "GiB");
+    else if (bytes >= mib)
+        writeScaledBytes(w, bytes, mib, "MiB");
+    else if (bytes >= kib)
+        writeScaledBytes(w, bytes, kib, "KiB");
+    else
+    {
+        writeInteger(w, bytes);
+        put(w, 'B');
+    }
+}
+
+/// Writes `bytes / unit` to one (half-up rounded) decimal place, then `suffix`.
+private void writeScaledBytes(Writer)(
+    ref Writer w, ulong bytes, ulong unit, string suffix)
+{
+    import std.range.primitives : put;
+
+    const ulong whole = bytes / unit;
+    const ulong rem = bytes % unit;       // rem < unit, so rem*10 cannot overflow
+    // The value scaled to tenths, half-up rounded; a `rem` that rounds up to a
+    // full unit carries into `whole` (writeFixedPoint divides the total by 10).
+    writeFixedPoint(w, whole * 10 + (rem * 10 + unit / 2) / unit, 1);
+    put(w, suffix);
+}
+
+/**
+Writes a duration to `precision` decimal places (default `1`).
+
+With `units == "auto"` (the default) the largest fitting unit is chosen — `ns`,
+`µs`, `ms` below one second, then `s`, `m`, `h`, `d` — each rendered to
+`precision` decimals; so the default `writeDuration(w, d)` gives `500.0ns`,
+`1.5µs`, `5.5s`, `3.0d`, and `writeDuration(w, d, 0)` gives `500ns`, `2µs`,
+`5s`. A negative duration is prefixed with `-`.
+
+Any other `units` is a `core.time` unit name — `"nsecs"`, `"hnsecs"`,
+`"usecs"`, `"msecs"`, `"seconds"`, `"minutes"`, `"hours"`, `"days"`, `"weeks"`
+— and the whole duration is rendered in that single unit, e.g.
+`writeDuration!"seconds"(w, d, 3)` → `5.500s`.
+
+`units` is compile-time (it selects the scale and suffix); `precision` is a
+runtime value (it only feeds $(LREF writeFixedPoint)'s decimal count) and must
+be `<= 19` so `10^^precision` fits in a `ulong`.
+
+@nogc-compatible. (Uses `total!"nsecs"`, which only overflows past ~292 years —
+far beyond any duration this is meant to format.)
+*/
+void writeDuration(string units = "auto", Writer)(
+    ref Writer w, in Duration duration, uint precision = 1)
+in (precision <= 19, "precision must be <= 19 (10^^precision must fit in a ulong)")
+{
+    import std.range.primitives : put;
+
+    long ns = duration.total!"nsecs";
+    if (ns < 0)
+    {
+        put(w, '-');
+        ns = -ns;
+    }
+
+    static if (units == "auto")
+    {
+        if (ns < 1_000)
+            writeDurationIn!"nsecs"(w, ns, precision);
+        else if (ns < 1_000_000)
+            writeDurationIn!"usecs"(w, ns, precision);
+        else if (ns < 1_000_000_000)
+            writeDurationIn!"msecs"(w, ns, precision);
+        else if (ns < 60_000_000_000L)
+            writeDurationIn!"seconds"(w, ns, precision);
+        else if (ns < 3_600_000_000_000L)
+            writeDurationIn!"minutes"(w, ns, precision);
+        else if (ns < 86_400_000_000_000L)
+            writeDurationIn!"hours"(w, ns, precision);
+        else
+            writeDurationIn!"days"(w, ns, precision);
+    }
+    else
+        writeDurationIn!units(w, ns, precision);
+}
+
+/// Renders `ns` nanoseconds in a single `unit` to `precision` decimal places
+/// via $(LREF writeFixedPoint), followed by the unit's abbreviation.
+private void writeDurationIn(string unit, Writer)(ref Writer w, long ns, uint precision)
+{
+    import std.range.primitives : put;
+
+    enum long per = nsecsPerUnit!unit;    // nanoseconds in one `unit`
+    ulong pow = 1;                        // 10^^precision
+    foreach (_; 0 .. precision)
+        pow *= 10;
+
+    // The value `ns / per`, scaled by `pow` and half-up rounded, as the
+    // fixed-point integer writeFixedPoint expects. Dividing first when `per`
+    // is a multiple of `pow` avoids the intermediate overflow (the usual case
+    // for these units and small `precision`).
+    ulong number;
+    if (per % pow == 0)
+    {
+        const ulong step = per / pow;     // step >= 1 (per is a multiple of pow)
+        number = (cast(ulong) ns + step / 2) / step;
+    }
+    else
+        number = (cast(ulong) ns * pow + per / 2) / per;
+
+    writeFixedPoint(w, number, precision);
+    put(w, durationUnitAbbrev!unit);
+}
+
+/// Nanoseconds in one `core.time` time unit.
+private template nsecsPerUnit(string unit)
+{
+    static if (unit == "nsecs")        enum long nsecsPerUnit = 1L;
+    else static if (unit == "hnsecs")  enum long nsecsPerUnit = 100L;
+    else static if (unit == "usecs")   enum long nsecsPerUnit = 1_000L;
+    else static if (unit == "msecs")   enum long nsecsPerUnit = 1_000_000L;
+    else static if (unit == "seconds") enum long nsecsPerUnit = 1_000_000_000L;
+    else static if (unit == "minutes") enum long nsecsPerUnit = 60_000_000_000L;
+    else static if (unit == "hours")   enum long nsecsPerUnit = 3_600_000_000_000L;
+    else static if (unit == "days")    enum long nsecsPerUnit = 86_400_000_000_000L;
+    else static if (unit == "weeks")   enum long nsecsPerUnit = 604_800_000_000_000L;
+    else static assert(false, "unsupported duration unit: " ~ unit);
+}
+
+/// Short suffix for a `core.time` time unit.
+private template durationUnitAbbrev(string unit)
+{
+    static if (unit == "nsecs")        enum durationUnitAbbrev = "ns";
+    else static if (unit == "hnsecs")  enum durationUnitAbbrev = "hns";
+    else static if (unit == "usecs")   enum durationUnitAbbrev = "µs";
+    else static if (unit == "msecs")   enum durationUnitAbbrev = "ms";
+    else static if (unit == "seconds") enum durationUnitAbbrev = "s";
+    else static if (unit == "minutes") enum durationUnitAbbrev = "m";
+    else static if (unit == "hours")   enum durationUnitAbbrev = "h";
+    else static if (unit == "days")    enum durationUnitAbbrev = "d";
+    else static if (unit == "weeks")   enum durationUnitAbbrev = "w";
+    else static assert(false, "unsupported duration unit: " ~ unit);
+}
+
+/// Writes a duration via $(LREF writeDuration), then right-pads with spaces to
+/// at least `width` characters. @nogc-compatible.
+void writeDurationPadded(Writer)(
+    ref Writer w, in Duration duration, size_t width)
+{
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import std.range.primitives : put;
+
+    SmallBuffer!(char, 16) buf;
+    writeDuration(buf, duration);
+    const text = buf[];
+    put(w, text);
+    if (text.length < width)
+        foreach (_; 0 .. width - text.length)
+            put(w, ' ');
+}
+
+@("writeBytes.units")
+@safe pure nothrow @nogc
+unittest
+{
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+    SmallBuffer!(char, 32) buf;
+    void check(ulong bytes, string expected)
+    {
+        buf.clear();
+        writeBytes(buf, bytes);
+        assert(buf[] == expected);
+    }
+
+    check(0, "0B");
+    check(1023, "1023B");
+    check(1024, "1.0KiB");
+    check(1536, "1.5KiB");
+    check(2047, "2.0KiB");                // rounds up across the unit boundary
+    check(1UL << 20, "1.0MiB");
+    check(1UL << 30, "1.0GiB");
+    check((1UL << 40) * 4, "4.0TiB");
+    check(1UL << 50, "1.0PiB");
+    check((1UL << 60) * 2 + (1UL << 60) / 2, "2.5EiB");
+    check(ulong.max, "16.0EiB");          // ulong.max ≈ 15.999… EiB, rounds to 16.0
+}
+
+@("writeDuration.units")
+@safe pure nothrow @nogc
+unittest
+{
+    import core.time : dur;
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+    SmallBuffer!(char, 32) buf;
+    void check(Duration d, string expected)
+    {
+        buf.clear();
+        writeDuration(buf, d);
+        assert(buf[] == expected);
+    }
+
+    // Default precision is 1, applied uniformly across every tier.
+    check(dur!"nsecs"(0), "0.0ns");
+    check(dur!"nsecs"(500), "500.0ns");
+    check(dur!"nsecs"(1_500), "1.5µs");   // crosses into µs, one decimal
+    check(dur!"usecs"(750), "750.0µs");
+    check(dur!"usecs"(1_500), "1.5ms");
+    check(dur!"msecs"(42), "42.0ms");
+    check(dur!"msecs"(999), "999.0ms");
+    check(dur!"msecs"(1_000), "1.0s");
+    check(dur!"msecs"(5_500), "5.5s");
+    check(dur!"msecs"(60_000), "1.0m");
+    check(dur!"msecs"(90_000), "1.5m");
+    check(dur!"hours"(1), "1.0h");
+    check(dur!"hours"(24), "1.0d");
+    check(dur!"nsecs"(-500), "-500.0ns");  // negative is prefixed with '-'
+    check(dur!"msecs"(-1_500), "-1.5s");
+}
+
+@("writeDuration.explicitUnitAndPrecision")
+@safe pure nothrow @nogc
+unittest
+{
+    import core.time : dur;
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+    SmallBuffer!(char, 32) buf;
+
+    // `units` is compile-time, `precision` is a runtime argument.
+    buf.clear();
+    writeDuration!"seconds"(buf, dur!"msecs"(5_500), 3);
+    assert(buf[] == "5.500s");
+
+    buf.clear();
+    writeDuration!"msecs"(buf, dur!"usecs"(1_500), 0);     // 1.5ms rounds to 2
+    assert(buf[] == "2ms");
+
+    buf.clear();
+    writeDuration!"minutes"(buf, dur!"seconds"(90), 2);
+    assert(buf[] == "1.50m");
+
+    buf.clear();
+    writeDuration!"usecs"(buf, dur!"nsecs"(2_500), 0);     // 2.5µs rounds to 3
+    assert(buf[] == "3µs");
+
+    // Precision flows through "auto" to sub-second tiers too.
+    buf.clear();
+    writeDuration(buf, dur!"nsecs"(500), 2);
+    assert(buf[] == "500.00ns");
+
+    buf.clear();
+    writeDuration(buf, dur!"nsecs"(1_500), 0);             // auto, integer → rounds
+    assert(buf[] == "2µs");
+}
+
+@("writeDurationPadded.padsToWidth")
+@safe pure nothrow @nogc
+unittest
+{
+    import core.time : dur;
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+    SmallBuffer!(char, 32) buf;
+    writeDurationPadded(buf, dur!"msecs"(1_500), 6);
+    assert(buf[] == "1.5s  ");            // "1.5s" then padded to 6 chars
+}

--- a/libs/core-cli/src/sparkles/core_cli/text/writers.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/writers.d
@@ -67,6 +67,82 @@ if (__traits(isUnsigned, T))
     enum sizeForUnsignedNumberBuffer = T.max.numDigits;
 }
 
+/// Writes an integer with at least `minDigits` digits, left-padded with
+/// `'0'`. For a negative signed value the `'-'` is written first and only
+/// the digit count (not the sign) is padded. `minDigits == 0` behaves like
+/// $(LREF writeInteger).
+void writeIntegerPadded(Writer, T)(ref Writer w, const T val, size_t minDigits)
+if (__traits(isIntegral, T))
+{
+    import std.range.primitives : put;
+    import std.traits : Unsigned, isSigned;
+
+    static if (isSigned!T)
+    {
+        alias U = Unsigned!T;
+
+        if (val < 0)
+        {
+            put(w, '-');
+            // unsigned arithmetic handles T.min correctly
+            writeUnsignedPadded(w, cast(U)(0 - cast(U) val), minDigits);
+        }
+        else
+            writeUnsignedPadded(w, cast(U) val, minDigits);
+    }
+    else
+        writeUnsignedPadded(w, val, minDigits);
+}
+
+private void writeUnsignedPadded(Writer, T)(ref Writer w, const T val, size_t minDigits)
+if (__traits(isUnsigned, T))
+{
+    import std.range.primitives : put;
+
+    size_t digits = 1;
+    for (T v = val; v >= 10; v /= 10)
+        digits++;
+    for (size_t i = digits; i < minDigits; i++)
+        put(w, '0');
+    writeUnsignedImpl(w, val);
+}
+
+@("writeIntegerPadded.pads")
+@safe pure nothrow @nogc
+unittest
+{
+    import sparkles.core_cli.smallbuffer : checkWriter;
+
+    checkWriter!((ref b) => writeIntegerPadded(b, 7, 3))("007");
+}
+
+@("writeIntegerPadded.noPadWhenWideEnough")
+@safe pure nothrow @nogc
+unittest
+{
+    import sparkles.core_cli.smallbuffer : checkWriter;
+
+    checkWriter!((ref b) => writeIntegerPadded(b, 1234, 3))("1234");
+}
+
+@("writeIntegerPadded.zeroWidthLikeWriteInteger")
+@safe pure nothrow @nogc
+unittest
+{
+    import sparkles.core_cli.smallbuffer : checkWriter;
+
+    checkWriter!((ref b) => writeIntegerPadded(b, 42u, 0))("42");
+}
+
+@("writeIntegerPadded.negativeSignExcludedFromWidth")
+@safe pure nothrow @nogc
+unittest
+{
+    import sparkles.core_cli.smallbuffer : checkWriter;
+
+    checkWriter!((ref b) => writeIntegerPadded(b, -5, 3))("-005");
+}
+
 @("writeInteger.positive")
 @safe pure nothrow @nogc
 unittest

--- a/libs/core-cli/src/sparkles/core_cli/text/writers.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/writers.d
@@ -239,36 +239,22 @@ if (__traits(isFloating, T))
 {
     import std.range.primitives : put;
 
-    // Integer part
+    // Integer part.
     ulong intPart = cast(ulong) value;
     writeInteger(w, intPart);
 
-    // Fractional part using fixed-point conversion
+    // Fractional part: a fixed-point integer of T.dig digits (6 for float, 15
+    // for double — more accurate than a repeated multiply), trailing zeros
+    // dropped. The integer/fraction split keeps `frac * scale` within a `ulong`
+    // and within double precision.
     T frac = value - cast(T) intPart;
     if (frac > 0)
     {
         put(w, '.');
-
-        // Convert to fixed-point integer (more accurate than repeated multiply)
-        // Use T.dig digits (6 for float, 15 for double)
         enum int numDigits = T.dig;
         enum ulong scale = 10UL ^^ numDigits;
-        ulong fracInt = cast(ulong)(frac * scale + cast(T) 0.5);
-
-        // Write digits to buffer (right-to-left)
-        char[numDigits] fracBuf = void;
-        foreach_reverse (i; 0 .. numDigits)
-        {
-            fracBuf[i] = cast(char)('0' + fracInt % 10);
-            fracInt /= 10;
-        }
-
-        // Strip trailing zeros
-        int fracLen = numDigits;
-        while (fracLen > 1 && fracBuf[fracLen - 1] == '0')
-            fracLen--;
-
-        put(w, fracBuf[0 .. fracLen]);
+        const ulong fracInt = cast(ulong)(frac * scale + cast(T) 0.5);
+        writeFractionDigits(w, fracInt, numDigits, stripTrailing: true);
     }
 }
 
@@ -1183,4 +1169,103 @@ unittest
     buf.clear();
     writeStyledValue(buf, 3.14, FloatHook(), true);
     assert(buf[] == "\x1b[34m3.14\x1b[39m");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Byte / Duration Formatting
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Writes `number` as a fixed-point value with `radixPoint` fractional digits
+/// in base `radix` (2 ≤ `radix` ≤ 16) — i.e. the value `number /
+/// radix^^radixPoint`. The integer part is written first, then (when
+/// `radixPoint > 0`) a `.` and exactly `radixPoint` zero-padded fractional
+/// digits. `radix^^radixPoint` must fit in a `ulong`. @nogc-compatible.
+///
+/// Examples: `writeFixedPoint(w, 15, 1)` → `1.5`;
+/// `writeFixedPoint(w, 1234, 2)` → `12.34`; `writeFixedPoint!16(w, 255, 2)` →
+/// `0.ff`.
+void writeFixedPoint(uint radix = 10, Writer)(
+    ref Writer w, ulong number, uint radixPoint)
+if (radix >= 2 && radix <= 16)
+in (radixPoint <= 64, "radixPoint must be <= 64")
+{
+    import std.range.primitives : put;
+
+    ulong divisor = 1;
+    foreach (_; 0 .. radixPoint)
+        divisor *= radix;
+
+    // Integer part. Base 10 reuses the optimized writeInteger; other bases use
+    // a most-significant-first digit walk.
+    const ulong intPart = number / divisor;
+    static if (radix == 10)
+        writeInteger(w, intPart);
+    else
+    {
+        char[64] buf = void;              // ≤ 64 digits for a ulong in base 2
+        size_t start = buf.length;
+        ulong v = intPart;
+        do
+        {
+            buf[--start] = hexDigit(cast(uint)(v % radix));
+            v /= radix;
+        }
+        while (v);
+        put(w, buf[start .. $]);
+    }
+
+    if (radixPoint > 0)
+    {
+        put(w, '.');
+        writeFractionDigits!radix(w, number % divisor, radixPoint);
+    }
+}
+
+/// Writes the low `digits` base-`radix` digits of `value`, most-significant
+/// first, zero-padded — a fixed-point fractional part, with no leading `.`.
+/// When `stripTrailing`, trailing `'0'` digits are dropped (keeping at least
+/// one). @nogc-compatible.
+private void writeFractionDigits(uint radix = 10, Writer)(
+    ref Writer w, ulong value, uint digits, bool stripTrailing = false)
+{
+    import std.range.primitives : put;
+
+    char[64] buf = void;
+    foreach_reverse (i; 0 .. digits)
+    {
+        buf[i] = hexDigit(cast(uint)(value % radix));
+        value /= radix;
+    }
+    uint len = digits;
+    if (stripTrailing)
+        while (len > 1 && buf[len - 1] == '0')
+            len--;
+    put(w, buf[0 .. len]);
+}
+
+/// Maps a digit value `0 … 15` to its lower-case character (`0-9`, `a-f`).
+private char hexDigit(uint d) @safe pure nothrow @nogc
+    => cast(char)(d < 10 ? '0' + d : 'a' + (d - 10));
+
+@("writeFixedPoint.basic")
+@safe pure nothrow @nogc
+unittest
+{
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+    SmallBuffer!(char, 32) buf;
+    void check(alias call)(string expected)
+    {
+        buf.clear();
+        call(buf);
+        assert(buf[] == expected);
+    }
+
+    check!((ref b) => writeFixedPoint(b, 15, 1))("1.5");
+    check!((ref b) => writeFixedPoint(b, 160, 1))("16.0");        // carries
+    check!((ref b) => writeFixedPoint(b, 1234, 2))("12.34");
+    check!((ref b) => writeFixedPoint(b, 1000, 3))("1.000");      // zero-padded
+    check!((ref b) => writeFixedPoint(b, 842, 0))("842");         // no point
+    check!((ref b) => writeFixedPoint!16(b, 255, 2))("0.ff");     // base 16
+    check!((ref b) => writeFixedPoint!16(b, 0xABC0, 1))("abc.0"); // base 16 int part
 }

--- a/libs/core-cli/src/sparkles/core_cli/text/writers.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/writers.d
@@ -6,6 +6,8 @@
  */
 module sparkles.core_cli.text.writers;
 
+import core.time : Duration;
+
 import sparkles.core_cli.term_style : Style;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -69,44 +71,36 @@ if (__traits(isUnsigned, T))
 @safe pure nothrow @nogc
 unittest
 {
-    import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import sparkles.core_cli.smallbuffer : checkWriter;
 
-    SmallBuffer!(char, 32) buf;
-    writeInteger(buf, 42);
-    assert(buf[] == "42");
+    checkWriter!((ref b) => writeInteger(b, 42))("42");
 }
 
 @("writeInteger.negative")
 @safe pure nothrow @nogc
 unittest
 {
-    import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import sparkles.core_cli.smallbuffer : checkWriter;
 
-    SmallBuffer!(char, 32) buf;
-    writeInteger(buf, -123);
-    assert(buf[] == "-123");
+    checkWriter!((ref b) => writeInteger(b, -123))("-123");
 }
 
 @("writeInteger.zero")
 @safe pure nothrow @nogc
 unittest
 {
-    import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import sparkles.core_cli.smallbuffer : checkWriter;
 
-    SmallBuffer!(char, 32) buf;
-    writeInteger(buf, 0);
-    assert(buf[] == "0");
+    checkWriter!((ref b) => writeInteger(b, 0))("0");
 }
 
 @("writeInteger.unsigned")
 @safe pure nothrow @nogc
 unittest
 {
-    import sparkles.core_cli.smallbuffer : SmallBuffer;
+    import sparkles.core_cli.smallbuffer : checkWriter;
 
-    SmallBuffer!(char, 32) buf;
-    writeInteger(buf, 0uL);
-    assert(buf[] == "0");
+    checkWriter!((ref b) => writeInteger(b, 0uL))("0");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/libs/core-cli/src/sparkles/core_cli/text/writers.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/writers.d
@@ -13,7 +13,7 @@ import sparkles.core_cli.term_style : Style;
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Writes an integer (signed or unsigned) to an output range. @nogc-compatible.
-void writeInteger(Writer, T)(ref Writer w, const T val) @trusted
+void writeInteger(Writer, T)(ref Writer w, const T val)
 if (__traits(isIntegral, T))
 {
     import std.range.primitives : put;
@@ -41,7 +41,7 @@ if (__traits(isIntegral, T))
     }
 }
 
-private void writeUnsignedImpl(Writer, T)(ref Writer w, const T val) @trusted
+private void writeUnsignedImpl(Writer, T)(ref Writer w, const T val)
 if (__traits(isUnsigned, T))
 {
     import std.range.primitives : put;
@@ -115,7 +115,7 @@ unittest
 
 /// Writes a floating-point value to an output range. @nogc-compatible.
 /// Handles NaN, infinity, negative zero, and uses scientific notation for extreme values.
-void writeFloat(Writer, T)(ref Writer w, const T val) @trusted
+void writeFloat(Writer, T)(ref Writer w, const T val)
 if (__traits(isFloating, T))
 {
     import std.math.traits : isNaN, isInfinity, signbit;
@@ -164,7 +164,7 @@ if (__traits(isFloating, T))
 }
 
 /// Writes a floating-point value in decimal format. @nogc-compatible.
-private void writeFloatDecimal(Writer, T)(ref Writer w, T value) @trusted
+private void writeFloatDecimal(Writer, T)(ref Writer w, T value)
 if (__traits(isFloating, T))
 {
     import std.range.primitives : put;
@@ -203,7 +203,7 @@ if (__traits(isFloating, T))
 }
 
 /// Writes a floating-point value in scientific notation. @nogc-compatible.
-private void writeFloatScientific(Writer, T)(ref Writer w, T value) @trusted
+private void writeFloatScientific(Writer, T)(ref Writer w, T value)
 if (__traits(isFloating, T))
 {
     import std.range.primitives : put;
@@ -322,7 +322,7 @@ unittest
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Writes an escaped character to an output range (without quotes). @nogc-compatible.
-void writeEscapedChar(Writer)(ref Writer w, char c) @trusted
+void writeEscapedChar(Writer)(ref Writer w, char c)
 {
     import std.range.primitives : put;
 
@@ -361,7 +361,7 @@ unittest
 }
 
 /// Writes an escaped string to an output range (with double quotes). @nogc-compatible.
-void writeEscapedString(Writer)(ref Writer w, const(char)[] s) @trusted
+void writeEscapedString(Writer)(ref Writer w, const(char)[] s)
 {
     import std.range.primitives : put;
 
@@ -383,7 +383,7 @@ unittest
 }
 
 /// Writes an escaped character literal to an output range (with single quotes). @nogc-compatible.
-void writeEscapedCharLiteral(Writer)(ref Writer w, char c) @trusted
+void writeEscapedCharLiteral(Writer)(ref Writer w, char c)
 {
     import std.range.primitives : put;
 
@@ -527,7 +527,7 @@ unittest
 /// 8. User types with @nogc `toString()` returning `string` — writes the result
 /// 9. User types with @nogc `string` cast — writes `cast(string) t`
 /// 10. Fallback — uses `std.conv.to!string` (GC-allocating)
-void writeValue(Writer, T)(ref Writer w, auto ref const T val) @trusted
+void writeValue(Writer, T)(ref Writer w, auto ref const T val)
 {
     import std.range.primitives : put;
     import std.traits : isSomeChar, isSomeString;
@@ -538,7 +538,10 @@ void writeValue(Writer, T)(ref Writer w, auto ref const T val) @trusted
     }
     else static if (isSomeChar!T)
     {
-        put(w, (&val)[0 .. 1]);
+        // Copy the char into a one-element stack array and write its slice;
+        // fully @safe, with no pointer aliasing of `val`.
+        T[1] arr = val;
+        put(w, arr[]);
     }
     else static if (__traits(isIntegral, T))
     {
@@ -657,7 +660,7 @@ unittest
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Writes ANSI escape sequence to an output range. @nogc-compatible.
-void writeEscapeSeq(Writer)(ref Writer w, uint code) @trusted
+void writeEscapeSeq(Writer)(ref Writer w, uint code)
 {
     import std.range.primitives : put;
 
@@ -678,7 +681,7 @@ unittest
 }
 
 /// Writes styled text to an output range. @nogc-compatible.
-void writeStylized(Writer)(ref Writer w, const(char)[] text, Style style, bool resetAfter = true) @trusted
+void writeStylized(Writer)(ref Writer w, const(char)[] text, Style style, bool resetAfter = true)
 {
     import std.range.primitives : put;
 
@@ -736,7 +739,7 @@ unittest
 /// Uses `static foreach` over `__traits(allMembers, E)` for a compile-time
 /// generated lookup. Falls back to writing the underlying integer value
 /// if no member matches (e.g., combined bit flags).
-void writeEnumMemberName(E, Writer)(ref Writer w, const E val) @trusted
+void writeEnumMemberName(E, Writer)(ref Writer w, const E val)
 if (is(E == enum))
 {
     import std.range.primitives : put;
@@ -849,7 +852,7 @@ unittest
 ///
 /// All hook primitives are optional (DbI §5). When absent, defaults apply:
 /// no styling, raw strings/chars, enums as underlying integers.
-void writeStyledValue(Hook, Writer, T)(ref Writer w, in T value, in Hook hook, bool useColors) @trusted
+void writeStyledValue(Hook, Writer, T)(ref Writer w, in T value, in Hook hook, bool useColors)
 {
     import std.range.primitives : put;
     import std.traits : isSomeChar, isSomeString;

--- a/libs/core-cli/src/sparkles/core_cli/text/writers.d
+++ b/libs/core-cli/src/sparkles/core_cli/text/writers.d
@@ -1443,6 +1443,85 @@ void writeDurationPadded(Writer)(
             put(w, ' ');
 }
 
+/**
+Writes `elapsed` as a human-readable relative-time phrase: the largest
+`maxUnits` (default `2`) non-zero units, joined Oxford-style and suffixed
+`ago` for a non-negative duration or prefixed `in ` for a negative one — e.g.
+`10 years and 3 months ago`, `in 2 days`, `5 seconds ago`, `500ms ago`.
+
+`Duration` is not calendar-aware, so the calendar is approximate: a year is
+365 days and a month is 30 days. Units descend years → months → days → hours
+→ minutes → seconds as spelled-out words, then the abbreviated sub-second
+units `ms` → `µs` → `ns`; zero units are skipped and a duration that rounds to
+nothing renders as `0ms`. @nogc-compatible.
+*/
+void writeRelativeTime(Writer)(ref Writer w, in Duration elapsed, uint maxUnits = 2)
+in (maxUnits >= 1, "maxUnits must be >= 1")
+{
+    import std.range.primitives : put;
+
+    Duration d = elapsed;
+    const past = !d.isNegative;
+    if (d.isNegative)
+        d = -d;
+
+    auto parts = d.split!("days", "hours", "minutes", "seconds", "msecs", "usecs", "nsecs")();
+    long days = parts.days;
+    const years = days / 365;
+    days %= 365;
+    const months = days / 30;
+    days %= 30;
+
+    // `abbrev` units render as a tight `42µs` suffix; the rest as spelled-out,
+    // pluralized words (`5 seconds`).
+    static struct Unit { long value; string name; bool abbrev; }
+    const Unit[9] units = [
+        Unit(years,         "year"),
+        Unit(months,        "month"),
+        Unit(days,          "day"),
+        Unit(parts.hours,   "hour"),
+        Unit(parts.minutes, "minute"),
+        Unit(parts.seconds, "second"),
+        Unit(parts.msecs,   "ms", true),
+        Unit(parts.usecs,   "µs", true),
+        Unit(parts.nsecs,   "ns", true),
+    ];
+    enum msIndex = 6;       // floor unit when everything rounds to zero
+
+    // The largest `maxUnits` non-zero units, in descending order.
+    size_t[9] pick = void;
+    size_t n = 0;
+    foreach (i, ref u; units)
+        if (u.value != 0 && n < maxUnits)
+            pick[n++] = i;
+    if (n == 0)             // everything rounded to zero → "0ms"
+    {
+        pick[0] = msIndex;
+        n = 1;
+    }
+
+    if (!past)
+        put(w, "in ");
+    foreach (k; 0 .. n)
+    {
+        if (k > 0)
+            put(w, k == n - 1 ? (n == 2 ? " and " : ", and ") : ", ");
+        const u = units[pick[k]];
+        writeInteger(w, u.value);
+        if (u.abbrev)
+            put(w, u.name);             // "500ms"
+        else
+        {
+            put(w, ' ');
+            put(w, u.name);             // "5 second"
+            if (u.value != 1)
+                put(w, 's');            // → "5 seconds"
+        }
+    }
+    if (past)
+        put(w, " ago");
+}
+
 @("writeBytes.units")
 @safe pure nothrow @nogc
 unittest
@@ -1549,4 +1628,39 @@ unittest
     SmallBuffer!(char, 32) buf;
     writeDurationPadded(buf, dur!"msecs"(1_500), 6);
     assert(buf[] == "1.5s  ");            // "1.5s" then padded to 6 chars
+}
+
+@("writeRelativeTime.phrases")
+@safe pure nothrow @nogc
+unittest
+{
+    import core.time : dur;
+    import sparkles.core_cli.smallbuffer : SmallBuffer;
+
+    SmallBuffer!(char, 64) buf;
+    void check(Duration d, uint maxUnits, string expected)
+    {
+        buf.clear();
+        writeRelativeTime(buf, d, maxUnits);
+        assert(buf[] == expected);
+    }
+
+    enum tenYrs = dur!"days"(365 * 10 + 30 * 3 + 10);   // ≈ 10y 3mo 10d
+    check(tenYrs, 3, "10 years, 3 months, and 10 days ago");
+    check(tenYrs, 2, "10 years and 3 months ago");
+    check(tenYrs, 1, "10 years ago");
+
+    check(dur!"minutes"(90), 2, "1 hour and 30 minutes ago");
+    check(dur!"seconds"(5), 2, "5 seconds ago");
+    check(dur!"days"(3), 2, "3 days ago");              // only one non-zero unit
+
+    // Sub-second units are abbreviated (no space, no plural).
+    check(dur!"msecs"(1_500), 2, "1 second and 500ms ago");
+    check(dur!"msecs"(500), 2, "500ms ago");
+    check(dur!"usecs"(42), 2, "42µs ago");
+    check(dur!"nsecs"(700), 2, "700ns ago");
+    check(dur!"msecs"(0), 2, "0ms ago");               // floors at ms, no special case
+
+    check(-dur!"days"(2), 2, "in 2 days");             // negative → future
+    check(-dur!"hours"(50), 2, "in 2 days and 2 hours");
 }

--- a/libs/core-cli/src/sparkles/core_cli/ui/header.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/header.d
@@ -86,14 +86,47 @@ unittest
     assert(result == "──── X ────");
 }
 
+/// A title wider than the requested width must not underflow the pad
+/// arithmetic (which previously tried to allocate a near-infinite line and
+/// exhausted memory). The banner widens to fit the title instead.
+@("header.drawBanner.titleWiderThanWidth")
+unittest
+{
+    import std.string : split;
+
+    const title = "a-very-long-title-that-exceeds-the-requested-banner-width";
+    const result = title.drawHeader(HeaderProps(style: HeaderStyle.banner, width: 20));
+    const lines = result.split('\n');
+    assert(lines.length == 3);
+    assert(lines[1] == title);                 // no padding, title verbatim
+    assert(lines[0].unstyledLength == title.unstyledLength); // rule fits title
+}
+
+/// The same guard for the divider style.
+@("header.drawDivider.titleWiderThanWidth")
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    const title = "a-very-long-title-that-exceeds-the-requested-divider-width";
+    const result = title.drawHeader(HeaderProps(width: 10));
+    // Must terminate and contain the title rather than allocate unboundedly.
+    assert(result.canFind(title));
+}
+
 private string drawDivider(string title, HeaderProps props)
 {
     const titleLen = title.unstyledLength;
     const padding = ' '.repeat(props.titlePadding).to!string;
 
     size_t totalWidth = props.width;
-    if (totalWidth == 0)
-        totalWidth = 4 + props.titlePadding * 2 + titleLen; // 2 chars each side minimum
+    // Never narrower than the title plus its padding (plus a line char each
+    // side): a requested width below that would underflow `remaining` (a
+    // `size_t`) and try to allocate a near-infinite line. `width == 0` (auto)
+    // and any too-narrow width both clamp to this minimum.
+    const minWidth = 2 + props.titlePadding * 2 + titleLen;
+    if (totalWidth < minWidth)
+        totalWidth = (props.width == 0) ? minWidth + 2 : minWidth;
 
     const remaining = totalWidth - titleLen - props.titlePadding * 2;
     const leftLen = remaining / 2;
@@ -107,7 +140,10 @@ private string drawDivider(string title, HeaderProps props)
 private string drawBanner(string title, HeaderProps props)
 {
     const titleLen = title.unstyledLength;
-    const totalWidth = props.width > 0 ? props.width : titleLen + 20;
+    const requested = props.width > 0 ? props.width : titleLen + 20;
+    // Never narrower than the title itself, or the pad arithmetic below
+    // underflows `size_t` and tries to allocate a near-infinite line.
+    const totalWidth = requested > titleLen ? requested : titleLen;
 
     const line = props.bannerLineChar.repeat(totalWidth).to!string;
     const leftPad = (totalWidth - titleLen) / 2;


### PR DESCRIPTION
## What's here

Twelve focused commits, each compiling and green on its own.

### `core_cli.text` package
- **refactor**: move `text_writers` into a `core_cli.text` package
  (`text/writers.d`), updating importers.
- **fix**: the writer templates were blanket-`@trusted`, which is unsound —
  a template's safety depends on the caller-supplied `Writer`/value types.
  Drop the attribute and let each instantiation **infer** its safety;
  `writeValue`'s single-char case copies into a one-element stack array
  instead of slicing `&val`, so the module needs **no `@trusted` anywhere**.
- **test**: `checkWriter` helper for testing output-range writers.

### New formatters in `text.writers`
- **`writeIntegerPadded`** — zero-padded integers.
- **`writeFixedPoint`** — a general base-2…16 fixed-point writer
  (`number / radix^^radixPoint`), plus a shared `writeFractionDigits` helper
  that `writeFloatDecimal` now reuses.
- **`writeBytes`** — binary byte units `B`…`EiB` (`1.5KiB`, `15.9GiB`).
- **`writeDuration`** — a duration in an auto-selected or caller-chosen
  `core.time` unit, to a runtime `precision` (`5.5s`, `1.50m`,
  `writeDuration!"seconds"(w, d, 3)` → `5.500s`). The delta-time logger's
  ad-hoc duration formatting moved here.
- **`writeRelativeTime`** — a humanized relative-time phrase
  (`10 years and 3 months ago`, `in 2 days`, `500ms ago`): the largest
  `maxUnits` non-zero units, Oxford-joined, sign-driven `ago`/`in`, with
  abbreviated sub-second units. Approximate calendar (year = 365d,
  month = 30d) since `Duration` isn't calendar-aware.

### Parsing primitives
- **`text.errors`** — the parse-error vocabulary (`ParseError`,
  `ParseErrorCode`, `ParseExpected`, `NoGcHook`).
- **`text.readers`** — `@nogc` slice-advance parsers (`readInteger`,
  `skipWhile`, `tryConsume`, `readUntil`).

### Process-resource monitoring
- **feat(core-cli)**: `executeMonitored` — runs a command like
  `std.process.execute` but spawns it non-blocking and samples the whole
  process tree's RSS/CPU from `/proc` while it runs, so a memory blow-up can
  be attributed to a specific process. Linux-only sampling (degrades
  gracefully elsewhere); pure, unit-tested `/proc` parsers; plus a per-line
  `stderr` flush in the logger so trace output survives a crash.
- **feat(ci)**: route `dub build`/`run`/`test` through the monitor at
  `--log-level trace`, logging each spawn's peak RSS / CPU.

### Bug fix
- **fix(core-cli)**: `drawHeader` computed side padding as
  `(totalWidth - titleLen) / 2`; a title wider than the requested width
  underflowed `size_t` and tried to allocate a near-infinite line —
  OOM-killing `ci` whenever a banner (e.g. `Verifying … from <path>`)
  exceeded its width. Clamp both banner and divider styles to never be
  narrower than the title; regression tests added.

## Testing
- `dub test :core-cli` — **263 passed**.
- `dub build --root=apps/ci` — builds clean.
