### PR TITLE
docs(guidelines): overhaul AGENTS.md for accuracy and structure

### DIFF
--- a/docs/guidelines/AGENTS.md
+++ b/docs/guidelines/AGENTS.md
@@ -1,49 +1,168 @@
 # Agent Guidelines for Sparkles
 
-This document provides instructions for AI agents working on the `sparkles` codebase.
+Instructions for AI agents working on the `sparkles` codebase. This file is the
+single source of truth: the root `AGENTS.md` is a symlink to it, and `CLAUDE.md`
+includes it. Keep it accurate — a stale fact here propagates into every agent's work.
 
 ## Project Overview
 
-`sparkles` is a D library providing utilities for building CLI applications. It consists of:
+`sparkles` is a D monorepo of CLI/library utilities. The root `dub.sdl` declares
+five sub-packages:
 
-- **core-cli** - Core CLI utilities: terminal styling, pretty-printing, small buffer optimization, process utilities
-- **test-utils** - Testing utilities: diff tools, temp filesystem helpers
+| Sub-package           | Path              | What it is                                                                                                                                                 |
+| --------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sparkles:core-cli`   | `libs/core-cli`   | Terminal styling, pretty-printing, UI components (table/box/header/OSC links), logger, `SmallBuffer`, text readers/writers, process utils, CLI arg parsing |
+| `sparkles:versions`   | `libs/versions`   | Design-by-Introspection versioning library (SemVer, DMD, CalVer, PyPI, Maven, Deb, …) with VERS/pURL interop                                               |
+| `sparkles:test-utils` | `libs/test-utils` | Testing helpers: diff tools, temp-filesystem helpers, string helpers                                                                                       |
+| `sparkles:math`       | `libs/math`       | Small math primitives for games/graphics (early stage)                                                                                                     |
+| `ci`                  | `apps/ci`         | Repository CI helper: runs/verifies markdown examples, standalone examples, sub-package tests, and markdown link maintenance                               |
 
-## Guidelines
+Each library **should** be documented under `docs/libs/<name>/` as a
+[Diátaxis](https://diataxis.fr/) tree (`tutorial/`, `how-to/`, `reference/`,
+`explanation/`). Today only `sparkles:versions` is fully documented
+([`docs/libs/versions/`](../libs/versions/index.md)); `core-cli`, `test-utils`,
+and `math` do not yet have a `docs/libs/<name>/` tree. When you add or substantially
+extend a library, add/extend its docs in that location.
 
-Detailed guidelines are in `docs/guidelines/`:
+## Detailed Guidelines
+
+Cross-cutting guides live in `docs/guidelines/`:
 
 - **[Code Style](./code-style.md)** — Formatting, naming, module layout, imports
+- **[D Style](./dstyle.md)** — Broader D style reference
 - **[Functional & Declarative Programming](./functional-declarative-programming-guidelines.md)** — Range pipelines, UFCS, purity, lazy evaluation
-- **[Design by Introspection](./design-by-introspection-01-guidelines.md)** — Capability traits, optional primitives, shell-with-hooks pattern
+- **[Design by Introspection — Intro](./design-by-introspection-00-intro.md)** & **[Guidelines](./design-by-introspection-01-guidelines.md)** — Capability traits, optional primitives, shell-with-hooks pattern
 - **[Interpolated Expression Sequences](./interpolated-expression-sequences.md)** — IES syntax, metadata processing, context-aware encoding
 - **[DDoc](./ddoc.md)** — Documentation comments, sections, macros, cross-referencing
+- **Idioms** — [Expected Error Handling](./idioms/expected/index.md), [Forcing Named Arguments](./idioms/forced-named-arguments/index.md)
 
-## Building and Testing
+## Repository Layout
 
-```bash
-# Build a specific sub-package
-dub build :core-cli
-
-# Run all tests
-ci --test
-
-# Test specific sub-package
-dub test :core-cli
-
-# Run tests matching a pattern
-dub test :core-cli -- -i "SmallBuffer"
+```
+sparkles/
+├── flake.nix                       # Nix flake (devshell, `ci` package, checks)
+├── dub.sdl                         # Root package; declares the 5 sub-packages
+├── apps/
+│   └── ci/                         # `ci` helper (executable sub-package)
+│       ├── src/app.d               # Markdown example runner / verifier, link maintenance
+│       ├── src/dub_deps.d          # In-tree dependency rewriting helpers
+│       ├── dub.sdl
+│       └── dub.selections.json
+├── libs/
+│   ├── core-cli/src/sparkles/core_cli/
+│   │   ├── args.d                  # CLI argument parsing (@CliOption, parseCliArgs)
+│   │   ├── common_dirs.d           # XDG / standard directory lookup
+│   │   ├── help_formatting.d       # --help output formatting
+│   │   ├── lifetime.d              # recycledInstance / recycledErrorInstance (@nogc throwing)
+│   │   ├── logger.d                # Delta-time-prefixed logger
+│   │   ├── prettyprint.d           # Colorized pretty-printing
+│   │   ├── process_utils.d         # Process execution + RSS/CPU monitoring
+│   │   ├── smallbuffer.d           # @nogc dynamic buffer + checkToString/checkWriter test helpers
+│   │   ├── source_uri.d            # OSC 8 source-URI hooks (editor links)
+│   │   ├── styled_template.d       # IES-based styled text processing
+│   │   ├── term_size.d             # Terminal size detection
+│   │   ├── term_style.d            # Terminal styling/colors
+│   │   ├── term_unstyle.d          # Strip ANSI escapes
+│   │   ├── text/                   # @nogc text package: readers.d, writers.d, errors.d, package.d
+│   │   └── ui/                     # box.d, header.d, table.d, osc_link.d, demo.d
+│   ├── versions/src/sparkles/versions/
+│   │   ├── schemes/                # semver.d, dmd.d, calver_*.d, pypi.d, maven.d, deb.d, … + registry.d
+│   │   ├── operations.d, ranges.d, parsing.d, traits.d, any.d
+│   │   ├── purl.d, vers.d          # pURL / VERS interop
+│   │   └── testing.d               # checkRoundTrip / checkRejects / checkAscending
+│   ├── test-utils/src/sparkles/test_utils/
+│   │   └── diff_tools.d, tmpfs.d, string.d, package.d
+│   └── math/src/sparkles/math/     # vector.d, package.d
+├── docs/
+│   ├── guidelines/                 # Cross-cutting agent/style guides (this file lives here)
+│   ├── libs/<name>/                # Per-library Diátaxis docs (currently: versions/)
+│   ├── research/                   # Background research notes
+│   ├── specs/                      # Design specs
+│   └── overview.md, index.md
+└── nix/
+    ├── dub-lock.json               # Nix-format lockfile shared by `ci` + examples (buildDubPackage)
+    └── shells/default.nix          # Nix dev shell
 ```
 
-## Module Layout
+For module-organization and import conventions, see
+[Code Style § Module Layout](./code-style.md#module-layout).
 
-See [Code Style Guide](./code-style.md#module-layout) for module organization and import conventions.
+## Environment, Build & Test
 
-## Code Style Philosophy
+The repo uses a Nix flake. `nix develop` (or `direnv`) provides the toolchain —
+`dub`, `ldc`, `dmd`, `delta`, and the `ci` helper — on `PATH`. Once the toolchain
+is available, prefer invoking `dub` **directly** for fast iteration:
 
-### Functional Style with UFCS
+```bash
+# Build / test a sub-package (run dub directly — fast)
+dub build :core-cli
+dub test  :core-cli
+dub test  :versions
 
-Prefer **functional style** with UFCS using `std.algorithm` and `std.range`:
+# Run tests matching / excluding a pattern (silly runner; see options below)
+dub test :core-cli -- -i "SmallBuffer"
+dub test :core-cli -- -e "slow"
+dub test :core-cli -- -v            # verbose: full stack traces + durations
+dub test :core-cli -- -t 1          # single-threaded
+
+# Test a sub-package in another worktree without cd:
+dub --root /path/to/worktree test :core-cli
+```
+
+`nix develop -c <cmd>` also works but is slower and can trigger a rebuild of the
+`ci` package; reserve it for entering the shell or for reproducing CI exactly.
+
+> [!IMPORTANT]
+> **The bare `ci` on `PATH` can be stale.** It is a Nix-store wrapper built from
+> the flake; after you change `apps/ci`, the `PATH` copy lags behind. Run the
+> in-tree version with `dub run :ci -- …` or `nix run .#ci -- …` instead of bare
+> `ci`. (This is a real, recurring footgun.)
+
+> [!IMPORTANT]
+> **New/untracked files are invisible to `nix develop`/flake builds until you
+> `git add` them** (stage — you don't need to commit). The flake evaluates the
+> git tree, which includes tracked files and uncommitted edits to them, but not
+> untracked files. Symptom: a freshly created `libs/foo/dub.sdl` or new module
+> "doesn't exist" / "No package file found". Fix: `git add` it.
+
+### Test runner (silly)
+
+The project uses the `silly` test runner (`~>1.1.1`). Options after `--`:
+
+```
+-i, --include    Run tests matching regex
+-e, --exclude    Skip tests matching regex
+-v, --verbose    Show full stack traces and durations
+-t, --threads    Number of worker threads (0 = auto)
+--no-colours     Disable colored output
+```
+
+> [!WARNING]
+> **silly does not discover unittests that live only in `package.d`.** `dub test`
+> generates a `dub_test_root.d` whose `allModules` list excludes `package.d`, so a
+> module whose tests are in `package.d` runs **zero** tests (and silently
+> "passes"). Put tests in feature modules; keep `package.d` for `public import`
+> re-exports only.
+
+### Run the full CI check locally
+
+```bash
+nix run .#ci -- --test --fail-fast       # dub test for every sub-package
+nix run .#ci -- --verify --files README.md   # verify markdown examples (see Examples below)
+```
+
+### Debugging tips
+
+- `dub test :core-cli -- -v` shows full stack traces and per-test durations.
+- `-i "name"` isolates a single test by its UDA name.
+- Ensure `@nogc`/`nothrow` tests actually compile with those attributes (don't
+  let an accidental allocation relax them).
+
+## Code Style & Idioms
+
+### Functional style with UFCS
+
+Prefer **functional pipelines** with UFCS over `std.algorithm`/`std.range`:
 
 ```d
 auto result = items
@@ -52,70 +171,73 @@ auto result = items
     .array;
 ```
 
-See [Functional & Declarative Programming Guidelines](./functional-declarative-programming-guidelines.md) for comprehensive patterns including lazy evaluation, purity, and composable abstractions.
+See [Functional & Declarative Programming Guidelines](./functional-declarative-programming-guidelines.md).
 
-### Safety Attributes
+### Safety attributes — annotate non-templates, infer on templates
 
-Strive for maximum safety. Apply attributes at module or scope level when possible:
+Strive for maximum safety, but apply attributes correctly:
 
-```d
-@safe pure nothrow:
+- **Non-templated functions:** annotate explicitly, e.g. `@safe pure nothrow @nogc`.
+  A module- or scope-level `@safe pure nothrow:` block is fine for plain functions.
+- **Templated functions** — and anything generic over a `Writer`, `Hook`, or other
+  caller-supplied type — **let the attributes infer**. Forcing `@safe` on such a
+  template rejects legitimately non-`@safe` writer/hook types it should accept.
+  Reserve explicit attributes on templates for cases where the attribute is
+  _intrinsic_ (e.g. `recycledErrorInstance` is deliberately `@system`).
+- **Avoid `@trusted` on a whole function — never on a template.** Wrap only the
+  unavoidable unsafe operation in a `@trusted` lambda/block, or sidestep it (e.g.
+  the array-copy trick `char[1] a = c; put(w, a[]);` keeps a writer call `@safe`).
 
-// Functions here inherit these attributes
+### Preview flags
 
-@nogc:
-// Additional @nogc section
-
-@trusted:
-// Functions requiring @trusted for low-level operations
-```
-
-### Preview Flags
-
-The project uses D preview features. These are configured in `dub.sdl`:
+Each sub-package's `dub.sdl` enables:
 
 ```
 dflags "-preview=in" "-preview=dip1000"
 ```
 
-- `-preview=in` - Enables `in` parameters as `scope const`
-- `-preview=dip1000` - Enables improved scope semantics for `@safe` code
+- `-preview=in` — `in` parameters become `scope const`.
+- `-preview=dip1000` — improved scope/lifetime checking for `@safe` code.
 
-### Contract Programming
+Unittest builds additionally pass `-checkaction=context -allinst` (richer assert
+messages; instantiate all templates). The root `dub.sdl` has no `dflags` — they're
+per-sub-package.
 
-Use expression-based `in` contracts for preconditions:
+> [!WARNING]
+> **`dip1000`/`-preview=in` clash with some Phobos functions that don't accept
+> `scope`** (e.g. `std.regex.replaceAll`, reached via `unstyle`). Errors like
+> "scope parameter may not be returned" mean you must relax that specific
+> parameter — drop `in`/`scope` and use `const(char)[]` or pass by value.
 
-```d
-void popBack()
-in (_length > 0, "Cannot pop from empty buffer")
-{
-    _length--;
-}
-```
+### Error handling — `Expected` in `@nogc nothrow` code
 
-See [Code Style Guide](./code-style.md#expression-based-contracts-dip1009) for the full pattern including `out` contracts.
+GC exceptions are disallowed in `@safe pure nothrow @nogc` code. Use the
+[`expected`](https://github.com/tchaloupka/expected) library (`~>0.4.0`, a runtime
+dependency of `core-cli` and `versions`):
 
-### Named Arguments
+- Construct with `ok(value)` / `err!ValType(error)`; check with `hasValue`/`hasError`.
+- Transform/chain with `map`, `mapError`, `andThen`, `orElse`, `mapOrElse`.
+- `Expected!(T, E)` is a range (a failure is empty, a success yields one element),
+  so `joiner` flattens a collection of results, filtering out errors.
+- For the rare path that must still `throw` in `@nogc`, use
+  `recycledErrorInstance!T("message")` from `sparkles.core_cli.lifetime`.
 
-Use named arguments for struct initialization (see [Code Style Guide](./code-style.md#named-arguments-dip1030)):
+See **[Expected Error Handling Idioms](./idioms/expected/index.md)** for the full
+guide (transform/chain/flatten patterns, Rust ↔ D comparisons, and a cheat sheet).
 
-```d
-auto opts = PrettyPrintOptions!void(
-    indentStep: 2,
-    maxDepth: 8,
-    maxItems: 32,
-    softMaxWidth: 80,
-    useColors: true,
-);
-```
+### `@nogc` primitives (and what breaks `@nogc`/`nothrow`)
 
-### @nogc Code
+- `SmallBuffer!(T, N)` — dynamic array with small-buffer optimization; works as an
+  output range. Use it instead of `appender` in `@nogc` code.
+- `sparkles.core_cli.text.writers` / `.readers` — `@nogc` integer/float/duration
+  formatting and parsing. Prefer these over `.text` / `std.conv` (which GC-allocate)
+  and over `std.format` in hot paths.
+- `pureMalloc`/`pureFree` from `core.memory` for manual allocation; static arrays
+  when the size is known at compile time.
 
-For @nogc contexts, use:
-
-- `SmallBuffer` for dynamic arrays without GC allocation
-- `pureMalloc`/`pureFree` from `core.memory` for manual allocation
-- Static arrays when size is known at compile time
+> [!WARNING]
+> `splitter(' ')` and `std.utf` operations can throw `UTFException` / allocate,
+> breaking `nothrow @nogc`. Use the `text` package primitives in those paths.
 
 ```d
 @safe pure nothrow @nogc
@@ -129,20 +251,86 @@ unittest
 }
 ```
 
-## Unit Tests
+### Contracts (DIP1009)
 
-### Test Placement
+Use expression-based `in`/`out` contracts for pre/postconditions:
 
-- Every public function should have a unit test following it
-- Functions should have at least one public/Ddoc-ed unit test (`///` comment at minimum)
+```d
+void popBack()
+in (_length > 0, "Cannot pop from empty buffer")
+{
+    _length--;
+}
+```
 
-### Test Attributes
+See [Code Style § Expression-based contracts](./code-style.md#expression-based-contracts-dip1009).
 
-All unit tests must have explicit safety attributes:
+### Named arguments (DIP1030)
 
-- Use `@safe` or `@system` - never omit the safety attribute
-- `@trusted unittest` is bad practice - tests should verify safety, not bypass it
-- Add `pure`, `nothrow`, and `@nogc` when possible
+Use named arguments for struct initialization (see
+[Code Style § Named arguments](./code-style.md#named-arguments-dip1030)):
+
+```d
+auto opts = PrettyPrintOptions!void(
+    indentStep: 2,
+    maxDepth: 8,
+    maxItems: 32,
+    softMaxWidth: 80,
+    useColors: true,
+);
+```
+
+### Output ranges
+
+Many utilities accept any output range for flexibility:
+
+```d
+ref Writer prettyPrint(T, Writer, Hook = void)(
+    in T value,
+    return ref Writer writer,
+    in PrettyPrintOptions!Hook opt = PrettyPrintOptions!Hook()
+)
+{
+    prettyPrintImpl(value, writer, opt, 0);
+    return writer;
+}
+
+import std.array : appender;
+auto w = appender!string;
+prettyPrint(myValue, w);
+string result = w[];
+```
+
+### Compile-time computation & template constraints
+
+```d
+// Computed at compile time via CTFE
+enum string formatted = "Format me".stylizedTextBuilder(true).bold.underline.blue;
+
+// Constrain templates for type safety
+string numToString(T)(T value)
+if (__traits(isUnsigned, T))
+{ /* ... */ }
+```
+
+For capability-detection patterns (traits, optional primitives, fallback paths),
+see [Design by Introspection Guidelines](./design-by-introspection-01-guidelines.md).
+
+## Testing
+
+### Placement & coverage
+
+- Every public function should have a unit test following it.
+- At minimum, one public/DDoc-ed unit test (`///`) per function.
+- Keep tests in feature modules, **not** in `package.d` (see the silly warning above).
+
+### Test attributes
+
+Always give unittests explicit safety attributes:
+
+- Use `@safe` or `@system` — never omit the safety attribute.
+- Avoid `@trusted unittest` — tests should verify safety, not bypass it.
+- Add `pure`, `nothrow`, `@nogc` whenever possible.
 
 ```d
 @("SmallBuffer.basic.creation")
@@ -155,12 +343,10 @@ unittest
 }
 ```
 
-### @nogc nothrow Testing
+### `@nogc nothrow` testing
 
-For `@nogc nothrow` unit tests, use:
-
-- `recycledErrorInstance` for throwing exceptions without GC allocation
-- `SmallBuffer` as an output range instead of `appender`
+- `recycledErrorInstance!T("msg")` throws without GC allocation.
+- `SmallBuffer` as an output range instead of `appender`.
 
 ```d
 @("prettyPrint.integers")
@@ -178,13 +364,16 @@ unittest
 }
 ```
 
-### Testing Output-Range `toString` Methods
+### Reusable check helpers
 
-For types that expose `void toString(Writer)(ref Writer w)`, prefer
-`checkToString` from `sparkles.core_cli.smallbuffer` over hand-rolling a
-`SmallBuffer` + `recycledErrorInstance` dance. It renders into a `SmallBuffer`
-so the test stays `@safe pure nothrow @nogc`, and reports the expected/actual
-diff via a recycled `AssertError` on mismatch.
+Prefer the project's helpers over hand-rolled assertions:
+
+- **`checkToString` / `checkWriter`** (`sparkles.core_cli.smallbuffer`) — for types
+  exposing `void toString(Writer)(ref Writer w)`. They render into a `SmallBuffer`
+  (so the test stays `@safe pure nothrow @nogc`) and report an expected/actual diff
+  via a recycled `AssertError` on mismatch.
+- **`checkRoundTrip` / `checkRejects` / `checkAscending`** (`sparkles.versions.testing`)
+  — for version-scheme parse/format/ordering tests.
 
 ```d
 @("MyType.toString.basic")
@@ -192,203 +381,34 @@ diff via a recycled `AssertError` on mismatch.
 unittest
 {
     import sparkles.core_cli.smallbuffer : checkToString;
-
     checkToString(MyType(42), "MyType(42)");
 }
 ```
 
-### Silly Test Runner
+(Note: a bare `check` is **not** an importable helper — it appears as an ad-hoc
+local function inside some tests. Use the named helpers above.)
 
-This project uses the `silly` test runner. Use UDA-based test names:
+### Test naming (silly UDAs)
 
 ```d
 @("ModuleName.functionName.testCase")
 @safe pure nothrow @nogc
-unittest
-{
-    // Test implementation
-}
+unittest { /* ... */ }
 ```
 
-#### Test Options
+## Examples & Documentation
 
-```
--i, --include    Run tests matching regex
--e, --exclude    Skip tests matching regex
--v, --verbose    Show full stack traces and durations
--t, --threads    Number of worker threads (0 = auto)
---no-colours     Disable colored output
-```
+### Where docs live
 
-#### Examples
+- Cross-cutting agent/style guides → `docs/guidelines/`.
+- Per-library docs → `docs/libs/<name>/` as a Diátaxis tree
+  (`tutorial/`, `how-to/`, `reference/`, `explanation/`). Mirror `libs/<name>/`.
+- Background → `docs/research/`; design specs → `docs/specs/`.
 
-```bash
-# Run tests matching "SmallBuffer"
-dub test :core-cli -- -i "SmallBuffer"
+### Runnable README examples
 
-# Run tests with verbose output
-dub test :core-cli -- -v
-
-# Exclude slow tests
-dub test :core-cli -- -e "slow"
-
-# Single-threaded execution
-dub test :core-cli -- -t 1
-```
-
-## File Structure
-
-```
-sparkles/
-├── .github/workflows/
-│   └── ci.yml                     # GitHub Actions CI
-├── apps/
-│   └── ci/                         # CI helper sub-package (tests, examples, link maintenance)
-│       ├── src/app.d
-│       ├── dub.sdl
-│       └── dub.selections.json     # Local dub-resolved versions
-├── libs/
-│   ├── core-cli/
-│   │   ├── src/sparkles/core_cli/
-│   │   │   ├── logger.d           # Delta-time-prefixed logger
-│   │   │   ├── prettyprint.d      # Colorized pretty-printing
-│   │   │   ├── process_utils.d    # Process execution
-│   │   │   ├── smallbuffer.d      # @nogc dynamic buffer
-│   │   │   ├── styled_template.d  # IES-based styled text processing
-│   │   │   ├── term_size.d        # Terminal size detection
-│   │   │   ├── term_style.d       # Terminal styling/colors
-│   │   │   ├── text_writers.d     # @nogc text writing utilities
-│   │   │   └── ...
-│   │   └── dub.sdl
-│   └── test-utils/
-│       ├── src/sparkles/test_utils/
-│       │   ├── diff_tools.d       # Diff utilities for tests
-│       │   ├── tmpfs.d            # Temp filesystem helpers
-│       │   └── ...
-│       └── dub.sdl
-├── nix/
-│   ├── dub-lock.json              # Nix-format lockfile shared by `ci` + examples (buildDubPackage)
-│   └── shells/default.nix         # Nix dev shell
-└── dub.sdl                        # Root package config
-```
-
-## Development Environment
-
-The project uses a Nix development shell. New dependencies can be added to `nix/shells/default.nix`.
-
-Run commands within the devshell:
-
-```bash
-nix develop -c dub build :core-cli
-nix develop -c ci --test
-```
-
-## CI/CD
-
-[GitHub Actions CI](../../.github/workflows/ci.yml) runs on both Linux and macOS:
-
-1. Lint checks via reusable workflow
-2. `nix flake check` for Nix validation
-3. `ci --test --fail-fast` to test all sub-packages
-
-## Commit Message Convention
-
-Follow the conventional commits format:
-
-```
-<type>(<scope>): <description>
-```
-
-### Types
-
-- `feat` - New feature
-- `fix` - Bug fix
-- `refactor` - Code refactoring
-- `chore` - Maintenance tasks
-- `build` - Build system changes
-- `ci` - CI/CD changes
-- `docs` - Documentation changes
-
-### Scopes
-
-- `core-cli` - For core-cli package changes
-- `test-utils` - For test-utils package changes
-- `dub` - For dub configuration changes
-- `nix` - For Nix configuration changes
-- `guidelines` - For documentation guidelines changes
-
-### Examples
-
-```
-feat(core-cli): Add SmallBuffer with small buffer optimization
-fix(core-cli): Handle edge case in prettyPrint for empty arrays
-refactor(core-cli): Rename staticInstance to recycledInstance
-chore(nix): Update flake inputs
-```
-
-## Common Patterns
-
-### Output Ranges
-
-Many utilities work with output ranges for flexibility:
-
-```d
-ref Writer prettyPrint(T, Writer, Hook)(
-    in T value,
-    return ref Writer writer,
-    in PrettyPrintOptions!Hook opt = PrettyPrintOptions!void()
-)
-{
-    prettyPrintImpl(value, writer, opt, 0);
-    return writer;
-}
-
-// Use with any output range
-import std.array : appender;
-auto w = appender!string;
-prettyPrint(myValue, w);
-string result = w[];
-```
-
-### Compile-Time Computation
-
-Leverage D's CTFE for compile-time computation:
-
-```d
-// Computed at compile time
-enum string formattedText = "Format me"
-    .stylizedTextBuilder(true)
-    .bold
-    .underline
-    .blue;
-```
-
-### Template Constraints
-
-Use template constraints for type safety:
-
-```d
-string numToString(T)(T value)
-if (__traits(isUnsigned, T))
-{
-    // Implementation
-}
-```
-
-For complex capability detection patterns (traits, optional primitives, fallback paths), see [Design by Introspection Guidelines](./design-by-introspection-01-guidelines.md).
-
-For `@nogc nothrow` error handling, see the [Expected Error Handling Idioms](./idioms/expected/index.md) guide which provides patterns on transforming, chaining, and flattening expected values, alongside comparisons for developers coming from Rust.
-
-## Debugging Tips
-
-1. **Use verbose test output**: `dub test :core-cli -- -v` shows full stack traces
-2. **Test single functions**: Use `-i "functionName"` to isolate tests
-3. **Check @nogc compatibility**: Ensure tests compile with `@nogc` attribute
-4. **Use `check` helper**: In tests, use the `check` function for pretty error messages with diffs
-
-## Documenting New Features
-
-When adding a new feature to sparkles, add a runnable example to `README.md` as a dub single-file program inside a fenced `d` code block:
+When adding a feature, add a runnable example to `README.md` as a dub single-file
+program inside a fenced `d` code block:
 
 ````markdown
 ```d
@@ -407,7 +427,7 @@ void main()
 ```
 ````
 
-Follow the code block with a `[Output]`-labelled fenced block showing the expected output:
+Follow it with a `[Output]`-labelled fenced block showing the expected output:
 
 ````markdown
 ```[Output]
@@ -415,28 +435,37 @@ Expected output here
 ```
 ````
 
-The `[Output]` label is the required convention: `--verify` only treats `[Output]` fences as expected output (a bare ` ``` ` fence is ignored). It renders as a labelled "Output" panel under VitePress and as a plain block on GitHub.
+The `[Output]` label is the **required convention**: `--verify` only treats
+`[Output]` fences as expected output (a bare ` ``` ` fence is ignored). It renders
+as a labelled "Output" panel under VitePress and as a plain block on GitHub.
 
-### Verifying README Examples
+### Verifying examples
 
-Use `nix run .#ci -- ...` to verify that runnable markdown examples compile and produce correct output:
-
-```bash
-# Verify all examples match their expected output
+````bash
+# Verify examples match their expected output
 nix run .#ci -- --verify --files README.md
 
-# Update output blocks with actual output (golden snapshot update)
+# Update output blocks with actual output (golden-snapshot update; writes ```[Output])
 nix run .#ci -- --update --files README.md
 
 # Just run examples and display results
 nix run .#ci -- --files README.md
-```
+````
+
+> [!NOTE]
+> README examples keep `version="*"`, which resolves against the registry by
+> default. To verify them against your working tree, `dub add-local <repo>` first;
+> CI relies on git **tags** so dub can derive a version. (In-repo example/dub files
+> instead use a relative `path=` — see the table below.)
 
 <div v-pre>
 
-### Dynamic Output with `<!-- md-example-expected -->`
+### Dynamic output with `<!-- md-example-expected -->`
 
-When an example produces dynamic output (timestamps, file paths, durations, etc.), add a `<!-- md-example-expected -->` HTML comment directive between the code block and the output block. The directive contains a wildcard pattern used by `--verify`, while the literal output block below it is preserved for readers. Use `{{_}}` as a wildcard that matches any non-empty text:
+For dynamic output (timestamps, paths, durations), put a `<!-- md-example-expected -->`
+HTML-comment directive between the code block and the output block. It holds a
+wildcard pattern used by `--verify`, while the literal `[Output]` block is kept for
+readers. Use `{{_}}` to match any non-empty text:
 
 ````markdown
 <!-- md-example-expected
@@ -448,21 +477,21 @@ When an example produces dynamic output (timestamps, file paths, durations, etc.
 ```
 ````
 
-The HTML comment is invisible in rendered markdown, so readers see the nice hardcoded values. The `--verify` mode uses the wildcard pattern instead of the literal block for comparison.
+The comment is invisible in rendered markdown, so readers see the nice hardcoded
+values while `--verify` uses the wildcard pattern.
 
 </div>
 
-## Dub Dependency Paths
+### In-repo dub dependency paths
 
-Internal files that live inside the repository must reference sibling sub-packages with a
-**relative `path`** to the repo root instead of `version="*"`:
+Files **inside** the repo must reference sibling sub-packages with a relative
+`path=` to the repo root, not `version="*"`:
 
 ```sdl
 dependency "sparkles:core-cli" path="../../.."
 ```
 
-The exact `path` value depends on the file's location relative to the repo root (where the
-root `dub.sdl` lives). For example:
+The `path` value depends on the file's depth relative to the repo root:
 
 | File location                | `path` value |
 | ---------------------------- | ------------ |
@@ -470,16 +499,97 @@ root `dub.sdl` lives). For example:
 | `libs/core-cli/examples/*.d` | `../../..`   |
 | `docs/guidelines/*.d`        | `../..`      |
 
-This applies to **all** in-repo files: `dub.sdl` configs, single-file example scripts, and
+This applies to all in-repo `dub.sdl` configs, single-file example scripts, and
 guideline runnable snippets.
 
-**Exception — public documentation (`README.md`):** README examples are intended to be
-copy-pasted by end-users who don't have the repo layout, so they must keep
-`version="*"`.
+**Exception — `README.md`:** README examples are copy-pasted by end users who don't
+have the repo layout, so they keep `version="*"`.
+
+## Conventions
+
+### Commit messages
+
+Conventional commits: `<type>(<scope>): <description>` (lowercase description).
+
+- **Scope** = a sub-package (`core-cli`, `versions`, `math`, `test-utils`, `ci`) or
+  an area (`nix`, `dub`, `guidelines`, `gh-actions`, `docs`, `research`).
+- **Type** — one of the following (one example each):
+
+| Type       | Use for                                  | Example                                                               |
+| ---------- | ---------------------------------------- | --------------------------------------------------------------------- |
+| `feat`     | new user-facing capability               | `feat(core-cli): add SmallBuffer with small-buffer optimization`      |
+| `fix`      | bug fix                                  | `fix(core-cli): handle empty arrays in prettyPrint`                   |
+| `refactor` | behavior-preserving restructuring        | `refactor(ci): extract dub dependency helpers into a testable module` |
+| `docs`     | documentation only                       | `docs(guidelines): document the [Output] example convention`          |
+| `build`    | build system / dependencies              | `build(dub): add expected as a runtime dependency of versions`        |
+| `ci`       | CI/CD pipelines & tooling                | `ci(gh-actions): add DC (D compiler) dimension to the test matrix`    |
+| `test`     | tests only                               | `test(core-cli): add checkWriter for testing writer functions`        |
+| `style`    | formatting / renames, no behavior change | `style(core-cli): use kebab-case names for example files`             |
+| `chore`    | maintenance (lockfiles, file modes, …)   | `chore(flake.lock): update all flake inputs`                          |
+| `config`   | config-file changes                      | `config(editorconfig): disable indent checking for markdown`          |
+
+Append `!` after the scope for a breaking change (e.g. `feat(ci)!: …`).
+
+Wrap the commit message **body** at 80 columns (the subject line stays a single
+line). Use a blank line between the subject and the body.
+
+### Git hygiene & atomic commits
+
+- **Confirm the current branch before any write/amend/rebase.** A misdirected
+  `--amend` silently folds work into the wrong commit. If you're on the default
+  branch, create a branch first.
+- **Commit as you go — only _pushing_ needs to be explicitly asked for.** Create a
+  commit at each significant step instead of batching everything at the end: a
+  clean, atomic, bisectable series is far easier to build incrementally than to
+  reconstruct afterward. Don't wait for permission to commit; do wait for it to push.
+- **Keep commits atomic.** One logical change per commit, and each commit should
+  pass build + test + lint _on its own_ so history stays bisectable. Use
+  `git commit --fixup=<sha>` for tweaks that belong to an earlier commit instead
+  of a fresh "address review" commit.
+- **Review the branch at the end of a session** and propose tidying it with an
+  interactive rebase (`git rebase -i <base>`) before it merges. Aim for:
+  - **Squash fixups** into their targets — `git rebase -i --autosquash <base>`.
+  - **Every commit green** — no commit that only builds/tests/lints once a later
+    commit lands.
+  - **Group commits by area** so related changes are adjacent.
+  - **Preparation commits first** — move `.gitignore` edits, dependency
+    add/remove/upgrade, config changes, and docs/scaffolding that later commits
+    build on to the front of the branch.
+  - Present the proposed reordering and rewrite only after the user agrees. Never
+    rewrite already-pushed history without `--force-with-lease` and explicit sign-off.
+
+### Pre-commit hooks (`prek`)
+
+Hooks run on commit and will modify or block your changes:
+
+- **editorconfig-checker** enforces 4-space-multiple indentation — including inside
+  DDoc comments (e.g. `$(LIST` / `$(ITEM` bodies).
+- **prettier** reformats markdown and can corrupt literal text in tables (it has
+  turned `5.004_05` into `5.004*05`); double-check tables of literal data after it runs.
+- **verify-md-examples** runs the example verifier and is OOM-prone on large runs;
+  bypass a single commit with `SKIP=verify-md-examples git commit …` when needed.
+
+## Pitfalls Checklist
+
+A quick scan of the gotchas above plus a few more:
+
+- [ ] `git add` new files before `nix develop`/flake builds see them.
+- [ ] Don't run bare `ci` after editing `apps/ci`; use `dub run :ci -- …` / `nix run .#ci -- …`.
+- [ ] Tests in `package.d` don't run under silly — move them to feature modules.
+- [ ] Don't force `@safe`/`@trusted` on templates; let attributes infer.
+- [ ] `dip1000`/`in` can reject `scope` for some Phobos calls — relax to `const(char)[]`.
+- [ ] `splitter`/`std.utf`/`.text`/`std.conv` break `nothrow @nogc` — use the `text` package.
+- [ ] Example output blocks must be ` ```[Output] `, never bare ` ``` `.
+- [ ] Cross-module-but-internal symbols use `package` visibility, not `private`.
+- [ ] Symbols used only as UDAs are camelCase (lowercase first letter).
+- [ ] `expected` is pinned to 0.4.0; the upstream fix is untagged, so `dub upgrade` is a no-op.
 
 ## Dependencies
 
-- `silly` - Test runner (dev dependency)
-- `delta` - Diff tool for test comparisons (system dependency via Nix)
+- `expected` (`~>0.4.0`) — `Expected!(T, E)` error handling; **runtime** dep of
+  `core-cli` and `versions`.
+- `silly` (`~>1.1.1`) — unittest runner; dev/configuration dependency.
+- `delta` — diff tool used by test diff output; system dependency via Nix.
 
-All D dependencies are managed via `dub.sdl` and system dependencies via Nix flake.
+D dependencies are managed via `dub.sdl` (pinned in `dub.selections.json` /
+`nix/dub-lock.json`); system tools come from the Nix flake.


### PR DESCRIPTION
## What

Overhaul `docs/guidelines/AGENTS.md` (the single source of truth — root
`AGENTS.md` symlinks to it and `CLAUDE.md` includes it) after an adversarial
review against the code, `git log`, and past agent transcripts.

## Why

The doc had drifted from reality: it described a 2-package repo (actually 5
sub-packages), a stale file tree, and a "debugging tip" pointing at a helper
that doesn't exist as a reusable symbol. Since every agent reads this file, each
inaccuracy propagates into their work.

## Changes

**Structure** — reorganized 15 flat sections into 8 task-ordered ones:
Overview → Repository Layout → Environment/Build/Test → Code Style & Idioms →
Testing → Examples & Documentation → Conventions → Pitfalls Checklist.

**Fact fixes (verified against code/git):**
- Overview lists all five sub-packages (`core-cli`, `versions`, `test-utils`,
  `math`, `ci`) + the `libs/<name>` ↔ `docs/libs/<name>` Diátaxis docs
  convention (only `versions` is documented today).
- Corrected file tree (`text/` and `ui/` packages, `lifetime`/`args`/etc.; added
  `versions` and `math` subtrees and `flake.nix`).
- Replaced the non-existent `check` tip with the real helpers
  (`checkToString`/`checkWriter`, `checkRoundTrip`/`checkRejects`/`checkAscending`).
- Fixed the `prettyPrint` signature; clarified preview flags are per-sub-package.

**Conventions** — documented every commit type in use with a real example each,
the 80-column body-wrap rule, and git hygiene: commit as you go (only pushing
needs asking), keep commits atomic and individually green, and review/rebase the
branch at end of session (squash fixups, group by area, preparation commits
first).

**Mined guidance** — template attribute inference (don't force `@safe`/`@trusted`
on templates), `@nogc`/`nothrow` traps, `dip1000` scope clashes, the stale `ci`
binary footgun, `git add` for flake visibility, silly + `package.d`, `prek`
behavior, and an `Expected` error-handling subsection linking the idioms guide.

## Verification

All `prek` pre-commit hooks pass (editorconfig, prettier, lychee links,
`verify-md-examples`, markdown-reference-links). Every symbol/path the doc names
was confirmed to exist; the `AGENTS.md` symlink resolves; no runnable examples
are affected.
