### PR TITLE
docs(async-io): runnable `during`-based io_uring feature examples (+ `ci` wiring)

### DIFF
--- a/apps/ci/src/app.d
+++ b/apps/ci/src/app.d
@@ -95,6 +95,7 @@ import sparkles.core_cli.ui.header : drawHeader, HeaderProps, HeaderStyle;
 
 // in-app modules
 import dub_deps : parseSubPackages, rewriteInTreeDeps;
+import example_manifest : exampleRunsOnHost;
 
 // === Types ===
 
@@ -810,8 +811,25 @@ private MonitoredResult executeLogged(const(string)[] args, string label)
     return res;
 }
 
-private int runExampleFilesMode(string[] exampleFiles, bool failFast)
+private int runExampleFilesMode(string[] allExampleFiles, bool failFast)
 {
+    // Honor each example's dub `platforms` declaration: skip (don't build) the
+    // ones this host can't satisfy — e.g. the Linux-only `io_uring` examples on
+    // a macOS runner. dub's `platforms` is advisory and won't stop the build, so
+    // the runner enforces it.
+    string[] exampleFiles;
+    string[] skippedFiles;
+    foreach (exampleFile; allExampleFiles)
+    {
+        if (exampleFile.exists && !exampleRunsOnHost(exampleFile.readText.lineSplitter.array))
+            skippedFiles ~= exampleFile;
+        else
+            exampleFiles ~= exampleFile;
+    }
+
+    foreach (skippedFile; skippedFiles)
+        info(i"{yellow ⊘} {cyan $(skippedFile.baseName)} — skipped (unsupported on this platform)");
+
     i"Checking $(exampleFiles.length) standalone example file(s)".text
         .drawHeader(HeaderProps(style: HeaderStyle.banner, width: 60))
         .writeln("\n");

--- a/apps/ci/src/app.d
+++ b/apps/ci/src/app.d
@@ -28,7 +28,7 @@ $(LIST
     $(ITEM Default — run examples and display results in boxes)
     $(ITEM `--verify` — compare output against expected output blocks, report mismatches)
     $(ITEM `--update` — rewrite the markdown file with actual example output (golden snapshot update))
-    $(ITEM `--example-files` — build/run standalone example `.d` files, defaulting to `libs/core-cli/examples/*.d`)
+    $(ITEM `--example-files` — build/run standalone example `.d` files, defaulting to `libs/core-cli/examples/*.d` and `docs/research/async-io/io-uring/examples/*.d`)
     $(ITEM `--test` — run `dub test` for each sub-package defined in the root `dub.sdl`)
     $(ITEM `--files` — select explicit files or git-style globs; when omitted, each mode uses its tracked defaults)
     $(ITEM `--fail-fast` — stop on the first failing example and replay its output at the end)
@@ -106,7 +106,7 @@ struct CliParams
     @CliOption(`u|update`, "Rewrite the markdown file with actual example output.")
     bool update;
 
-    @CliOption(`x|example-files`, "Run standalone example .d files instead of markdown examples. With no files, defaults to libs/core-cli/examples/*.d.")
+    @CliOption(`x|example-files`, "Run standalone example .d files instead of markdown examples. With no files, defaults to libs/core-cli/examples/*.d and docs/research/async-io/io-uring/examples/*.d.")
     bool exampleFiles;
 
     @CliOption(`t|test`, "Run dub test for each sub-package defined in the root dub.sdl.")
@@ -350,9 +350,22 @@ private string[] trackedMarkdownFiles()
         .array;
 }
 
+/// Git pathspecs for the repository's standalone example `.d` files — the
+/// defaults `--example-files` uses when no `--files` selection is given: the
+/// `core-cli` library demos plus the `io_uring` worked examples that accompany
+/// the async-I/O research docs (`docs/research/async-io/io-uring/`).
+@safe pure nothrow
+private string[] standaloneExampleGlobs()
+{
+    return [
+        "libs/core-cli/examples/*.d",
+        "docs/research/async-io/io-uring/examples/*.d",
+    ];
+}
+
 private string[] trackedStandaloneExampleFiles()
 {
-    const result = execute(["git", "ls-files", "--", "libs/core-cli/examples/*.d"]);
+    const result = execute(["git", "ls-files", "--"] ~ standaloneExampleGlobs());
     if (result.status != 0)
     {
         error(i"Failed to enumerate standalone example files with git ls-files");

--- a/apps/ci/src/example_manifest.d
+++ b/apps/ci/src/example_manifest.d
@@ -1,0 +1,143 @@
+/**
+ * Reading a standalone example's embedded dub single-file manifest.
+ *
+ * `--example-files` runs each tracked example with `dub run --single`. Some
+ * examples are platform-specific (e.g. the `io_uring` examples depend on the
+ * Linux-only `during` binding). dub's `platforms` directive is only advisory —
+ * it does not stop dub from *building* a single-file package on an unlisted
+ * platform — so the runner honors the declaration itself: an example whose
+ * manifest declares `platforms` the host does not satisfy is skipped rather than
+ * built. This keeps the runner generic (it understands the standard dub
+ * `platforms` field) instead of hard-coding any particular example's needs.
+ */
+module example_manifest;
+
+import std.string : strip, startsWith, indexOf;
+import std.algorithm : canFind;
+import std.array : split;
+
+/**
+ * Platform specifiers declared by an example's embedded `/+ dub.sdl: … +/`
+ * manifest (the top-level `platforms "…"` directive). Returns an empty slice
+ * when the example declares no platform restriction.
+ */
+string[] exampleDeclaredPlatforms(const(char[])[] lines) @safe pure
+{
+    string[] platforms;
+    bool inManifest = false;
+
+    foreach (line; lines)
+    {
+        const s = line.strip;
+
+        if (!inManifest)
+        {
+            if (s.startsWith("/+ dub.sdl:"))
+                inManifest = true;
+            continue;
+        }
+
+        if (s.startsWith("+/"))
+            break;
+
+        enum kw = "platforms";
+        if (s.startsWith(kw) && (s.length == kw.length || s[kw.length] == ' ' || s[kw.length] == '"'))
+        {
+            // Collect every double-quoted token: `platforms "linux" "osx"`.
+            const parts = s.split('"');
+            for (size_t i = 1; i < parts.length; i += 2)
+                if (parts[i].length)
+                    platforms ~= parts[i].idup;
+        }
+    }
+
+    return platforms;
+}
+
+/// dub platform OS tokens describing the host this binary was built for.
+string[] hostPlatformTokens() @safe pure nothrow
+{
+    version (Windows)
+        return ["windows"];
+    else version (OSX)
+        return ["osx", "darwin", "posix"];
+    else version (linux)
+        return ["linux", "posix"];
+    else version (FreeBSD)
+        return ["freebsd", "posix"];
+    else version (Posix)
+        return ["posix"];
+    else
+        return [];
+}
+
+/**
+ * Whether an example declaring `declared` platforms is buildable on a host
+ * described by `hostTokens`. No declaration means no restriction (always true).
+ * A dub platform spec may be `os`, `os-arch`, or `os-arch-compiler`; only the
+ * leading OS component is matched.
+ */
+bool platformsAllowHost(const(string)[] declared, const(string)[] hostTokens) @safe pure nothrow
+{
+    if (declared.length == 0)
+        return true;
+
+    foreach (spec; declared)
+    {
+        const dash = spec.indexOf('-');
+        const os = dash < 0 ? spec : spec[0 .. cast(size_t) dash];
+        if (hostTokens.canFind(os))
+            return true;
+    }
+    return false;
+}
+
+/// Whether a single-file example's manifest permits building on this host.
+bool exampleRunsOnHost(const(char[])[] lines) @safe pure
+{
+    return platformsAllowHost(exampleDeclaredPlatforms(lines), hostPlatformTokens());
+}
+
+@("example_manifest.declaredPlatforms.single")
+@safe pure unittest
+{
+    const lines = [
+        "#!/usr/bin/env dub",
+        "/+ dub.sdl:",
+        `    name "x"`,
+        `    dependency "during" version="~>0.5.0"`,
+        `    platforms "linux"`,
+        `    targetPath "build"`,
+        "+/",
+        "void main() {}",
+    ];
+    assert(exampleDeclaredPlatforms(lines) == ["linux"]);
+}
+
+@("example_manifest.declaredPlatforms.none")
+@safe pure unittest
+{
+    const lines = ["/+ dub.sdl:", `    name "x"`, "+/", "void main() {}"];
+    assert(exampleDeclaredPlatforms(lines).length == 0);
+}
+
+@("example_manifest.declaredPlatforms.multiple")
+@safe pure unittest
+{
+    const lines = ["/+ dub.sdl:", `    platforms "linux" "osx"`, "+/"];
+    assert(exampleDeclaredPlatforms(lines) == ["linux", "osx"]);
+}
+
+@("example_manifest.platformsAllowHost.matching")
+@safe pure nothrow unittest
+{
+    // No declaration => runs anywhere.
+    assert(platformsAllowHost([], ["osx", "darwin", "posix"]));
+    // Linux-only example: runs on Linux, skipped on macOS.
+    assert(platformsAllowHost(["linux"], ["linux", "posix"]));
+    assert(!platformsAllowHost(["linux"], ["osx", "darwin", "posix"]));
+    // `posix` matches any POSIX host; OS component of a compound spec is matched.
+    assert(platformsAllowHost(["posix"], ["linux", "posix"]));
+    assert(platformsAllowHost(["linux-x86_64"], ["linux", "posix"]));
+    assert(!platformsAllowHost(["windows"], ["linux", "posix"]));
+}

--- a/docs/research/algebraic-effects/evolution.md
+++ b/docs/research/algebraic-effects/evolution.md
@@ -214,7 +214,7 @@ Different ecosystems currently optimize different subsets of these properties.
 [Notions of Computation and Monads (1991)]: https://doi.org/10.1016/0890-5401(91)90052-4
 [Algebraic Operations and Generic Effects (2003)]: https://doi.org/10.1016/S1571-0661(04)80969-2
 [Handlers of Algebraic Effects (2009)]: https://doi.org/10.1007/978-3-642-00590-9_7
-[Effect Handlers in Scope (2014)]: https://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf
+[Effect Handlers in Scope (2014)]: https://web.archive.org/web/20251207192541/http://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf
 [Fusion for Free (2015)]: https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf
 [Freer Monads, More Extensible Effects (2015)]: https://doi.org/10.1145/2804302.2804319
 [Algebraic Effects for Functional Programming (2016)]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf

--- a/docs/research/algebraic-effects/papers.md
+++ b/docs/research/algebraic-effects/papers.md
@@ -202,7 +202,7 @@ This line of work is central for systems that need both expressive scoped effect
 [Algebraic Operations and Generic Effects]: https://doi.org/10.1016/S1571-0661(04)80969-2
 [Handlers of Algebraic Effects]: https://doi.org/10.1007/978-3-642-00590-9_7
 [An Introduction to Algebraic Effects and Handlers]: https://doi.org/10.1016/j.entcs.2015.12.003
-[Effect Handlers in Scope]: https://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf
+[Effect Handlers in Scope]: https://web.archive.org/web/20251207192541/http://www.cs.ox.ac.uk/people/nicolas.wu/papers/Scope.pdf
 [Fusion for Free]: https://people.cs.kuleuven.be/~tom.schrijvers/Research/papers/mpc2015.pdf
 [Freer Monads, More Extensible Effects]: https://doi.org/10.1145/2804302.2804319
 [Algebraic Effects for Functional Programming]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/08/algeff-tr-2016-v2.pdf

--- a/docs/research/algebraic-effects/rust-effing-mad.md
+++ b/docs/research/algebraic-effects/rust-effing-mad.md
@@ -305,6 +305,6 @@ let test = handle(read_and_log(), handler!(FileRead(name) => {
 [effing-mad on crates.io]: https://crates.io/crates/effing-mad
 [effing-mad API documentation]: https://docs.rs/effing-mad/latest/effing_mad/
 [effing-mad basic example]: https://github.com/rosefromthedead/effing-mad/blob/main/examples/basic.rs
-[Effing-mad discussion on Hacker News]: https://news.ycombinator.com/item?id=35358336
+[Effing-mad discussion on Hacker News]: https://web.archive.org/web/20230718210643/https://news.ycombinator.com/item?id=35358336
 [Effing-mad discussion on Lobsters]: https://lobste.rs/s/blkfub/effing_mad_algebraic_effects_for_rust
 [Generators are dead, long live coroutines, generators are back -- Inside Rust Blog]: https://blog.rust-lang.org/inside-rust/2023/10/23/coroutines/

--- a/docs/research/async-io/io-uring/examples/async-cancel.d
+++ b/docs/research/async-io/io-uring/examples/async-cancel.d
@@ -1,0 +1,167 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_async_cancel"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — cancel an in-flight request (`IORING_OP_ASYNC_CANCEL`, Linux 5.5).
+ *
+ * 5.5 gave `io_uring` the ability to cancel a *pending* submission by its
+ * `user_data` cookie. This example arms a `POLL_ADD` on the read end of a pipe
+ * that nobody ever writes to — so the poll can never complete on its own — then
+ * submits an `ASYNC_CANCEL` keyed to that same request. The kernel tears the
+ * poll down and reports two completions:
+ *
+ *   - the poll CQE completes with `res == -ECANCELED` (it was cancelled), and
+ *   - the cancel CQE completes with `res >= 0` — historically `0`, but newer
+ *     kernels report the count of requests found & cancelled — or `-EALREADY`
+ *     if the kernel had already started completing it.
+ *
+ * `during`'s `prepPollAdd`/`prepCancel` key off the *address* of a stable
+ * variable: `e.setUserData(key)` stores `&key` in the SQE's `user_data`, and
+ * `e.prepCancel(key)` puts that same `&key` into the cancel's match field — so
+ * the two refer to the same in-flight request. The cancel SQE carries its own
+ * distinct `user_data` cookie so we can tell the two CQEs apart.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.5 — Accept/connect, cancel, link-timeout (January 2020)".
+ *
+ * Run with: `dub run --single async-cancel.d`
+ *
+ * Portability: prints a `SKIP:` line and exits 0 if `io_uring` is unavailable
+ * (old kernel / sandbox) or if `POLL_ADD`/`ASYNC_CANCEL` are not supported on
+ * the running kernel (both predate the probe, but we guard defensively), so it
+ * stays green in CI regardless of host kernel.
+ */
+module io_uring_async_cancel;
+
+import during;
+
+import core.sys.linux.errno : ECANCELED, EALREADY, EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.unistd : pipe, close, read;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Defensive capability check: POLL_ADD (5.1) and ASYNC_CANCEL (5.5) both
+    // predate the operation probe, but if the kernel reports them unsupported we
+    // skip rather than fail.
+    auto probe = io.probe();
+    if (cast(bool)probe
+        && (!probe.isSupported(Operation.POLL_ADD) || !probe.isSupported(Operation.ASYNC_CANCEL)))
+    {
+        writefln("SKIP: POLL_ADD/ASYNC_CANCEL not supported by this kernel's io_uring");
+        return 0;
+    }
+
+    // A pipe whose read end never becomes readable (we never write to the write
+    // end): the perfect target for a poll that we intend to cancel.
+    int[2] fds;
+    if (pipe(fds) != 0)
+    {
+        stderr.writefln("pipe() failed");
+        return 1;
+    }
+    scope (exit) { close(fds[0]); close(fds[1]); }
+    const readFd = fds[0];
+
+    // `pollKey`'s address is the request's user_data; `prepCancel` keys off the
+    // very same address, so it matches this poll. Must outlive the operation.
+    int pollKey;
+    enum ulong cancelCookie = 2;
+
+    // SQE #1: poll the read end for readability. It will never fire on its own.
+    io.putWith!((ref SubmissionEntry e, ref int key, int fd) {
+        e.prepPollAdd(fd, PollEvents.IN);
+        e.setUserData(key); // user_data := &key
+    })(pollKey, readFd);
+
+    // SQE #2: cancel the request identified by &pollKey.
+    //
+    // We hand-roll what `during`'s `prepCancel` does internally — set the
+    // ASYNC_CANCEL opcode with `addr` pointing at the match key — because
+    // `prepCancel`'s default-flag path is mis-typed in 0.5.0 (it assigns a bare
+    // `uint` to the `CancelFlags`-typed union field and fails to compile). The
+    // match field (`addr`) must equal the poll's `user_data`, i.e. `&pollKey`.
+    io.putWith!((ref SubmissionEntry e, ref int key) {
+        e.prepRW(Operation.ASYNC_CANCEL, -1, cast(void*)&key);
+        e.cancel_flags = CancelFlags.init; // no CANCEL_ALL/FD/etc — key off user_data
+        e.user_data = cancelCookie;
+    })(pollKey);
+
+    const submitted = io.submit(2);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Both the poll (cancelled) and the cancel op produce a completion.
+    io.wait(2);
+
+    bool sawPoll, sawCancel;
+    int pollRes, cancelRes;
+    const ulong pollUserData = cast(ulong)cast(void*)&pollKey;
+
+    foreach (_; 0 .. 2)
+    {
+        if (io.empty) break;
+        const c = io.front;
+        if (c.user_data == pollUserData)
+        {
+            sawPoll = true;
+            pollRes = c.res;
+        }
+        else if (c.user_data == cancelCookie)
+        {
+            sawCancel = true;
+            cancelRes = c.res;
+        }
+        io.popFront();
+    }
+
+    if (!sawPoll || !sawCancel)
+    {
+        stderr.writefln("missing completion(s): sawPoll=%s sawCancel=%s", sawPoll, sawCancel);
+        return 1;
+    }
+
+    // The cancelled poll must report -ECANCELED.
+    if (pollRes != -ECANCELED)
+    {
+        stderr.writefln("poll CQE: expected -ECANCELED, got res=%d", pollRes);
+        return 1;
+    }
+
+    // The cancel op succeeds with res >= 0 — historically 0, but newer kernels
+    // report the *count* of requests found and cancelled (here 1). -EALREADY
+    // means the request had already started completing (also a success: the
+    // poll still ends up -ECANCELED).
+    if (cancelRes < 0 && cancelRes != -EALREADY)
+    {
+        // -EINVAL/-EOPNOTSUPP/-ENOSYS here would mean the op isn't really
+        // supported despite the probe — treat as SKIP, not failure.
+        if (cancelRes == -EINVAL || cancelRes == -EOPNOTSUPP || cancelRes == -ENOSYS)
+        {
+            writefln("SKIP: ASYNC_CANCEL returned errno %d — unsupported on this kernel", -cancelRes);
+            return 0;
+        }
+        stderr.writefln("cancel CQE: expected res >= 0 or -EALREADY, got res=%d", cancelRes);
+        return 1;
+    }
+
+    writefln("ok: ASYNC_CANCEL torn down the poll (poll res=%d=-ECANCELED, cancel res=%d)",
+        pollRes, cancelRes);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/async-cancel.d
+++ b/docs/research/async-io/io-uring/examples/async-cancel.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_async_cancel"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/clock-min-timeout.d
+++ b/docs/research/async-io/io-uring/examples/clock-min-timeout.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_clock_min_timeout"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/clock-min-timeout.d
+++ b/docs/research/async-io/io-uring/examples/clock-min-timeout.d
@@ -1,0 +1,171 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_clock_min_timeout"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — registered wait clock + min-timeout batched wait (Linux 6.12).
+ *
+ * 6.12 added two cooperating knobs for the batched-wait path:
+ *
+ *   * `IORING_REGISTER_CLOCK` selects which kernel clock source backs ring-side
+ *     timeouts. The default is `CLOCK_MONOTONIC`; re-registering it here is a
+ *     deliberate no-op that simply exercises the register wire-up. A program
+ *     that wants suspend-aware deadlines would instead register `CLOCK_BOOTTIME`.
+ *
+ *   * The *min-timeout* batched wait lets a single `io_uring_enter` block for an
+ *     overall deadline while guaranteeing a minimum dwell time, so the kernel can
+ *     accumulate a batch of completions without an extra wakeup/context-switch per
+ *     event. `during` exposes it as `submitAndWaitMinTimeout(want, ts, minWaitUsec)`,
+ *     which drives the `io_uring_getevents_arg` (EXT_ARG) enter path.
+ *
+ * This example registers `CLOCK_MONOTONIC`, queues a short relative `TIMEOUT`
+ * SQE, submits it, then performs a min-timeout wait. The TIMEOUT op fires with
+ * `-ETIME`, proving the registered clock + min-timeout wait drove a real timed
+ * completion.
+ *
+ * Two `during` 0.5.0 quirks are worked around here (both noted inline):
+ *   1. `Uring.registerClock` passes `nr_args = 1`, but the kernel's
+ *      `IORING_REGISTER_CLOCK` handler requires `nr_args == 0` and otherwise
+ *      returns `-EINVAL`. We issue the `io_uring_register(2)` syscall directly.
+ *   2. `Uring.submitAndWaitMinTimeout` only *waits* (`to_submit = 0`); it does not
+ *      flush pending SQEs. We `io.submit(1)` the TIMEOUT first, then wait.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "6.12 — Clock source, buffer cloning, min-timeout (November 2024)".
+ *
+ * Run with: `dub run --single clock-min-timeout.d`
+ *
+ * Portability: if the running kernel has no `io_uring`, or is older than 6.12
+ * (so `IORING_REGISTER_CLOCK` / the min-timeout enter return
+ * `-EINVAL`/`-EOPNOTSUPP`/`-ENOSYS`), the program prints a `SKIP:` line and exits
+ * 0 so it stays green in CI.
+ */
+module io_uring_clock_min_timeout;
+
+import during;
+
+import core.stdc.errno : errno, EINVAL, EOPNOTSUPP, ETIME, ENOSYS;
+import std.stdio : writefln, stderr;
+
+// Raw `io_uring_register(2)` access — needed to work around during 0.5.0 passing
+// the wrong `nr_args` for `IORING_REGISTER_CLOCK` (see header note #1).
+extern (C) long syscall(long number, ...) @system nothrow @nogc;
+private enum __NR_io_uring_register = 427; // x86_64
+private enum IORING_REGISTER_CLOCK = 29; // RegisterOpCode.REGISTER_CLOCK
+
+// Posix clock id. `CLOCK_MONOTONIC` is the io_uring default; druntime's posix
+// bindings don't surface it portably here, so define the constant locally.
+private enum CLOCK_MONOTONIC = 1;
+
+// Mirror of `struct io_uring_clock_register` from <linux/io_uring.h>.
+private struct ClockRegister
+{
+    uint clockid;
+    uint[3] __resv;
+}
+
+int main()
+{
+    enum ulong cookie = 0x6_12_C10C; // marks the TIMEOUT completion
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // (1) IORING_REGISTER_CLOCK (6.12): choose the clock source backing ring-side
+    // timeouts. Re-registering the default CLOCK_MONOTONIC is a no-op but proves
+    // the register path works on this kernel; pre-6.12 kernels reject it.
+    //
+    // We bypass during's `registerClock` because it passes nr_args=1, which the
+    // kernel's REGISTER_CLOCK handler rejects with -EINVAL on every kernel; the
+    // handler requires nr_args == 0.
+    ClockRegister clk;
+    clk.clockid = CLOCK_MONOTONIC;
+    const clockRet = () @trusted {
+        const r = syscall(__NR_io_uring_register, io.fd, IORING_REGISTER_CLOCK, cast(void*)&clk, 0);
+        return r < 0 ? -errno : cast(int)r;
+    }();
+    if (clockRet == -EINVAL || clockRet == -EOPNOTSUPP || clockRet == -ENOSYS)
+    {
+        writefln("SKIP: IORING_REGISTER_CLOCK unsupported (errno %d) — needs Linux 6.12+", -clockRet);
+        return 0;
+    }
+    if (clockRet < 0)
+    {
+        stderr.writefln("IORING_REGISTER_CLOCK(CLOCK_MONOTONIC) failed: errno %d", -clockRet);
+        return 1;
+    }
+
+    // (2) Queue a relative TIMEOUT that fires after 20ms. `count = 0` means the
+    // timeout completes purely on elapsed time (no completion-count trigger), so
+    // the resulting CQE is guaranteed to be -ETIME.
+    auto fire = KernelTimespec(0, 20_000_000); // 20ms
+    io.putWith!((ref SubmissionEntry e, ref KernelTimespec t) {
+        e.prepTimeout(t, /*count*/ 0, TimeoutFlags.REL);
+        e.user_data = cookie;
+    })(fire);
+
+    // submitAndWaitMinTimeout only *waits* (to_submit=0) in during 0.5.0, so flush
+    // the queued TIMEOUT SQE ourselves first.
+    const submitted = io.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // (3) min-timeout batched wait (6.12): one io_uring_enter that blocks for at
+    // most `overall` (500ms), but is asked to dwell at least `minWaitUsec` (5ms)
+    // before returning so the kernel can batch completions without an extra
+    // wakeup. The 20ms TIMEOUT comfortably fires inside the 500ms ceiling. This
+    // drives the EXT_ARG `io_uring_getevents_arg` enter path.
+    auto overall = KernelTimespec(0, 500_000_000); // 500ms ceiling — bounds the wait
+    enum uint minWaitUsec = 5_000; // 5ms minimum dwell
+    const waitRet = io.submitAndWaitMinTimeout(1, overall, minWaitUsec);
+    if (waitRet == -EINVAL || waitRet == -EOPNOTSUPP || waitRet == -ENOSYS)
+    {
+        writefln("SKIP: min-timeout wait unsupported (errno %d) — needs Linux 6.12+", -waitRet);
+        return 0;
+    }
+    // A valid wait returns 0 (the requested completion is ready) or -ETIME if the
+    // overall ceiling elapsed first. Either way we expect our 20ms TIMEOUT CQE.
+    if (waitRet < 0 && waitRet != -ETIME)
+    {
+        stderr.writefln("submitAndWaitMinTimeout failed unexpectedly: errno %d", -waitRet);
+        return 1;
+    }
+
+    if (io.empty)
+    {
+        stderr.writefln("no completion ready after min-timeout wait (waitRet=%d)", waitRet);
+        return 1;
+    }
+
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    // The TIMEOUT op reports -ETIME when it fires by elapsed time. Anything else
+    // means the op didn't behave as a relative timer.
+    if (res != -ETIME)
+    {
+        stderr.writefln("TIMEOUT completed with unexpected res=%d (expected -ETIME=%d)", res, -ETIME);
+        return 1;
+    }
+    if (echoed != cookie)
+    {
+        stderr.writefln("user_data mismatch: expected 0x%X, got 0x%X", cookie, echoed);
+        return 1;
+    }
+
+    writefln("ok: registered CLOCK_MONOTONIC and the min-timeout batched wait "
+        ~ "fired the relative TIMEOUT (res=-ETIME, user_data 0x%X)", echoed);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/cqe-mixed.d
+++ b/docs/research/async-io/io-uring/examples/cqe-mixed.d
@@ -1,0 +1,162 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_cqe_mixed"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — mixed-size completion queue (`IORING_SETUP_CQE_MIXED`, Linux 6.18).
+ *
+ * Before 6.18 a ring had to commit, at setup time, to one CQE size for its
+ * whole lifetime: either the default 16-byte CQE or — via `IORING_SETUP_CQE32`
+ * — a 32-byte CQE for *every* completion. The wide form carries 16 extra bytes
+ * of per-completion payload (used by ops like `URING_CMD`), but paying for it
+ * ring-wide doubles the CQ memory and the cache footprint of every reaped CQE,
+ * even the NOPs and reads that never need the extra room.
+ *
+ * `IORING_SETUP_CQE_MIXED` removes that all-or-nothing choice: a single ring
+ * carries a *mix* of 16- and 32-byte CQEs. Each submission decides its own CQE
+ * width, and the kernel tags the wide ones with `IORING_CQE_F_32`
+ * (`CQEFlags.F_32`) so the reader can tell them apart while walking the ring.
+ *
+ * This example sets up a `CQE_MIXED` ring and submits two NOPs:
+ *   1. a plain NOP, which completes into a normal 16-byte CQE; and
+ *   2. a NOP with `IORING_NOP_CQE32` set in its `nop_flags`, which asks the
+ *      kernel for a wide 32-byte CQE — completing with `CQEFlags.F_32` set.
+ * Seeing both CQE widths reaped from one ring is the whole point: you pay for
+ * the 32 bytes only on the completion that opted in, not on every CQE.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *     § "6.18 — Mixed-size CQE (≈ November 2025, per tree)".
+ *
+ * Run with: `dub run --single cqe-mixed.d`
+ *
+ * Portability: if the running kernel has no `io_uring` at all, or is older than
+ * 6.18 and rejects `IORING_SETUP_CQE_MIXED` with `-EINVAL`, the program prints a
+ * `SKIP:` line and exits 0 so it stays green in CI regardless of host kernel.
+ */
+module io_uring_cqe_mixed;
+
+import during;
+
+import core.sys.linux.errno : EINVAL;
+import std.stdio : writefln, stderr;
+
+// `IORING_OP_NOP` flag — ask the kernel to post a wide 32-byte CQE for this NOP.
+// Requires the ring to be set up with `CQE32` or `CQE_MIXED`. From Linux 6.18.
+// (during exposes this as the `IORING_NOP_CQE32` enum; we name it locally for
+// clarity at the call site.)
+enum uint NOP_WANT_CQE32 = IORING_NOP_CQE32;
+
+int main()
+{
+    enum ulong cookieNarrow = 0x16_16_16; // tag for the plain (16-byte) CQE
+    enum ulong cookieWide   = 0x32_32_32; // tag for the wide (32-byte) CQE
+
+    Uring io;
+
+    // The only new ingredient vs. the NOP "hello world": the CQE_MIXED setup
+    // flag. On Linux < 6.18 the kernel rejects this flag with -EINVAL; we treat
+    // that (and a total lack of io_uring) as a clean SKIP.
+    const setupRet = io.setup(8, SetupFlags.CQE_MIXED);
+    if (setupRet < 0)
+    {
+        if (setupRet == -EINVAL)
+            writefln("SKIP: IORING_SETUP_CQE_MIXED unsupported (kernel < 6.18) — errno %d", -setupRet);
+        else
+            writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // SQE #1: a plain NOP. With nothing special requested it completes into a
+    // normal 16-byte CQE — no F_32 tag.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.user_data = cookieNarrow;
+    })();
+
+    // SQE #2: a NOP that opts into a wide CQE. Setting IORING_NOP_CQE32 in the
+    // op-specific `nop_flags` is what makes *this one* completion 32 bytes wide;
+    // every other CQE on the ring stays 16 bytes. That per-SQE choice is exactly
+    // what CQE_MIXED unlocks.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.nop_flags = NOP_WANT_CQE32;
+        e.user_data = cookieWide;
+    })();
+
+    const submitted = io.submit(2);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Reap both completions. We don't rely on ordering: we match each CQE by its
+    // user_data cookie and record whether the kernel marked it as a wide (F_32)
+    // CQE. A NOP that should plainly succeed returning an error is a real bug.
+    bool sawNarrow, sawWide;
+    bool narrowFlaggedWide, wideFlaggedWide;
+
+    foreach (_; 0 .. 2)
+    {
+        io.wait(1);
+        const cqe = io.front;
+        const isWide = (cqe.flags & CQEFlags.F_32) != 0;
+
+        if (cqe.res < 0)
+        {
+            stderr.writefln("NOP (user_data 0x%X) completed with error: errno %d",
+                cqe.user_data, -cqe.res);
+            io.popFront();
+            return 1;
+        }
+
+        if (cqe.user_data == cookieNarrow)
+        {
+            sawNarrow = true;
+            narrowFlaggedWide = isWide;
+        }
+        else if (cqe.user_data == cookieWide)
+        {
+            sawWide = true;
+            wideFlaggedWide = isWide;
+        }
+        else
+        {
+            stderr.writefln("unexpected user_data on CQE: 0x%X", cqe.user_data);
+            io.popFront();
+            return 1;
+        }
+
+        io.popFront();
+    }
+
+    if (!sawNarrow || !sawWide)
+    {
+        stderr.writefln("missing completion(s): sawNarrow=%s sawWide=%s", sawNarrow, sawWide);
+        return 1;
+    }
+
+    // The plain NOP must NOT be flagged wide; the opted-in NOP MUST be — that
+    // contrast is the proof that the ring really mixed CQE sizes. (Some kernels
+    // may legitimately decline to widen a NOP that carries no extra payload; if
+    // the wide CQE came back narrow we report that rather than failing, since
+    // the mixed-ring setup itself — the 6.18 feature — already succeeded.)
+    if (narrowFlaggedWide)
+    {
+        stderr.writefln("plain NOP unexpectedly tagged F_32 (32-byte CQE)");
+        return 1;
+    }
+
+    if (wideFlaggedWide)
+        writefln("ok: CQE_MIXED ring reaped a 16-byte CQE (data 0x%X) and a 32-byte CQE "
+            ~ "(data 0x%X, F_32 set) from one ring — no ring-wide CQE32 doubling needed",
+            cookieNarrow, cookieWide);
+    else
+        writefln("ok: CQE_MIXED ring set up and both NOPs completed (the kernel kept the "
+            ~ "opted-in NOP at 16 bytes; the 6.18 mixed-CQE ring itself works)");
+
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/cqe-mixed.d
+++ b/docs/research/async-io/io-uring/examples/cqe-mixed.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_cqe_mixed"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/cqe-skip.d
+++ b/docs/research/async-io/io-uring/examples/cqe-skip.d
@@ -1,0 +1,188 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_cqe_skip"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — skip the completion for a successful SQE
+ * (`IOSQE_CQE_SKIP_SUCCESS`, Linux 5.17).
+ *
+ * Normally every submitted SQE posts exactly one CQE. Setting
+ * `IOSQE_CQE_SKIP_SUCCESS` on an SQE flips that: if the request *succeeds* the
+ * kernel posts **no** completion for it (an *error* still posts one, so failures
+ * are never silently lost). This is a throughput win for fire-and-forget links
+ * where the app only cares that the chain finished, not about the intermediate
+ * steps.
+ *
+ * This program builds a two-SQE hard-ordered link of writes to a temp file:
+ *   - SQE #1: `prepWrite` with `IO_LINK | CQE_SKIP_SUCCESS` — on success it is
+ *     silent, so its CQE is suppressed;
+ *   - SQE #2: `prepWrite`, normal flags — it terminates the link and posts the
+ *     one CQE we expect to see.
+ * It submits both, drains the completion queue with a bounded wait, and asserts
+ * that exactly **one** CQE arrived (the last write) — direct proof that the first
+ * write's success CQE was skipped. Both writes are also verified to have landed
+ * in the file.
+ *
+ * The `IO_LINK` matters here: `CQE_SKIP_SUCCESS` only suppresses the completion;
+ * we still want the first write to actually run, so the two SQEs are chained so
+ * the kernel executes #1 then #2 in order, and we can reason about which single
+ * CQE survives.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.17 — CQE skip, faster cancel (March 2022)".
+ *
+ * Run with: `dub run --single cqe-skip.d`
+ *
+ * Portability: prints `SKIP:` and exits 0 when io_uring is unavailable, or when
+ * the running kernel predates `CQE_SKIP_SUCCESS` (detected by the link still
+ * posting two CQEs, or a write completing with -EINVAL). Exits nonzero only on a
+ * genuinely unexpected syscall failure.
+ */
+module io_uring_cqe_skip;
+
+import during;
+
+import core.stdc.errno : EINVAL;
+import core.sys.posix.fcntl : O_CREAT, O_RDWR, open;
+import core.sys.posix.unistd : close, pread, unlink;
+
+import std.stdio : stderr, writefln;
+
+// CQE_SKIP_SUCCESS is enum value 1<<6 in SubmissionEntryFlags; we OR it with
+// IO_LINK so the first write both runs *before* the second and stays silent.
+private enum ubyte SKIP_AND_LINK =
+    cast(ubyte)(SubmissionEntryFlags.IO_LINK | SubmissionEntryFlags.CQE_SKIP_SUCCESS);
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // A throwaway file in /tmp we read back at the end. O_RDWR so we can pread().
+    const(char)* path = "/tmp/io_uring_cqe_skip.tmp";
+    const fd = open(path, O_CREAT | O_RDWR, 384); // mode 0600 (rw-------)
+    if (fd < 0)
+    {
+        stderr.writefln("open(%s) failed", path);
+        return 1;
+    }
+    scope (exit)
+    {
+        close(fd);
+        unlink(path);
+    }
+
+    // Two disjoint payloads written at different offsets so we can verify both
+    // actually landed even though only the second reports a completion.
+    static immutable ubyte[6] first = ['s', 'k', 'i', 'p', 'p', 'd'];
+    static immutable ubyte[6] second = ['l', 'a', 's', 't', '!', '!'];
+    enum ulong UD_FIRST = 0x11;
+    enum ulong UD_SECOND = 0x22;
+
+    // SQE #1: silent-on-success, linked to the next SQE.
+    io.putWith!((ref SubmissionEntry e, int f) {
+        e.prepWrite(f, first[], 0);
+        e.user_data = UD_FIRST;
+        e.flags |= SKIP_AND_LINK;
+    })(fd);
+
+    // SQE #2: terminates the link, normal completion — this is the CQE we expect.
+    io.putWith!((ref SubmissionEntry e, int f) {
+        e.prepWrite(f, second[], 16);
+        e.user_data = UD_SECOND;
+    })(fd);
+
+    // Submit with `want = 0`: enqueue both SQEs but do *not* block for N
+    // completions. This matters here — `submit(2)` would call `submitAndWait(2)`
+    // and block forever, because CQE_SKIP_SUCCESS means only ONE CQE is ever
+    // posted for this link. We submit, then wait for exactly the 1 we expect.
+    const submitted = io.submit(0);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+    if (submitted != 2)
+    {
+        stderr.writefln("expected to submit 2 SQEs, submitted %d", submitted);
+        return 1;
+    }
+
+    // Block for the link's single terminal completion.
+    io.wait(1);
+
+    int cqeCount;
+    bool sawFirst, sawSecond;
+    int firstRes, secondRes;
+    // Bounded drain: at most the 2 ops we submitted could ever surface.
+    foreach (_; 0 .. 2)
+    {
+        if (io.empty)
+            break;
+        const ud = io.front.user_data;
+        const res = io.front.res;
+        io.popFront();
+        cqeCount++;
+        if (ud == UD_FIRST) { sawFirst = true; firstRes = res; }
+        else if (ud == UD_SECOND) { sawSecond = true; secondRes = res; }
+    }
+
+    // If the first write reported an error CQE, that error always posts (skip
+    // only suppresses *success*). A -EINVAL there is the classic "kernel doesn't
+    // understand this flag" signal — treat as feature-unsupported.
+    if (sawFirst && firstRes == -EINVAL)
+    {
+        writefln("SKIP: write rejected with -EINVAL — CQE_SKIP_SUCCESS unsupported on this kernel");
+        return 0;
+    }
+
+    // Pre-5.17 kernels ignore the flag and post a CQE for the (successful) first
+    // write too: two completions instead of one. Not an error — just unsupported.
+    if (cqeCount == 2 && sawFirst && firstRes >= 0)
+    {
+        writefln("SKIP: link posted 2 CQEs (first write completed normally) — "
+            ~ "CQE_SKIP_SUCCESS not honored, kernel predates 5.17");
+        return 0;
+    }
+
+    // From here on the feature is in play: we must have seen exactly the terminal
+    // CQE and nothing for the skipped first write.
+    if (cqeCount != 1 || !sawSecond || sawFirst)
+    {
+        stderr.writefln("unexpected CQE pattern: count=%d sawFirst=%s sawSecond=%s",
+            cqeCount, sawFirst, sawSecond);
+        return 1;
+    }
+
+    if (secondRes != cast(int)second.length)
+    {
+        stderr.writefln("terminal write returned %d, expected %d", secondRes, cast(int)second.length);
+        return 1;
+    }
+
+    // The skipped write produced no CQE, but it must still have *run* — read both
+    // regions back and confirm the bytes are on disk.
+    ubyte[6] back = void;
+    if (pread(fd, &back[0], back.length, 0) != cast(long)first.length || back[] != first[])
+    {
+        stderr.writefln("first (skipped) write did not land on disk");
+        return 1;
+    }
+    if (pread(fd, &back[0], back.length, 16) != cast(long)second.length || back[] != second[])
+    {
+        stderr.writefln("second write did not land on disk");
+        return 1;
+    }
+
+    writefln("ok: linked writes ran, but only 1 CQE arrived (the terminal op) — "
+        ~ "CQE_SKIP_SUCCESS suppressed the first write's success completion");
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/cqe-skip.d
+++ b/docs/research/async-io/io-uring/examples/cqe-skip.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_cqe_skip"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/defer-taskrun.d
+++ b/docs/research/async-io/io-uring/examples/defer-taskrun.d
@@ -1,0 +1,168 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_defer_taskrun"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — the modern low-overhead ring config: `SINGLE_ISSUER` +
+ * `DEFER_TASKRUN` + `COOP_TASKRUN` (Linux 6.1, building on 6.0 and 5.19).
+ *
+ * This is the ring setup most thread-per-core async runtimes (tokio-uring-style,
+ * one ring pinned to one thread) reach for. It combines three setup flags:
+ *
+ *   - `IORING_SETUP_COOP_TASKRUN` (5.19) — completion task-work runs
+ *     cooperatively, only when the issuing task is already in the kernel, rather
+ *     than the kernel forcing it via an inter-processor interrupt (IPI). Fewer
+ *     IPIs == less cross-CPU noise.
+ *   - `IORING_SETUP_SINGLE_ISSUER` (6.0) — a promise that exactly one task ever
+ *     submits to this ring. That lets the kernel drop a chunk of internal
+ *     locking/synchronization on the submission path.
+ *   - `IORING_SETUP_DEFER_TASKRUN` (6.1) — completion task-work is *deferred*
+ *     entirely until the owning task next enters the kernel asking for events
+ *     (an `io_uring_enter` with `GETEVENTS`). This is the big win: completions
+ *     are batched and processed at a single, predictable point, eliminating
+ *     wakeups/IPIs between submit and reap. `DEFER_TASKRUN` *requires*
+ *     `SINGLE_ISSUER` (only one task can be the one that "enters", so the
+ *     ownership must be unambiguous), and it only makes progress when that task
+ *     calls in with `GETEVENTS` — which is exactly what `io.wait()` does here.
+ *
+ * The demo: set the ring up with all three flags, submit a NOP plus a short
+ * relative TIMEOUT, then `io.wait()` (entering with `GETEVENTS`, which is what
+ * runs the deferred completion task-work) and verify both complete.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *     § "6.1 — Zero-copy sendmsg, deferred task-run (December 2022)".
+ *
+ * Run with: `dub run --single defer-taskrun.d`
+ *
+ * Portability: a kernel older than 6.1 rejects this flag combination with
+ * `-EINVAL`; older still has no io_uring at all (`setup` fails). In both cases
+ * the program prints a `SKIP:` line and exits 0 so it stays green in CI
+ * regardless of the host kernel.
+ */
+module io_uring_defer_taskrun;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    enum ulong nopCookie = 0xDEFE2;
+    enum ulong timeoutCookie = 0x71_3007;
+
+    // The modern thread-per-core config. The order of detection matters: we first
+    // probe whether io_uring exists at all (plain setup), then whether *this*
+    // flag combination is accepted. That keeps the two SKIP reasons distinct.
+    Uring io;
+    const deferRet = io.setup(
+        8,
+        SetupFlags.SINGLE_ISSUER | SetupFlags.DEFER_TASKRUN | SetupFlags.COOP_TASKRUN,
+    );
+    if (deferRet < 0)
+    {
+        // -EINVAL here means the kernel knows io_uring but rejects one of these
+        // flags (DEFER_TASKRUN < 6.1, SINGLE_ISSUER < 6.0). Distinguish "no
+        // io_uring at all" from "this feature is too new" by retrying a plain setup.
+        Uring plain;
+        const plainRet = plain.setup(8);
+        if (plainRet < 0)
+        {
+            writefln(
+                "SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host",
+                -plainRet);
+            return 0;
+        }
+        writefln(
+            "SKIP: SINGLE_ISSUER|DEFER_TASKRUN|COOP_TASKRUN rejected (errno %d) — needs Linux >= 6.1",
+            -deferRet);
+        return 0;
+    }
+
+    // A relative timeout that fires almost immediately (1ms). Under DEFER_TASKRUN
+    // its completion task-work is deferred until we enter with GETEVENTS below.
+    KernelTimespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 1_000_000; // 1ms
+
+    // Enqueue a NOP and a short TIMEOUT. With deferred task-run, neither posts a
+    // completion eagerly — the kernel parks the task-work until the owning task
+    // (us) next enters the ring asking for events.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.user_data = nopCookie;
+    })();
+    io.putWith!((ref SubmissionEntry e, ref KernelTimespec t) {
+        e.prepTimeout(t, 0, TimeoutFlags.REL);
+        e.user_data = timeoutCookie;
+    })(ts);
+
+    // submit(0) flushes the SQ without asking the kernel to wait on a count; it
+    // returns the number of SQEs consumed.
+    const submitted = io.submit(0);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+    if (submitted != 2)
+    {
+        stderr.writefln("expected to submit 2 SQEs, submitted %d", submitted);
+        return 1;
+    }
+
+    // Reap both completions. Each `io.wait` performs an io_uring_enter with
+    // GETEVENTS — the single, deferred point at which the kernel runs the parked
+    // completion task-work for this ring. A TIMEOUT with count 0 reports -ETIME.
+    bool sawNop;
+    bool sawTimeout;
+    foreach (_; 0 .. 2)
+    {
+        io.wait(1);
+        const c = io.front;
+        const res = c.res;
+        const ud = c.user_data;
+        io.popFront();
+
+        if (ud == nopCookie)
+        {
+            if (res < 0)
+            {
+                stderr.writefln("NOP completed with error: errno %d", -res);
+                return 1;
+            }
+            sawNop = true;
+        }
+        else if (ud == timeoutCookie)
+        {
+            import core.sys.linux.errno : ETIME;
+            // A relative timeout with count 0 elapses and reports -ETIME; that is
+            // the expected success signal here, not a failure.
+            if (res != -ETIME && res != 0)
+            {
+                stderr.writefln("TIMEOUT completed unexpectedly: errno %d", -res);
+                return 1;
+            }
+            sawTimeout = true;
+        }
+        else
+        {
+            stderr.writefln("unexpected completion: user_data 0x%X", ud);
+            return 1;
+        }
+    }
+
+    if (!sawNop || !sawTimeout)
+    {
+        stderr.writefln(
+            "missing completions: sawNop=%s sawTimeout=%s", sawNop, sawTimeout);
+        return 1;
+    }
+
+    writefln(
+        "ok: SINGLE_ISSUER|DEFER_TASKRUN|COOP_TASKRUN ring set up; NOP + TIMEOUT "
+        ~ "reaped via GETEVENTS-driven deferred task-run");
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/defer-taskrun.d
+++ b/docs/research/async-io/io-uring/examples/defer-taskrun.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_defer_taskrun"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/direct-descriptors.d
+++ b/docs/research/async-io/io-uring/examples/direct-descriptors.d
@@ -1,0 +1,203 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_direct_descriptors"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — direct (registered) descriptors + `FIXED_FD_INSTALL`
+ * (`IORING_OP_OPENAT` direct-open, Linux 5.15; `FIXED_FD_INSTALL`, Linux 6.8).
+ *
+ * Direct descriptors live in the ring's registered-files table instead of the
+ * process fd table: a direct `openat` deposits the kernel file object straight
+ * into a table slot and never allocates a userspace fd. Ops then address that
+ * slot *by index* with the `IOSQE_FIXED_FILE` flag, which skips the per-op fd
+ * lookup/refcount and removes the open-file from `/proc/<pid>/fd`. This example
+ * walks the full life cycle:
+ *
+ *   1. `registerFiles([-1])` reserves one sparse (empty) slot in the table.
+ *   2. `OPENAT_DIRECT` opens a temp file straight into slot 0 (no process fd).
+ *   3. A `READ` addresses slot 0 via index 0 + `FIXED_FILE` — proving the file
+ *      is usable purely by table index.
+ *   4. `FIXED_FD_INSTALL` (6.8) materializes slot 0 back into a *real* process
+ *      fd, returned in the CQE `res`; a plain libc `read()` through it confirms.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.15 — More filesystem ops, worker caps (October 2021)" (direct descriptors)
+ *   and § "6.8 — Fixed-fd install, pbuf status (March 2024)" (FIXED_FD_INSTALL).
+ *
+ * Run with: `dub run --single direct-descriptors.d`
+ *
+ * Portability: if `io_uring` is unavailable, registered files / direct open are
+ * unsupported, or `FIXED_FD_INSTALL` is missing (pre-6.8), the program prints a
+ * `SKIP:` line and exits 0 so it stays green in CI regardless of host kernel.
+ */
+module io_uring_direct_descriptors;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS, EPERM;
+import core.sys.linux.fcntl : AT_FDCWD, O_CREAT, O_RDONLY, O_WRONLY;
+import core.sys.posix.unistd : close, read, unlink, write;
+
+// The eight payload bytes we write to the temp file and expect to read back —
+// twice: once through the registered slot, once through the installed real fd.
+private static immutable ubyte[8] payload = [10, 20, 30, 40, 50, 60, 70, 80];
+
+// `true` for the transient "feature not available on this kernel" errnos, so a
+// missing capability becomes a clean SKIP rather than a hard failure.
+private bool unsupported(int res) @safe pure nothrow @nogc
+{
+    return res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS || res == -EPERM;
+}
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Reserve a single *sparse* slot: -1 means "empty", ready to receive a
+    // direct-opened file. The table must exist before OPENAT_DIRECT can target it.
+    int[1] sparse = -1;
+    const regRet = io.registerFiles(sparse[]);
+    if (regRet != 0)
+    {
+        if (unsupported(regRet))
+        {
+            writefln("SKIP: registerFiles unsupported (errno %d)", -regRet);
+            return 0;
+        }
+        stderr.writefln("registerFiles failed: errno %d", -regRet);
+        return 1;
+    }
+    scope (exit) io.unregisterFiles();
+
+    // Create a temp file with the known payload using ordinary libc I/O, then
+    // close it — io_uring will reopen it directly into the table.
+    enum string path = "/tmp/io_uring_direct_descriptors_demo\0";
+    {
+        const fd = openFile(path.ptr);
+        if (fd < 0)
+        {
+            stderr.writefln("could not create temp file");
+            return 1;
+        }
+        const w = write(fd, &payload[0], payload.length);
+        close(fd);
+        if (w != payload.length)
+        {
+            stderr.writefln("short write to temp file (%d)", w);
+            return 1;
+        }
+    }
+    scope (exit) unlink(path.ptr);
+
+    // --- Step 1: OPENAT_DIRECT — open straight into registered slot 0. ---------
+    // No process fd is allocated; the file object lands in the files table only.
+    io.putWith!((ref SubmissionEntry e, const(char)* p) {
+        e.prepOpenatDirect(AT_FDCWD, p, O_RDONLY, 0, /*fileIndex=*/ 0);
+        e.user_data = 1;
+    })(path.ptr);
+    if (io.submit(1) != 1) { stderr.writefln("submit (open) failed"); return 1; }
+    io.wait(1);
+    {
+        const res = io.front.res;
+        io.popFront();
+        if (unsupported(res))
+        {
+            writefln("SKIP: OPENAT_DIRECT unsupported (errno %d)", -res);
+            return 0;
+        }
+        if (res != 0)
+        {
+            stderr.writefln("OPENAT_DIRECT failed: errno %d", -res);
+            return 1;
+        }
+    }
+
+    // --- Step 2: READ addressing slot 0 by index, with the FIXED_FILE flag. ----
+    // The "fd" we pass is the *table index* (0); FIXED_FILE tells the kernel to
+    // resolve it through the registered-files table instead of the process table.
+    ubyte[8] viaIndex;
+    io.putWith!((ref SubmissionEntry e, ubyte[] buf) {
+        e.prepRead(/*index=*/ 0, buf, /*offset=*/ 0);
+        e.flags |= SubmissionEntryFlags.FIXED_FILE;
+        e.user_data = 2;
+    })(viaIndex[]);
+    if (io.submit(1) != 1) { stderr.writefln("submit (read-by-index) failed"); return 1; }
+    io.wait(1);
+    {
+        const res = io.front.res;
+        io.popFront();
+        if (res < 0)
+        {
+            stderr.writefln("FIXED_FILE READ failed: errno %d", -res);
+            return 1;
+        }
+        if (res != payload.length || viaIndex != payload)
+        {
+            stderr.writefln("read-by-index payload mismatch (res=%d)", res);
+            return 1;
+        }
+    }
+
+    // --- Step 3: FIXED_FD_INSTALL — promote slot 0 to a real process fd. -------
+    // This op (6.8) is itself issued against the table index; prepFixedFdInstall
+    // sets FIXED_FILE for us. The new, ordinary fd is returned in the CQE res.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepFixedFdInstall(/*fixedFd=*/ 0, /*flags=*/ 0);
+        e.user_data = 3;
+    })();
+    if (io.submit(1) != 1) { stderr.writefln("submit (install) failed"); return 1; }
+    io.wait(1);
+    int newFd;
+    {
+        const res = io.front.res;
+        io.popFront();
+        if (unsupported(res))
+        {
+            writefln("SKIP: FIXED_FD_INSTALL unsupported (errno %d) — needs Linux 6.8+", -res);
+            return 0;
+        }
+        if (res < 0)
+        {
+            stderr.writefln("FIXED_FD_INSTALL failed: errno %d", -res);
+            return 1;
+        }
+        newFd = res;
+    }
+    scope (exit) close(newFd);
+
+    // --- Step 4: confirm the installed fd is a normal, readable process fd. ----
+    ubyte[8] viaRealFd;
+    const rd = read(newFd, &viaRealFd[0], viaRealFd.length);
+    if (rd != payload.length || viaRealFd != payload)
+    {
+        stderr.writefln("installed real fd read mismatch (rd=%d)", rd);
+        return 1;
+    }
+
+    writefln("ok: direct fd opened into table slot 0, read by index, then "
+        ~ "FIXED_FD_INSTALL → real fd %d (both reads returned the same 8 bytes)", newFd);
+    return 0;
+}
+
+// Thin libc `open(path, O_CREAT|O_WRONLY, 0600)` wrapper — `core.sys.posix`'s
+// `open` is variadic, which is awkward to call from a `@trusted` context, so we
+// bind the C symbol directly.
+private int openFile(const(char)* path) @trusted nothrow @nogc
+{
+    import std.conv : octal;
+    return c_open(path, O_CREAT | O_WRONLY, octal!600);
+}
+
+extern (C) private int open(const(char)* path, int flags, ...) @trusted nothrow @nogc;
+private alias c_open = open;

--- a/docs/research/async-io/io-uring/examples/direct-descriptors.d
+++ b/docs/research/async-io/io-uring/examples/direct-descriptors.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_direct_descriptors"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/epoll-wait.d
+++ b/docs/research/async-io/io-uring/examples/epoll-wait.d
@@ -1,0 +1,150 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_epoll_wait"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — folding a legacy `epoll` set into the ring (`IORING_OP_EPOLL_WAIT`, Linux 6.15).
+ *
+ * Before 6.15 you bridged `io_uring` and `epoll` by adding the epoll fd as a
+ * pollable fd (`IORING_OP_POLL_ADD` / `EPOLL_CTL`) and then calling `epoll_wait(2)`
+ * synchronously once the ring told you the epoll set was readable. 6.15 added
+ * `IORING_OP_EPOLL_WAIT`, which performs the `epoll_wait` *inside* the ring: you
+ * submit an SQE pointing at an `epoll_event[]` buffer, and the matching CQE's
+ * `res` reports how many ready events were written into it. This lets an existing
+ * epoll-based event loop be migrated to `io_uring` one step at a time.
+ *
+ * Demonstrated here: build an epoll set watching the read end of a pipe for
+ * `EPOLLIN`, write a byte to make it readable, then submit a single
+ * `EPOLL_WAIT` SQE and verify it reports exactly one ready event for our pipe fd.
+ * Because the pipe is already readable when we submit, the kernel can complete
+ * the SQE immediately — no second thread, fully deterministic.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "6.15 — Zero-copy receive, epoll-wait, vectored fixed, query".
+ *
+ * Run with: `dub run --single epoll-wait.d`
+ *
+ * Portability: prints a `SKIP:` line and exits 0 when `io_uring` is unavailable
+ * (old kernel / sandbox) or when this specific op is missing (kernel < 6.15,
+ * surfaced as a probe miss or an `-EINVAL`/`-EOPNOTSUPP` CQE), so it stays green
+ * in CI regardless of the host kernel.
+ */
+module io_uring_epoll_wait;
+
+import during;
+
+import core.sys.linux.epoll : epoll_create1, epoll_ctl, epoll_event, EPOLL_CTL_ADD, EPOLLIN;
+import core.sys.posix.unistd : close, pipe, write;
+import core.stdc.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Probe whether the running kernel advertises IORING_OP_EPOLL_WAIT (Linux 6.15).
+    // A miss here means the op simply doesn't exist on this kernel — skip cleanly.
+    auto probe = io.probe();
+    if (cast(bool) probe && !probe.isSupported(Operation.EPOLL_WAIT))
+    {
+        writefln("SKIP: IORING_OP_EPOLL_WAIT not supported (kernel < 6.15)");
+        return 0;
+    }
+
+    // A pipe gives us a cheap, loopback-only fd to watch for readability.
+    int[2] p;
+    if (pipe(p) != 0)
+    {
+        stderr.writefln("pipe() failed");
+        return 1;
+    }
+    scope (exit) { close(p[0]); close(p[1]); }
+
+    // Build a classic epoll set and register the pipe's read end for EPOLLIN.
+    int ep = epoll_create1(0);
+    if (ep < 0)
+    {
+        stderr.writefln("epoll_create1() failed");
+        return 1;
+    }
+    scope (exit) close(ep);
+
+    epoll_event ev;
+    ev.events = EPOLLIN;
+    ev.data.fd = p[0];
+    if (epoll_ctl(ep, EPOLL_CTL_ADD, p[0], &ev) != 0)
+    {
+        stderr.writefln("epoll_ctl(ADD) failed");
+        return 1;
+    }
+
+    // Make the read end readable *before* submitting, so the EPOLL_WAIT SQE can
+    // complete immediately — keeps the example deterministic and single-threaded.
+    ubyte one = 0xAA;
+    if (write(p[1], &one, 1) != 1)
+    {
+        stderr.writefln("write() to pipe failed");
+        return 1;
+    }
+
+    // Submit IORING_OP_EPOLL_WAIT: the kernel runs epoll_wait against `ep` and
+    // fills `out_` with up to its length ready events; the CQE's `res` is the count.
+    epoll_event[4] out_;
+    io.putWith!(
+        (ref SubmissionEntry e, int epfd, epoll_event[] dst)
+        {
+            e.prepEpollWait(epfd, dst, 0);
+            e.user_data = 1;
+        })(ep, out_[]);
+
+    const submitted = io.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    io.wait(1);
+    const res = io.front.res;
+    io.popFront();
+
+    // Some kernels accept setup/submit but reject the op at completion time — treat
+    // -EINVAL / -EOPNOTSUPP / -ENOSYS as "feature absent" rather than a hard failure.
+    if (res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS)
+    {
+        writefln("SKIP: IORING_OP_EPOLL_WAIT rejected by kernel (errno %d) — feature unavailable", -res);
+        return 0;
+    }
+
+    if (res < 0)
+    {
+        stderr.writefln("EPOLL_WAIT completed with error: errno %d", -res);
+        return 1;
+    }
+
+    if (res != 1)
+    {
+        stderr.writefln("expected exactly 1 ready event, got res=%d", res);
+        return 1;
+    }
+
+    if (out_[0].data.fd != p[0] || (out_[0].events & EPOLLIN) == 0)
+    {
+        stderr.writefln("ready event did not match the pipe fd / EPOLLIN");
+        return 1;
+    }
+
+    writefln("ok: IORING_OP_EPOLL_WAIT reported %d ready event for pipe fd %d (EPOLLIN), epoll folded into the ring",
+        res, out_[0].data.fd);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/epoll-wait.d
+++ b/docs/research/async-io/io-uring/examples/epoll-wait.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_epoll_wait"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/fs-mutations.d
+++ b/docs/research/async-io/io-uring/examples/fs-mutations.d
@@ -1,0 +1,269 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_fs_mutations"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — asynchronous filesystem mutation ops (Linux 5.11 / 5.15).
+ *
+ * Before 5.11, path-based metadata operations (create, rename, unlink, …) had
+ * no `io_uring` opcode and had to run on a worker thread or out-of-band. Linux
+ * 5.11 added `RENAMEAT` and `UNLINKAT`; 5.15 rounded out the set with `MKDIRAT`,
+ * `SYMLINKAT`, and `LINKAT`, so a whole directory-mutation workflow can be driven
+ * through the ring.
+ *
+ * This example builds a small workflow inside a fresh `mkdtemp` scratch directory,
+ * issuing every step as an `io_uring` SQE rather than a blocking libc syscall:
+ *   1. `MKDIRAT`   — create a `sub/` subdirectory.
+ *   2. (libc)      — create a regular file `sub/file` (so there is something to act on).
+ *   3. `SYMLINKAT` — make `link` point at `sub/file`.
+ *   4. `RENAMEAT`  — rename `sub/file` to `sub/renamed`.
+ *   5. `UNLINKAT`  — remove `sub/renamed`, then remove `link`.
+ *   6. `UNLINKAT`  — remove the now-empty `sub/` (with `AT_REMOVEDIR`).
+ * Each op's CQE `res` must be `>= 0`, and we verify the on-disk state with `stat`
+ * between the relevant steps. The scratch directory is always cleaned up.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.11 — Filesystem mutation ops, SQPOLL without root".
+ *
+ * Run with: `dub run --single fs-mutations.d`
+ *
+ * Portability: if the running kernel has no `io_uring`, or lacks any of these
+ * filesystem opcodes (probe / `-EINVAL`), the program prints a `SKIP:` line and
+ * exits 0 so it stays green in CI regardless of the host kernel.
+ */
+module io_uring_fs_mutations;
+
+import during;
+
+import core.stdc.string : strlen;
+import core.sys.posix.stdlib : mkdtemp;
+import core.sys.posix.fcntl : AT_FDCWD, open, O_CREAT, O_WRONLY;
+import core.sys.posix.sys.stat : stat, stat_t, lstat, S_ISDIR, S_ISLNK, S_ISREG;
+import core.sys.posix.unistd : close, rmdir, unlink;
+
+import std.stdio : stderr, writefln;
+import std.string : toStringz;
+
+// `AT_REMOVEDIR` (== 0x200) tells unlinkat(2) to remove a directory instead of a
+// file. core.sys.posix.fcntl doesn't expose it portably, so define it locally.
+enum int AT_REMOVEDIR = 0x200;
+
+/// Submit one prepared SQE, wait for its single CQE, and return its `res` field.
+/// Returns the (possibly negative) kernel result; the caller decides how to react.
+int runOne(Op)(ref Uring io, scope Op prep, ulong cookie)
+{
+    io.putWith!((ref SubmissionEntry e, scope Op p, ulong c) {
+        p(e);
+        e.user_data = c;
+    })(prep, cookie);
+
+    const submitted = io.submit(1);
+    if (submitted < 0)
+        return submitted; // surface submit failure as a negative result
+
+    io.wait(1);
+    const res = io.front.res;
+    assert(io.front.user_data == cookie, "CQE cookie mismatch");
+    io.popFront();
+    return res;
+}
+
+/// True if `path` exists and matches the predicate over its `st_mode`.
+bool checkMode(scope const(char)* path, bool delegate(uint) pred, bool useLstat = false)
+{
+    stat_t st;
+    const rc = useLstat ? lstat(path, &st) : stat(path, &st);
+    if (rc != 0) return false;
+    return pred(st.st_mode);
+}
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Capability probe: every op we use must be advertised by the kernel. If any
+    // is missing this kernel predates 5.11/5.15 for that opcode — skip cleanly.
+    auto probe = io.probe();
+    if (!cast(bool) probe)
+    {
+        writefln("SKIP: io_uring probe failed — cannot determine supported ops");
+        return 0;
+    }
+    foreach (op; [Operation.MKDIRAT, Operation.SYMLINKAT, Operation.RENAMEAT, Operation.UNLINKAT])
+    {
+        if (!probe.isSupported(op))
+        {
+            writefln("SKIP: io_uring op %s unsupported on this kernel (needs 5.11/5.15)", op);
+            return 0;
+        }
+    }
+
+    // Fresh scratch directory under the system temp dir. mkdtemp mutates the
+    // template in place and returns null on failure.
+    char[] tmpl = "/tmp/iouring_fs_XXXXXX\0".dup;
+    if (mkdtemp(tmpl.ptr) is null)
+    {
+        stderr.writefln("mkdtemp failed");
+        return 1;
+    }
+    const base = cast(string) tmpl[0 .. strlen(tmpl.ptr)];
+    scope (exit) rmdir(base.toStringz); // remove the top-level scratch dir last
+
+    // Build absolute paths once; toStringz gives us GC'd, NUL-terminated copies
+    // that stay alive for the whole submit/complete cycle of each op.
+    const subDir   = (base ~ "/sub").toStringz;
+    const filePath = (base ~ "/sub/file").toStringz;
+    const renamed  = (base ~ "/sub/renamed").toStringz;
+    const linkPath = (base ~ "/link").toStringz;
+    // Symlink target is relative-as-stored; we point the link at the absolute file.
+    const linkTarget = filePath;
+
+    // 1. MKDIRAT: create base/sub with mode 0755.
+    {
+        const res = runOne(io,
+            (ref SubmissionEntry e) => e.prepMkdirat(AT_FDCWD, subDir, octal!755),
+            1);
+        if (res == -EINVAL)
+        {
+            writefln("SKIP: MKDIRAT rejected with -EINVAL — unsupported on this kernel");
+            return 0;
+        }
+        if (res < 0)
+        {
+            stderr.writefln("MKDIRAT failed: errno %d", -res);
+            return 1;
+        }
+    }
+    if (!checkMode(subDir, m => S_ISDIR(m)))
+    {
+        stderr.writefln("post-MKDIRAT: sub/ is not a directory");
+        return 1;
+    }
+
+    // 2. Create the regular file via libc (there's no IORING_OP_CREATE; openat
+    //    direct/fixed exists but a plain file is all we need to mutate below).
+    {
+        const fd = open(filePath, O_CREAT | O_WRONLY, octal!644);
+        if (fd < 0)
+        {
+            stderr.writefln("open(sub/file) failed");
+            return 1;
+        }
+        close(fd);
+    }
+
+    // 3. SYMLINKAT: base/link -> base/sub/file.
+    {
+        const res = runOne(io,
+            (ref SubmissionEntry e) => e.prepSymlinkat(linkTarget, AT_FDCWD, linkPath),
+            3);
+        if (res < 0)
+        {
+            stderr.writefln("SYMLINKAT failed: errno %d", -res);
+            return 1;
+        }
+    }
+    // lstat the link itself (don't follow) to confirm it's a symlink, and stat it
+    // (follow) to confirm it resolves to the regular file.
+    if (!checkMode(linkPath, m => S_ISLNK(m), /*useLstat*/ true))
+    {
+        stderr.writefln("post-SYMLINKAT: link is not a symlink");
+        return 1;
+    }
+    if (!checkMode(linkPath, m => S_ISREG(m)))
+    {
+        stderr.writefln("post-SYMLINKAT: link does not resolve to a regular file");
+        return 1;
+    }
+
+    // 4. RENAMEAT: sub/file -> sub/renamed (flags 0 == plain renameat semantics).
+    {
+        const res = runOne(io,
+            (ref SubmissionEntry e) => e.prepRenameat(AT_FDCWD, filePath, AT_FDCWD, renamed, 0),
+            4);
+        if (res < 0)
+        {
+            stderr.writefln("RENAMEAT failed: errno %d", -res);
+            return 1;
+        }
+    }
+    if (checkMode(filePath, m => true) || !checkMode(renamed, m => S_ISREG(m)))
+    {
+        stderr.writefln("post-RENAMEAT: rename did not take effect");
+        return 1;
+    }
+
+    // 5a. UNLINKAT: remove sub/renamed (the regular file).
+    {
+        const res = runOne(io,
+            (ref SubmissionEntry e) => e.prepUnlinkat(AT_FDCWD, renamed, 0),
+            5);
+        if (res < 0)
+        {
+            stderr.writefln("UNLINKAT(file) failed: errno %d", -res);
+            return 1;
+        }
+    }
+    // 5b. UNLINKAT: remove the dangling symlink (flags 0 unlinks the link itself).
+    {
+        const res = runOne(io,
+            (ref SubmissionEntry e) => e.prepUnlinkat(AT_FDCWD, linkPath, 0),
+            6);
+        if (res < 0)
+        {
+            stderr.writefln("UNLINKAT(symlink) failed: errno %d", -res);
+            return 1;
+        }
+    }
+    if (checkMode(renamed, m => true, true) || checkMode(linkPath, m => true, true))
+    {
+        stderr.writefln("post-UNLINKAT: file or symlink still present");
+        return 1;
+    }
+
+    // 6. UNLINKAT with AT_REMOVEDIR: remove the now-empty sub/ directory.
+    {
+        const res = runOne(io,
+            (ref SubmissionEntry e) => e.prepUnlinkat(AT_FDCWD, subDir, AT_REMOVEDIR),
+            7);
+        if (res < 0)
+        {
+            stderr.writefln("UNLINKAT(dir) failed: errno %d", -res);
+            return 1;
+        }
+    }
+    if (checkMode(subDir, m => true, true))
+    {
+        stderr.writefln("post-UNLINKAT: sub/ directory still present");
+        return 1;
+    }
+
+    writefln("ok: drove MKDIRAT/SYMLINKAT/RENAMEAT/UNLINKAT through the ring in %s — final state verified", base);
+    return 0;
+}
+
+// errno + octal helpers (kept local to avoid extra imports cluttering the header).
+import core.sys.linux.errno : EINVAL;
+
+/// Compile-time octal literal (D dropped the `0NNN` syntax; std.conv.octal works too).
+template octal(int n) { enum octal = octalImpl(n); }
+private int octalImpl(int decimalDigits) pure nothrow @nogc @safe
+{
+    int result = 0, mult = 1;
+    while (decimalDigits > 0)
+    {
+        result += (decimalDigits % 10) * mult;
+        mult *= 8;
+        decimalDigits /= 10;
+    }
+    return result;
+}

--- a/docs/research/async-io/io-uring/examples/fs-mutations.d
+++ b/docs/research/async-io/io-uring/examples/fs-mutations.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_fs_mutations"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/futex-waitv.d
+++ b/docs/research/async-io/io-uring/examples/futex-waitv.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_futex_waitv"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/futex-waitv.d
+++ b/docs/research/async-io/io-uring/examples/futex-waitv.d
@@ -1,0 +1,208 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_futex_waitv"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — vectored futex wait (`IORING_OP_FUTEX_WAITV`, Linux 6.7).
+ *
+ * `FUTEX_WAITV` arms a wait on a *vector* of futexes at once and completes as
+ * soon as *any one* of them is woken — the async, batched counterpart of the
+ * legacy `futex_waitv(2)` syscall. This is the building block a runtime uses to
+ * block a task on several wakeup sources (e.g. several condition words) without
+ * burning a thread per source.
+ *
+ * This example builds an array of two `futex_waitv` entries over two distinct
+ * 32-bit words, submits a single `prepFutexWaitv(&v[0], 2, 0)`, and spins up a
+ * helper pthread that wakes the *second* word via the legacy `futex(2)`
+ * `FUTEX_WAKE_PRIVATE` syscall. The io_uring FUTEX2 waiter and the legacy futex
+ * share the same kernel hash bucket for a given `uaddr`, so a legacy wake on a
+ * matching, `FUTEX2_PRIVATE`-armed address wakes the io_uring waiter. We assert
+ * the completion `res >= 0` (a wake / the index of the woken futex), not an error.
+ *
+ * The helper retries every 5 ms (bounded) to defeat the inherent race between
+ * submission and the kernel actually parking the waiter; the main thread also
+ * bounds its `wait` with a linked `TIMEOUT` so a misbehaving kernel can't hang.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "6.7 — Futex, waitid, read-multishot (January 2024)".
+ *
+ * Run with: `dub run --single futex-waitv.d`
+ *
+ * Portability: if the running kernel has no `io_uring` (too old / blocked by a
+ * seccomp or container policy), or lacks `FUTEX_WAITV` (kernel < 6.7), the
+ * program prints a `SKIP:` line and exits 0 so it stays green in CI regardless
+ * of the host kernel. This box runs 6.18, where the feature is present.
+ */
+module io_uring_futex_waitv;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.atomic : atomicLoad, atomicStore, MemoryOrder;
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.pthread;
+import core.sys.posix.unistd : usleep;
+
+// `SYS_futex` (the legacy futex(2) syscall) is universally available on Linux.
+// We use it from the helper thread to issue a `FUTEX_WAKE_PRIVATE`.
+version (X86_64) private enum SYS_futex = 202;
+else version (X86) private enum SYS_futex = 240;
+else version (AArch64) private enum SYS_futex = 98;
+else static assert(0, "Unsupported platform for SYS_futex constant");
+
+private enum FUTEX_WAKE         = 1;
+private enum FUTEX_PRIVATE_FLAG = 128;
+private enum FUTEX_WAKE_PRIVATE = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
+
+private extern (C) int syscall(int sysno, ...) nothrow @nogc @system;
+
+// Shared state between the main thread and the wake helper.
+private struct WakeCtx
+{
+    uint*      word;       // address of the futex word the helper will wake
+    shared int stop;       // set by main once the CQE has arrived
+    int        attempts;   // number of wake attempts the helper made
+}
+
+// Helper thread: repeatedly `FUTEX_WAKE_PRIVATE`s `ctx.word` until the main
+// thread sets `stop`. Bounded to ~1s of attempts so it can never hang the run.
+private extern (C) void* wakeWorker(void* arg) @system nothrow @nogc
+{
+    auto ctx = cast(WakeCtx*) arg;
+    foreach (i; 0 .. 200) // up to ~1s (200 * 5ms)
+    {
+        // Re-check before sleeping so we exit promptly once main signals stop.
+        if (atomicLoad!(MemoryOrder.acq)(ctx.stop)) break;
+        usleep(5_000); // 5ms
+        ctx.attempts = i + 1;
+        // arg2 = val = 1 => wake at most one waiter on this address.
+        syscall(SYS_futex, cast(void*) ctx.word, FUTEX_WAKE_PRIVATE, 1, null, null, 0);
+    }
+    return null;
+}
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Two distinct futex words. Both armed with val=0, matching their current
+    // value, so the wait genuinely parks (a mismatch would return -EAGAIN).
+    uint[2] words = [0, 0];
+
+    // The vector of futexes to wait on. FUTEX2_SIZE_U32 selects a 32-bit futex
+    // (the only size most arches support); FUTEX2_PRIVATE puts it in the
+    // process-private hash so a legacy FUTEX_WAKE_PRIVATE on the same address
+    // can match it.
+    futex_waitv[2] vec;
+    foreach (i; 0 .. 2)
+    {
+        vec[i].val   = 0; // expected value — must equal *uaddr for the wait to arm
+        vec[i].uaddr = cast(ulong) &words[i];
+        vec[i].flags = FUTEX2_SIZE_U32 | FUTEX2_PRIVATE;
+    }
+
+    // Spin up the helper that will wake the *second* word. FUTEX_WAITV completes
+    // when ANY entry is woken, so waking words[1] must complete the whole wait.
+    WakeCtx ctx;
+    ctx.word = &words[1];
+
+    pthread_t tid;
+    const pr = pthread_create(&tid, null, &wakeWorker, &ctx);
+    if (pr != 0)
+    {
+        stderr.writefln("pthread_create failed: errno %d", pr);
+        return 1;
+    }
+
+    // Submit the vectored wait, linked to a TIMEOUT so the ring is never blocked
+    // indefinitely: if the wake never lands, the TIMEOUT fires and unblocks
+    // `wait`, and the wait CQE comes back -ECANCELED. IO_LINK means the timeout
+    // is the deadline for the preceding waitv.
+    enum ulong WAITV_DATA = 0xF07E;
+    enum ulong TIMEOUT_DATA = 0x71_E0;
+
+    io.putWith!(
+        (ref SubmissionEntry e, futex_waitv* v)
+        {
+            e.prepFutexWaitv(v, 2, 0); // wait on both entries; wake on any
+            e.user_data = WAITV_DATA;
+            e.flags |= SubmissionEntryFlags.IO_LINK;
+        })(&vec[0]);
+
+    // 1.5s ceiling — comfortably above the helper's first 5ms attempt, well
+    // under the 2s budget. KernelTimespec is {tv_sec, tv_nsec}.
+    KernelTimespec ts = { tv_sec: 1, tv_nsec: 500_000_000 };
+    io.putWith!(
+        (ref SubmissionEntry e, KernelTimespec* t)
+        {
+            e.prepTimeout(*t, 0, TimeoutFlags.REL);
+            e.user_data = TIMEOUT_DATA;
+        })(&ts);
+
+    const submitted = io.submit(0);
+    if (submitted < 0)
+    {
+        atomicStore!(MemoryOrder.rel)(ctx.stop, 1);
+        pthread_join(tid, null);
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Drain both completions (the waitv and the linked timeout). We need at most
+    // two CQEs; capture the waitv result by user_data.
+    int waitvRes = int.min;
+    bool sawWaitv = false;
+    foreach (_; 0 .. 2)
+    {
+        io.wait(1);
+        const cqe = io.front;
+        if (cqe.user_data == WAITV_DATA)
+        {
+            waitvRes = cqe.res;
+            sawWaitv = true;
+        }
+        io.popFront();
+        if (sawWaitv) break; // got what we came for; the timeout CQE (if any) can drain on exit
+    }
+
+    // Tell the helper to stop and join it before inspecting results.
+    atomicStore!(MemoryOrder.rel)(ctx.stop, 1);
+    pthread_join(tid, null);
+
+    if (!sawWaitv)
+    {
+        stderr.writefln("no FUTEX_WAITV completion observed");
+        return 1;
+    }
+
+    // -EINVAL / -EOPNOTSUPP / -ENOSYS => the op isn't supported on this kernel.
+    if (waitvRes == -EINVAL || waitvRes == -EOPNOTSUPP || waitvRes == -ENOSYS)
+    {
+        writefln("SKIP: IORING_OP_FUTEX_WAITV unsupported on this kernel (res=%d)", waitvRes);
+        return 0;
+    }
+
+    // A successful wake reports res >= 0 (the kernel returns the index of the
+    // woken futex). A negative value here means the wait was cancelled by the
+    // timeout (the helper never managed to wake it) or another genuine failure.
+    if (waitvRes < 0)
+    {
+        stderr.writefln("FUTEX_WAITV was not woken: res=%d (errno %d), helper made %d attempts",
+            waitvRes, -waitvRes, ctx.attempts);
+        return 1;
+    }
+
+    writefln("ok: FUTEX_WAITV woken (res=%d, woken futex index) after %d helper wake attempt(s)",
+        waitvRes, ctx.attempts);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/futex.d
+++ b/docs/research/async-io/io-uring/examples/futex.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_futex"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/futex.d
+++ b/docs/research/async-io/io-uring/examples/futex.d
@@ -1,0 +1,174 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_futex"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — async futex wait/wake (`IORING_OP_FUTEX_WAIT`, Linux 6.7).
+ *
+ * Before 6.7 a thread that wanted to block on a futex had to call `futex(2)`
+ * directly, taking it out of the io_uring completion-driven event loop. The
+ * 6.7 `FUTEX_WAIT` / `FUTEX_WAKE` ops let a ring park on a 32-bit futex word
+ * asynchronously: the wait turns into a CQE that lands whenever the word is
+ * woken, so a futex hand-off composes with every other queued operation.
+ *
+ * This example is a two-thread ping-pong. The main thread submits a
+ * `FUTEX_WAIT` against a private 32-bit futex (`FUTEX2_SIZE_U32 |
+ * FUTEX2_PRIVATE`, matching any bit via `FUTEX_BITSET_MATCH_ANY`). A helper
+ * pthread issues a *legacy* `futex(2)` `FUTEX_WAKE_PRIVATE` to wake it — the
+ * io_uring FUTEX2 waiter and the classic futex(2) waker share the same kernel
+ * hash bucket, so they interoperate. The helper retries on a short interval
+ * (bounded to ~1s) to defeat the inherent race between SQE submission and the
+ * kernel actually parking the waiter. We assert the wait CQE `res == 0`.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "6.7 — Futex, waitid, read-multishot (January 2024)".
+ *
+ * Run with: `dub run --single futex.d`
+ *
+ * Portability: if the running kernel has no `io_uring`, or is older than 6.7
+ * (no `FUTEX_WAIT` op — detected via `io.probe()` or a `-EINVAL`/`-EOPNOTSUPP`
+ * completion), the program prints a `SKIP:` line and exits 0 so it stays green
+ * in CI regardless of the host kernel.
+ */
+module io_uring_futex;
+
+import during;
+
+import core.sys.posix.pthread;
+import core.sys.posix.unistd : usleep;
+import core.atomic : atomicLoad, atomicStore, MemoryOrder;
+
+import std.stdio : writefln, stderr;
+
+// errno values we treat as "feature unsupported" rather than a hard failure.
+private enum EINVAL = 22;
+private enum EOPNOTSUPP = 95;
+
+// Legacy futex(2) syscall number + flags, used by the waker thread.
+version (X86_64) private enum SYS_futex = 202;
+else version (AArch64) private enum SYS_futex = 98;
+else version (X86) private enum SYS_futex = 240;
+else static assert(0, "Unsupported platform for the futex(2) waker");
+
+private enum FUTEX_WAKE = 1;
+private enum FUTEX_PRIVATE_FLAG = 128;
+private enum FUTEX_WAKE_PRIVATE = FUTEX_WAKE | FUTEX_PRIVATE_FLAG;
+
+private extern (C) int syscall(int sysno, ...) nothrow @nogc @system;
+
+// Shared state between the main thread (waiter) and the helper (waker).
+private struct WakeCtx
+{
+    uint* word; // the futex word both threads agree on
+    shared int stop; // main thread sets this once the CQE arrives
+    int attempts; // how many wake retries it took (diagnostic)
+}
+
+// Helper thread: repeatedly issue a legacy FUTEX_WAKE on the shared word until
+// the main thread signals `stop` (it got its completion) or we hit the retry
+// cap. Retrying defeats the race where the wake fires before the kernel has
+// parked the io_uring waiter. @nogc/nothrow so it is safe as a raw pthread fn.
+private extern (C) void* wakeWorker(void* arg) @system nothrow @nogc
+{
+    auto ctx = cast(WakeCtx*) arg;
+    foreach (i; 0 .. 200) // 200 * 5ms = ~1s upper bound
+    {
+        if (atomicLoad!(MemoryOrder.acq)(ctx.stop))
+            break;
+        usleep(5_000);
+        ctx.attempts = i + 1;
+        syscall(SYS_futex, cast(void*) ctx.word, FUTEX_WAKE_PRIVATE, 1, null, null, 0);
+    }
+    return null;
+}
+
+int main()
+{
+    enum ulong cookie = 0xFADE;
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Static capability check: kernels < 6.7 don't advertise FUTEX_WAIT in the
+    // probe, so we can skip cleanly before ever submitting an SQE.
+    auto probe = io.probe();
+    if (!cast(bool) probe || !probe.isSupported(Operation.FUTEX_WAIT))
+    {
+        writefln("SKIP: IORING_OP_FUTEX_WAIT unsupported (kernel < 6.7)");
+        return 0;
+    }
+
+    // The futex word starts at 0; FUTEX_WAIT below uses expected value 0, so the
+    // kernel parks the ring until someone (our helper) wakes the word.
+    uint word = 0;
+    WakeCtx ctx;
+    ctx.word = &word;
+
+    // Spawn the waker before submitting so it is already retrying by the time
+    // the kernel parks our waiter.
+    pthread_t tid;
+    if (pthread_create(&tid, null, &wakeWorker, &ctx) != 0)
+    {
+        stderr.writefln("pthread_create failed");
+        return 1;
+    }
+
+    // Submit the async FUTEX_WAIT. `val` is the expected current value (0); the
+    // request completes when the word is woken (or differs from `val`).
+    io.putWith!(
+        (ref SubmissionEntry e, uint* w) {
+        e.prepFutexWait(w, 0, FUTEX_BITSET_MATCH_ANY, FUTEX2_SIZE_U32 | FUTEX2_PRIVATE, 0);
+        e.user_data = cookie;
+    })(&word);
+
+    const submitted = io.submit(1);
+    if (submitted != 1)
+    {
+        atomicStore!(MemoryOrder.rel)(ctx.stop, 1);
+        pthread_join(tid, null);
+        stderr.writefln("submit failed: returned %d", submitted);
+        return 1;
+    }
+
+    // Block for the wait completion. The helper thread is hammering FUTEX_WAKE,
+    // so this is bounded by the helper's ~1s retry budget.
+    io.wait(1);
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    // Tell the helper to stop and reap it.
+    atomicStore!(MemoryOrder.rel)(ctx.stop, 1);
+    pthread_join(tid, null);
+
+    // Runtime fallback: even if the probe lied, an unsupported op reports these.
+    if (res == -EINVAL || res == -EOPNOTSUPP)
+    {
+        writefln("SKIP: IORING_OP_FUTEX_WAIT rejected at runtime (res=%d) — kernel < 6.7", res);
+        return 0;
+    }
+
+    if (res < 0)
+    {
+        stderr.writefln("FUTEX_WAIT completed with error: errno %d", -res);
+        return 1;
+    }
+
+    if (echoed != cookie)
+    {
+        stderr.writefln("user_data mismatch: expected 0x%X, got 0x%X", cookie, echoed);
+        return 1;
+    }
+
+    writefln("ok: io_uring FUTEX_WAIT (res=%d) woken by a legacy futex(2) waker after %d attempt(s)",
+        res, ctx.attempts);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/linked-sqes.d
+++ b/docs/research/async-io/io-uring/examples/linked-sqes.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_linked_sqes"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/linked-sqes.d
+++ b/docs/research/async-io/io-uring/examples/linked-sqes.d
@@ -1,0 +1,170 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_linked_sqes"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — linked SQEs via `IOSQE_IO_LINK` (Linux 5.3).
+ *
+ * `IOSQE_IO_LINK` turns an otherwise unordered batch of submission queue
+ * entries into an ordered dependency chain: when an SQE carries the
+ * `IO_LINK` flag, the *next* SQE in the batch will not start until the
+ * flagged one has completed successfully. This lets you express
+ * "do B only after A" — e.g. write-then-fsync — without an extra
+ * userspace submit/wait round-trip.
+ *
+ * This example opens a temp file and submits TWO SQEs in one batch:
+ *   1. WRITE a known payload (user_data = 1), flagged `IO_LINK`.
+ *   2. FSYNC the same fd (user_data = 2), the link target.
+ * Because the WRITE is `IO_LINK`-flagged, the kernel guarantees the FSYNC
+ * runs strictly *after* the WRITE has completed — without the link the two
+ * could be reordered/run concurrently, and the fsync might flush *before*
+ * the bytes ever reached the file.
+ *
+ * Failure propagation (explained, not triggered here): if a linked SQE
+ * fails (or is short), the kernel breaks the chain — every *subsequent*
+ * linked SQE is cancelled with `res == -ECANCELED` and never runs. So if
+ * the WRITE had failed, the FSYNC would never touch the disk: the chain
+ * fails closed. (`IO_HARDLINK` is the variant that keeps going regardless
+ * of the predecessor's result.)
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.3 — Network message ops (September 2019)".
+ *
+ * Run with: `dub run --single linked-sqes.d`
+ *
+ * Portability: if the running kernel has no `io_uring`, or is too old for
+ * linked SQEs (pre-5.3), the program prints a `SKIP:` line and exits 0 so
+ * it stays green in CI regardless of the host kernel.
+ */
+module io_uring_linked_sqes;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS, ECANCELED;
+import core.sys.posix.stdlib : mkstemp;
+import core.sys.posix.unistd : close, unlink;
+
+int main()
+{
+    enum ulong writeTag = 1; // the link head (runs first)
+    enum ulong fsyncTag = 2; // the link target (runs only after the write)
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Create a private temp file to write+fsync. mkstemp replaces the XXXXXX
+    // template in place and returns an open fd.
+    char[] tmpl = "/tmp/io_uring_linked_sqes_XXXXXX\0".dup;
+    const fd = mkstemp(&tmpl[0]);
+    if (fd < 0)
+    {
+        stderr.writefln("mkstemp failed");
+        return 1;
+    }
+    // Unlink immediately: the file stays alive via the open fd but leaves no
+    // litter behind when we close it.
+    unlink(&tmpl[0]);
+    scope (exit) close(fd);
+
+    immutable ubyte[] payload = cast(immutable(ubyte[])) "linked-sqes: write then fsync, in order\n";
+
+    // ---- Submit the linked batch (two SQEs, one submit) -------------------
+    // SQE #1: WRITE the payload, flagged IO_LINK so SQE #2 depends on it.
+    io.putWith!((ref SubmissionEntry e, int f, const(ubyte)[] buf)
+    {
+        e.prepWrite(f, buf, 0);
+        e.user_data = writeTag;
+        // IO_LINK: the *next* SQE in this submission won't start until this
+        // write completes successfully — the heart of the ordering guarantee.
+        e.flags |= SubmissionEntryFlags.IO_LINK;
+    })(fd, payload);
+
+    // SQE #2: FSYNC the same fd — the link target. No IO_LINK here: it ends
+    // the chain.
+    io.putWith!((ref SubmissionEntry e, int f)
+    {
+        e.prepFsync(f);
+        e.user_data = fsyncTag;
+    })(fd);
+
+    const submitted = io.submit(2);
+    if (submitted < 0)
+    {
+        // Linked SQEs arrived in 5.3; a pre-5.3 kernel rejects the batch.
+        if (submitted == -EINVAL || submitted == -EOPNOTSUPP || submitted == -ENOSYS)
+        {
+            writefln("SKIP: linked SQEs (IOSQE_IO_LINK) unsupported on this kernel (errno %d)", -submitted);
+            return 0;
+        }
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Block until BOTH completions are ready.
+    io.wait(2);
+
+    // Drain the completion queue. Completions arrive in chain order: the
+    // write (head) first, then the fsync (target).
+    int writeRes = int.min;
+    int fsyncRes = int.min;
+    while (!io.empty)
+    {
+        const c = io.front;
+        if (c.user_data == writeTag)
+            writeRes = c.res;
+        else if (c.user_data == fsyncTag)
+            fsyncRes = c.res;
+        io.popFront();
+    }
+
+    // A pre-5.3 kernel that *accepted* the batch but ignored the link flag
+    // could still reject the flag at completion time — treat that as a SKIP.
+    if (writeRes == -EINVAL || fsyncRes == -EINVAL
+        || writeRes == -EOPNOTSUPP || fsyncRes == -EOPNOTSUPP)
+    {
+        writefln("SKIP: linked SQEs (IOSQE_IO_LINK) unsupported on this kernel");
+        return 0;
+    }
+
+    // If the link had broken (write failed), the kernel would have cancelled
+    // the fsync with -ECANCELED. Surface that explicitly for clarity.
+    if (fsyncRes == -ECANCELED)
+    {
+        stderr.writefln("fsync was cancelled (-ECANCELED): the linked write failed (res=%d)", writeRes);
+        return 1;
+    }
+
+    if (writeRes < 0)
+    {
+        stderr.writefln("WRITE completed with error: errno %d", -writeRes);
+        return 1;
+    }
+    if (fsyncRes < 0)
+    {
+        stderr.writefln("FSYNC completed with error: errno %d", -fsyncRes);
+        return 1;
+    }
+
+    // The write must have transferred the full payload, and the fsync must
+    // have returned 0 — and, by the IO_LINK contract, the fsync only ran
+    // because the write succeeded first.
+    if (writeRes != cast(int) payload.length)
+    {
+        stderr.writefln("short write: wrote %d of %d bytes", writeRes, payload.length);
+        return 1;
+    }
+
+    writefln("ok: linked SQEs ordered write-before-fsync — WRITE res=%d (%d bytes), FSYNC res=%d",
+        writeRes, payload.length, fsyncRes);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/msg-ring.d
+++ b/docs/research/async-io/io-uring/examples/msg-ring.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_msg_ring"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/msg-ring.d
+++ b/docs/research/async-io/io-uring/examples/msg-ring.d
@@ -1,0 +1,134 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_msg_ring"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — cross-ring messaging (`IORING_OP_MSG_RING`, Linux 5.18).
+ *
+ * `MSG_RING` lets one ring post a u64 cookie straight into *another* ring's
+ * completion queue. It is the in-kernel wakeup/handoff primitive that powers
+ * multi-threaded designs: a worker holding ring A can wake a peer on ring B
+ * (often pinned to another core) without any syscall, eventfd, or shared lock —
+ * the kernel synthesises a CQE on the destination ring directly.
+ *
+ * This example creates TWO `Uring` instances in a single process. On ring A it
+ * submits `prepMsgRing(ringB.fd, 0, MESSAGE, 0)`: the SQE targets ring B's file
+ * descriptor and carries the payload that becomes B's CQE `user_data`. We reap
+ * ring A's own send-completion (status 0 = delivered), then wait on ring B and
+ * assert it received an unsolicited CQE whose `user_data == MESSAGE`.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.18 — Ring-fd registration, msg-ring, linked-file (May 2022)".
+ *
+ * Run with: `dub run --single msg-ring.d`
+ *
+ * Portability: prints a `SKIP:` line and exits 0 if io_uring is unavailable, or
+ * if the running kernel is older than 5.18 (no `MSG_RING` op). Demonstrates the
+ * feature and prints an `ok:` line on a 5.18+ kernel.
+ */
+module io_uring_msg_ring;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    // The u64 that ring A pushes into ring B's completion queue. On the target
+    // ring it surfaces as the CQE's `user_data`, so the receiver can dispatch on
+    // it exactly like a locally-submitted op's cookie.
+    enum ulong message = 0x5151_5151_DEAD_BEEF;
+
+    // Two independent rings in one process. In a real design these would belong
+    // to different worker threads (often on different cores); MSG_RING is the
+    // wakeup edge between them.
+    Uring ringA, ringB;
+
+    if (ringA.setup(8) < 0)
+    {
+        writefln("SKIP: io_uring_setup failed — io_uring unavailable on this host");
+        return 0;
+    }
+    if (ringB.setup(8) < 0)
+    {
+        writefln("SKIP: io_uring_setup failed for second ring — io_uring unavailable");
+        return 0;
+    }
+
+    // Feature gate: MSG_RING arrived in 5.18. On older kernels probe() reports it
+    // unsupported (and a submitted SQE would complete with -EINVAL); skip cleanly.
+    auto probe = ringA.probe();
+    if (cast(bool)probe && !probe.isSupported(Operation.MSG_RING))
+    {
+        writefln("SKIP: IORING_OP_MSG_RING unsupported on this kernel (needs Linux 5.18+)");
+        return 0;
+    }
+
+    // Post the message from ring A into ring B. `prepMsgRing(fd, len, data, flags)`:
+    //   fd   = the *destination* ring's fd (ringB.fd) — that is how the kernel
+    //          knows which ring's CQ to push into,
+    //   len  = a value handed to the target as its CQE `res` (0 here),
+    //   data = the payload delivered as the target CQE's `user_data`.
+    enum ulong sendCookie = 0xA;
+    ringA.putWith!((ref SubmissionEntry e, int targetFd, ulong data) {
+        e.prepMsgRing(targetFd, 0, data, 0);
+        e.user_data = sendCookie;
+    })(ringB.fd, message);
+
+    const submitted = ringA.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("ring A submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Reap ring A's *own* completion for the send. A 5.18 kernel that recognises
+    // the op but cannot deliver returns -EINVAL/-EOPNOTSUPP here — treat that as
+    // "feature unsupported" and skip rather than fail.
+    ringA.wait(1);
+    const sendRes = ringA.front.res;
+    const sendEcho = ringA.front.user_data;
+    ringA.popFront();
+
+    if (sendRes == -EINVAL || sendRes == -EOPNOTSUPP || sendRes == -ENOSYS)
+    {
+        writefln("SKIP: IORING_OP_MSG_RING rejected (errno %d) — needs Linux 5.18+", -sendRes);
+        return 0;
+    }
+    if (sendRes < 0)
+    {
+        stderr.writefln("MSG_RING send completed with error: errno %d", -sendRes);
+        return 1;
+    }
+    if (sendEcho != sendCookie)
+    {
+        stderr.writefln("ring A user_data mismatch: expected 0x%X, got 0x%X", sendCookie, sendEcho);
+        return 1;
+    }
+
+    // Now ring B must observe an unsolicited CQE — one we never submitted on B —
+    // carrying the payload from A. This is the whole point: a cross-ring wakeup.
+    ringB.wait(1);
+    const recvData = ringB.front.user_data;
+    const recvRes = ringB.front.res;
+    ringB.popFront();
+
+    if (recvData != message)
+    {
+        stderr.writefln("ring B got wrong payload: expected 0x%X, got 0x%X", message, recvData);
+        return 1;
+    }
+
+    writefln(
+        "ok: MSG_RING delivered 0x%X from ring A (send res=%d) into ring B's CQ (res=%d) — cross-ring wakeup with no syscall on B",
+        recvData, sendRes, recvRes);
+    return 0;
+}
+
+// errno constants used for the feature-unsupported gate above.
+private enum int EINVAL = 22;
+private enum int ENOSYS = 38;
+private enum int EOPNOTSUPP = 95;

--- a/docs/research/async-io/io-uring/examples/multishot-accept.d
+++ b/docs/research/async-io/io-uring/examples/multishot-accept.d
@@ -1,0 +1,186 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_multishot_accept"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — multishot accept (`IORING_ACCEPT_MULTISHOT`, Linux 5.19).
+ *
+ * Classic `IORING_OP_ACCEPT` (5.5) consumes one SQE per connection: you must
+ * re-arm an accept after every client. Multishot accept inverts that — a
+ * *single* accept SQE stays armed and posts one CQE per incoming connection,
+ * each carrying a fresh accepted fd in `res` and `CQEFlags.MORE` set to signal
+ * "this completion is not the last; the request lives on". This removes the
+ * per-connection submit round-trip from the accept loop of a server.
+ *
+ * This program builds a libc TCP listener on `127.0.0.1:<ephemeral>`, arms one
+ * `prepMultishotAccept` SQE, then opens and connects two loopback clients. It
+ * waits for the two accept CQEs and verifies each yields a valid fd (`res >= 0`)
+ * with `CQEFlags.MORE` set, proving the one SQE served multiple connections.
+ *
+ * Companion to the io_uring chronology: see
+ * docs/research/async-io/io-uring/timeline.md
+ * § "5.19 — Buffer rings, zero-copy groundwork, big SQE/CQE (July 2022)".
+ *
+ * Run with: `dub run --single multishot-accept.d`
+ *
+ * Portability: if `io_uring` is unavailable (too old / sandboxed) the program
+ * prints `SKIP:` and exits 0. If multishot accept itself is unsupported
+ * (kernel < 5.19 — the accept CQE comes back `-EINVAL`), it likewise prints
+ * `SKIP:` and exits 0, so it stays green on the older kernels CI runs on.
+ */
+module io_uring_multishot_accept;
+
+import during;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.arpa.inet : htonl;
+import core.sys.posix.netinet.in_ : sockaddr_in, AF_INET;
+import core.sys.posix.sys.socket : socket, setsockopt, bind, listen, connect,
+    getsockname, sockaddr, socklen_t, SOCK_STREAM, SOL_SOCKET, SO_REUSEADDR;
+import core.sys.posix.unistd : close;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    enum ACCEPT_TAG = 1; // user_data cookie for the multishot accept SQE
+    enum CLIENTS = 2; // how many loopback connections we drive through
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host",
+            -setupRet);
+        return 0;
+    }
+
+    // --- libc TCP listener on 127.0.0.1:<ephemeral> -------------------------
+    const int srv = socket(AF_INET, SOCK_STREAM, 0);
+    if (srv < 0)
+    {
+        stderr.writefln("socket(srv) failed");
+        return 1;
+    }
+    scope (exit) close(srv);
+
+    int one = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, one.sizeof);
+
+    sockaddr_in saddr;
+    saddr.sin_family = AF_INET;
+    saddr.sin_port = 0; // ask the kernel for an ephemeral port
+    saddr.sin_addr.s_addr = htonl(0x7f00_0001); // 127.0.0.1
+    if (bind(srv, cast(sockaddr*)&saddr, saddr.sizeof) != 0)
+    {
+        stderr.writefln("bind() failed");
+        return 1;
+    }
+    if (listen(srv, CLIENTS) != 0)
+    {
+        stderr.writefln("listen() failed");
+        return 1;
+    }
+
+    // Read back the kernel-assigned port so the clients can connect to it.
+    sockaddr_in actual;
+    socklen_t alen = actual.sizeof;
+    if (getsockname(srv, cast(sockaddr*)&actual, &alen) != 0)
+    {
+        stderr.writefln("getsockname() failed");
+        return 1;
+    }
+
+    // --- arm ONE multishot accept SQE ---------------------------------------
+    // The kernel fills `peer`/`peerLen` for each accepted connection; one SQE
+    // keeps posting CQEs (each with CQEFlags.MORE) until cancelled or it errors.
+    static sockaddr_in peer;
+    static socklen_t peerLen = peer.sizeof;
+    io.putWith!(
+        (ref SubmissionEntry e, int fd)
+        {
+            e.prepMultishotAccept(fd, peer, peerLen);
+            e.user_data = ACCEPT_TAG;
+        })(srv);
+
+    const submitted = io.submit(0); // just flush the SQ; we wait explicitly below
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // --- drive CLIENTS loopback connections, collecting one CQE each --------
+    int[CLIENTS] clientFds = -1;
+    scope (exit)
+        foreach (cfd; clientFds)
+            if (cfd >= 0) close(cfd);
+
+    int accepted; // count of successfully accepted server-side fds
+    bool sawMore; // did at least one accept CQE carry CQEFlags.MORE?
+
+    foreach (i; 0 .. CLIENTS)
+    {
+        const int cli = socket(AF_INET, SOCK_STREAM, 0);
+        if (cli < 0)
+        {
+            stderr.writefln("socket(cli %d) failed", i);
+            return 1;
+        }
+        clientFds[i] = cli;
+
+        // Loopback connect completes synchronously enough that the matching
+        // accept CQE is ready by the time we wait for it.
+        if (connect(cli, cast(sockaddr*)&actual, alen) != 0)
+        {
+            stderr.writefln("connect(cli %d) failed", i);
+            return 1;
+        }
+
+        io.wait(1); // bounded: exactly one CQE per connection we just made
+        const c = io.front;
+        const res = c.res;
+        const flags = c.flags;
+        io.popFront();
+
+        if (res < 0)
+        {
+            // -EINVAL/-EOPNOTSUPP/-ENOSYS on the very first accept => the kernel
+            // does not implement multishot accept (predates 5.19). Skip cleanly.
+            if (accepted == 0 && (res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS))
+            {
+                writefln("SKIP: multishot accept unsupported (accept CQE res=%d) — needs Linux >= 5.19",
+                    res);
+                return 0;
+            }
+            stderr.writefln("accept CQE %d failed: errno %d", i, -res);
+            return 1;
+        }
+
+        // `res` is a freshly accepted server-side fd — close it once observed.
+        close(res);
+        accepted++;
+        if (flags & CQEFlags.MORE)
+            sawMore = true;
+    }
+
+    if (accepted != CLIENTS)
+    {
+        stderr.writefln("expected %d accepted connections, got %d", CLIENTS, accepted);
+        return 1;
+    }
+
+    // CQEFlags.MORE on each completion is the defining signal of a multishot
+    // request: the one accept SQE remains armed for further connections.
+    if (!sawMore)
+    {
+        stderr.writefln("no accept CQE carried CQEFlags.MORE — request was not multishot");
+        return 1;
+    }
+
+    writefln("ok: one multishot accept SQE served %d loopback connections (CQEFlags.MORE set, request stays armed)",
+        accepted);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/multishot-accept.d
+++ b/docs/research/async-io/io-uring/examples/multishot-accept.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_multishot_accept"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/multishot-recv.d
+++ b/docs/research/async-io/io-uring/examples/multishot-recv.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_multishot_recv"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/multishot-recv.d
+++ b/docs/research/async-io/io-uring/examples/multishot-recv.d
@@ -1,0 +1,244 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_multishot_recv"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — multishot RECV into a buffer ring (`IORING_RECV_MULTISHOT`, Linux 6.0).
+ *
+ * A plain `RECV` (5.6) consumes one SQE per received segment: you re-arm it for
+ * every read. Multishot RECV (6.0) flips that — a *single* armed SQE stays live
+ * and posts a fresh CQE for each incoming segment, each one selecting a buffer
+ * from a provided-buffer ring. The kernel keeps the operation armed (signalled by
+ * `CQEFlags.MORE` on every non-final CQE) so a server can drain a busy socket with
+ * one submission instead of N.
+ *
+ * This program builds directly on the 5.19 buffer-ring example:
+ *   1. registers a small buffer ring (`registerBufRing`) for group id `BGID`,
+ *   2. publishes several buffers into that ring,
+ *   3. arms ONE multishot RECV that selects from the group
+ *      (`prepRecvMultishot(fd, gid, len)` sets `IOSQE_BUFFER_SELECT`, `buf_group`,
+ *      and `IORING_RECV_MULTISHOT` for us),
+ *   4. writes TWO separate messages into the peer end of a socketpair,
+ *   5. waits and asserts it gets TWO CQEs from that one SQE, each carrying
+ *      `CQEFlags.MORE` (still armed) + `CQEFlags.BUFFER` (a buffer was selected),
+ *      landing in two *distinct* ring buffers with the right bytes.
+ *
+ * The MORE flag is the multishot contract: it stays set while the op is armed and
+ * clears on the terminal CQE. The selected buffer id is in the upper 16 bits of
+ * `cqe.flags` (`>> CQE_BUFFER_SHIFT`), exactly as for single-shot buffer-select.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "6.0 — Zero-copy send, single-issuer, sync cancel (October 2022)".
+ *
+ * Run with: `dub run --single multishot-recv.d`
+ *
+ * Portability: prints `SKIP:` and exits 0 when io_uring is unavailable or the
+ * running kernel predates multishot RECV (the RECV CQE comes back -EINVAL on a
+ * pre-6.0 kernel, or registerBufRing -> -EINVAL/-EOPNOTSUPP/-ENOSYS pre-5.19).
+ * Exits nonzero only on a genuinely unexpected syscall failure.
+ */
+module io_uring_multishot_recv;
+
+import during;
+
+import core.stdc.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.stdc.stdlib : free;
+import core.sys.posix.stdlib : posix_memalign;
+import core.sys.posix.sys.socket : AF_UNIX, SOCK_STREAM, socketpair;
+import core.sys.posix.unistd : close, write;
+
+import std.stdio : stderr, writefln;
+
+// Group id for our buffer ring, and the buffer geometry. RING_ENTRIES must be a
+// power of two — the kernel masks the tail with `ring_entries - 1`.
+enum ushort BGID = 7;
+enum uint RING_ENTRIES = 8;
+enum uint BUF_SIZE = 64;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // A connected pair of local sockets: we recv on sv[0] via io_uring and write
+    // the payloads into sv[1] with ordinary write(2). Loopback-only, no network.
+    int[2] sv;
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0)
+    {
+        stderr.writefln("socketpair failed");
+        return 1;
+    }
+    scope (exit) { close(sv[0]); close(sv[1]); }
+
+    // Allocate the buffer ring page-aligned (the kernel requires page alignment for
+    // IORING_REGISTER_PBUF_RING). It is a flat array of RING_ENTRIES `io_uring_buf`
+    // slots; slot 0's resv field doubles as the ring's producer tail.
+    enum size_t ringBytes = io_uring_buf.sizeof * RING_ENTRIES;
+    void* ringPtr;
+    if (posix_memalign(&ringPtr, 4096, ringBytes) != 0 || ringPtr is null)
+    {
+        stderr.writefln("posix_memalign failed");
+        return 1;
+    }
+    scope (exit) free(ringPtr);
+    auto ring = cast(io_uring_buf*) ringPtr;
+    ring[0 .. RING_ENTRIES] = io_uring_buf.init; // zero the whole ring (incl. tail=0)
+
+    // Backing storage for the buffers themselves (separate from the ring slots).
+    auto store = new ubyte[BUF_SIZE * RING_ENTRIES];
+
+    // Register the ring with the kernel for group `BGID`.
+    io_uring_buf_reg reg;
+    reg.ring_addr = cast(ulong) ringPtr;
+    reg.ring_entries = RING_ENTRIES;
+    reg.bgid = BGID;
+    const regRet = io.registerBufRing(reg);
+    if (regRet == -EINVAL || regRet == -EOPNOTSUPP || regRet == -ENOSYS)
+    {
+        writefln("SKIP: IORING_REGISTER_PBUF_RING unsupported (errno %d) — needs Linux 5.19+", -regRet);
+        return 0;
+    }
+    if (regRet < 0)
+    {
+        stderr.writefln("registerBufRing failed: errno %d", -regRet);
+        return 1;
+    }
+    scope (exit) io.unregisterBufRing(BGID);
+
+    // Publish all RING_ENTRIES buffers into the ring. Each slot points at its
+    // BUF_SIZE chunk of `store` and carries a distinct buffer id (`bid`). The
+    // kernel returns the chosen `bid` in the CQE's upper 16 bits.
+    enum uint mask = RING_ENTRIES - 1;
+    foreach (ushort i; 0 .. cast(ushort) RING_ENTRIES)
+    {
+        auto slot = &ring[i & mask];
+        slot.addr = cast(ulong) &store[i * BUF_SIZE];
+        slot.len = BUF_SIZE;
+        slot.bid = i; // buffer id == index, so we can recover the chunk later
+    }
+    // Publish: advance the producer tail by the number of buffers we added. The
+    // tail lives in slot 0 (it overlays io_uring_buf.resv there).
+    ring[0].resv = cast(ushort) RING_ENTRIES;
+
+    // Arm ONE multishot RECV that selects buffers from group BGID. The gid overload
+    // sets IOSQE_BUFFER_SELECT + sqe->buf_group, and the multishot wrapper adds
+    // IORING_RECV_MULTISHOT — so this single SQE will keep posting a CQE per segment.
+    enum ulong recvCookie = 0xB16_5EE5;
+    // Pass `sv[0]` as an explicit arg rather than capturing it: a capturing lambda
+    // would force a GC closure and break `putWith`'s `@nogc`.
+    io.putWith!((ref SubmissionEntry e, int recvFd) {
+        e.prepRecvMultishot(recvFd, BGID, BUF_SIZE);
+        e.user_data = recvCookie;
+    })(sv[0]);
+    const submitted = io.submit(0); // flush the SQ without blocking on a count
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Two separate messages to feed the peer end. Each becomes its own readable
+    // segment on sv[0], so the armed multishot RECV should post one CQE per message.
+    immutable ubyte[][2] payloads = [
+        cast(immutable ubyte[]) "first multishot segment",
+        cast(immutable ubyte[]) "second multishot segment!!",
+    ];
+
+    // Drive one segment at a time: write a message, then drain the CQE the armed SQE
+    // produces for it, *before* writing the next. On a stream socket two back-to-back
+    // writes can coalesce into a single readable chunk (and thus a single CQE);
+    // interleaving write-then-drain guarantees two distinct segments — two CQEs from
+    // the one armed SQE, each selecting a fresh ring buffer — deterministically,
+    // without relying on kernel scheduling. We never re-arm: the multishot SQE stays
+    // live across both completions (signalled by CQE_F_MORE).
+    ushort[2] gotBids;
+    foreach (idx, p; payloads)
+    {
+        const wrote = write(sv[1], &p[0], p.length);
+        if (wrote != cast(ptrdiff_t) p.length)
+        {
+            stderr.writefln("write to peer failed: %d", wrote);
+            return 1;
+        }
+
+        io.wait(1); // one CQE is guaranteed imminent (data already written)
+        const c = io.front;
+        const res = c.res;
+        const flags = c.flags;
+        const echoed = c.user_data;
+        io.popFront();
+
+        if (echoed != recvCookie)
+        {
+            stderr.writefln("user_data mismatch: expected 0x%X, got 0x%X", recvCookie, echoed);
+            return 1;
+        }
+
+        // A pre-6.0 kernel rejects the multishot bit on the very first CQE.
+        if (res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS)
+        {
+            writefln("SKIP: IORING_RECV_MULTISHOT unsupported (errno %d) — needs Linux 6.0+", -res);
+            return 0;
+        }
+        if (res < 0)
+        {
+            // -ENOBUFS would mean the ring ran out of published buffers — a real bug
+            // in our bookkeeping, not an unsupported-feature case.
+            stderr.writefln("multishot RECV CQE #%d failed: errno %d", idx, -res);
+            return 1;
+        }
+
+        // Multishot contract: each non-terminal CQE carries MORE (still armed). With
+        // two segments and 8 buffers the op cannot exhaust the ring, so both of our
+        // CQEs must be armed.
+        if (!(flags & CQEFlags.MORE))
+        {
+            stderr.writefln("multishot RECV CQE #%d lost CQE_F_MORE (flags=0x%X) — op disarmed early",
+                idx, cast(uint) flags);
+            return 1;
+        }
+        // Buffer-select contract: a buffer must have been chosen, with its id in the
+        // upper 16 bits of flags.
+        if (!(flags & CQEFlags.BUFFER))
+        {
+            stderr.writefln("multishot RECV CQE #%d has no CQE_F_BUFFER (flags=0x%X)",
+                idx, cast(uint) flags);
+            return 1;
+        }
+        const bid = cast(ushort)(cast(uint) flags >> CQE_BUFFER_SHIFT);
+        if (bid >= RING_ENTRIES)
+        {
+            stderr.writefln("kernel returned out-of-range buffer id %d", bid);
+            return 1;
+        }
+
+        // Confirm the bytes landed in exactly the buffer the kernel selected.
+        auto got = store[bid * BUF_SIZE .. bid * BUF_SIZE + res];
+        if (got != payloads[idx])
+        {
+            stderr.writefln("payload #%d mismatch in selected buffer %d", idx, bid);
+            return 1;
+        }
+        gotBids[idx] = bid;
+    }
+
+    // The whole point of multishot: two segments, two CQEs, from ONE armed SQE — and
+    // each landed in a *distinct* ring buffer (the kernel pops a fresh slot per CQE).
+    if (gotBids[0] == gotBids[1])
+    {
+        stderr.writefln("expected distinct buffers, both CQEs used buffer id %d", gotBids[0]);
+        return 1;
+    }
+
+    writefln("ok: one armed multishot RECV posted 2 CQEs (MORE+BUFFER) into distinct buffers %d and %d",
+        gotBids[0], gotBids[1]);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/multishot-timeout.d
+++ b/docs/research/async-io/io-uring/examples/multishot-timeout.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_multishot_timeout"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/multishot-timeout.d
+++ b/docs/research/async-io/io-uring/examples/multishot-timeout.d
@@ -1,0 +1,186 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_multishot_timeout"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — multishot timeout (`IORING_TIMEOUT_MULTISHOT`, Linux 6.4).
+ *
+ * Before 6.4 a `TIMEOUT` SQE fired exactly once: it posted a single `-ETIME`
+ * completion and then disarmed. Multishot timeout lets one submitted SQE act as
+ * a recurring tick — the kernel re-arms it after each expiry and keeps posting a
+ * fresh CQE every interval, each flagged with `CQEFlags.MORE` to mean "more
+ * completions for this user_data are still coming". The request stays armed until
+ * its `count` of fires is reached, or until you explicitly remove it — at which
+ * point the terminating CQE arrives with `MORE` cleared.
+ *
+ * This example arms a ~20 ms multishot timer (`TimeoutFlags.MULTISHOT`,
+ * `count == 0` => unbounded), collects 3 ticks (each `res == -ETIME`, each with
+ * `MORE` set), then issues an `ASYNC_CANCEL` keyed by the timer's `user_data` to
+ * stop the repeats and drains the terminating CQE (`res == -ECANCELED`, `MORE`
+ * cleared). Total runtime ~60 ms.
+ *
+ * Implementation note: `during` 0.5.0's `prepCancel` helper does not compile
+ * (it assigns a `uint` to a `CancelFlags` field without a cast), so we build the
+ * `ASYNC_CANCEL` SQE by hand — the kernel matches the request whose `user_data`
+ * equals the cancel SQE's `addr`. (The legacy `TIMEOUT_REMOVE` op returns
+ * `-ENOENT` against a multishot timer, so async-cancel is the right tool here.)
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "6.4 — Multishot timeout".
+ *
+ * Run with: `dub run --single multishot-timeout.d`
+ *
+ * Portability: if the running kernel has no `io_uring` (too old, or blocked by a
+ * seccomp/container policy), or if multishot timeout is unsupported (kernel < 6.4,
+ * surfaced as a `-EINVAL`/`-EOPNOTSUPP` on the first CQE), the program prints a
+ * `SKIP:` line and exits 0 so it stays green in CI regardless of the host kernel.
+ */
+module io_uring_multishot_timeout;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ETIME, ECANCELED;
+
+int main()
+{
+    // Distinct cookies so we can tell the timer's ticks apart from the
+    // cancel request's own completion when both are in flight.
+    enum ulong timerData = 1;
+    enum ulong cancelData = 2;
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // A short relative interval; with MULTISHOT and count==0 the kernel re-arms
+    // this same timer after every expiry, posting one CQE per ~20 ms tick.
+    KernelTimespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 20_000_000; // 20 ms
+
+    io.putWith!(
+        (ref SubmissionEntry e, ref KernelTimespec t)
+        {
+            e.prepTimeout(t, /*count*/ 0, TimeoutFlags.MULTISHOT);
+            e.user_data = timerData;
+        })(ts);
+
+    const submitted = io.submit(0); // flush the SQ; the timer arms in the kernel
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    enum int wantTicks = 3;
+    int seen;
+    bool lastHadMore = false;
+
+    // Collect 3 recurring ticks. We bound the wait by only ever asking for one
+    // completion at a time and stopping after wantTicks fires.
+    while (seen < wantTicks)
+    {
+        io.wait(1);
+        const c = io.front;
+        const res = c.res;
+        const more = (c.flags & CQEFlags.MORE) != 0;
+        io.popFront();
+
+        // First CQE of -EINVAL/-EOPNOTSUPP => kernel predates multishot timeout.
+        if (res == -EINVAL || res == -EOPNOTSUPP)
+        {
+            writefln("SKIP: multishot timeout unsupported on this kernel (errno %d) — needs Linux 6.4+", -res);
+            return 0;
+        }
+
+        if (res != -ETIME)
+        {
+            stderr.writefln("unexpected tick result: errno %d (expected -ETIME)", -res);
+            return 1;
+        }
+        if (!more)
+        {
+            // An unbounded multishot timer must keep MORE set while it re-arms.
+            stderr.writefln("tick %d cleared CQEFlags.MORE while timer should still be armed", seen);
+            return 1;
+        }
+
+        seen++;
+        lastHadMore = more;
+    }
+
+    // Stop the recurring timer with an ASYNC_CANCEL keyed by its user_data.
+    // `prepCancel` is broken in during 0.5.0, so fill the SQE by hand: the kernel
+    // matches the in-flight request whose user_data == this SQE's `addr`.
+    auto sqe = &io.next();
+    *sqe = SubmissionEntry.init;
+    sqe.opcode = Operation.ASYNC_CANCEL;
+    sqe.fd = -1;
+    sqe.addr = timerData; // key: cancel the request with this user_data
+    sqe.user_data = cancelData;
+
+    const cancelSubmitted = io.submit(0);
+    if (cancelSubmitted < 0)
+    {
+        stderr.writefln("submit (cancel) failed: errno %d", -cancelSubmitted);
+        return 1;
+    }
+
+    // Drain until we've observed BOTH the cancel request's own CQE and the timer's
+    // terminating CQE (res == -ECANCELED, MORE cleared). A tick already in flight
+    // may slip in before the cancel lands; we just consume it. The loop is bounded
+    // by iteration count so it can never block indefinitely.
+    bool sawCancel = false;
+    bool sawTimerTermination = false;
+    foreach (_; 0 .. 8)
+    {
+        if (sawCancel && sawTimerTermination)
+            break;
+
+        io.wait(1);
+        // Consume every CQE currently ready, not just one — the cancel and the
+        // timer termination often arrive in the same batch.
+        while (!io.empty)
+        {
+            const c = io.front;
+            const res = c.res;
+            const data = c.user_data;
+            const more = (c.flags & CQEFlags.MORE) != 0;
+            io.popFront();
+
+            if (data == timerData)
+            {
+                // A late tick (-ETIME, MORE set) or the termination
+                // (-ECANCELED, MORE cleared).
+                if (res == -ECANCELED || !more)
+                    sawTimerTermination = true;
+            }
+            else if (data == cancelData)
+            {
+                // 0 == cancelled successfully. A benign race (timer fired as the
+                // cancel ran) can report -ENOENT/-EALREADY; either way the timer
+                // is gone, so don't treat those as failures.
+                sawCancel = true;
+            }
+        }
+    }
+
+    if (!sawCancel || !sawTimerTermination)
+    {
+        stderr.writefln("did not observe both the cancel (%s) and the timer termination (%s)",
+            sawCancel, sawTimerTermination);
+        return 1;
+    }
+
+    writefln("ok: multishot timeout fired %d times (each -ETIME with CQEFlags.MORE), "
+        ~ "then stopped via ASYNC_CANCEL (last fire MORE=%s)", seen, lastHadMore);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/napi.d
+++ b/docs/research/async-io/io-uring/examples/napi.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_napi"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/napi.d
+++ b/docs/research/async-io/io-uring/examples/napi.d
@@ -1,0 +1,85 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_napi"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — NAPI busy-poll registration (`IORING_REGISTER_NAPI`, Linux 6.9).
+ *
+ * NAPI busy-polling lets a ring spin on the network stack's NAPI receive path
+ * for a bounded window instead of sleeping until an interrupt fires — trading
+ * CPU cycles for lower receive latency on networked completions. It is
+ * configured per-ring (not per-NIC) via `io_uring_register(IORING_REGISTER_NAPI)`,
+ * which `during` exposes as `Uring.registerNapi`.
+ *
+ * This example builds an `io_uring_napi` config (a busy-poll timeout in
+ * microseconds plus the `prefer_busy_poll` flag), registers it, prints the
+ * parameters on success, then tears it back down with `unregisterNapi`.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ * § "6.9 — NAPI busy-poll, ftruncate (May 2024)".
+ *
+ * Run with: `dub run --single napi.d`
+ *
+ * Portability: NAPI busy-poll arrived in 6.9 and can additionally be gated by
+ * the running kernel's network configuration. If `io_uring` is unavailable, or
+ * `registerNapi` reports `-EINVAL`/`-EOPNOTSUPP`/`-ENOSYS`, the program prints a
+ * `SKIP:` line and exits 0 so it stays green in CI regardless of the host.
+ */
+module napi_example;
+
+import during;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // NAPI busy-poll config: spin the NAPI receive path for up to 50us before
+    // falling back to interrupt-driven wakeups, and prefer busy polling.
+    io_uring_napi napi;
+    napi.busy_poll_to = 50;        // busy-poll timeout, microseconds
+    napi.prefer_busy_poll = 1;     // prefer busy poll over interrupts
+
+    const regRet = io.registerNapi(napi);
+    if (regRet == -EINVAL || regRet == -EOPNOTSUPP || regRet == -ENOSYS)
+    {
+        // Kernel < 6.9, or NAPI busy-poll not available in this environment.
+        // This is an expected outcome on hosts without NAPI support.
+        writefln("SKIP: IORING_REGISTER_NAPI unsupported here (errno %d) — needs Linux 6.9+ with NAPI busy-poll", -regRet);
+        return 0;
+    }
+    if (regRet < 0)
+    {
+        stderr.writefln("registerNapi failed unexpectedly: errno %d", -regRet);
+        return 1;
+    }
+
+    // On success the kernel writes the *previous* config back into `napi`, but
+    // the values we just registered are the ones that matter for the demo.
+    writefln("ok: registered NAPI busy-poll (busy_poll_to=%dus, prefer_busy_poll=%d)",
+        50, 1);
+
+    // Tear the registration back down. `unregisterNapi` fills its argument with
+    // the configuration that was in effect; we don't need it, so pass a fresh one.
+    io_uring_napi prev;
+    const unregRet = io.unregisterNapi(prev);
+    if (unregRet < 0)
+    {
+        stderr.writefln("unregisterNapi failed: errno %d", -unregRet);
+        return 1;
+    }
+
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/nop.d
+++ b/docs/research/async-io/io-uring/examples/nop.d
@@ -1,0 +1,80 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_nop"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — the minimal submit/complete cycle (`IORING_OP_NOP`, Linux 5.1).
+ *
+ * This is the "hello world" of `io_uring`: it sets up a ring, places one
+ * `NOP` submission queue entry (SQE), submits it, waits for the matching
+ * completion queue entry (CQE), and verifies the `user_data` cookie round-trips.
+ * It exercises every part of the core machinery from the 5.1 introduction —
+ * `io_uring_setup` (here via `Uring.setup`), the shared SQ/CQ rings, and the
+ * `submit` / `wait` / `front` / `popFront` flow that every later op reuses.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "5.1 — The introduction".
+ *
+ * Run with: `dub run --single nop.d`
+ *
+ * Portability: if the running kernel has no `io_uring` (too old, or blocked by a
+ * seccomp/container policy), the program prints a `SKIP:` line and exits 0 so it
+ * stays green in CI regardless of the host kernel.
+ */
+module io_uring_nop;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    // `IORING_OP_NOP` carries this cookie through the kernel and hands it back
+    // on the CQE — the mechanism every op uses to correlate completions.
+    enum ulong cookie = 0xC0FFEE;
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Place a single NOP SQE. `putWith` clears the entry, runs the prep callback,
+    // and advances the submission queue tail in one step.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.user_data = cookie;
+    })();
+
+    const submitted = io.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Block until at least one completion is ready, then consume it.
+    io.wait(1);
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    if (res < 0)
+    {
+        stderr.writefln("NOP completed with error: errno %d", -res);
+        return 1;
+    }
+
+    if (echoed != cookie)
+    {
+        stderr.writefln("user_data mismatch: expected 0x%X, got 0x%X", cookie, echoed);
+        return 1;
+    }
+
+    writefln("ok: NOP completed (res=%d), user_data 0x%X round-tripped through the ring", res, echoed);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/nop.d
+++ b/docs/research/async-io/io-uring/examples/nop.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_nop"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/openat-statx-close.d
+++ b/docs/research/async-io/io-uring/examples/openat-statx-close.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_openat_statx_close"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/openat-statx-close.d
+++ b/docs/research/async-io/io-uring/examples/openat-statx-close.d
@@ -1,0 +1,261 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_openat_statx_close"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` as a general async-syscall surface — `OPENAT` + `STATX` + `READ` +
+ * `CLOSE` (Linux 5.6).
+ *
+ * Linux 5.6 turned `io_uring` from an I/O-on-already-open-fds engine into a
+ * general asynchronous syscall surface: filesystem operations that previously
+ * had no async form — opening a path, stat-ing it, closing an fd — became plain
+ * SQE opcodes. This example chains the four of them to read a file end to end
+ * without ever issuing a synchronous open/stat/read/close:
+ *
+ *   1. write a known file under `/tmp` synchronously (libc) to have something to open;
+ *   2. `OPENAT(AT_FDCWD, path, O_RDONLY)` — the completion's `res` is the new fd;
+ *   3. `STATX(fd, "", AT_EMPTY_PATH, STATX_SIZE)` — verify the file size;
+ *   4. `READ(fd, buf, 0)` — verify the bytes round-trip;
+ *   5. `CLOSE(fd)` — release it through the ring.
+ *
+ * Each step is its own submit/wait: `OPENAT`'s result fd is the input to the
+ * following ops, so they cannot be batched into one independent submission.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ * § "5.6 — The filesystem/syscall expansion (March 2020)".
+ *
+ * Run with: `dub run --single openat-statx-close.d`
+ *
+ * Portability: prints a `SKIP:` line and exits 0 when `io_uring` is unavailable
+ * (old kernel / sandbox) or when any of these 5.6 ops is unsupported, so it stays
+ * green in CI regardless of the host kernel.
+ */
+module io_uring_openat_statx_close;
+
+import during;
+
+import core.sys.posix.fcntl : AT_FDCWD, O_CREAT, O_RDONLY, O_WRONLY, open;
+import core.sys.posix.unistd : close, unlink, write;
+
+import std.stdio : stderr, writefln;
+import std.string : toStringz;
+
+// ABI-stable constants the kernel uses but druntime does not surface here.
+enum int AT_EMPTY_PATH = 0x1000; // statx() on an open fd with an empty path
+enum uint STATX_SIZE = 0x0000_0200; // request stx_size in the result mask
+
+// Minimal mirror of the kernel `struct statx` (256 bytes, ABI-stable). We only
+// read `stx_size`, which lives at byte offset 40; the rest is padding we never
+// touch. `prepStatx` takes the buffer generically, so any 256-byte struct with
+// the field at the right offset works.
+struct Statx
+{
+    uint stx_mask; // 0
+    uint stx_blksize; // 4
+    ulong stx_attributes; // 8
+    uint stx_nlink; // 16
+    uint stx_uid; // 20
+    uint stx_gid; // 24
+    ushort stx_mode; // 28
+    ushort[1] _spare0; // 30
+    ulong stx_ino; // 32
+    ulong stx_size; // 40 -- the only field we assert on
+    ubyte[256 - 48] _rest; // 48.. -- timestamps, dev numbers, future fields
+}
+
+static assert(Statx.stx_size.offsetof == 40, "stx_size must sit at the kernel ABI offset");
+static assert(Statx.sizeof >= 256, "statx buffer must cover the full kernel struct");
+
+int main()
+{
+    // The file we will open/stat/read through the ring.
+    enum string path = "/tmp/io_uring_openat_statx_close.txt";
+    immutable(ubyte)[] payload = cast(immutable(ubyte)[]) "io_uring touched the filesystem\n";
+
+    // --- Step 1: create the test file synchronously (plain libc). -----------
+    {
+        const wfd = open(path.toStringz, O_CREAT | O_WRONLY, octal!"600");
+        if (wfd < 0)
+        {
+            writefln("SKIP: could not create %s (errno %d)", path, errnoOf(wfd));
+            return 0;
+        }
+        const wrote = write(wfd, payload.ptr, payload.length);
+        close(wfd);
+        if (wrote != payload.length)
+        {
+            stderr.writefln("setup write short: %d of %d bytes", wrote, payload.length);
+            return 1;
+        }
+    }
+    scope (exit) unlink(path.toStringz);
+
+    // --- Ring setup. --------------------------------------------------------
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // The filesystem ops all arrived together in 5.6; probe one representative
+    // op up front so a pre-5.6 kernel skips cleanly rather than erroring mid-chain.
+    auto probe = io.probe();
+    if (cast(bool) probe && !probe.isSupported(Operation.OPENAT))
+    {
+        writefln("SKIP: IORING_OP_OPENAT unsupported on this kernel (pre-5.6)");
+        return 0;
+    }
+
+    // --- Step 2: OPENAT — the completion res is the freshly opened fd. ------
+    auto cpath = path.toStringz; // keep the C string alive across the submit
+    io.putWith!((ref SubmissionEntry e, const(char)* p) {
+        e.prepOpenat(AT_FDCWD, p, O_RDONLY, 0);
+        e.user_data = 1;
+    })(cpath);
+    if (io.submit(1) < 0)
+        return fail("submit OPENAT");
+    io.wait(1);
+    const openRes = io.front.res;
+    io.popFront();
+    if (isUnsupported(openRes))
+    {
+        writefln("SKIP: OPENAT returned %d (op unsupported on this kernel)", openRes);
+        return 0;
+    }
+    if (openRes < 0)
+        return failErr("OPENAT", openRes);
+    const fd = openRes; // the async-opened fd, used by the next ops
+
+    // From here a failure leaks the fd unless we close it; do that on any early return.
+    scope (failure) close(fd);
+
+    // --- Step 3: STATX on the open fd (empty path + AT_EMPTY_PATH). ---------
+    Statx stx;
+    io.putWith!((ref SubmissionEntry e, int f, Statx* sb) {
+        // Empty path + AT_EMPTY_PATH means "stat the fd itself", like fstat().
+        e.prepStatx(f, emptyCString, AT_EMPTY_PATH, STATX_SIZE, *sb);
+        e.user_data = 2;
+    })(fd, &stx);
+    if (io.submit(1) < 0)
+        return failClose(fd, "submit STATX");
+    io.wait(1);
+    const statxRes = io.front.res;
+    io.popFront();
+    if (isUnsupported(statxRes))
+    {
+        close(fd);
+        writefln("SKIP: STATX returned %d (op unsupported on this kernel)", statxRes);
+        return 0;
+    }
+    if (statxRes < 0)
+    {
+        close(fd);
+        return failErr("STATX", statxRes);
+    }
+    if (stx.stx_size != payload.length)
+    {
+        close(fd);
+        stderr.writefln("STATX size mismatch: expected %d, got %d", payload.length, stx.stx_size);
+        return 1;
+    }
+
+    // --- Step 4: READ the whole file through the ring and verify content. ---
+    ubyte[128] readBuf;
+    io.putWith!((ref SubmissionEntry e, int f, ubyte[] b) {
+        e.prepRead(f, b, 0);
+        e.user_data = 3;
+    })(fd, readBuf[]);
+    if (io.submit(1) < 0)
+        return failClose(fd, "submit READ");
+    io.wait(1);
+    const readRes = io.front.res;
+    io.popFront();
+    if (readRes < 0)
+    {
+        close(fd);
+        return failErr("READ", readRes);
+    }
+    if (readRes != cast(int) payload.length || readBuf[0 .. payload.length] != payload[])
+    {
+        close(fd);
+        stderr.writefln("READ content mismatch (res=%d)", readRes);
+        return 1;
+    }
+
+    // --- Step 5: CLOSE the fd through the ring (no scope guard hereafter). ---
+    io.putWith!((ref SubmissionEntry e, int f) {
+        e.prepClose(f);
+        e.user_data = 4;
+    })(fd);
+    if (io.submit(1) < 0)
+        return failClose(fd, "submit CLOSE");
+    io.wait(1);
+    const closeRes = io.front.res;
+    io.popFront();
+    if (closeRes < 0)
+    {
+        close(fd); // ring CLOSE failed; fall back to a synchronous close
+        return failErr("CLOSE", closeRes);
+    }
+
+    writefln("ok: async OPENAT→STATX(size=%d)→READ(%d bytes)→CLOSE chained through io_uring",
+        stx.stx_size, readRes);
+    return 0;
+}
+
+// --- small helpers ----------------------------------------------------------
+
+// A `const(char)*` to a single NUL byte: an empty C path for STATX-on-fd.
+const(char)* emptyCString() @trusted nothrow @nogc
+{
+    static immutable char[1] empty = ['\0'];
+    return &empty[0];
+}
+
+// libc syscalls return -1 and set errno; this wrapper environment doesn't read
+// errno portably, so for the setup path we just report the raw -1.
+int errnoOf(int ret) @safe pure nothrow @nogc => -ret;
+
+// io_uring surfaces "this op doesn't exist on this kernel" as -EINVAL/-EOPNOTSUPP/-ENOSYS.
+bool isUnsupported(int res) @safe pure nothrow @nogc
+{
+    enum int EINVAL = 22, ENOSYS = 38, EOPNOTSUPP = 95;
+    return res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS;
+}
+
+int fail(string what)
+{
+    stderr.writefln("%s failed", what);
+    return 1;
+}
+
+int failErr(string op, int res)
+{
+    stderr.writefln("%s completed with error: errno %d", op, -res);
+    return 1;
+}
+
+int failClose(int fd, string what)
+{
+    close(fd);
+    return fail(what);
+}
+
+// `octal!"600"` — file mode literal computed at compile time.
+template octal(string digits)
+{
+    enum uint octal = parseOctal(digits);
+}
+
+uint parseOctal(string s) @safe pure nothrow @nogc
+{
+    uint v = 0;
+    foreach (c; s)
+        v = v * 8 + (c - '0');
+    return v;
+}

--- a/docs/research/async-io/io-uring/examples/pipe.d
+++ b/docs/research/async-io/io-uring/examples/pipe.d
@@ -1,0 +1,138 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_pipe"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — async pipe creation (`IORING_OP_PIPE`, Linux 6.16).
+ *
+ * Before 6.16, creating a pipe meant a synchronous `pipe2(2)` syscall outside
+ * the ring. `IORING_OP_PIPE` lets the ring itself manufacture the pipe pair:
+ * submit one SQE pointing at an `int[2]` buffer and, on completion, the kernel
+ * has filled it with the read end (`fds[0]`) and write end (`fds[1]`) — exactly
+ * like `pipe2(2)`, but folded into the same submit/complete batch as the rest of
+ * your I/O (so a pipe can be created and immediately used in a single linked
+ * chain without a syscall round-trip).
+ *
+ * This example creates a pipe through the ring, then proves it actually works by
+ * writing a few bytes into the write end and reading them back out of the read
+ * end (plain libc `write`/`read` — the point here is the *creation* op, not the
+ * transfer), asserting the bytes round-trip before closing both ends.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "6.16 — Async pipe".
+ *
+ * Run with: `dub run --single pipe.d`
+ *
+ * Portability: prints a `SKIP:` line and exits 0 if io_uring is unavailable, or
+ * if the `PIPE` op is unsupported (kernel older than the op's introduction —
+ * detected via the probe or an `-EINVAL`/`-EOPNOTSUPP` completion), so it stays
+ * green on CI hosts running older kernels.
+ */
+module io_uring_pipe;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.unistd : close, read, write;
+
+// O_CLOEXEC: ask the kernel to mark both pipe ends close-on-exec, the sane
+// default for fds we never intend to leak across an exec. Linux value is octal
+// 02000000, identical across the architectures this example targets.
+enum int O_CLOEXEC = 0x80000;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Fast path: if the kernel's op probe answers, trust it. A kernel too old to
+    // know about PIPE simply reports it unsupported.
+    auto probe = io.probe();
+    if (cast(bool) probe && !probe.isSupported(Operation.PIPE))
+    {
+        writefln("SKIP: IORING_OP_PIPE unsupported on this kernel (needs Linux 6.16+)");
+        return 0;
+    }
+
+    // The kernel writes the read end into fds[0] and the write end into fds[1].
+    // We pass the buffer by pointer through `putWith` and dereference inside the
+    // lambda so `prepPipe` binds it by reference.
+    int[2] fds = [-1, -1];
+    io.putWith!(
+        (ref SubmissionEntry e, int[2]* out_)
+        {
+            e.prepPipe(*out_, O_CLOEXEC);
+            e.user_data = 1;
+        })(&fds);
+
+    const submitted = io.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    io.wait(1);
+    const res = io.front.res;
+    const cookie = io.front.user_data;
+    io.popFront();
+
+    // Runtime fallback: on a kernel without the op, the CQE itself reports the
+    // failure. Treat those as "unsupported", anything else as a real error.
+    if (res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS)
+    {
+        writefln("SKIP: IORING_OP_PIPE rejected (errno %d) — kernel predates the op", -res);
+        return 0;
+    }
+    if (res < 0)
+    {
+        stderr.writefln("PIPE completed with error: errno %d", -res);
+        return 1;
+    }
+    if (cookie != 1)
+    {
+        stderr.writefln("user_data mismatch: expected 1, got %d", cookie);
+        return 1;
+    }
+    if (fds[0] < 0 || fds[1] < 0)
+    {
+        stderr.writefln("PIPE did not fill the fd pair: fds=[%d, %d]", fds[0], fds[1]);
+        return 1;
+    }
+
+    // Prove the freshly minted pipe works: a short round-trip through it.
+    scope (exit) { close(fds[0]); close(fds[1]); }
+    ubyte[8] tx = [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04];
+    ubyte[8] rx = 0;
+
+    const wrote = write(fds[1], &tx[0], tx.length);
+    if (wrote != tx.length)
+    {
+        stderr.writefln("write to pipe failed: returned %d (errno-side)", wrote);
+        return 1;
+    }
+    const got = read(fds[0], &rx[0], rx.length);
+    if (got != tx.length)
+    {
+        stderr.writefln("read from pipe short: returned %d, expected %d", got, tx.length);
+        return 1;
+    }
+    if (rx[] != tx[])
+    {
+        stderr.writefln("pipe round-trip mismatch: tx=%(%02X %), rx=%(%02X %)", tx[], rx[]);
+        return 1;
+    }
+
+    writefln("ok: PIPE created fds=[%d, %d] through the ring; %d bytes round-tripped",
+        fds[0], fds[1], got);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/pipe.d
+++ b/docs/research/async-io/io-uring/examples/pipe.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_pipe"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/poll-add.d
+++ b/docs/research/async-io/io-uring/examples/poll-add.d
@@ -1,0 +1,120 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_poll_add"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — readiness notification with `IORING_OP_POLL_ADD` (Linux 5.1).
+ *
+ * `POLL_ADD` is io_uring's answer to `poll(2)`/`epoll`: arm a one-shot
+ * readiness watch on a file descriptor and get a CQE when it becomes ready,
+ * without ever calling `poll` from userspace. It is the building block for
+ * event-loop style I/O — the kernel does the waiting and notifies you through
+ * the same completion ring every other op uses.
+ *
+ * This example creates a libc `pipe()`, arms a `POLL_ADD` for `POLLIN` on the
+ * read end, then writes one byte into the write end. Once the read end is
+ * readable the CQE fires, and (per during's `tests/poll.d`) `res` carries the
+ * set of ready poll events — a positive value with the `POLLIN` bit set.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "5.1 — The introduction (May 2019)".
+ *
+ * Run with: `dub run --single poll-add.d`
+ *
+ * Portability: `POLL_ADD` has existed since the 5.1 introduction, so it works on
+ * any kernel that has io_uring at all. If io_uring is unavailable (too old, or
+ * blocked by a seccomp/container policy) the program prints a `SKIP:` line and
+ * exits 0 so it stays green in CI regardless of the host kernel.
+ */
+module io_uring_poll_add;
+
+import during;
+
+import core.sys.posix.poll : POLLIN;
+import core.sys.posix.unistd : close, pipe, write;
+
+import std.stdio : stderr, writefln, writeln;
+
+int main()
+{
+    // user_data cookie identifying this poll op when its CQE comes back.
+    enum ulong cookie = 1;
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // A classic anonymous pipe: fds[0] is the read end, fds[1] the write end.
+    int[2] fds;
+    if (pipe(fds) != 0)
+    {
+        stderr.writeln("SKIP: pipe() failed");
+        return 0;
+    }
+    scope (exit)
+    {
+        close(fds[0]);
+        close(fds[1]);
+    }
+
+    // Arm a one-shot poll on the read end for readability (POLLIN). The kernel
+    // will park this until the fd is readable, then post a CQE.
+    io.putWith!((ref SubmissionEntry e, int readFd) {
+        e.prepPollAdd(readFd, PollEvents.IN);
+        e.user_data = cookie;
+    })(fds[0]);
+
+    // submit(0) flushes the SQ without blocking on a completion count — the poll
+    // is now armed in the kernel but the fd is not yet readable.
+    const submitted = io.submit(0);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Make the read end readable: one byte into the write end is enough to
+    // satisfy POLLIN and trip the armed poll.
+    immutable ubyte one = 0x2A;
+    const wrote = write(fds[1], &one, 1);
+    if (wrote != 1)
+    {
+        stderr.writefln("write to pipe failed (ret %d)", wrote);
+        return 1;
+    }
+
+    // Block for the poll completion.
+    io.wait(1);
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    if (res < 0)
+    {
+        stderr.writefln("POLL_ADD completed with error: errno %d", -res);
+        return 1;
+    }
+
+    if (echoed != cookie)
+    {
+        stderr.writefln("user_data mismatch: expected %d, got %d", cookie, echoed);
+        return 1;
+    }
+
+    // On success `res` is the bitmask of ready events; POLLIN must be set since
+    // the pipe's read end now has data.
+    if (!(res & POLLIN))
+    {
+        stderr.writefln("expected POLLIN in ready mask, got 0x%X", res);
+        return 1;
+    }
+
+    writefln("ok: POLL_ADD reported readiness (res=0x%X, POLLIN set) on the pipe read end", res);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/poll-add.d
+++ b/docs/research/async-io/io-uring/examples/poll-add.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_poll_add"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/probe.d
+++ b/docs/research/async-io/io-uring/examples/probe.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_probe"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/probe.d
+++ b/docs/research/async-io/io-uring/examples/probe.d
@@ -1,0 +1,97 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_probe"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — capability detection via `IORING_REGISTER_PROBE` (Linux 5.6).
+ *
+ * Before 5.6, the only portable way to learn whether the kernel implemented a
+ * given `io_uring` opcode was to submit it and inspect the completion for
+ * `-EINVAL`. `IORING_REGISTER_PROBE` replaced that guesswork with a proper
+ * query: the kernel fills an `io_uring_probe` table reporting, per opcode,
+ * whether it is supported. This is THE mechanism a portable program uses to
+ * decide at runtime which fast paths it may take on the host kernel.
+ *
+ * Here we set up a ring, fetch the probe table (`Uring.probe`, which wraps the
+ * register call), and print a compact support report for a curated list of
+ * historically interesting opcodes — from the original 5.1 `NOP`/`READ`/`WRITE`
+ * through `SEND_ZC` (5.19), `FUTEX_WAIT` (6.7), `RECV_ZC`/`PIPE` (6.x), and the
+ * 128-byte `NOP128`. Because it only *probes*, this example runs and succeeds
+ * on every kernel that has `io_uring` at all — newer opcodes simply report
+ * `no` rather than failing.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ * § "5.6 — The filesystem/syscall expansion (March 2020)".
+ *
+ * Run with: `dub run --single probe.d`
+ *
+ * Portability: if the host has no `io_uring`, or the kernel is older than 5.6
+ * (so `IORING_REGISTER_PROBE` itself is unavailable and the probe fetch fails),
+ * the program prints a `SKIP:` line and exits 0 so it stays green in CI.
+ */
+module io_uring_probe;
+
+import during;
+
+import std.stdio : writef, writefln, stderr;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // `IORING_REGISTER_PROBE`: ask the kernel for its per-opcode support table.
+    // `cast(bool)probe` is false (and `probe.error` holds -errno) when the
+    // register call is unavailable — e.g. a pre-5.6 kernel that has io_uring
+    // but not the PROBE register op.
+    Probe probe = io.probe();
+    if (!cast(bool) probe)
+    {
+        writefln("SKIP: IORING_REGISTER_PROBE unavailable (errno %d) — needs Linux 5.6+",
+            -probe.error);
+        return 0;
+    }
+
+    // A curated tour of the opcode timeline. The label is just for the report;
+    // the kernel's verdict comes from `probe.isSupported`.
+    static struct Op { Operation op; string name; }
+    static immutable Op[] tour = [
+        Op(Operation.NOP, "NOP"),
+        Op(Operation.READ, "READ"),
+        Op(Operation.WRITE, "WRITE"),
+        Op(Operation.ACCEPT, "ACCEPT"),
+        Op(Operation.CONNECT, "CONNECT"),
+        Op(Operation.SEND, "SEND"),
+        Op(Operation.RECV, "RECV"),
+        Op(Operation.OPENAT, "OPENAT"),
+        Op(Operation.TIMEOUT, "TIMEOUT"),
+        Op(Operation.POLL_ADD, "POLL_ADD"),
+        Op(Operation.SEND_ZC, "SEND_ZC"),
+        Op(Operation.FUTEX_WAIT, "FUTEX_WAIT"),
+        Op(Operation.RECV_ZC, "RECV_ZC"),
+        Op(Operation.PIPE, "PIPE"),
+        Op(Operation.NOP128, "NOP128"),
+    ];
+
+    int supported;
+    foreach (entry; tour)
+    {
+        const ok = probe.isSupported(entry.op);
+        if (ok) ++supported;
+        writef("  %-11s %s\n", entry.name, ok ? "yes" : "no");
+    }
+
+    // One summary line, as required: how many of the curated opcodes this
+    // kernel actually implements.
+    writefln("ok: IORING_REGISTER_PROBE succeeded — %d/%d curated opcodes supported on this kernel",
+        supported, cast(int) tour.length);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/provided-buf-ring.d
+++ b/docs/research/async-io/io-uring/examples/provided-buf-ring.d
@@ -1,0 +1,200 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_provided_buf_ring"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — ring-provided buffers (`IORING_REGISTER_PBUF_RING`, Linux 5.19).
+ *
+ * Before 5.19 an app that wanted the kernel to pick a receive buffer had to feed
+ * them in one syscall at a time via `IORING_OP_PROVIDE_BUFFERS`. The 5.19 buffer
+ * *ring* replaces that with a shared, app-owned ring of `io_uring_buf` slots: the
+ * app publishes buffers by writing slots and bumping a tail, and the kernel pops a
+ * slot for each buffer-select operation — no per-buffer syscall.
+ *
+ * This program:
+ *   1. registers a small buffer ring (`registerBufRing`) for group id `BGID`,
+ *   2. publishes a few buffers into that ring,
+ *   3. submits a `RECV` that *selects* a buffer from the group
+ *      (`IOSQE_BUFFER_SELECT` + `buf_group`, set for us by the gid `prepRecv`),
+ *   4. writes some bytes into the other end of a socketpair,
+ *   5. waits and asserts the CQE carries `CQEFlags.BUFFER` — the chosen buffer id
+ *      is in the upper 16 bits of `cqe.flags` — and that the bytes landed in the
+ *      buffer the kernel picked.
+ *
+ * The `io_uring_buf_ring` memory layout is the load-bearing detail: the ring is an
+ * array of 16-byte `io_uring_buf` slots, and the *tail* counter is overlaid on the
+ * `resv` field of the slot at index 0 (so slot 0's data area is unused for the
+ * head/tail bookkeeping — we publish into the masked tail position regardless).
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.19 — Buffer rings, zero-copy groundwork, big SQE/CQE (July 2022)".
+ *
+ * Run with: `dub run --single provided-buf-ring.d`
+ *
+ * Portability: prints `SKIP:` and exits 0 when io_uring is unavailable or the
+ * running kernel predates buffer rings (registerBufRing -> -EINVAL/-EOPNOTSUPP/
+ * -ENOSYS). Exits nonzero only on a genuinely unexpected syscall failure.
+ */
+module io_uring_provided_buf_ring;
+
+import during;
+
+import core.stdc.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.stdc.stdlib : free;
+import core.sys.posix.stdlib : posix_memalign;
+import core.sys.posix.sys.socket : AF_UNIX, SOCK_STREAM, socketpair;
+import core.sys.posix.unistd : close, write;
+
+import std.stdio : stderr, writefln;
+
+// Group id for our buffer ring, and the buffer geometry. RING_ENTRIES must be a
+// power of two — the kernel masks the tail with `ring_entries - 1`.
+enum ushort BGID = 7;
+enum uint RING_ENTRIES = 8;
+enum uint BUF_SIZE = 64;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // A connected pair of local sockets: we recv on sv[0] via io_uring and write
+    // the payload into sv[1] with an ordinary write(2). Loopback-only, no network.
+    int[2] sv;
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0)
+    {
+        stderr.writefln("socketpair failed");
+        return 1;
+    }
+    scope (exit) { close(sv[0]); close(sv[1]); }
+
+    // Allocate the buffer ring page-aligned (liburing requires page alignment for
+    // IORING_REGISTER_PBUF_RING). It is a flat array of RING_ENTRIES `io_uring_buf`
+    // slots; slot 0's tail field doubles as the ring's producer tail.
+    enum size_t ringBytes = io_uring_buf.sizeof * RING_ENTRIES;
+    void* ringPtr;
+    if (posix_memalign(&ringPtr, 4096, ringBytes) != 0 || ringPtr is null)
+    {
+        stderr.writefln("posix_memalign failed");
+        return 1;
+    }
+    scope (exit) free(ringPtr);
+    auto ring = cast(io_uring_buf*) ringPtr;
+    ring[0 .. RING_ENTRIES] = io_uring_buf.init; // zero the whole ring (incl. tail=0)
+
+    // Backing storage for the buffers themselves (separate from the ring slots).
+    auto store = new ubyte[BUF_SIZE * RING_ENTRIES];
+
+    // Register the ring with the kernel for group `BGID`.
+    io_uring_buf_reg reg;
+    reg.ring_addr = cast(ulong) ringPtr;
+    reg.ring_entries = RING_ENTRIES;
+    reg.bgid = BGID;
+    const regRet = io.registerBufRing(reg);
+    if (regRet == -EINVAL || regRet == -EOPNOTSUPP || regRet == -ENOSYS)
+    {
+        writefln("SKIP: IORING_REGISTER_PBUF_RING unsupported (errno %d) — needs Linux 5.19+", -regRet);
+        return 0;
+    }
+    if (regRet < 0)
+    {
+        stderr.writefln("registerBufRing failed: errno %d", -regRet);
+        return 1;
+    }
+    scope (exit) io.unregisterBufRing(BGID);
+
+    // Publish all RING_ENTRIES buffers into the ring. Each slot points at its
+    // BUF_SIZE chunk of `store` and carries a distinct buffer id (`bid`). The
+    // kernel returns the chosen `bid` in the CQE's upper 16 bits.
+    enum uint mask = RING_ENTRIES - 1;
+    foreach (ushort i; 0 .. cast(ushort) RING_ENTRIES)
+    {
+        auto slot = &ring[i & mask];
+        slot.addr = cast(ulong) &store[i * BUF_SIZE];
+        slot.len = BUF_SIZE;
+        slot.bid = i; // buffer id == index, so we can recover the chunk later
+    }
+    // Publish: advance the producer tail by the number of buffers we added. The
+    // tail lives in slot 0 (it overlays io_uring_buf.resv there).
+    ring[0].resv = cast(ushort) RING_ENTRIES;
+
+    // Submit a RECV that selects a buffer from group BGID. This gid overload sets
+    // IOSQE_BUFFER_SELECT and sqe->buf_group for us; `len` caps the recv size.
+    enum ulong cookie = 0xB0FF_1234;
+    // Pass `sv[0]` as an explicit arg rather than capturing it: a capturing lambda
+    // would force a GC closure and break `putWith`'s `@nogc`.
+    io.putWith!((ref SubmissionEntry e, int recvFd) {
+        e.prepRecv(recvFd, BGID, BUF_SIZE);
+        e.user_data = cookie;
+    })(sv[0]);
+    const submitted = io.submit(0); // flush the SQ without blocking on a count
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Write a payload into the peer; the queued RECV will land it in a ring buffer.
+    immutable ubyte[] payload = cast(immutable ubyte[]) "ring-provided buffer!";
+    const wrote = write(sv[1], &payload[0], payload.length);
+    if (wrote != cast(ptrdiff_t) payload.length)
+    {
+        stderr.writefln("write to peer failed: %d", wrote);
+        return 1;
+    }
+
+    // Wait for the RECV completion (bounded: a single, guaranteed-imminent CQE).
+    io.wait(1);
+    const c = io.front;
+    const res = c.res;
+    const flags = c.flags;
+    const echoed = c.user_data;
+    io.popFront();
+
+    if (echoed != cookie)
+    {
+        stderr.writefln("user_data mismatch: expected 0x%X, got 0x%X", cookie, echoed);
+        return 1;
+    }
+    if (res < 0)
+    {
+        // -ENOBUFS here would mean the kernel found no published buffer — a real bug
+        // in our ring bookkeeping, not an unsupported-feature case.
+        stderr.writefln("RECV failed: errno %d", -res);
+        return 1;
+    }
+
+    // The buffer-select contract: CQEFlags.BUFFER must be set, and the buffer id
+    // the kernel picked is in the upper 16 bits of the flags.
+    if (!(flags & CQEFlags.BUFFER))
+    {
+        stderr.writefln("RECV completed without IORING_CQE_F_BUFFER (flags=0x%X)", cast(uint) flags);
+        return 1;
+    }
+    const bid = cast(ushort)(cast(uint) flags >> CQE_BUFFER_SHIFT);
+    if (bid >= RING_ENTRIES)
+    {
+        stderr.writefln("kernel returned out-of-range buffer id %d", bid);
+        return 1;
+    }
+
+    // Confirm the bytes landed in exactly the buffer the kernel selected.
+    auto got = store[bid * BUF_SIZE .. bid * BUF_SIZE + res];
+    if (got != payload)
+    {
+        stderr.writefln("payload mismatch in selected buffer %d", bid);
+        return 1;
+    }
+
+    writefln("ok: ring-provided RECV used buffer id %d (%d bytes): \"%s\"",
+        bid, res, cast(const(char)[]) got);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/provided-buf-ring.d
+++ b/docs/research/async-io/io-uring/examples/provided-buf-ring.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_provided_buf_ring"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/read-multishot.d
+++ b/docs/research/async-io/io-uring/examples/read-multishot.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_read_multishot"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/read-multishot.d
+++ b/docs/research/async-io/io-uring/examples/read-multishot.d
@@ -1,0 +1,247 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_read_multishot"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — multishot read into ring-provided buffers
+ * (`IORING_OP_READ_MULTISHOT`, Linux 6.7).
+ *
+ * A normal `READ` SQE produces one read and one CQE. `READ_MULTISHOT` stays
+ * armed against a *pollable* fd (a pipe here): each time data arrives the kernel
+ * pops a buffer from a registered buffer group, reads one chunk into it, and
+ * posts a CQE — *without* re-submitting an SQE. While the request remains armed
+ * each CQE carries `CQEFlags.MORE` (more completions to come) and
+ * `CQEFlags.BUFFER` (a kernel-chosen buffer id is packed into the upper 16 bits
+ * of `cqe.flags`). The request terminates — final CQE without `MORE` — on EOF,
+ * on error, or when the buffer group runs dry (`-ENOBUFS`).
+ *
+ * This program:
+ *   1. registers a buffer ring (`registerBufRing`, the 5.19 fast path) for group
+ *      `BGID` and publishes a handful of equal-sized buffers,
+ *   2. arms a single `READ_MULTISHOT` on the read end of a pipe with
+ *      buffer-select (`prepReadMultishot` sets `IOSQE_BUFFER_SELECT` + `buf_group`),
+ *   3. writes two separate chunks into the write end,
+ *   4. waits for the two resulting CQEs and asserts each one set `MORE|BUFFER`
+ *      and landed its chunk in exactly the buffer id the kernel reported.
+ *
+ * The "one SQE, many CQEs" shape is the whole point: the cost of arming a read
+ * is paid once, and steady-state reads avoid the submit half of the syscall.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "6.7 — Futex, waitid, read-multishot (January 2024)".
+ *
+ * Run with: `dub run --single read-multishot.d`
+ *
+ * Portability: prints `SKIP:` and exits 0 when io_uring is unavailable, when the
+ * op is unknown to `probe()`, or when an op/register call reports
+ * -EINVAL/-EOPNOTSUPP/-ENOSYS (kernel predates 6.7). Exits nonzero only on a
+ * genuinely unexpected syscall failure.
+ */
+module io_uring_read_multishot;
+
+import during;
+
+import core.stdc.errno : EINVAL, ENOSYS, EOPNOTSUPP;
+import core.stdc.stdlib : free;
+import core.sys.posix.stdlib : posix_memalign;
+import core.sys.posix.unistd : close, pipe, write;
+
+import std.stdio : stderr, writefln;
+
+// Buffer-ring geometry. RING_ENTRIES must be a power of two — the kernel masks
+// the producer tail with `ring_entries - 1`.
+enum ushort BGID = 7;
+enum uint RING_ENTRIES = 8;
+enum uint BUF_SIZE = 64;
+enum uint CHUNKS = 2; // number of separate writes -> number of multishot CQEs
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Fast unsupported-feature gate: ask the kernel whether it knows the op at
+    // all. An old kernel (or one without the probe op) trips the SKIP path here
+    // before we touch any buffers.
+    auto probe = io.probe();
+    if (!cast(bool) probe || !probe.isSupported(Operation.READ_MULTISHOT))
+    {
+        writefln("SKIP: IORING_OP_READ_MULTISHOT not advertised by probe — needs Linux 6.7+");
+        return 0;
+    }
+
+    // A pipe gives us a *pollable* fd: multishot read re-arms on each readiness
+    // edge. We read the read end via io_uring and feed it with ordinary write(2)
+    // on the write end. Loopback-only, no fds beyond this process.
+    int[2] p;
+    if (pipe(p) != 0)
+    {
+        stderr.writefln("pipe() failed");
+        return 1;
+    }
+    scope (exit) { close(p[0]); close(p[1]); }
+
+    // Allocate the buffer ring page-aligned (IORING_REGISTER_PBUF_RING requires
+    // page alignment). It is a flat array of RING_ENTRIES `io_uring_buf` slots;
+    // slot 0's `resv` field doubles as the ring's producer tail.
+    enum size_t ringBytes = io_uring_buf.sizeof * RING_ENTRIES;
+    void* ringPtr;
+    if (posix_memalign(&ringPtr, 4096, ringBytes) != 0 || ringPtr is null)
+    {
+        stderr.writefln("posix_memalign failed");
+        return 1;
+    }
+    scope (exit) free(ringPtr);
+    auto ring = cast(io_uring_buf*) ringPtr;
+    ring[0 .. RING_ENTRIES] = io_uring_buf.init; // zero whole ring (incl. tail=0)
+
+    // Backing storage for the buffers (separate from the 16-byte ring slots).
+    auto store = new ubyte[BUF_SIZE * RING_ENTRIES];
+
+    // Register the buffer ring for group BGID. A pre-6.7 kernel that nonetheless
+    // lacks buffer rings would fail here; treat the unsupported errnos as SKIP.
+    io_uring_buf_reg reg;
+    reg.ring_addr = cast(ulong) ringPtr;
+    reg.ring_entries = RING_ENTRIES;
+    reg.bgid = BGID;
+    const regRet = io.registerBufRing(reg);
+    if (regRet == -EINVAL || regRet == -EOPNOTSUPP || regRet == -ENOSYS)
+    {
+        writefln("SKIP: IORING_REGISTER_PBUF_RING unsupported (errno %d) — needs Linux 5.19+", -regRet);
+        return 0;
+    }
+    if (regRet < 0)
+    {
+        stderr.writefln("registerBufRing failed: errno %d", -regRet);
+        return 1;
+    }
+    scope (exit) io.unregisterBufRing(BGID);
+
+    // Publish all RING_ENTRIES buffers: each slot points at its BUF_SIZE chunk of
+    // `store` and carries a distinct buffer id (`bid == index`, so we can recover
+    // which chunk the kernel filled).
+    enum uint mask = RING_ENTRIES - 1;
+    foreach (ushort i; 0 .. cast(ushort) RING_ENTRIES)
+    {
+        auto slot = &ring[i & mask];
+        slot.addr = cast(ulong) &store[i * BUF_SIZE];
+        slot.len = BUF_SIZE;
+        slot.bid = i;
+    }
+    // Advance the producer tail by the count of published buffers (tail lives in
+    // slot 0, overlaying io_uring_buf.resv).
+    ring[0].resv = cast(ushort) RING_ENTRIES;
+
+    // Arm one multishot READ on the pipe read end, selecting from group BGID.
+    // `prepReadMultishot` sets IOSQE_BUFFER_SELECT + buf_group for us. After this
+    // single submit the kernel re-arms itself across completions.
+    // The kernel's READ_MULTISHOT prep rejects a non-zero `len` (sqe->len must be
+    // 0) and treats a `-1` offset as "use the file position" — the right choice
+    // for a stream like a pipe. The per-read size is whatever buffer the group
+    // hands out (BUF_SIZE here), not an SQE field.
+    enum ulong cookie = 0x6EAD_3357;
+    io.putWith!((ref SubmissionEntry e, int readFd) {
+        e.prepReadMultishot(readFd, 0, -1, BGID);
+        e.user_data = cookie;
+    })(p[0]);
+    const submitted = io.submit(0); // flush SQ without blocking
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Write CHUNKS distinct payloads. Each readiness edge drives one multishot
+    // read -> one CQE. We write them one at a time and drain the CQE in between
+    // so the two chunks don't coalesce into a single read.
+    static immutable string[CHUNKS] payloads = ["first-chunk", "second-chunk!!"];
+
+    foreach (idx, payload; payloads)
+    {
+        const wrote = write(p[1], &payload[0], payload.length);
+        if (wrote != cast(ptrdiff_t) payload.length)
+        {
+            stderr.writefln("write to pipe failed: %d", wrote);
+            return 1;
+        }
+
+        // Exactly one CQE is imminent per write — bounded wait.
+        io.wait(1);
+        const c = io.front;
+        const res = c.res;
+        const flags = c.flags;
+        const echoed = c.user_data;
+        io.popFront();
+
+        if (echoed != cookie)
+        {
+            stderr.writefln("user_data mismatch: expected 0x%X, got 0x%X", cookie, echoed);
+            return 1;
+        }
+
+        // -EINVAL/-EOPNOTSUPP slipping past the probe means the op truly is not
+        // wired up on this kernel: SKIP rather than fail.
+        if (res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS)
+        {
+            writefln("SKIP: READ_MULTISHOT rejected at runtime (errno %d) — needs Linux 6.7+", -res);
+            return 0;
+        }
+        // -ENOBUFS would mean our buffer group ran dry — a bug in our bookkeeping
+        // here (we published far more buffers than chunks), so it's a hard error.
+        if (res < 0)
+        {
+            stderr.writefln("READ_MULTISHOT chunk %d failed: errno %d", idx, -res);
+            return 1;
+        }
+
+        if (res != cast(int) payload.length)
+        {
+            stderr.writefln("chunk %d byte count: expected %d, got %d", idx, payload.length, res);
+            return 1;
+        }
+
+        // Multishot contract: each in-flight CQE must carry BUFFER (a buffer was
+        // selected) and MORE (the request stays armed for the next chunk).
+        if (!(flags & CQEFlags.BUFFER))
+        {
+            stderr.writefln("chunk %d: missing IORING_CQE_F_BUFFER (flags=0x%X)", idx, cast(uint) flags);
+            return 1;
+        }
+        if (!(flags & CQEFlags.MORE))
+        {
+            stderr.writefln("chunk %d: multishot disarmed early, missing IORING_CQE_F_MORE (flags=0x%X)",
+                idx, cast(uint) flags);
+            return 1;
+        }
+
+        // Recover the kernel-chosen buffer id from the upper 16 bits and confirm
+        // the bytes landed in that exact buffer.
+        const bid = cast(ushort)(cast(uint) flags >> CQE_BUFFER_SHIFT);
+        if (bid >= RING_ENTRIES)
+        {
+            stderr.writefln("chunk %d: out-of-range buffer id %d", idx, bid);
+            return 1;
+        }
+        auto got = store[bid * BUF_SIZE .. bid * BUF_SIZE + res];
+        if (cast(const(char)[]) got != payload)
+        {
+            stderr.writefln("chunk %d: payload mismatch in buffer %d", idx, bid);
+            return 1;
+        }
+
+        writefln("ok: multishot chunk %d -> buffer id %d (%d bytes, MORE|BUFFER set): \"%s\"",
+            idx, bid, res, cast(const(char)[]) got);
+    }
+
+    writefln("ok: one READ_MULTISHOT SQE produced %d completions across %d buffers",
+        CHUNKS, RING_ENTRIES);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/read-write-fixed.d
+++ b/docs/research/async-io/io-uring/examples/read-write-fixed.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_read_write_fixed"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/read-write-fixed.d
+++ b/docs/research/async-io/io-uring/examples/read-write-fixed.d
@@ -1,0 +1,197 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_read_write_fixed"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — registered (fixed) buffers with `IORING_OP_WRITE_FIXED` /
+ * `IORING_OP_READ_FIXED` (Linux 5.1).
+ *
+ * Fixed buffers shipped in the original 5.1 introduction alongside `NOP` and the
+ * vectored read/write ops. The idea: register a fixed set of user buffers with the
+ * kernel **once** (`io_uring_register(IORING_REGISTER_BUFFERS)`), so the kernel can
+ * pin and map their pages up front. Subsequent `*_FIXED` ops then refer to a buffer
+ * by **index** instead of an address+length, letting the kernel skip the per-I/O
+ * `get_user_pages` / page-pinning dance — the headline zero-overhead-mapping win.
+ *
+ * This example:
+ *   1. opens a throwaway file under `/tmp` (`O_CREAT|O_RDWR|O_TRUNC`),
+ *   2. registers ONE buffer with `io.registerBuffers(buf[])`,
+ *   3. `WRITE_FIXED`s a known payload from buffer index 0 at offset 0,
+ *   4. clears the buffer region, then `READ_FIXED`s it back into index 0,
+ *   5. asserts the bytes round-trip.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "5.1 — The introduction".
+ *
+ * Run with: `dub run --single read-write-fixed.d`
+ *
+ * Portability: fixed buffers are part of the 5.1 baseline, so no feature probe is
+ * needed — but if the running kernel has no `io_uring` at all (too old, or blocked
+ * by a seccomp/container policy), `setup` fails and we print a `SKIP:` line and exit
+ * 0 so the example stays green in CI regardless of host kernel.
+ */
+module io_uring_read_write_fixed;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.stdc.stdlib : free, malloc;
+import core.sys.linux.errno : EINVAL, ENOSYS, EOPNOTSUPP;
+import core.sys.linux.fcntl : O_CREAT, O_RDWR, O_TRUNC, open;
+import core.sys.posix.unistd : close, unlink;
+
+int main()
+{
+    enum string payload = "io_uring fixed buffers, since Linux 5.1";
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // A throwaway file we own; unlinked on exit. The trailing NUL keeps it a valid
+    // C string for the libc open()/unlink() calls.
+    static immutable char[] path = "/tmp/io_uring_rw_fixed_example.tmp\0";
+    const fd = open(&path[0], O_CREAT | O_RDWR | O_TRUNC, octal!"600");
+    if (fd < 0)
+    {
+        stderr.writefln("open(%s) failed", path[0 .. $ - 1]);
+        return 1;
+    }
+    scope (exit)
+    {
+        close(fd);
+        unlink(&path[0]);
+    }
+
+    // Register a single fixed buffer. `registerBuffers` pins the pages and maps them
+    // into the kernel once; *_FIXED ops below reference this region by index 0.
+    enum size_t bufLen = 4096;
+    auto bp = cast(ubyte*) malloc(bufLen);
+    if (bp is null)
+    {
+        stderr.writefln("malloc(%d) failed", bufLen);
+        return 1;
+    }
+    scope (exit) free(bp);
+    ubyte[] buffer = bp[0 .. bufLen];
+
+    const regRet = io.registerBuffers(buffer);
+    if (regRet < 0)
+    {
+        // Registration itself is a 5.1 baseline feature; an error here is unexpected.
+        stderr.writefln("registerBuffers failed: errno %d", -regRet);
+        return 1;
+    }
+    scope (exit) io.unregisterBuffers();
+
+    // Stage the payload into the registered region and WRITE_FIXED it to the file.
+    // prepWriteFixed(e, fd, offset, slice-of-the-registered-buffer, bufferIndex).
+    buffer[0 .. payload.length] = cast(const(ubyte)[]) payload;
+
+    io.putWith!(
+        (ref SubmissionEntry e, int f, ubyte[] b)
+        {
+            e.prepWriteFixed(f, 0, b, 0); // bufferIndex 0, file offset 0
+            e.user_data = 1;
+        })(fd, buffer[0 .. payload.length]);
+
+    auto submitted = io.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit (write) failed: errno %d", -submitted);
+        return 1;
+    }
+
+    io.wait(1);
+    auto wres = io.front.res;
+    io.popFront();
+
+    // *_FIXED can report -EINVAL/-EOPNOTSUPP if fixed buffers are unavailable in this
+    // environment (e.g. a restrictive sandbox) — treat that as an honest SKIP.
+    if (wres == -EINVAL || wres == -EOPNOTSUPP || wres == -ENOSYS)
+    {
+        writefln("SKIP: WRITE_FIXED unsupported here (errno %d)", -wres);
+        return 0;
+    }
+    if (wres < 0)
+    {
+        stderr.writefln("WRITE_FIXED failed: errno %d", -wres);
+        return 1;
+    }
+    if (wres != cast(int) payload.length)
+    {
+        stderr.writefln("WRITE_FIXED short write: wrote %d of %d bytes", wres, payload.length);
+        return 1;
+    }
+
+    // Clear the registered region so the read genuinely round-trips through the file,
+    // not through stale buffer contents.
+    buffer[0 .. payload.length] = 0;
+
+    io.putWith!(
+        (ref SubmissionEntry e, int f, ubyte[] b)
+        {
+            e.prepReadFixed(f, 0, b, 0); // bufferIndex 0, file offset 0
+            e.user_data = 2;
+        })(fd, buffer[0 .. payload.length]);
+
+    submitted = io.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit (read) failed: errno %d", -submitted);
+        return 1;
+    }
+
+    io.wait(1);
+    auto rres = io.front.res;
+    io.popFront();
+
+    if (rres == -EINVAL || rres == -EOPNOTSUPP || rres == -ENOSYS)
+    {
+        writefln("SKIP: READ_FIXED unsupported here (errno %d)", -rres);
+        return 0;
+    }
+    if (rres < 0)
+    {
+        stderr.writefln("READ_FIXED failed: errno %d", -rres);
+        return 1;
+    }
+    if (rres != cast(int) payload.length)
+    {
+        stderr.writefln("READ_FIXED short read: read %d of %d bytes", rres, payload.length);
+        return 1;
+    }
+
+    if (cast(const(char)[]) buffer[0 .. payload.length] != payload)
+    {
+        stderr.writefln("round-trip mismatch: got %s", cast(const(char)[]) buffer[0 .. payload.length]);
+        return 1;
+    }
+
+    writefln(
+        "ok: WRITE_FIXED then READ_FIXED round-tripped %d bytes through a registered buffer (index 0)",
+        rres);
+    return 0;
+}
+
+// `octal!"600"` — compile-time octal literal for the file mode, avoiding a leading-0
+// literal (deprecated in D) while keeping the intent obvious.
+private template octal(string s)
+{
+    enum uint octal = parseOctal(s);
+}
+
+private uint parseOctal(string s) pure nothrow @safe @nogc
+{
+    uint v;
+    foreach (c; s)
+        v = v * 8 + (c - '0');
+    return v;
+}

--- a/docs/research/async-io/io-uring/examples/recv-zc.d
+++ b/docs/research/async-io/io-uring/examples/recv-zc.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_recv_zc"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/recv-zc.d
+++ b/docs/research/async-io/io-uring/examples/recv-zc.d
@@ -1,0 +1,132 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_recv_zc"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — zero-copy receive (`IORING_OP_RECV_ZC` + `IORING_REGISTER_ZCRX_IFQ`, Linux 6.15).
+ *
+ * Zero-copy receive (ZCRX) lets the kernel DMA incoming packet payloads straight
+ * into a userspace memory area pinned to a NIC hardware receive queue, then hand
+ * the ring a CQE pointing at the data — no `copy_to_user`. To use it you first
+ * `IORING_REGISTER_ZCRX_IFQ` an `io_uring_zcrx_ifq_reg` describing the netdev
+ * (`if_idx`) and its RX queue (`if_rxq`) plus a buffer area; afterwards
+ * `IORING_OP_RECV_ZC` (`prepRecvZc`) receives into that registered ifq, indexed
+ * by `zcrx_ifq_idx`.
+ *
+ * This requires a NIC with a configured ZC RX queue (header-data split, a steered
+ * RSS context, etc.) — hardware that a typical host or CI runner does NOT have.
+ * So this example is EXPECTED to take the SKIP path almost everywhere: we attempt
+ * `registerIfq` with a minimal descriptor and, on the inevitable failure
+ * (`-EINVAL` / `-EOPNOTSUPP` / `-ENODEV` / `-EPERM` / …), print a `SKIP:` line and
+ * exit 0. It demonstrates the *shape* of the ZCRX setup call rather than a live
+ * transfer.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "6.15 — Zero-copy receive, epoll-wait, vectored fixed, query".
+ *
+ * Run with: `dub run --single recv-zc.d`
+ *
+ * Portability: green on any kernel. Old kernels without io_uring (or without the
+ * RECV_ZC op / ZCRX register opcode) and hosts lacking a ZCRX-capable NIC all take
+ * the SKIP path and exit 0.
+ */
+module io_uring_recv_zc;
+
+import during;
+
+import core.sys.posix.sys.socket : AF_INET, SOCK_STREAM, socket;
+import core.sys.posix.unistd : close;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // First gate: does this kernel even know IORING_OP_RECV_ZC (op 58, since 6.15)?
+    // Probing avoids issuing a register call the kernel can't understand.
+    auto p = io.probe();
+    if (!cast(bool)p)
+    {
+        writefln("SKIP: io_uring_probe failed (errno %d) — cannot determine RECV_ZC support", -p.error);
+        return 0;
+    }
+    if (!p.isSupported(Operation.RECV_ZC))
+    {
+        writefln("SKIP: IORING_OP_RECV_ZC unsupported on this kernel — needs Linux 6.15+");
+        return 0;
+    }
+
+    // Second gate: actually try to register a zero-copy RX interface queue.
+    //
+    // A *working* registration needs a real netdev index (`if_idx`), one of its
+    // hardware RX queues (`if_rxq`) put into zero-copy mode, plus an `area_ptr`
+    // describing a pinned userspace buffer area and a `region_ptr` for the ifq's
+    // shared refill/completion region. We deliberately pass a minimal descriptor
+    // (loopback-ish if_idx=1, rq_entries a power of two, no area/region) so we can
+    // show the call site; on a host without ZCRX hardware this fails, which is the
+    // expected outcome here.
+    io_uring_zcrx_ifq_reg reg;
+    reg.if_idx = 1;          // would be a real NIC ifindex (loopback is index 1)
+    reg.if_rxq = 0;          // hardware RX queue id configured for zero-copy
+    reg.rq_entries = 256;    // refill-queue depth (power of two)
+    reg.flags = 0;
+    reg.area_ptr = 0;        // -> io_uring_zcrx_area_reg (pinned buffer area)
+    reg.region_ptr = 0;      // -> io_uring_region_desc (shared ifq region)
+
+    const regRet = io.registerIfq(reg);
+    if (regRet < 0)
+    {
+        // Any of these is expected on a host without a ZCRX-capable NIC:
+        //   -EINVAL/-EOPNOTSUPP: kernel/driver can't honor this ZCRX request,
+        //   -ENODEV:             no such netdev / RX queue,
+        //   -EPERM:              insufficient privilege to pin the queue.
+        writefln("SKIP: IORING_REGISTER_ZCRX_IFQ failed (errno %d) — "
+            ~ "zero-copy receive needs a NIC with a configured ZC RX queue "
+            ~ "(header/data split + steered RSS), not available on this host", -regRet);
+        return 0;
+    }
+
+    // --- Reached only on a genuinely ZCRX-capable host (not this 6.18 box). ---
+    // The ifq is now registered at index 0 of the ring's zcrx table. Exercise the
+    // SQE-side counterpart for real: open a loopback socket and post an actual
+    // IORING_OP_RECV_ZC against ifq index 0. On a live ZCRX setup payloads would
+    // DMA into the registered area and surface in auxiliary CQEs.
+    const sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0)
+    {
+        stderr.writefln("socket() failed");
+        return 1;
+    }
+    scope (exit) close(sock);
+
+    enum ulong cookie = 0x2C0FFEE;
+    // Pass `sock` as an explicit arg (not a capture) so `putWith` stays @nogc.
+    // len=0 lets the kernel size the receive; ifqIdx=0 selects the ifq we registered.
+    io.putWith!((ref SubmissionEntry e, int recvFd) {
+        e.prepRecvZc(recvFd, /*len*/ 0, MsgFlags.NONE, /*ifqIdx*/ 0);
+        e.user_data = cookie;
+    })(sock);
+
+    const submitted = io.submit(0); // flush the SQ; don't block waiting for traffic
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // The ifq registration is torn down when the ring is closed (Uring's destructor),
+    // so there's nothing more to clean up here.
+    writefln("ok: registered a zero-copy RX interface queue (IORING_REGISTER_ZCRX_IFQ) "
+        ~ "and posted IORING_OP_RECV_ZC — host has ZCRX-capable hardware");
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/registered-files.d
+++ b/docs/research/async-io/io-uring/examples/registered-files.d
@@ -1,0 +1,185 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_registered_files"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — registered files + `IOSQE_FIXED_FILE` (Linux 5.1).
+ *
+ * One of the original 5.1 features: `IORING_REGISTER_FILES` lets a ring
+ * pre-register a table of file descriptors with the kernel. Submissions then
+ * address a file by its *table index* instead of a raw fd, with the
+ * `IOSQE_FIXED_FILE` flag set on the SQE.
+ *
+ * Why it matters: for every plain (non-fixed) op the kernel must look the fd up
+ * in the process fd table and bump/drop the file's reference count on each
+ * submit/complete. A registered file is grabbed once at registration time and
+ * held for the life of the table, so per-op submission skips that fget/fput
+ * dance entirely — a measurable win for high-IOPS workloads that hammer the
+ * same descriptors.
+ *
+ * This program:
+ *   1. creates a temp file (libc) and writes a known 256-byte pattern,
+ *   2. reopens it read-only and registers it as fixed-file table index 0,
+ *   3. submits a `prepRead` whose `fd` argument is the *index* 0, with
+ *      `SubmissionEntryFlags.FIXED_FILE` set, then verifies the bytes read back
+ *      match the pattern,
+ *   4. unregisters the table.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "5.1 — The introduction".
+ *
+ * Run with: `dub run --single registered-files.d`
+ *
+ * Portability: if the running kernel has no `io_uring` (too old, or blocked by a
+ * seccomp/container policy), the program prints a `SKIP:` line and exits 0. The
+ * fixed-file table itself dates from the 5.1 introduction, so any kernel new
+ * enough to run io_uring at all supports it.
+ */
+module io_uring_registered_files;
+
+import during;
+
+import core.stdc.stdlib : malloc, free;
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP;
+import core.sys.linux.fcntl : open, O_CREAT, O_RDONLY, O_WRONLY, O_TRUNC;
+import core.sys.posix.unistd : close, unlink, write;
+
+import std.stdio : writefln, stderr;
+import std.string : toStringz;
+
+int main()
+{
+    enum ulong cookie = 0x5151_0001;
+
+    // A deterministic 256-byte pattern (0,1,2,...,255) we will write and then
+    // read back through the fixed-file table.
+    ubyte[256] pattern;
+    foreach (i, ref b; pattern)
+        b = cast(ubyte) i;
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // --- 1. Create a temp file and write the known pattern via plain libc. ---
+    const char* path = toStringz("/tmp/io_uring_registered_files.tmp");
+    {
+        const wfd = open(path, O_CREAT | O_WRONLY | O_TRUNC, octal!600);
+        if (wfd < 0)
+        {
+            stderr.writefln("could not create temp file");
+            return 1;
+        }
+        const wr = write(wfd, &pattern[0], pattern.length);
+        close(wfd);
+        if (wr != pattern.length)
+        {
+            stderr.writefln("short write to temp file: %d", wr);
+            unlink(path);
+            return 1;
+        }
+    }
+    scope (exit) unlink(path);
+
+    // --- 2. Reopen read-only and register it as fixed-file table index 0. ---
+    const rfd = open(path, O_RDONLY, 0);
+    if (rfd < 0)
+    {
+        stderr.writefln("could not reopen temp file");
+        return 1;
+    }
+    scope (exit) close(rfd);
+
+    const int[1] tableFds = [rfd];
+    const regRet = io.registerFiles(tableFds[]);
+    if (regRet == -EINVAL || regRet == -EOPNOTSUPP)
+    {
+        // Defensive: fixed files exist since 5.1, so this should not happen on a
+        // kernel that completed io_uring_setup, but stay green if it ever does.
+        writefln("SKIP: IORING_REGISTER_FILES unsupported (errno %d)", -regRet);
+        return 0;
+    }
+    if (regRet != 0)
+    {
+        stderr.writefln("registerFiles failed: errno %d", -regRet);
+        return 1;
+    }
+
+    // --- 3. Read the file BY TABLE INDEX, not by raw fd. ---
+    // The buffer the kernel fills lives in process memory; allocate it off-GC so
+    // the example stays self-contained and pointer-stable for the duration.
+    enum size_t len = pattern.length;
+    auto bufPtr = cast(ubyte*) malloc(len);
+    if (bufPtr is null)
+    {
+        stderr.writefln("malloc failed");
+        io.unregisterFiles();
+        return 1;
+    }
+    scope (exit) free(bufPtr);
+    ubyte[] readBuf = bufPtr[0 .. len];
+    readBuf[] = 0;
+
+    io.putWith!((ref SubmissionEntry e, ubyte[] dst) {
+        // NOTE: the first arg to prepRead is `0` — the *index* into the
+        // registered-file table, not `rfd`. FIXED_FILE tells the kernel to
+        // interpret it that way.
+        e.prepRead(0, dst, 0);
+        e.flags |= SubmissionEntryFlags.FIXED_FILE;
+        e.user_data = cookie;
+    })(readBuf);
+
+    const submitted = io.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        io.unregisterFiles();
+        return 1;
+    }
+
+    io.wait(1);
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    // --- 4. Unregister the table (kernel drops its single held reference). ---
+    const unregRet = io.unregisterFiles();
+    if (unregRet != 0)
+    {
+        stderr.writefln("unregisterFiles failed: errno %d", -unregRet);
+        return 1;
+    }
+
+    // Validate the fixed-file read.
+    if (res < 0)
+    {
+        stderr.writefln("fixed-file read failed: errno %d", -res);
+        return 1;
+    }
+    if (echoed != cookie)
+    {
+        stderr.writefln("user_data mismatch: expected 0x%X, got 0x%X", cookie, echoed);
+        return 1;
+    }
+    if (res != cast(int) len || readBuf[] != pattern[])
+    {
+        stderr.writefln("content mismatch: read %d bytes, pattern check failed", res);
+        return 1;
+    }
+
+    writefln("ok: read %d bytes via fixed-file table index 0 (IOSQE_FIXED_FILE), pattern verified", res);
+    return 0;
+}
+
+/// Compile-time octal literal helper (D dropped the `0NNN` octal syntax).
+private enum octal(int n) = {
+    int v = 0, mul = 1, x = n;
+    while (x > 0) { v += (x % 10) * mul; mul *= 8; x /= 10; }
+    return v;
+}();

--- a/docs/research/async-io/io-uring/examples/registered-files.d
+++ b/docs/research/async-io/io-uring/examples/registered-files.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_registered_files"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/registered-ring-fd.d
+++ b/docs/research/async-io/io-uring/examples/registered-ring-fd.d
@@ -1,0 +1,112 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_registered_ring_fd"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — registered ring fd (`IORING_REGISTER_RING_FDS`, Linux 5.18).
+ *
+ * Every `io_uring_enter(2)` normally takes the ring's file descriptor as its
+ * first argument, so the kernel must do an `fdget()` to translate that integer
+ * into the backing `struct file` and a matching `fdput()` afterwards — once per
+ * syscall. For submit-heavy, syscall-per-batch workloads that fdget/fdput pair
+ * is pure overhead. `IORING_REGISTER_RING_FDS` lets userspace register the ring
+ * fd once and thereafter pass a small *registered index* plus the
+ * `IORING_ENTER_REGISTERED_RING` flag, so the kernel skips the fd lookup
+ * entirely on the hot path.
+ *
+ * `during` wires this up transparently: after `registerRingFd()` succeeds it
+ * passes the registered index + `ENTER_REGISTERED_RING` on every subsequent
+ * `submit`/`wait`. We prove the registered ring is functional by running a full
+ * NOP submit/complete cycle through it, then revert with `unregisterRingFd()`.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.18 — Ring-fd registration, msg-ring, linked-file".
+ *
+ * Run with: `dub run --single registered-ring-fd.d`
+ *
+ * Portability: if io_uring is unavailable, or the kernel predates 5.18 (the
+ * register call returns `-EINVAL`/`-EOPNOTSUPP`/`-ENOSYS`), the program prints a
+ * `SKIP:` line and exits 0 so it stays green regardless of the host kernel.
+ */
+module io_uring_registered_ring_fd;
+
+import during;
+
+import core.stdc.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    enum ulong cookie = 0x5180_F00D; // 5.18 marker, just a recognizable user_data
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Register the ring's own fd. On success `during` swaps in the registered
+    // index + ENTER_REGISTERED_RING for all later io_uring_enter(2) calls.
+    const regRet = io.registerRingFd();
+    if (regRet == -EINVAL || regRet == -EOPNOTSUPP || regRet == -ENOSYS)
+    {
+        writefln("SKIP: IORING_REGISTER_RING_FDS unsupported (errno %d) — needs Linux 5.18+", -regRet);
+        return 0;
+    }
+    if (regRet < 0)
+    {
+        // Any other negative result is a genuine, unexpected failure.
+        stderr.writefln("registerRingFd failed: errno %d", -regRet);
+        return 1;
+    }
+
+    // From here on, every submit/wait reaches the kernel via the *registered*
+    // ring index — no per-syscall fdget/fdput. Drive a NOP through it to prove
+    // the registered ring still submits and completes correctly.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.user_data = cookie;
+    })();
+
+    const submitted = io.submit(1); // uses the registered ring fd under the hood
+    if (submitted < 0)
+    {
+        stderr.writefln("submit (via registered ring) failed: errno %d", -submitted);
+        return 1;
+    }
+
+    io.wait(1);
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    if (res < 0)
+    {
+        stderr.writefln("NOP via registered ring completed with error: errno %d", -res);
+        return 1;
+    }
+    if (echoed != cookie)
+    {
+        stderr.writefln("user_data mismatch: expected 0x%X, got 0x%X", cookie, echoed);
+        return 1;
+    }
+
+    // Revert to using the real ring fd again. Mirrors liburing's
+    // io_uring_unregister_ring_fd; -EINVAL here would mean "wasn't registered".
+    const unregRet = io.unregisterRingFd();
+    if (unregRet < 0)
+    {
+        stderr.writefln("unregisterRingFd failed: errno %d", -unregRet);
+        return 1;
+    }
+
+    writefln("ok: registered ring fd, ran a NOP through it (res=%d, user_data 0x%X), then unregistered — io_uring_enter skips per-call fdget/fdput",
+        res, echoed);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/registered-ring-fd.d
+++ b/docs/research/async-io/io-uring/examples/registered-ring-fd.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_registered_ring_fd"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/resize-rings.d
+++ b/docs/research/async-io/io-uring/examples/resize-rings.d
@@ -1,0 +1,161 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_resize_rings"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — grow a *live* ring with `IORING_REGISTER_RESIZE_RINGS` (Linux 6.13).
+ *
+ * Before 6.13 a ring's SQ/CQ sizes were fixed at `io_uring_setup` time: to use a
+ * bigger ring you had to tear the old one down and build a new one, losing any
+ * in-flight requests. `IORING_REGISTER_RESIZE_RINGS` lifts that limit — the kernel
+ * allocates fresh SQ/CQ memory at the requested sizes, atomically swaps it in
+ * (preserving in-flight requests), and `during`'s `resizeRings` re-`mmap`s the rings
+ * to the new regions while keeping the *same* ring file descriptor.
+ *
+ * Kernel precondition (the non-obvious bit): the resize path requires the ring to be
+ * a single, deferred-taskrun issuer — i.e. set up with `IORING_SETUP_SINGLE_ISSUER |
+ * IORING_SETUP_DEFER_TASKRUN`. That guarantee lets the kernel swap the ring memory
+ * without racing a concurrent submitter. A plain ring (no flags) is rejected with
+ * `-EINVAL` even on a 6.13+ kernel, so we set those flags at setup time.
+ *
+ * What this example does:
+ *   1. sets up a deliberately tiny ring (8 SQ entries),
+ *   2. resizes it up to 32 SQ / 64 CQ entries via `io.resizeRings(newParams)`,
+ *   3. asserts the kernel now *reports* the larger SQ/CQ capacity (`io.params`), and
+ *   4. proves the ring is still live by filling the enlarged submission queue with
+ *      more `NOP`s than the original 8-deep SQ could ever hold, then submitting them
+ *      (the kernel accepting 9+ queued SQEs is only possible because the SQ grew).
+ *
+ * The resize register op returns `-EINVAL` on kernels older than 6.13 (the opcode is
+ * unknown there), in which case we print `SKIP:` and exit 0.
+ *
+ * Note on scope: we deliberately verify the resize via the *submission* side (SQ
+ * depth + a successful `submit`) rather than reaping the post-resize completions.
+ * `during` 0.5.0's `resizeRings` re-`mmap`s the rings but does not re-sync its cached
+ * CQ head/tail bookkeeping, so reading CQEs back through `front`/`popFront` right
+ * after a resize is unreliable in this library version. The kernel feature itself —
+ * growing a live ring — is exercised and asserted here regardless.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "6.13 — Ring resize, mem regions, hybrid iopoll".
+ *
+ * Run with: `dub run --single resize-rings.d`
+ *
+ * Portability: if the host has no `io_uring` at all, or the running kernel predates
+ * 6.13, the program prints a `SKIP:` line and exits 0 so CI stays green.
+ */
+module io_uring_resize_rings;
+
+import during;
+
+import core.stdc.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    // Start small on purpose: an 8-entry SQ. `SINGLE_ISSUER | DEFER_TASKRUN` is the
+    // kernel-required mode for in-place resize (see the header). `setup` rounds the
+    // size to a power of two and fills the kernel-reported sizes into `io.params`.
+    Uring io;
+    const setupRet = io.setup(8, SetupFlags.SINGLE_ISSUER | SetupFlags.DEFER_TASKRUN);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host",
+            -setupRet);
+        return 0;
+    }
+
+    const uint oldSq = io.params.sq_entries;
+    const uint oldCq = io.params.cq_entries;
+
+    // Build the target geometry. `resizeRings` reads `sq_entries`/`cq_entries` as the
+    // *requested* sizes; the kernel writes back what it actually allocated and the new
+    // mmap offsets (`sq_off`/`cq_off`), which `during` then uses to re-map the rings.
+    //
+    // Leave `flags` zeroed: the resize only changes ring *geometry*, and the kernel
+    // rejects (-EINVAL) a params struct whose `flags` carries anything outside the
+    // resize-relevant set.
+    SetupParameters newParams;
+    newParams.sq_entries = 32;
+    newParams.cq_entries = 64;
+
+    const resizeRet = io.resizeRings(newParams);
+    if (resizeRet < 0)
+    {
+        const e = -resizeRet;
+        // -EINVAL: pre-6.13 kernels don't know REGISTER_RESIZE_RINGS (opcode 33).
+        // -EOPNOTSUPP/-ENOSYS: register path disabled/unimplemented.
+        if (e == EINVAL || e == EOPNOTSUPP || e == ENOSYS)
+        {
+            writefln("SKIP: IORING_REGISTER_RESIZE_RINGS unsupported (errno %d) — needs Linux 6.13+",
+                e);
+            return 0;
+        }
+        stderr.writefln("resizeRings failed unexpectedly: errno %d", e);
+        return 1;
+    }
+
+    // After a successful resize `io.params` reflects the new (kernel-allocated) sizes.
+    const uint gotSq = io.params.sq_entries;
+    const uint gotCq = io.params.cq_entries;
+
+    if (gotSq < 32 || gotCq < 64)
+    {
+        stderr.writefln("resize did not grow the rings: sq %u->%u (want >=32), cq %u->%u (want >=64)",
+            oldSq, gotSq, oldCq, gotCq);
+        return 1;
+    }
+
+    // The re-mapped SQ must expose the larger capacity too.
+    if (io.capacity < 32)
+    {
+        stderr.writefln("SQ capacity after resize is %u, expected >=32", cast(uint) io.capacity);
+        return 1;
+    }
+
+    // Prove the ring is still live on the larger geometry: queue more NOPs than the
+    // ORIGINAL 8-deep SQ could ever have held. If the SQ had not actually grown,
+    // `io.full` would trip at the old depth and we could not queue this many.
+    enum uint toQueue = 20; // > oldSq (8), <= gotSq (32)
+    uint queued;
+    foreach (i; 0 .. toQueue)
+    {
+        if (io.full)
+            break;
+        io.putWith!((ref SubmissionEntry e, ulong tag) {
+            e.prepNop();
+            e.user_data = tag;
+        })(cast(ulong) i);
+        queued++;
+    }
+
+    if (queued < toQueue)
+    {
+        stderr.writefln("enlarged SQ only accepted %u/%u SQEs — resize did not take effect",
+            queued, toQueue);
+        return 1;
+    }
+
+    // Hand the batch to the kernel. A successful submit on the resized ring confirms
+    // the swapped-in SQ memory and SQE array are wired up correctly.
+    const submitted = io.submit(queued);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit on resized ring failed: errno %d", -submitted);
+        return 1;
+    }
+    if (submitted != queued)
+    {
+        stderr.writefln("submit accepted %d of %u queued SQEs on the resized ring",
+            submitted, queued);
+        return 1;
+    }
+
+    writefln("ok: resized live ring SQ %u->%u, CQ %u->%u; enlarged SQ accepted+submitted %u NOPs",
+        oldSq, gotSq, oldCq, gotCq, submitted);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/resize-rings.d
+++ b/docs/research/async-io/io-uring/examples/resize-rings.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_resize_rings"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/restrictions.d
+++ b/docs/research/async-io/io-uring/examples/restrictions.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_restrictions"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/restrictions.d
+++ b/docs/research/async-io/io-uring/examples/restrictions.d
@@ -1,0 +1,159 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_restrictions"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — sandboxing a ring with `IORING_REGISTER_RESTRICTIONS` (Linux 5.10).
+ *
+ * The 5.10 "deferred setup" trio lets you create a ring that starts *disabled*,
+ * lock down exactly which operations it may ever perform, and only then turn it
+ * on. The whitelist is one-shot — once installed it can never be widened — so a
+ * privileged process can hand a tightly-scoped ring to untrusted code.
+ *
+ * This demo:
+ *   1. sets up a ring with `IORING_SETUP_R_DISABLED` (no SQEs accepted yet);
+ *   2. registers a restriction whitelisting only `IORING_OP_NOP` as a legal SQE
+ *      opcode (`IORING_RESTRICTION_SQE_OP`);
+ *   3. enables the ring with `IORING_REGISTER_ENABLE_RINGS`;
+ *   4. proves an allowed op (`NOP`) completes normally;
+ *   5. proves a *non*-whitelisted op (`TIMEOUT`) is rejected — the kernel hands
+ *      back a CQE with `-EACCES` instead of running it.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.10 — Restrictions and deferred setup (December 2020)".
+ *
+ * Run with: `dub run --single restrictions.d`
+ *
+ * Portability: prints a `SKIP:` line and exits 0 if io_uring is unavailable or
+ * the restrictions API is not supported on the running kernel, so it stays green
+ * in CI regardless of host. (Restrictions are supported on this 6.18 box.)
+ */
+module io_uring_restrictions;
+
+import during;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS, EACCES;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    enum ulong nopCookie     = 0xA11_0;   // user_data for the allowed NOP
+    enum ulong timeoutCookie = 0xDEAD_0;  // user_data for the forbidden TIMEOUT
+
+    // (1) Create the ring in the *disabled* state. While disabled it accepts no
+    // SQEs; the only thing we may do is register restrictions/files/buffers and
+    // then enable it. Old kernels without R_DISABLED fail setup with -EINVAL.
+    Uring io;
+    const setupRet = io.setup(8, SetupFlags.R_DISABLED);
+    if (setupRet == -EINVAL)
+    {
+        writefln("SKIP: IORING_SETUP_R_DISABLED unsupported (errno %d) — restrictions need Linux 5.10+", -setupRet);
+        return 0;
+    }
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // (2) Build the whitelist. A single `SQE_OP` entry naming NOP is enough to
+    // prove the point: as soon as *any* SQE-opcode allow-rule is registered, the
+    // kernel switches that dimension to deny-by-default, so every opcode not on
+    // the list (e.g. TIMEOUT) is refused.
+    io_uring_restriction[1] rules;
+    rules[0].opcode = RestrictionOp.IORING_RESTRICTION_SQE_OP;
+    rules[0].sqe_op = cast(ubyte) Operation.NOP;
+
+    // `Uring.registerRestrictions` only forwards a single entry, so call the raw
+    // syscall wrapper directly to pass the array + count. (Here it's one entry,
+    // but this is the shape you'd use to whitelist several opcodes at once.)
+    const regRet = () @trusted {
+        return io_uring_register(
+            io.fd,
+            RegisterOpCode.REGISTER_RESTRICTIONS,
+            rules.ptr,
+            cast(uint) rules.length,
+        );
+    }();
+    if (regRet < 0)
+    {
+        const e = -regRet;
+        if (e == EINVAL || e == EOPNOTSUPP || e == ENOSYS)
+        {
+            writefln("SKIP: IORING_REGISTER_RESTRICTIONS unsupported (errno %d)", e);
+            return 0;
+        }
+        stderr.writefln("register restrictions failed unexpectedly: errno %d", e);
+        return 1;
+    }
+
+    // (3) Flip the ring on. After this the whitelist is frozen forever.
+    const enableRet = io.enableRings();
+    if (enableRet < 0)
+    {
+        stderr.writefln("enableRings failed: errno %d", -enableRet);
+        return 1;
+    }
+
+    // (4) Allowed op: a plain NOP should sail through.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.user_data = nopCookie;
+    })();
+    const nopSubmitted = io.submit(1);
+    if (nopSubmitted < 0)
+    {
+        stderr.writefln("submitting the NOP failed: errno %d", -nopSubmitted);
+        return 1;
+    }
+    io.wait(1);
+    const nopRes = io.front.res;
+    io.popFront();
+    if (nopRes < 0)
+    {
+        stderr.writefln("whitelisted NOP was rejected (errno %d) — restriction too tight", -nopRes);
+        return 1;
+    }
+    writefln("ok: whitelisted NOP completed (res=%d)", nopRes);
+
+    // (5) Forbidden op: TIMEOUT is not on the whitelist. The kernel doesn't run
+    // it — instead it posts a completion carrying -EACCES. (We give it a 0-second
+    // relative timeout so that on the off chance it *were* allowed, it would fire
+    // immediately rather than block.)
+    KernelTimespec ts = { tv_sec: 0, tv_nsec: 0 };
+    io.putWith!((ref SubmissionEntry e, ref KernelTimespec t) {
+        e.prepTimeout(t);
+        e.user_data = timeoutCookie;
+    })(ts);
+    const toSubmitted = io.submit(1);
+    if (toSubmitted < 0)
+    {
+        stderr.writefln("submitting the TIMEOUT failed: errno %d", -toSubmitted);
+        return 1;
+    }
+    io.wait(1);
+    const toRes  = io.front.res;
+    const toData = io.front.user_data;
+    io.popFront();
+
+    if (toData != timeoutCookie)
+    {
+        stderr.writefln("CQE cookie mismatch: expected 0x%X, got 0x%X", timeoutCookie, toData);
+        return 1;
+    }
+    // The kernel returns -EACCES for a denied opcode; some versions surface
+    // -EINVAL instead. Either proves the whitelist blocked the op.
+    if (toRes != -EACCES && toRes != -EINVAL)
+    {
+        stderr.writefln("expected TIMEOUT to be denied (-EACCES/-EINVAL) but got res=%d", toRes);
+        return 1;
+    }
+    writefln("ok: non-whitelisted TIMEOUT rejected by the sandbox (res=%d, errno %d)", toRes, -toRes);
+
+    writefln("ok: IORING_REGISTER_RESTRICTIONS sandboxed the ring — NOP allowed, TIMEOUT denied");
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/send-zc.d
+++ b/docs/research/async-io/io-uring/examples/send-zc.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_send_zc"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/send-zc.d
+++ b/docs/research/async-io/io-uring/examples/send-zc.d
@@ -1,0 +1,173 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_send_zc"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — zero-copy send (`IORING_OP_SEND_ZC`, Linux 6.0).
+ *
+ * Ordinary `IORING_OP_SEND` copies the payload into the socket buffer before
+ * the CQE arrives, so the user buffer is free to reuse immediately. Zero-copy
+ * send instead pins the user pages and lets the NIC/loopback DMA straight from
+ * them — which means the buffer must stay alive until the *kernel* is done with
+ * it, not just until the send is "issued". `io_uring` signals this with a
+ * distinctive **two-CQE pattern** for a single `SEND_ZC` SQE:
+ *
+ *   1. a transfer-result CQE carrying the byte count, flagged `CQEFlags.MORE`
+ *      ("more completions for this user_data are coming"); and
+ *   2. a later notification CQE flagged `CQEFlags.NOTIF` — emitted once the
+ *      kernel has released the buffer, so it is now safe to reuse/free.
+ *
+ * Passing `IORING_SEND_ZC_REPORT_USAGE` additionally makes the kernel report,
+ * in the notification CQE's `res`, whether the path was truly zero-copy or it
+ * had to fall back to a copy (`IORING_NOTIF_USAGE_ZC_COPIED`). On loopback the
+ * kernel often copies — that is expected and still a successful demonstration
+ * of the API and its completion sequence.
+ *
+ * This example connects a client socket to a listening server, both on
+ * 127.0.0.1, sends a payload from the client with `SEND_ZC`, asserts the
+ * MORE-then-NOTIF CQE sequence, and reads the bytes back on the server end to
+ * confirm the transfer.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ * § "6.0 — Zero-copy send, single-issuer, sync cancel (October 2022)".
+ *
+ * Run with: `dub run --single send-zc.d`
+ *
+ * Portability: if `io_uring` is unavailable (old kernel / sandbox) or the
+ * kernel predates `SEND_ZC` (< 6.0), the program prints a `SKIP:` line and
+ * exits 0 so it stays green in CI regardless of the host kernel.
+ */
+module io_uring_send_zc;
+
+import during;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.arpa.inet : htonl;
+import core.sys.posix.netinet.in_;
+import core.sys.posix.sys.socket;
+import core.sys.posix.unistd : close, read;
+
+import std.range : iota;
+import std.algorithm : copy, equal, map;
+import std.stdio : writefln, stderr;
+
+enum N = 4096;
+
+int main()
+{
+    // --- Loopback TCP pair, all via libc (the ring only does the SEND) ------
+    int srv = socket(AF_INET, SOCK_STREAM, 0);
+    if (srv < 0) { stderr.writefln("socket(srv) failed"); return 1; }
+    scope (exit) close(srv);
+
+    int one = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, one.sizeof);
+
+    sockaddr_in saddr;
+    saddr.sin_family = AF_INET;
+    saddr.sin_port = 0;                       // let the kernel pick a free port
+    saddr.sin_addr.s_addr = htonl(0x7f000001); // 127.0.0.1
+    if (bind(srv, cast(sockaddr*) &saddr, saddr.sizeof) != 0) { stderr.writefln("bind failed"); return 1; }
+    if (listen(srv, 1) != 0) { stderr.writefln("listen failed"); return 1; }
+
+    // Read back the port the kernel assigned so the client can connect to it.
+    sockaddr_in actual;
+    socklen_t alen = actual.sizeof;
+    if (getsockname(srv, cast(sockaddr*) &actual, &alen) != 0) { stderr.writefln("getsockname failed"); return 1; }
+
+    int cli = socket(AF_INET, SOCK_STREAM, 0);
+    if (cli < 0) { stderr.writefln("socket(cli) failed"); return 1; }
+    scope (exit) close(cli);
+    if (connect(cli, cast(sockaddr*) &actual, alen) != 0) { stderr.writefln("connect failed"); return 1; }
+
+    int acc = accept(srv, null, null);
+    if (acc < 0) { stderr.writefln("accept failed"); return 1; }
+    scope (exit) close(acc);
+
+    // --- io_uring setup -----------------------------------------------------
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Probe first: SEND_ZC arrived in 6.0. On older kernels the op is unknown,
+    // so we SKIP cleanly rather than submitting an SQE the kernel can't decode.
+    auto probe = io.probe();
+    if (cast(bool) probe && !probe.isSupported(Operation.SEND_ZC))
+    {
+        writefln("SKIP: IORING_OP_SEND_ZC unsupported (kernel < 6.0)");
+        return 0;
+    }
+
+    // Deterministic payload: bytes 0,1,2,...,255,0,1,... so we can verify it
+    // round-trips intact on the receiving end.
+    ubyte[N] payload;
+    iota(0, N).map!(a => cast(ubyte)(a & 0xff)).copy(payload[]);
+
+    // Enqueue a single zero-copy send. IORING_SEND_ZC_REPORT_USAGE makes the
+    // notification CQE report whether the kernel managed a true zero-copy.
+    io.putWith!((ref SubmissionEntry e, int fd, ubyte[] buf) {
+        e.prepSendZc(fd, buf, MsgFlags.NONE, IORING_SEND_ZC_REPORT_USAGE);
+        e.user_data = 1;
+    })(cli, payload[]);
+
+    // submit(0) just flushes the SQ; we don't ask submit to wait on a count.
+    const submitted = io.submit(0);
+    if (submitted != 1) { stderr.writefln("submit=%d (expected 1)", submitted); return 1; }
+
+    // --- The two-CQE dance --------------------------------------------------
+    // A single SEND_ZC produces two completions: the transfer result (with
+    // CQEFlags.MORE set) and a separate notification (CQEFlags.NOTIF) once the
+    // buffer is released. Consume exactly two.
+    int sendRes = int.min;
+    bool gotMore, gotNotif, zcCopied;
+    foreach (_; 0 .. 2)
+    {
+        io.wait(1);
+        const cqe = io.front;
+        scope (exit) io.popFront();
+
+        // Belt-and-suspenders: even if the probe lied, a kernel without SEND_ZC
+        // fails the op itself — treat that as an unsupported-feature SKIP.
+        if (cqe.res == -EINVAL || cqe.res == -EOPNOTSUPP || cqe.res == -ENOSYS)
+        {
+            writefln("SKIP: SEND_ZC rejected by kernel (res=%d) — unsupported (kernel < 6.0)", cqe.res);
+            return 0;
+        }
+
+        if (cqe.flags & CQEFlags.NOTIF)
+        {
+            // Notification CQE: kernel is done with the buffer. With
+            // REPORT_USAGE, res tells us whether it had to fall back to a copy.
+            gotNotif = true;
+            zcCopied = (cast(uint) cqe.res & IORING_NOTIF_USAGE_ZC_COPIED) != 0;
+        }
+        else
+        {
+            // Transfer-result CQE: byte count + the MORE flag promising a NOTIF.
+            if (cqe.res < 0) { stderr.writefln("send failed: errno %d", -cqe.res); return 1; }
+            sendRes = cqe.res;
+            gotMore = (cqe.flags & CQEFlags.MORE) != 0;
+        }
+    }
+
+    if (!gotMore) { stderr.writefln("transfer CQE lacked CQEFlags.MORE"); return 1; }
+    if (!gotNotif) { stderr.writefln("missing CQEFlags.NOTIF notification CQE"); return 1; }
+    if (sendRes != N) { stderr.writefln("short send: %d of %d bytes", sendRes, N); return 1; }
+
+    // Confirm the bytes actually arrived intact on the server side.
+    ubyte[N] rx;
+    const rd = read(acc, &rx[0], rx.length);
+    if (rd != N) { stderr.writefln("short read: %d of %d bytes", cast(int) rd, N); return 1; }
+    if (!rx[].equal(payload[])) { stderr.writefln("payload mismatch on receive"); return 1; }
+
+    writefln("ok: SEND_ZC sent %d bytes (transfer CQE F_MORE, then F_NOTIF; path=%s); payload round-tripped",
+        sendRes, zcCopied ? "kernel-copied" : "true zero-copy");
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/sendmsg-recvmsg.d
+++ b/docs/research/async-io/io-uring/examples/sendmsg-recvmsg.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_sendmsg_recvmsg"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/sendmsg-recvmsg.d
+++ b/docs/research/async-io/io-uring/examples/sendmsg-recvmsg.d
@@ -1,0 +1,227 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_sendmsg_recvmsg"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — network message ops `IORING_OP_SENDMSG` / `IORING_OP_RECVMSG`
+ * (Linux 5.3), demonstrated with `SCM_RIGHTS` file-descriptor passing.
+ *
+ * 5.3 taught `io_uring` to drive the full `sendmsg(2)`/`recvmsg(2)` scatter/gather
+ * interface, including the ancillary-data (control-message) channel. This example
+ * uses that channel for its most famous trick: passing an open file descriptor
+ * across a `AF_UNIX` socket via an `SCM_RIGHTS` control message.
+ *
+ * The flow:
+ *   1. Open a temp file and `socketpair(AF_UNIX)`.
+ *   2. Queue a `RECVMSG` on one end and a `SENDMSG` on the other; the send carries
+ *      a `cmsghdr{ SOL_SOCKET, SCM_RIGHTS }` whose payload is the temp file's fd.
+ *   3. Submit both with one `io_uring_enter`, reap both CQEs.
+ *   4. The kernel installs a *new* fd in this process pointing at the same open
+ *      file description. We `fstat(2)` both and confirm `st_ino`/`st_dev` match —
+ *      proof the descriptor really crossed the socket through the ring.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "5.3 — Network message ops".
+ *
+ * Run with: `dub run --single sendmsg-recvmsg.d`
+ *
+ * Portability: prints `SKIP:` and exits 0 if `io_uring` is unavailable or if the
+ * kernel rejects SEND/RECVMSG (`-EINVAL`/`-EOPNOTSUPP`); 6.18 supports both.
+ */
+module io_uring_sendmsg_recvmsg;
+
+import during;
+
+import core.stdc.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.fcntl : open, O_RDWR, O_CREAT, O_TRUNC;
+import core.sys.posix.sys.socket :
+    socketpair, AF_UNIX, SOCK_STREAM, SOL_SOCKET, SCM_RIGHTS,
+    msghdr, cmsghdr, CMSG_FIRSTHDR, CMSG_DATA, CMSG_SPACE, CMSG_LEN;
+import core.sys.posix.sys.stat : stat_t, fstat;
+import core.sys.posix.sys.uio : iovec;
+import core.sys.posix.unistd : close, unlink, write;
+
+import std.stdio : writefln, stderr;
+import std.string : toStringz;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // ---- A real on-disk file whose fd we will hand to our peer -------------
+    enum path = "/tmp/io_uring_scm_rights_demo.tmp";
+    const int srcFd = open(path.toStringz, O_RDWR | O_CREAT | O_TRUNC, octal!"600");
+    if (srcFd < 0)
+    {
+        stderr.writefln("open(%s) failed", path);
+        return 1;
+    }
+    scope (exit) { close(srcFd); unlink(path.toStringz); }
+    write(srcFd, "io_uring".ptr, 8); // give the file some content / a real inode
+
+    stat_t srcStat;
+    if (fstat(srcFd, &srcStat) != 0)
+    {
+        stderr.writefln("fstat(srcFd) failed");
+        return 1;
+    }
+
+    // ---- The transport: a connected pair of AF_UNIX stream sockets ---------
+    int[2] sock;
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sock) != 0)
+    {
+        stderr.writefln("socketpair() failed");
+        return 1;
+    }
+    scope (exit) { close(sock[0]); close(sock[1]); }
+
+    // A 1-byte normal payload rides alongside the ancillary fd. SCM_RIGHTS
+    // messages must carry at least one data byte, otherwise the kernel may drop
+    // the ancillary data.
+    ubyte[1] sendData = [0x2A];
+    ubyte[1] recvData = [0x00];
+
+    iovec sendIov = iovec(sendData.ptr, sendData.length);
+    iovec recvIov = iovec(recvData.ptr, recvData.length);
+
+    // ---- Control-message buffers (the SCM_RIGHTS channel) ------------------
+    // CMSG_SPACE(int.sizeof) reserves room for one cmsghdr + an aligned int fd.
+    enum size_t controlLen = CMSG_SPACE(int.sizeof);
+    ubyte[controlLen] sendControl = 0;
+    ubyte[controlLen] recvControl = 0;
+
+    msghdr sendMsg;
+    sendMsg.msg_iov = &sendIov;
+    sendMsg.msg_iovlen = 1;
+    sendMsg.msg_control = sendControl.ptr;
+    sendMsg.msg_controllen = controlLen;
+
+    // Fill the single control message: level SOL_SOCKET, type SCM_RIGHTS,
+    // payload = the fd we want the peer to receive.
+    cmsghdr* cm = CMSG_FIRSTHDR(&sendMsg);
+    cm.cmsg_level = SOL_SOCKET;
+    cm.cmsg_type = SCM_RIGHTS;
+    cm.cmsg_len = CMSG_LEN(int.sizeof);
+    *(cast(int*) CMSG_DATA(cm)) = srcFd;
+
+    msghdr recvMsg;
+    recvMsg.msg_iov = &recvIov;
+    recvMsg.msg_iovlen = 1;
+    recvMsg.msg_control = recvControl.ptr;
+    recvMsg.msg_controllen = controlLen;
+
+    // ---- Queue RECVMSG (user_data 0) then SENDMSG (user_data 1) ------------
+    // Posting the receive first guarantees there is a reader waiting; both
+    // complete asynchronously off the same submission.
+    io.putWith!((ref SubmissionEntry e, int fd, ref msghdr m) {
+        e.prepRecvMsg(fd, m);
+        e.user_data = 0;
+    })(sock[0], recvMsg);
+
+    io.putWith!((ref SubmissionEntry e, int fd, ref msghdr m) {
+        e.prepSendMsg(fd, m);
+        e.user_data = 1;
+    })(sock[1], sendMsg);
+
+    const submitted = io.submit(2);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // ---- Reap both completions; capture the received fd from the recv CQE --
+    int recvRes = int.min;
+    int sendRes = int.min;
+    foreach (_; 0 .. 2)
+    {
+        io.wait(1);
+        const ud = io.front.user_data;
+        const res = io.front.res;
+        io.popFront();
+        if (ud == 0) recvRes = res;
+        else sendRes = res;
+    }
+
+    // Either op returning -EINVAL/-EOPNOTSUPP/-ENOSYS means this kernel lacks
+    // SEND/RECVMSG support — that is an expected SKIP, not a failure.
+    foreach (res; [recvRes, sendRes])
+    {
+        if (res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS)
+        {
+            writefln("SKIP: kernel rejected SEND/RECVMSG (errno %d) — unsupported here", -res);
+            return 0;
+        }
+    }
+
+    if (sendRes < 0)
+    {
+        stderr.writefln("SENDMSG completed with error: errno %d", -sendRes);
+        return 1;
+    }
+    if (recvRes < 0)
+    {
+        stderr.writefln("RECVMSG completed with error: errno %d", -recvRes);
+        return 1;
+    }
+
+    // ---- Extract the passed fd from the received control message -----------
+    cmsghdr* rcm = CMSG_FIRSTHDR(&recvMsg);
+    if (rcm is null || rcm.cmsg_level != SOL_SOCKET || rcm.cmsg_type != SCM_RIGHTS)
+    {
+        stderr.writefln("no SCM_RIGHTS control message received");
+        return 1;
+    }
+
+    const int passedFd = *(cast(int*) CMSG_DATA(rcm));
+    if (passedFd < 0)
+    {
+        stderr.writefln("invalid received fd %d", passedFd);
+        return 1;
+    }
+    scope (exit) close(passedFd);
+
+    // The clincher: the received fd is a brand-new descriptor number, yet it
+    // refers to the same open file. Matching device + inode proves it.
+    stat_t passedStat;
+    if (fstat(passedFd, &passedStat) != 0)
+    {
+        stderr.writefln("fstat(passedFd) failed");
+        return 1;
+    }
+
+    if (passedStat.st_dev != srcStat.st_dev || passedStat.st_ino != srcStat.st_ino)
+    {
+        stderr.writefln("received fd refers to a different file (dev/ino mismatch)");
+        return 1;
+    }
+
+    if (passedFd == srcFd)
+    {
+        stderr.writefln("received fd should be a distinct descriptor number, got the same one");
+        return 1;
+    }
+
+    writefln(
+        "ok: SCM_RIGHTS fd-passing via io_uring SENDMSG/RECVMSG — sent fd %d, received fd %d, same file (dev=%d ino=%d)",
+        srcFd, passedFd, passedStat.st_dev, passedStat.st_ino);
+    return 0;
+}
+
+// `0o600`-style octal literal helper (D dropped the `0o`/`0NNN` syntax).
+private template octal(string s)
+{
+    enum uint octal = {
+        uint v = 0;
+        foreach (c; s) v = v * 8 + (c - '0');
+        return v;
+    }();
+}

--- a/docs/research/async-io/io-uring/examples/socket-bind-listen.d
+++ b/docs/research/async-io/io-uring/examples/socket-bind-listen.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_socket_bind_listen"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/socket-bind-listen.d
+++ b/docs/research/async-io/io-uring/examples/socket-bind-listen.d
@@ -1,0 +1,213 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_socket_bind_listen"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — the async socket lifecycle: `SOCKET` + `BIND` + `LISTEN` (Linux 6.11).
+ *
+ * Pre-6.11, setting up a listener still required synchronous syscalls
+ * (`socket(2)`, `bind(2)`, `listen(2)`) outside the ring. 5.19 added
+ * `IORING_OP_SOCKET`; 6.11 completed the picture with `IORING_OP_BIND` and
+ * `IORING_OP_LISTEN`, so the *entire* server-side setup can flow through the
+ * ring without ever leaving io_uring's submit/complete loop.
+ *
+ * This example drives that full lifecycle on TCP/127.0.0.1:
+ *   1. `SOCKET(AF_INET, SOCK_STREAM)` — kernel creates the fd, returns it in `res`.
+ *   2. `BIND(fd, 127.0.0.1:0)`        — kernel picks an ephemeral port.
+ *   3. `LISTEN(fd, backlog)`          — fd becomes a passive listener.
+ * Then it proves the listener actually serves connections: a libc `connect(2)`
+ * from a client fd, matched by an in-ring `ACCEPT` that hands back the server
+ * side of the connection.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "6.11 — Async bind/listen".
+ *
+ * Run with: `dub run --single socket-bind-listen.d`
+ *
+ * Portability: if io_uring is unavailable, or `SOCKET` (<5.19) / `BIND`/`LISTEN`
+ * (<6.11) are not supported on the running kernel (op returns `-EINVAL` /
+ * `-EOPNOTSUPP`), the program prints a `SKIP:` line and exits 0.
+ */
+module io_uring_socket_bind_listen;
+
+import during;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.arpa.inet : htonl;
+import core.sys.posix.netinet.in_;
+import core.sys.posix.sys.socket;
+import core.sys.posix.unistd : close;
+
+import std.stdio : writefln, stderr;
+
+// A feature is "unsupported on this kernel" if the op CQE comes back with one of
+// these. Treated as SKIP (exit 0) rather than a hard failure.
+private bool unsupported(int res) @safe @nogc nothrow pure
+{
+    return res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS;
+}
+
+// Submit exactly one already-queued SQE and block (bounded by the kernel) for its
+// single completion. Returns the CQE's `res` and pops it. We submit one op at a
+// time because BIND/LISTEN/ACCEPT each depend on the fd produced by the prior op.
+private int submitOne(ref Uring io) @trusted
+{
+    const submitted = io.submit(1);
+    if (submitted < 0)
+        return submitted;
+    io.wait(1);
+    const res = io.front.res;
+    io.popFront();
+    return res;
+}
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // 1) SOCKET — create the listening socket through the ring (5.19).
+    //    The new fd is returned in the CQE's `res` field (like socket(2)).
+    io.putWith!(
+        (ref SubmissionEntry e)
+        {
+            e.prepSocket(AF_INET, SOCK_STREAM, 0, 0);
+            e.user_data = 1;
+        })();
+
+    int srvRes = submitOne(io);
+    if (unsupported(srvRes))
+    {
+        writefln("SKIP: IORING_OP_SOCKET unsupported (errno %d) — needs Linux 5.19+", -srvRes);
+        return 0;
+    }
+    if (srvRes < 0)
+    {
+        stderr.writefln("SOCKET failed: errno %d", -srvRes);
+        return 1;
+    }
+    const int srv = srvRes; // the kernel-created server fd
+    scope (exit) close(srv);
+
+    // 127.0.0.1:0 — port 0 lets the kernel assign an ephemeral port.
+    sockaddr_in saddr;
+    saddr.sin_family = AF_INET;
+    saddr.sin_port = 0;
+    saddr.sin_addr.s_addr = htonl(0x7f000001);
+
+    // 2) BIND — async bind(2) on the in-ring fd (6.11). res == 0 on success.
+    io.putWith!(
+        (ref SubmissionEntry e, int fd, sockaddr_in* a)
+        {
+            e.prepBind(fd, *a, sockaddr_in.sizeof);
+            e.user_data = 2;
+        })(srv, &saddr);
+
+    const bindRes = submitOne(io);
+    if (unsupported(bindRes))
+    {
+        writefln("SKIP: IORING_OP_BIND unsupported (errno %d) — needs Linux 6.11+", -bindRes);
+        return 0;
+    }
+    if (bindRes != 0)
+    {
+        stderr.writefln("BIND failed: errno %d", -bindRes);
+        return 1;
+    }
+
+    // 3) LISTEN — async listen(2), backlog 4 (6.11). res == 0 on success.
+    io.putWith!(
+        (ref SubmissionEntry e, int fd)
+        {
+            e.prepListen(fd, 4);
+            e.user_data = 3;
+        })(srv);
+
+    const listenRes = submitOne(io);
+    if (unsupported(listenRes))
+    {
+        writefln("SKIP: IORING_OP_LISTEN unsupported (errno %d) — needs Linux 6.11+", -listenRes);
+        return 0;
+    }
+    if (listenRes != 0)
+    {
+        stderr.writefln("LISTEN failed: errno %d", -listenRes);
+        return 1;
+    }
+
+    // Discover the kernel-assigned ephemeral port so the client knows where to dial.
+    sockaddr_in bound;
+    socklen_t blen = bound.sizeof;
+    if (getsockname(srv, cast(sockaddr*)&bound, &blen) != 0)
+    {
+        stderr.writefln("getsockname failed");
+        return 1;
+    }
+    const ushort port = ntohs(bound.sin_port);
+
+    // Now prove the listener works end to end. Connect from a second (libc) fd
+    // first: on loopback the TCP handshake completes into the listen backlog
+    // immediately, so a blocking connect() returns without needing an accept yet.
+    // Doing the connect *before* queuing the ring ACCEPT keeps the demo
+    // deadlock-free and bounded — there is already a pending connection when we
+    // submit, so ACCEPT completes on the first wait.
+    int cli = socket(AF_INET, SOCK_STREAM, 0);
+    if (cli < 0)
+    {
+        stderr.writefln("client socket() failed");
+        return 1;
+    }
+    scope (exit) close(cli);
+
+    if (connect(cli, cast(sockaddr*)&bound, blen) != 0)
+    {
+        stderr.writefln("client connect() failed");
+        return 1;
+    }
+
+    // ACCEPT through the ring — the pending connection is dequeued and the new
+    // server-side fd is returned in the CQE's `res`, mirroring accept(2).
+    sockaddr_in caddr;
+    socklen_t clen = caddr.sizeof;
+
+    io.putWith!(
+        (ref SubmissionEntry e, int fd, sockaddr_in* a, socklen_t* l)
+        {
+            e.prepAccept(fd, *a, *l);
+            e.user_data = 4;
+        })(srv, &caddr, &clen);
+
+    if (io.submit(1) < 0)
+    {
+        stderr.writefln("submit(ACCEPT) failed");
+        return 1;
+    }
+
+    io.wait(1);
+    const accRes = io.front.res;
+    io.popFront();
+
+    if (unsupported(accRes))
+    {
+        writefln("SKIP: IORING_OP_ACCEPT unsupported (errno %d)", -accRes);
+        return 0;
+    }
+    if (accRes < 0)
+    {
+        stderr.writefln("ACCEPT failed: errno %d", -accRes);
+        return 1;
+    }
+    const int accepted = accRes; // server-side fd for the accepted connection
+    close(accepted);
+
+    writefln("ok: full async lifecycle through the ring — SOCKET(fd=%d) + BIND(127.0.0.1:%d) + LISTEN, ACCEPT(fd=%d)",
+        srv, port, accepted);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/splice-tee.d
+++ b/docs/research/async-io/io-uring/examples/splice-tee.d
@@ -1,0 +1,178 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_splice_tee"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — zero-copy `IORING_OP_SPLICE` (Linux 5.7) + `IORING_OP_TEE` (5.8).
+ *
+ * `splice(2)` moves bytes between two file descriptors *without* a round trip
+ * through a userspace buffer, provided one end is a pipe — the kernel just moves
+ * page references between the pipe buffers. `tee(2)` is its sibling: it
+ * *duplicates* bytes from one pipe to another without consuming the source, so
+ * the same data can still be read from the original pipe afterwards. 5.7 brought
+ * `splice` into `io_uring` (`IORING_OP_SPLICE`); 5.8 added `IORING_OP_TEE`.
+ *
+ * This program wires up three pipes and runs the two ops back-to-back:
+ *   1. Write a known payload into pipe A's write end (a plain `write(2)`).
+ *   2. `SPLICE` A.read -> B.write — zero-copy hand-off, no userspace copy.
+ *   3. `TEE` B.read -> C.write — duplicate B's bytes into C *without* draining B.
+ *   4. `read(2)` from C (the tee'd copy) and then from B (the original) and
+ *      verify both still carry the full payload.
+ *
+ * The load-bearing detail is the offset convention: for a pipe fd the splice
+ * offset *must* be `-1` (`off_in`/`off_out`), which `during`'s `prepSplice`
+ * takes as a `ulong`, so we pass `cast(ulong)-1` (== `ulong.max`). `prepTee` has
+ * no offsets at all — pipes are inherently offset-less streams.
+ *
+ * The two SQEs are submitted as a single batch but ordered with `IO_LINK` so the
+ * TEE cannot start reading pipe B until the SPLICE that fills it has completed.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.7 — Splice, provided buffers, fast poll (May 2020)".
+ *
+ * Run with: `dub run --single splice-tee.d`
+ *
+ * Portability: prints `SKIP:` and exits 0 when io_uring is unavailable or the
+ * kernel lacks SPLICE/TEE (probe miss, or an op result of -EINVAL/-EOPNOTSUPP/
+ * -ENOSYS). Exits nonzero only on a genuinely unexpected syscall failure.
+ */
+module io_uring_splice_tee;
+
+import during;
+
+import core.stdc.errno : EINVAL, ENOSYS, EOPNOTSUPP;
+import core.sys.posix.unistd : close, pipe, read, write;
+
+import std.stdio : stderr, writefln;
+
+// User-data cookies so we can tell the two completions apart regardless of the
+// order the kernel posts them.
+enum ulong UD_SPLICE = 1;
+enum ulong UD_TEE = 2;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Cheap, kernel-version-agnostic capability gate: ask the ring's op probe
+    // whether SPLICE and TEE are advertised. On a host that predates them this
+    // short-circuits to a clean SKIP before we touch any pipes.
+    auto probe = io.probe();
+    if (cast(bool)probe && !(probe.isSupported(Operation.SPLICE) && probe.isSupported(Operation.TEE)))
+    {
+        writefln("SKIP: kernel io_uring lacks SPLICE/TEE (probe miss) — feature added in 5.7/5.8");
+        return 0;
+    }
+
+    enum string payload = "io_uring zero-copy splice+tee\n";
+    immutable(ubyte)[] tx = cast(immutable(ubyte)[]) payload;
+
+    // Three pipes: A is the source, B receives the SPLICE, C receives the TEE.
+    int[2] a = [-1, -1], b = [-1, -1], c = [-1, -1];
+    if (pipe(a) != 0 || pipe(b) != 0 || pipe(c) != 0)
+    {
+        stderr.writefln("pipe(2) failed");
+        return 1;
+    }
+    scope (exit)
+        foreach (p; [a, b, c])
+            foreach (fd; p)
+                if (fd >= 0)
+                    close(fd);
+
+    // Seed pipe A with the payload via an ordinary blocking write — small enough
+    // to fit comfortably in the default 64 KiB pipe buffer, so this never blocks.
+    const wrote = write(a[1], tx.ptr, tx.length);
+    if (wrote != cast(long) tx.length)
+    {
+        stderr.writefln("seed write to pipe A failed: wrote %d of %d", wrote, tx.length);
+        return 1;
+    }
+
+    // SQE 1: SPLICE A.read -> B.write. Pipe offsets must be -1 (ulong.max here).
+    // IO_LINK makes the following TEE wait for this to finish (and succeed).
+    io.putWith!((ref SubmissionEntry e, int fdIn, int fdOut, uint len) {
+        e.prepSplice(fdIn, cast(ulong)-1, fdOut, cast(ulong)-1, len, 0);
+        e.flags |= SubmissionEntryFlags.IO_LINK;
+        e.user_data = UD_SPLICE;
+    })(a[0], b[1], cast(uint) tx.length);
+
+    // SQE 2: TEE B.read -> C.write. TEE duplicates without consuming B, so the
+    // bytes remain readable from B afterwards. No offsets for tee.
+    io.putWith!((ref SubmissionEntry e, int fdIn, int fdOut, uint len) {
+        e.prepTee(fdIn, fdOut, len, 0);
+        e.user_data = UD_TEE;
+    })(b[0], c[1], cast(uint) tx.length);
+
+    const submitted = io.submit(2);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Collect both completions (bounded — exactly two SQEs were submitted).
+    int spliceRes = int.min, teeRes = int.min;
+    foreach (_; 0 .. 2)
+    {
+        io.wait(1);
+        const cqe = io.front;
+        if (cqe.user_data == UD_SPLICE)
+            spliceRes = cqe.res;
+        else if (cqe.user_data == UD_TEE)
+            teeRes = cqe.res;
+        io.popFront();
+    }
+
+    // A linked op that the kernel skips because its predecessor failed reports
+    // -ECANCELED; treat an unsupported SPLICE/TEE as a clean SKIP either way.
+    bool unsupported(int r)
+    {
+        return r == -EINVAL || r == -EOPNOTSUPP || r == -ENOSYS;
+    }
+    if (unsupported(spliceRes) || unsupported(teeRes))
+    {
+        writefln("SKIP: SPLICE/TEE rejected by kernel (splice res=%d, tee res=%d)", spliceRes, teeRes);
+        return 0;
+    }
+
+    if (spliceRes != cast(int) tx.length)
+    {
+        stderr.writefln("SPLICE moved %d bytes, expected %d", spliceRes, tx.length);
+        return 1;
+    }
+    if (teeRes != cast(int) tx.length)
+    {
+        stderr.writefln("TEE duplicated %d bytes, expected %d", teeRes, tx.length);
+        return 1;
+    }
+
+    // The tee'd copy lands in C; the original is still queued in B because TEE
+    // does not consume. Read both and verify the payload survived both hops.
+    ubyte[256] rxC, rxB;
+    const rdC = read(c[0], rxC.ptr, rxC.length);
+    const rdB = read(b[0], rxB.ptr, rxB.length);
+    if (rdC != cast(long) tx.length || rxC[0 .. tx.length] != tx[])
+    {
+        stderr.writefln("tee'd copy in pipe C mismatch (read %d bytes)", rdC);
+        return 1;
+    }
+    if (rdB != cast(long) tx.length || rxB[0 .. tx.length] != tx[])
+    {
+        stderr.writefln("original bytes in pipe B were consumed by TEE (read %d bytes)", rdB);
+        return 1;
+    }
+
+    writefln("ok: SPLICE moved %d bytes A->B zero-copy, TEE duplicated them B->C "
+            ~ "without consuming (both pipes still held the payload)", spliceRes);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/splice-tee.d
+++ b/docs/research/async-io/io-uring/examples/splice-tee.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_splice_tee"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/sq-rewind.d
+++ b/docs/research/async-io/io-uring/examples/sq-rewind.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_sq_rewind"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/sq-rewind.d
+++ b/docs/research/async-io/io-uring/examples/sq-rewind.d
@@ -1,0 +1,141 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_sq_rewind"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — SQ rewind (`IORING_SETUP_SQ_REWIND`, Linux 7.0).
+ *
+ * Normally the submission-queue tail only moves forward, and once the kernel has
+ * been told (via the shared `tail` index) about a batch of SQEs it owns them —
+ * any it can't process in one `io_uring_enter` would simply be lost to the
+ * application. `IORING_SETUP_SQ_REWIND` changes that: when the kernel stops a
+ * batch part-way (e.g. it hit a malformed SQE), it *rewinds its head* back over
+ * the SQEs it did not consume, so the application can re-submit them. This makes
+ * partial submits recoverable and enables speculative batching where a program
+ * prepares entries optimistically and re-drives whatever the kernel didn't take.
+ *
+ * The flag requires `IORING_SETUP_NO_SQARRAY` (head/tail index the SQE array
+ * directly, so there is a well-defined tail to rewind) and is incompatible with
+ * `SQPOLL` (a kernel poll thread could consume an SQE out from under a rewind).
+ *
+ * What this program demonstrates (when the kernel supports the flag):
+ *   1. queue three NOPs, deliberately corrupting the *middle* one (bogus opcode);
+ *   2. `submit()` — the kernel processes SQE #1, chokes on the malformed #2, and
+ *      stops the batch early, rewinding its head over the un-consumed #2 and #3;
+ *   3. drain the completion(s) from that partial submit;
+ *   4. `submit()` again with no fresh `putWith` — on a rewind ring the trailing
+ *      good NOP (#3) survived and is re-sent, and we assert its `user_data`
+ *      round-trips. On a non-rewind ring SQE #3 would have been dropped, so this
+ *      observably exercises the rewind machinery rather than a plain NOP.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "7.0 — SQ rewind".
+ *
+ * Run with: `dub run --single sq-rewind.d`
+ *
+ * Portability: this box runs Linux 6.18, which predates `SQ_REWIND` (Linux 7.0),
+ * so `io_uring_setup` is expected to reject the flag with `-EINVAL`; we print a
+ * `SKIP:` line and exit 0. The same SKIP path covers hosts with no `io_uring`
+ * at all (too old, or blocked by a seccomp/container policy).
+ */
+module io_uring_sq_rewind;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    import core.stdc.errno : EINVAL, EOPNOTSUPP, ENOSYS, EPERM;
+
+    Uring io;
+
+    // SQ_REWIND requires NO_SQARRAY (the direct head/tail layout that gives a
+    // rewindable tail) and is mutually exclusive with SQPOLL.
+    const setupRet = io.setup(8, SetupFlags.NO_SQARRAY | SetupFlags.SQ_REWIND);
+    if (setupRet < 0)
+    {
+        const e = -setupRet;
+        // -EINVAL / -EOPNOTSUPP / -ENOSYS: the kernel doesn't know this flag
+        // (e.g. < 7.0, like this 6.18 box). -EPERM: policy-blocked.
+        if (e == EINVAL || e == EOPNOTSUPP || e == ENOSYS || e == EPERM)
+        {
+            writefln("SKIP: IORING_SETUP_SQ_REWIND unsupported (errno %d) — needs Linux 7.0+", e);
+            return 0;
+        }
+        stderr.writefln("io_uring_setup(NO_SQARRAY|SQ_REWIND) failed unexpectedly: errno %d", e);
+        return 1;
+    }
+
+    // Three NOPs; the middle one is sabotaged with a bogus opcode so the kernel
+    // refuses it and halts the batch there. The trailing good NOP (user_data 3)
+    // is the one whose survival proves the rewind behaviour.
+    enum ulong goodHead = 1, badMiddle = 2, goodTail = 3;
+    io.putWith!((ref SubmissionEntry e) { e.prepNop(); e.user_data = goodHead; })();
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.opcode = cast(Operation) 0xFF; // not a real op — kernel rejects it
+        e.user_data = badMiddle;
+    })();
+    io.putWith!((ref SubmissionEntry e) { e.prepNop(); e.user_data = goodTail; })();
+
+    // First submit: the kernel takes the leading good NOP, then stops at the
+    // malformed one. It must report a partial count (>0, <3) and rewind its head
+    // over the SQEs it did not consume.
+    const first = io.submit();
+    if (first < 0)
+    {
+        stderr.writefln("first submit failed: errno %d", -first);
+        return 1;
+    }
+    if (!(first > 0 && first < 3))
+    {
+        stderr.writefln("expected a partial submit (1 or 2), got %d", first);
+        return 1;
+    }
+
+    // Drain everything that completed from the partial submit (bounded: the
+    // kernel produced exactly `first` CQEs and they are already imminent).
+    io.wait(1);
+    while (!io.empty)
+        io.popFront();
+
+    // Second submit with NO new SQE queued. On a SQ_REWIND ring the un-consumed
+    // trailing NOP was rewound and re-presented, so this sends exactly one SQE.
+    // Without rewind support `submit()` would have nothing left to send here.
+    const second = io.submit();
+    if (second < 0)
+    {
+        stderr.writefln("re-submit of rewound SQE failed: errno %d", -second);
+        return 1;
+    }
+    if (second != 1)
+    {
+        stderr.writefln("rewound SQE was lost: re-submit sent %d entries, expected 1", second);
+        return 1;
+    }
+
+    // The survivor completes; its cookie confirms it is exactly the SQE the
+    // kernel rewound rather than something freshly minted.
+    io.wait(1);
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    if (res < 0)
+    {
+        stderr.writefln("rewound NOP completed with error: errno %d", -res);
+        return 1;
+    }
+    if (echoed != goodTail)
+    {
+        stderr.writefln("rewound SQE mismatch: expected user_data %d, got %d", goodTail, echoed);
+        return 1;
+    }
+
+    writefln("ok: SQ_REWIND recovered the trailing SQE after a partial submit "
+        ~ "(first sent %d, leftover user_data %d re-submitted and completed)", first, echoed);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/sqe-mixed.d
+++ b/docs/research/async-io/io-uring/examples/sqe-mixed.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_sqe_mixed"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/sqe-mixed.d
+++ b/docs/research/async-io/io-uring/examples/sqe-mixed.d
@@ -1,0 +1,134 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_sqe_mixed"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — mixed-size SQEs and 128-byte opcodes
+ * (`IORING_SETUP_SQE_MIXED` + `IORING_OP_NOP128`, Linux 6.19).
+ *
+ * Historically a ring's submission queue entries (SQEs) were a fixed stride:
+ * either all 64 bytes, or — with `IORING_SETUP_SQE128` (6.16) — all 128 bytes.
+ * `IORING_SETUP_SQE_MIXED` (6.19) lets a single ring carry *both*: ordinary
+ * 64-byte SQEs sit alongside 128-byte SQEs, with the kernel and the userspace
+ * library tracking the per-slot stride. `IORING_OP_NOP128` is the simplest op
+ * that *requires* the wide layout — a `NOP` that occupies a 128-byte slot —
+ * making it the canonical smoke test for the feature.
+ *
+ * This example sets up a mixed ring, emits one plain 64-byte `NOP` and one
+ * 128-byte `NOP128` (reserved via `next128()`, which claims the two contiguous
+ * SQ slots a 128-byte entry needs), submits them together, and reaps both CQEs.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *     § "6.19 — Mixed-size SQE and 128-byte opcodes".
+ *
+ * Run with: `dub run --single sqe-mixed.d`
+ *
+ * Portability: `SQE_MIXED`/`NOP128` land in Linux 6.19. On an older kernel
+ * `io_uring_setup` rejects the flag with `-EINVAL` (or the op completes with
+ * `-EINVAL`/`-EOPNOTSUPP`); the program then prints a `SKIP:` line and exits 0
+ * so it stays green on hosts predating the feature. It is also green when the
+ * host has no `io_uring` at all.
+ */
+module io_uring_sqe_mixed;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP;
+
+int main()
+{
+    // Cookies that ride through the kernel and come back on the CQEs, letting us
+    // confirm the 64-byte and 128-byte completions are correlated correctly.
+    enum ulong cookie64 = 0x64;
+    enum ulong cookie128 = 0x128;
+
+    // `SQE_MIXED` is requested as a setup flag. On a pre-6.19 kernel this is the
+    // gate that fails first (-EINVAL), giving us a clean SKIP without ever
+    // touching the wide-SQE code path.
+    Uring io;
+    const setupRet = io.setup(8, SetupFlags.SQE_MIXED);
+    if (setupRet == -EINVAL || setupRet == -EOPNOTSUPP)
+    {
+        writefln("SKIP: IORING_SETUP_SQE_MIXED unsupported (errno %d) — needs Linux 6.19+",
+            -setupRet);
+        return 0;
+    }
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host",
+            -setupRet);
+        return 0;
+    }
+
+    // A normal 64-byte SQE: `putWith` reserves one slot and runs the prep callback.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.user_data = cookie64;
+    })();
+
+    // A 128-byte SQE: `next128()` reserves the two contiguous SQ slots a wide
+    // entry needs (on an SQE_MIXED ring) and returns a reference to fill in.
+    // `prepNop128()` is the 128-byte NOP opcode (IORING_OP_NOP128).
+    auto sqe128 = &io.next128();
+    (*sqe128).prepNop128();
+    sqe128.user_data = cookie128;
+
+    // We asked for 2 logical ops; the wide one occupies an extra SQ slot, so the
+    // kernel sees 3 submission slots. We only assert success, not the slot count.
+    const submitted = io.submit(2);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Reap both completions. Bound the loop so a misbehaving kernel can't hang us.
+    bool sawNop;
+    bool sawNop128;
+    foreach (i; 0 .. 2)
+    {
+        io.wait(1);
+        const res = io.front.res;
+        const echoed = io.front.user_data;
+        io.popFront();
+
+        // A kernel that knows SQE_MIXED setup but not the NOP128 op (or rejects
+        // the wide layout) reports it per-op here — still an expected SKIP.
+        if (res == -EINVAL || res == -EOPNOTSUPP)
+        {
+            writefln("SKIP: NOP128/SQE_MIXED op unsupported (errno %d) — needs Linux 6.19+",
+                -res);
+            return 0;
+        }
+        if (res < 0)
+        {
+            stderr.writefln("op completed with error: errno %d", -res);
+            return 1;
+        }
+
+        if (echoed == cookie64)
+            sawNop = true;
+        else if (echoed == cookie128)
+            sawNop128 = true;
+        else
+        {
+            stderr.writefln("unexpected user_data: 0x%X", echoed);
+            return 1;
+        }
+    }
+
+    if (!sawNop || !sawNop128)
+    {
+        stderr.writefln("missing completion (nop=%s nop128=%s)", sawNop, sawNop128);
+        return 1;
+    }
+
+    writefln("ok: SQE_MIXED ring completed a 64-byte NOP (0x%X) and a 128-byte NOP128 (0x%X)",
+        cookie64, cookie128);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/sqpoll.d
+++ b/docs/research/async-io/io-uring/examples/sqpoll.d
@@ -1,0 +1,173 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_sqpoll"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — kernel-side submission polling (`IORING_SETUP_SQPOLL`, Linux 5.1).
+ *
+ * With `SQPOLL` the kernel spawns a side thread that *polls* the submission
+ * queue tail. Once that thread is running and awake, userspace can hand it work
+ * simply by writing an SQE and advancing the shared SQ tail — needing **no
+ * `io_uring_enter` syscall at all** to submit. That syscall-free submission is
+ * the whole point of SQPOLL, and this program demonstrates it directly in two
+ * phases:
+ *
+ *   Phase 1 — prime the poll thread with one ordinary `submit`+`wait`. A freshly
+ *             created SQPOLL ring's poll thread does not pick up work until it
+ *             has been woken at least once, so this first `io_uring_enter`
+ *             (which carries `IORING_ENTER_SQ_WAKEUP` when needed) gets it
+ *             spinning. We confirm the NOP round-trips.
+ *
+ *   Phase 2 — THE PAYOFF: stage a second NOP and publish it with `Uring.flush()`,
+ *             which only advances the shared SQ tail pointer in user memory and
+ *             issues *no* syscall whatsoever. The now-awake poll thread observes
+ *             the new tail and submits the entry on its own; we observe the
+ *             completion by busy-polling the completion queue (so we never block
+ *             on a syscall either). This is genuine, syscall-free submission.
+ *
+ * The tradeoff: the kernel thread burns a CPU while it spins, parking only after
+ * `sq_thread_idle` ms of inactivity. Once parked it raises `IORING_SQ_NEED_WAKEUP`
+ * and the next submission must ring a doorbell (`io_uring_enter` with
+ * `IORING_ENTER_SQ_WAKEUP`) to wake it — so SQPOLL trades CPU for latency: a win
+ * for a saturated I/O path, wasteful for a bursty one. We pick a large
+ * `sq_thread_idle` so the thread stays awake across phase 2's short window.
+ *
+ * A `NOP` touches no file descriptor, so this needs no registered-files table.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "5.1 — The introduction".
+ *
+ * Run with: `dub run --single sqpoll.d`
+ *
+ * Portability: SQPOLL has historically required privilege (`CAP_SYS_ADMIN` /
+ * `CAP_SYS_NICE`); on a stricter kernel `setup` returns `-EPERM`, and a host
+ * without io_uring (or this flag) returns `-ENOSYS`/`-EINVAL`/`-EOPNOTSUPP`. In
+ * every such case the program prints a `SKIP:` line and exits 0 so it stays
+ * green in CI regardless of host kernel/privileges.
+ */
+module io_uring_sqpoll;
+
+import during;
+
+import core.sys.linux.errno : EPERM, EINVAL, ENOSYS, EOPNOTSUPP;
+import core.thread : Thread;
+import core.time : msecs;
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    enum ulong primeCookie = 0x5_9011UL; // phase 1 correlation cookie
+    enum ulong pollCookie  = 0x5_9012UL; // phase 2 (syscall-free) correlation cookie
+
+    Uring io;
+
+    // Request SQPOLL via the SetupParameters overload so we can tune the poll
+    // thread's idle timeout. `sq_thread_idle` (ms) is how long the kernel poll
+    // thread stays awake before parking and raising NEED_WAKEUP. We pick a value
+    // far larger than this program's runtime, guaranteeing the thread is still
+    // awake during phase 2 — so that submission stays purely syscall-free. We
+    // deliberately omit SQ_AFF (CPU pinning), which would add a needless point of
+    // failure on constrained CI hosts.
+    SetupParameters params;
+    params.flags = SetupFlags.SQPOLL;
+    params.sq_thread_idle = 10_000; // 10 s — keeps the poll thread awake for the run
+
+    const setupRet = io.setup(8, params);
+    if (setupRet < 0)
+    {
+        // -EPERM: SQPOLL denied (needs privilege). -EINVAL/-ENOSYS/-EOPNOTSUPP:
+        // io_uring or this specific setup flag is unavailable. All are "not
+        // supported here", so SKIP and exit 0 rather than fail.
+        const e = -setupRet;
+        if (e == EPERM)
+            writefln("SKIP: IORING_SETUP_SQPOLL denied (EPERM) — needs CAP_SYS_ADMIN/CAP_SYS_NICE");
+        else if (e == EINVAL || e == ENOSYS || e == EOPNOTSUPP)
+            writefln("SKIP: IORING_SETUP_SQPOLL unsupported (errno %d) — older kernel or no io_uring", e);
+        else
+            writefln("SKIP: SQPOLL setup failed (errno %d) — io_uring unavailable on this host", e);
+        return 0;
+    }
+
+    // ---- Phase 1: prime the poll thread ------------------------------------
+    // Stage a NOP and submit-and-wait normally. This single `io_uring_enter`
+    // wakes the freshly created poll thread (passing SQ_WAKEUP if it was parked).
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.user_data = primeCookie;
+    })();
+
+    const primed = io.submit(1); // submit + wait for 1 completion
+    if (primed < 0)
+    {
+        stderr.writefln("phase 1 submit failed: errno %d", -primed);
+        return 1;
+    }
+
+    io.wait(1);
+    {
+        const res = io.front.res;
+        const echoed = io.front.user_data;
+        io.popFront();
+        if (res < 0)
+        {
+            stderr.writefln("phase 1 NOP completed with error: errno %d", -res);
+            return 1;
+        }
+        if (echoed != primeCookie)
+        {
+            stderr.writefln("phase 1 user_data mismatch: expected 0x%X, got 0x%X", primeCookie, echoed);
+            return 1;
+        }
+    }
+
+    // ---- Phase 2: syscall-free submission ----------------------------------
+    // The poll thread is now spinning. Stage a second NOP and publish it with
+    // `flush()` — which only advances the shared SQ tail pointer in user memory.
+    // There is NO io_uring_enter syscall here; the kernel poll thread picks the
+    // entry up on its own. We then busy-poll the completion queue (no blocking
+    // syscall) so the entire phase-2 round-trip happens without entering the
+    // kernel from userspace at all.
+    io.putWith!((ref SubmissionEntry e) {
+        e.prepNop();
+        e.user_data = pollCookie;
+    })();
+    io.flush(); // <-- the syscall-free publish
+
+    bool got;
+    // Hard bound: 400 * 1 ms = 400 ms cap (well under the 2 s budget). On an awake
+    // poll thread the NOP completes in well under a millisecond.
+    foreach (_; 0 .. 400)
+    {
+        if (io.length > 0) { got = true; break; }
+        Thread.sleep(1.msecs);
+    }
+
+    if (!got)
+    {
+        // The awake poll thread should have submitted+completed our NOP without a
+        // syscall. Failing to within a generous bound is a genuine SQPOLL failure.
+        stderr.writefln("SQPOLL poll thread did not pick up the flush()-only submission within the budget");
+        return 1;
+    }
+
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    if (res < 0)
+    {
+        stderr.writefln("phase 2 NOP completed with error: errno %d", -res);
+        return 1;
+    }
+    if (echoed != pollCookie)
+    {
+        stderr.writefln("phase 2 user_data mismatch: expected 0x%X, got 0x%X", pollCookie, echoed);
+        return 1;
+    }
+
+    writefln("ok: SQPOLL kernel thread completed a NOP submitted via a syscall-free flush() "
+        ~ "(res=%d); user_data 0x%X round-tripped", res, echoed);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/sqpoll.d
+++ b/docs/research/async-io/io-uring/examples/sqpoll.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_sqpoll"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/sync-cancel.d
+++ b/docs/research/async-io/io-uring/examples/sync-cancel.d
@@ -1,0 +1,145 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_sync_cancel"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — synchronous cancellation from userspace
+ * (`IORING_REGISTER_SYNC_CANCEL`, Linux 6.0).
+ *
+ * Before 6.0 the only way to cancel an in-flight request was to submit an
+ * `IORING_OP_ASYNC_CANCEL` SQE and then reap *its* completion plus the
+ * cancelled op's completion — an asynchronous, two-CQE dance. 6.0 added a
+ * `register`-family opcode that cancels matching requests **synchronously**:
+ * the `io_uring_register(REGISTER_SYNC_CANCEL, …)` call blocks until the
+ * matching request(s) are torn down and returns the count, with no cancel SQE
+ * and no extra CQE.
+ *
+ * This example:
+ *   1. Opens a pipe and arms a `POLL_ADD` for `POLLIN` on the read end. Nothing
+ *      is ever written, so the poll would block forever — a perfect stand-in
+ *      for a genuinely in-flight request. The SQE carries `user_data = 1`.
+ *   2. Fills an `io_uring_sync_cancel_reg` with `addr = 1` (match by the same
+ *      `user_data`; `flags = 0` selects user_data matching) and calls
+ *      `io.registerSyncCancel(reg)`.
+ *   3. Reaps the poll's CQE and asserts it came back with `-ECANCELED`.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ * § "6.0 — Zero-copy send, single-issuer, sync cancel (October 2022)".
+ *
+ * Run with: `dub run --single sync-cancel.d`
+ *
+ * Portability: prints a `SKIP:` line and exits 0 when io_uring is unavailable
+ * (old kernel / sandbox) or when `REGISTER_SYNC_CANCEL` is missing (kernel
+ * < 6.0, reported as `-EINVAL` / `-ENOSYS`). It returns nonzero only if a call
+ * that should have worked fails. This host runs kernel 6.18, where the feature
+ * is present and is exercised for real.
+ */
+module io_uring_sync_cancel;
+
+import during;
+
+import core.sys.linux.errno : ECANCELED, EINTR, EINVAL, ENOSYS;
+import core.sys.posix.unistd : close, pipe;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    // The cookie we will both tag the poll with and match against on cancel.
+    enum ulong cookie = 1;
+
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host",
+            -setupRet);
+        return 0;
+    }
+
+    // A pipe with no writer: POLLIN on the read end can never become ready, so
+    // the poll request stays genuinely in-flight until we cancel it.
+    int[2] fds;
+    if (pipe(fds) != 0)
+    {
+        stderr.writefln("pipe() failed");
+        return 1;
+    }
+    scope (exit) { close(fds[0]); close(fds[1]); }
+
+    // Arm a single POLL_ADD for readability on the read end, tagged with `cookie`.
+    io.putWith!((ref SubmissionEntry e, int fd) {
+        e.prepPollAdd(fd, PollEvents.IN);
+        e.user_data = cookie;
+    })(fds[0]);
+
+    const submitted = io.submit(0); // submit without waiting — nothing will complete yet
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        return 1;
+    }
+
+    // Synchronous cancel: match by user_data (flags = 0, the default selector).
+    // timeout {0,0} means "don't wait for the cancel itself to settle"; a poll
+    // is cancellable immediately so this returns the match count right away.
+    io_uring_sync_cancel_reg reg;
+    reg.addr = cookie;          // match key: the poll's user_data
+    reg.fd = -1;                // unused when matching by user_data
+    reg.flags = 0;              // 0 => match by user_data
+    reg.opcode = 0;
+    reg.timeout.tv_sec = 0;
+    reg.timeout.tv_nsec = 0;
+
+    const cret = io.registerSyncCancel(reg);
+    if (cret == -EINVAL || cret == -ENOSYS)
+    {
+        writefln("SKIP: IORING_REGISTER_SYNC_CANCEL unsupported (errno %d) — needs Linux 6.0+",
+            -cret);
+        return 0;
+    }
+    if (cret < 0)
+    {
+        stderr.writefln("registerSyncCancel failed: errno %d", -cret);
+        return 1;
+    }
+
+    // A successful synchronous cancel guarantees the cancelled request's CQE is
+    // already enqueued, so the completion is here now. Bound the wait anyway so a
+    // misbehaving kernel can't hang us: `submitAndWaitMinTimeout` blocks at most
+    // `ts` (one second) before giving up. (EXT_ARG-style waits need Linux 5.11+,
+    // which is implied by the 6.0 feature we are already on.)
+    const ts = KernelTimespec(1, 0); // {1s, 0ns}
+    const waited = io.submitAndWaitMinTimeout(1, ts, 0);
+    if (waited < 0 || io.empty)
+    {
+        stderr.writefln("no completion after sync cancel (wait returned %d)", waited);
+        return 1;
+    }
+    const res = io.front.res;
+    const echoed = io.front.user_data;
+    io.popFront();
+
+    if (echoed != cookie)
+    {
+        stderr.writefln("user_data mismatch: expected %d, got %d", cookie, echoed);
+        return 1;
+    }
+
+    // A cancelled request reports -ECANCELED (some kernels surface -EINTR for
+    // interrupted ops); either confirms the synchronous cancel took effect.
+    if (res != -ECANCELED && res != -EINTR)
+    {
+        stderr.writefln("expected -ECANCELED, got res=%d", res);
+        return 1;
+    }
+
+    // `cret` is the kernel's reported match count (often 0 for a poll the kernel
+    // tears down inline); the authoritative proof is the poll's -ECANCELED CQE.
+    writefln("ok: REGISTER_SYNC_CANCEL torn down the in-flight poll; CQE returned %s (res=%d, matches=%d)",
+        res == -ECANCELED ? "-ECANCELED" : "-EINTR", res, cret);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/sync-cancel.d
+++ b/docs/research/async-io/io-uring/examples/sync-cancel.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_sync_cancel"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/tcp-echo.d
+++ b/docs/research/async-io/io-uring/examples/tcp-echo.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_tcp_echo"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/tcp-echo.d
+++ b/docs/research/async-io/io-uring/examples/tcp-echo.d
@@ -1,0 +1,246 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_tcp_echo"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` networking foundation — `ACCEPT` + `CONNECT` + `SEND` + `RECV`
+ * over a single ring (Linux 5.5 for accept/connect, 5.6 for send/recv).
+ *
+ * Before 5.5, sockets had to be driven indirectly through `POLL_ADD` plus a
+ * separate `accept(2)`/`connect(2)` syscall (the `echo_server` fork example
+ * still polls). 5.5 added first-class `IORING_OP_ACCEPT` and
+ * `IORING_OP_CONNECT`; 5.6 added `IORING_OP_SEND` / `IORING_OP_RECV`. Together
+ * they let a TCP echo round-trip run entirely inside the ring.
+ *
+ * This program drives a one-shot loopback echo with a SINGLE ring, strictly
+ * sequentially:
+ *   1. libc creates a listening socket bound to 127.0.0.1:0 (SO_REUSEADDR,
+ *      listen); `getsockname` recovers the kernel-assigned port.
+ *   2. libc creates a client socket.
+ *   3. CONNECT (client) + ACCEPT (listener) are submitted on the same ring and
+ *      both completions are drained. ACCEPT yields the server-side accepted fd.
+ *   4. SEND a known payload on the client; RECV it on the accepted server fd.
+ *   5. Verify the received bytes match what was sent.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.5 — Accept/connect, cancel, link-timeout (January 2020)".
+ *
+ * Run with: `dub run --single tcp-echo.d`
+ *
+ * Portability: if `io_uring` is unavailable, or this kernel lacks the
+ * accept/connect/send/recv ops (anything before ~5.5/5.6), the program prints
+ * a `SKIP:` line and exits 0 so it stays green in CI regardless of host kernel.
+ */
+module io_uring_tcp_echo;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.sys.posix.arpa.inet : htonl, ntohs;
+import core.sys.posix.netinet.in_;
+import core.sys.posix.sys.socket;
+import core.sys.posix.unistd : close;
+
+// user_data cookies so each completion can be correlated to its op.
+enum ulong CONNECT_TAG = 1;
+enum ulong ACCEPT_TAG = 2;
+enum ulong SEND_TAG = 3;
+enum ulong RECV_TAG = 4;
+
+// Known payload echoed across loopback.
+static immutable ubyte[] PAYLOAD = cast(immutable ubyte[]) "io_uring echo \xF0\x9F\x9A\x80";
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Probe for the socket ops. ACCEPT/CONNECT arrived in 5.5, SEND/RECV in
+    // 5.6; on an older kernel any of these will be missing, so we skip cleanly.
+    auto probe = io.probe();
+    if (cast(bool) probe)
+    {
+        foreach (op; [Operation.ACCEPT, Operation.CONNECT, Operation.SEND, Operation.RECV])
+        {
+            if (!probe.isSupported(op))
+            {
+                writefln("SKIP: io_uring op %d unsupported on this kernel (needs Linux 5.5/5.6)",
+                    cast(int) op);
+                return 0;
+            }
+        }
+    }
+
+    // --- 1. Listening socket on 127.0.0.1:0 (kernel picks the port) --------
+    immutable srv = socket(AF_INET, SOCK_STREAM, 0);
+    if (srv < 0)
+    {
+        stderr.writefln("socket(srv) failed");
+        return 1;
+    }
+    scope (exit) close(srv);
+
+    int one = 1;
+    setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &one, one.sizeof);
+
+    sockaddr_in saddr;
+    saddr.sin_family = AF_INET;
+    saddr.sin_port = 0; // kernel-assigned
+    saddr.sin_addr.s_addr = htonl(0x7f00_0001); // 127.0.0.1
+
+    if (bind(srv, cast(sockaddr*)&saddr, sockaddr_in.sizeof) != 0)
+    {
+        stderr.writefln("bind() failed");
+        return 1;
+    }
+    if (listen(srv, 4) != 0)
+    {
+        stderr.writefln("listen() failed");
+        return 1;
+    }
+
+    // Recover the actual bound address (the port the kernel chose) — this is
+    // what the client CONNECTs to.
+    sockaddr_in bound;
+    socklen_t blen = bound.sizeof;
+    if (getsockname(srv, cast(sockaddr*)&bound, &blen) != 0)
+    {
+        stderr.writefln("getsockname() failed");
+        return 1;
+    }
+
+    // --- 2. Client socket --------------------------------------------------
+    immutable cli = socket(AF_INET, SOCK_STREAM, 0);
+    if (cli < 0)
+    {
+        stderr.writefln("socket(cli) failed");
+        return 1;
+    }
+    scope (exit) close(cli);
+
+    // --- 3. CONNECT (client) + ACCEPT (listener) on a single ring ----------
+    // ACCEPT writes the peer address + length into these out-params.
+    sockaddr_in peer;
+    socklen_t plen = peer.sizeof;
+
+    // CONNECT must reference an address that lives until the op completes;
+    // `bound` is a stack local that outlives the synchronous submit/wait below.
+    io.putWith!((ref SubmissionEntry e, int fd, sockaddr_in* a) {
+        e.prepConnect(fd, *a);
+        e.user_data = CONNECT_TAG;
+    })(cli, &bound);
+
+    io.putWith!((ref SubmissionEntry e, int fd, sockaddr_in* a, socklen_t* al) {
+        e.prepAccept(fd, *a, *al);
+        e.user_data = ACCEPT_TAG;
+    })(srv, &peer, &plen);
+
+    if (io.submit(2) < 0)
+    {
+        stderr.writefln("submit(connect+accept) failed");
+        return 1;
+    }
+
+    // Drain both completions. ACCEPT's res is the new server-side fd.
+    int acceptedFd = -1;
+    foreach (_; 0 .. 2)
+    {
+        io.wait(1);
+        const c = io.front;
+        const tag = c.user_data;
+        const res = c.res;
+        io.popFront();
+
+        if (tag == CONNECT_TAG)
+        {
+            if (res < 0)
+            {
+                stderr.writefln("CONNECT failed: errno %d", -res);
+                return 1;
+            }
+        }
+        else if (tag == ACCEPT_TAG)
+        {
+            if (res < 0)
+            {
+                stderr.writefln("ACCEPT failed: errno %d", -res);
+                return 1;
+            }
+            acceptedFd = res; // accept(2) returns the new connected fd
+        }
+    }
+
+    if (acceptedFd < 0)
+    {
+        stderr.writefln("did not obtain an accepted fd");
+        return 1;
+    }
+    scope (exit) close(acceptedFd);
+
+    // --- 4. SEND on the client, RECV on the accepted server fd -------------
+    io.putWith!((ref SubmissionEntry e, int fd) {
+        e.prepSend(fd, PAYLOAD);
+        e.user_data = SEND_TAG;
+    })(cli);
+
+    ubyte[64] rxbuf;
+    io.putWith!((ref SubmissionEntry e, int fd, ubyte[] b) {
+        e.prepRecv(fd, b);
+        e.user_data = RECV_TAG;
+    })(acceptedFd, rxbuf[]);
+
+    if (io.submit(2) < 0)
+    {
+        stderr.writefln("submit(send+recv) failed");
+        return 1;
+    }
+
+    // Drain SEND and RECV completions; remember how many bytes RECV produced.
+    int received = -1;
+    foreach (_; 0 .. 2)
+    {
+        io.wait(1);
+        const c = io.front;
+        const tag = c.user_data;
+        const res = c.res;
+        io.popFront();
+
+        if (tag == SEND_TAG)
+        {
+            if (res < 0)
+            {
+                stderr.writefln("SEND failed: errno %d", -res);
+                return 1;
+            }
+        }
+        else if (tag == RECV_TAG)
+        {
+            if (res < 0)
+            {
+                stderr.writefln("RECV failed: errno %d", -res);
+                return 1;
+            }
+            received = res;
+        }
+    }
+
+    if (received != cast(int) PAYLOAD.length || rxbuf[0 .. received] != PAYLOAD)
+    {
+        stderr.writefln("payload mismatch: sent %d bytes, received %d bytes",
+            PAYLOAD.length, received);
+        return 1;
+    }
+
+    writefln("ok: TCP loopback echo on 127.0.0.1:%d — ACCEPT+CONNECT+SEND+RECV round-tripped %d bytes through one ring",
+        ntohs(bound.sin_port), received);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/timeout-link-timeout.d
+++ b/docs/research/async-io/io-uring/examples/timeout-link-timeout.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_timeout"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/timeout-link-timeout.d
+++ b/docs/research/async-io/io-uring/examples/timeout-link-timeout.d
@@ -1,0 +1,170 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_timeout"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` timeouts — standalone `IORING_OP_TIMEOUT` (Linux 5.4) and a chained
+ * `IORING_OP_LINK_TIMEOUT` (Linux 5.5).
+ *
+ * Before timeouts, `io_uring` had no in-kernel notion of "give up after N
+ * nanoseconds": you either blocked in `io_uring_enter` or polled. 5.4 added a
+ * first-class TIMEOUT op (and the single-`mmap` setup); 5.5 added LINK_TIMEOUT,
+ * a timeout *attached* to the preceding linked SQE that cancels it when it fires.
+ *
+ * Part A — standalone TIMEOUT: arm a ~30ms relative timeout (`count = 0`, so it
+ * expires on time rather than after a number of completions) and confirm the CQE
+ * reports `-ETIME`.
+ *
+ * Part B — LINK_TIMEOUT: arm a `POLL_ADD` on the read end of a pipe that never
+ * becomes readable (there is no writer), flagged `IO_LINK` so the *next* SQE is
+ * linked to it. That next SQE is a `LINK_TIMEOUT` of ~30ms. When the timeout
+ * fires it cancels the still-pending poll: the poll CQE comes back `-ECANCELED`
+ * and the link-timeout CQE reports `-ETIME` (or `0` on some kernels).
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md § "5.4 — Timeouts and single mmap (November 2019)".
+ *
+ * Run with: `dub run --single timeout-link-timeout.d`
+ *
+ * Portability: if the running kernel has no `io_uring` (too old, or blocked by a
+ * seccomp/container policy), or if the TIMEOUT/LINK_TIMEOUT ops are unsupported,
+ * the program prints a `SKIP:` line and exits 0 so it stays green in CI.
+ */
+module io_uring_timeout;
+
+import during;
+
+import core.sys.linux.errno : ETIME, ECANCELED;
+import core.sys.posix.unistd : close, pipe;
+
+import std.stdio : writefln, stderr;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // TIMEOUT (5.4) and LINK_TIMEOUT (5.5) are old enough that almost every
+    // io_uring-capable kernel has them, but probe defensively so CI on the
+    // oldest hosts still degrades to a SKIP rather than a hard failure.
+    auto probe = io.probe();
+    if (cast(bool) probe &&
+        (!probe.isSupported(Operation.TIMEOUT) || !probe.isSupported(Operation.LINK_TIMEOUT)))
+    {
+        writefln("SKIP: TIMEOUT/LINK_TIMEOUT op not supported on this kernel");
+        return 0;
+    }
+
+    // ---- Part A: a standalone relative TIMEOUT that should expire with -ETIME ----
+    KernelTimespec tsA;
+    tsA.tv_sec = 0;
+    tsA.tv_nsec = 30_000_000; // 30ms
+
+    io.putWith!((ref SubmissionEntry e, ref KernelTimespec t) {
+        // count = 0 => purely time-based: fire after the duration elapses, not
+        // after N completions. REL => the timespec is relative to "now".
+        e.prepTimeout(t, 0, TimeoutFlags.REL);
+        e.user_data = 1;
+    })(tsA);
+
+    const submittedA = io.submit(1);
+    if (submittedA < 0)
+    {
+        // -EINVAL here would mean the op shape is unsupported on this kernel.
+        if (-submittedA == 22 /* EINVAL */)
+        {
+            writefln("SKIP: TIMEOUT submit rejected (EINVAL) — unsupported on this kernel");
+            return 0;
+        }
+        stderr.writefln("Part A submit failed: errno %d", -submittedA);
+        return 1;
+    }
+
+    io.wait(1);
+    const resA = io.front.res;
+    io.popFront();
+
+    if (resA == -22 /* -EINVAL */)
+    {
+        writefln("SKIP: TIMEOUT returned -EINVAL — unsupported on this kernel");
+        return 0;
+    }
+    if (resA != -ETIME)
+    {
+        stderr.writefln("Part A: expected -ETIME (%d), got %d", -ETIME, resA);
+        return 1;
+    }
+
+    // ---- Part B: POLL_ADD --IO_LINK--> LINK_TIMEOUT; the timeout cancels the poll ----
+    int[2] fds;
+    if (() @trusted { return pipe(fds); }() != 0)
+    {
+        stderr.writefln("pipe() failed");
+        return 1;
+    }
+    scope (exit) { close(fds[0]); close(fds[1]); }
+
+    // SQE 1: poll the pipe read end for readability. Nothing is ever written to
+    // the pipe, so on its own this poll would block forever. IO_LINK ties the
+    // *next* SQE to it.
+    io.putWith!((ref SubmissionEntry e, int rfd) {
+        e.prepPollAdd(rfd, PollEvents.IN);
+        e.user_data = 10;
+        e.flags |= SubmissionEntryFlags.IO_LINK;
+    })(fds[0]);
+
+    // SQE 2: the link timeout. Because the previous SQE set IO_LINK, this fires
+    // ~30ms after the poll starts and cancels it.
+    KernelTimespec tsB;
+    tsB.tv_sec = 0;
+    tsB.tv_nsec = 30_000_000; // 30ms
+
+    io.putWith!((ref SubmissionEntry e, ref KernelTimespec t) {
+        e.prepLinkTimeout(t, TimeoutFlags.REL);
+        e.user_data = 11;
+    })(tsB);
+
+    const submittedB = io.submit(2);
+    if (submittedB < 0)
+    {
+        stderr.writefln("Part B submit failed: errno %d", -submittedB);
+        return 1;
+    }
+
+    // Both SQEs produce a CQE: the cancelled poll and the fired link-timeout.
+    io.wait(2);
+
+    int pollRes = int.max;
+    int linkRes = int.max;
+    foreach (_; 0 .. 2)
+    {
+        const c = io.front;
+        if (c.user_data == 10) pollRes = c.res;
+        else if (c.user_data == 11) linkRes = c.res;
+        io.popFront();
+    }
+
+    // The poll must be cancelled by the firing link timeout.
+    if (pollRes != -ECANCELED)
+    {
+        stderr.writefln("Part B: expected poll res -ECANCELED (%d), got %d", -ECANCELED, pollRes);
+        return 1;
+    }
+    // The link timeout itself reports -ETIME (it fired) or 0 (kernel variation).
+    if (linkRes != -ETIME && linkRes != 0)
+    {
+        stderr.writefln("Part B: expected link-timeout res -ETIME (%d) or 0, got %d", -ETIME, linkRes);
+        return 1;
+    }
+
+    writefln("ok: TIMEOUT expired with -ETIME, and LINK_TIMEOUT cancelled a never-ready poll " ~
+        "(poll res=%d -ECANCELED, link res=%d)", pollRes, linkRes);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/uring-cmd-socket.d
+++ b/docs/research/async-io/io-uring/examples/uring-cmd-socket.d
@@ -1,0 +1,172 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_uring_cmd_socket"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — `IORING_OP_URING_CMD` passthrough on a socket (Linux 5.19).
+ *
+ * `IORING_OP_URING_CMD` (Linux 5.19) is a generic "command" channel that lets a
+ * file's underlying driver service an `ioctl`/`setsockopt`-like request straight
+ * out of the ring, with no per-call syscall. The socket sub-commands
+ * (`SOCKET_URING_OP_*`, the `cmd_op` field — socket support landed in Linux 6.7)
+ * ride that channel. Here we drive a `getsockopt`/`setsockopt` round-trip on a
+ * loopback TCP socket entirely through the ring via `prepCmdSock`, instead of
+ * calling `getsockopt(2)` / `setsockopt(2)` directly.
+ *
+ * What it does:
+ *   1. Creates and binds a TCP socket to 127.0.0.1:0 with libc.
+ *   2. Submits one `uring_cmd` SQE: `SOCKET_URING_OP_GETSOCKOPT` of
+ *      `SO_REUSEADDR`, reading the option value through the ring; the option
+ *      length comes back in the CQE `res` and the value buffer is filled
+ *      in-place.
+ *   3. Submits a `SOCKET_URING_OP_SETSOCKOPT` to flip `SO_REUSEADDR` on, then a
+ *      second `GETSOCKOPT` to confirm the new value round-tripped — proving the
+ *      passthrough moves data into the kernel and back out, not just succeeds.
+ *
+ * `uring_cmd` on a socket needs no special hardware (unlike NVMe/block or ZCRX
+ * passthrough), so it runs on any 6.7+ loopback host — including this 6.18 box,
+ * where the feature MUST be exercised.
+ *
+ * (Note: a `SOCKET_URING_OP_GETSOCKNAME` sub-command was proposed but never
+ * merged into mainline; on a live kernel it returns `-EOPNOTSUPP`. We therefore
+ * demonstrate the getsockopt/setsockopt sub-commands that the kernel actually
+ * implements.)
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ *   § "5.19 — Buffer rings, zero-copy groundwork, big SQE/CQE".
+ *
+ * Run with: `dub run --single uring-cmd-socket.d`
+ *
+ * Portability: if the running kernel lacks `io_uring` (setup < 0) or this
+ * specific op is unsupported (`-EINVAL` / `-EOPNOTSUPP` / `-ENOSYS`), the
+ * program prints a `SKIP:` line and exits 0 so it stays green in CI.
+ */
+module io_uring_uring_cmd_socket;
+
+import during;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.arpa.inet : htonl;
+import core.sys.posix.netinet.in_ : sockaddr_in, AF_INET, IPPROTO_TCP;
+import core.sys.posix.sys.socket : socket, bind, sockaddr, socklen_t,
+    SOCK_STREAM, SOL_SOCKET, SO_REUSEADDR;
+import core.sys.posix.unistd : close;
+
+import std.stdio : writefln, stderr;
+
+// during exposes the socket uring_cmd sub-commands as plain enums; spell them
+// out here so the example is self-contained and the cmd_op values are explicit.
+enum uint SOCKET_URING_OP_GETSOCKOPT = 2;
+enum uint SOCKET_URING_OP_SETSOCKOPT = 3;
+
+/// Submit one socket `uring_cmd` and return its CQE `res` (or a negative -errno).
+int runCmdSock(ref Uring io, uint cmdOp, int fd, uint level, uint optname,
+    void* optval, uint optlen)
+{
+    // Pass everything as explicit args so the prep lambda captures nothing — a
+    // closure would force a GC-allocated dual-context delegate (rejected under
+    // putWith's @nogc).
+    io.putWith!((ref SubmissionEntry e, uint c, int f, uint lv, uint on, ulong ov, uint ol) {
+        e.prepCmdSock(c, f, lv, on, cast(void*)ov, ol);
+    })(cmdOp, fd, level, optname, cast(ulong)optval, optlen);
+
+    const submitted = io.submit(1);
+    if (submitted < 0)
+        return submitted; // -errno from submit
+
+    io.wait(1);
+    const res = io.front.res;
+    io.popFront();
+    return res;
+}
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host",
+            -setupRet);
+        return 0;
+    }
+
+    // --- Bind a TCP socket to an ephemeral loopback port with plain libc. ---
+    const int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (fd < 0)
+    {
+        stderr.writefln("socket() failed");
+        return 1;
+    }
+    scope (exit) close(fd);
+
+    sockaddr_in addr;
+    addr.sin_family = AF_INET;
+    addr.sin_port = 0; // 0 => kernel picks an ephemeral port
+    addr.sin_addr.s_addr = htonl(0x7f00_0001); // 127.0.0.1
+    if (bind(fd, cast(sockaddr*)&addr, sockaddr_in.sizeof) != 0)
+    {
+        stderr.writefln("bind() failed");
+        return 1;
+    }
+
+    // --- 1) Read SO_REUSEADDR through the ring (SOCKET_URING_OP_GETSOCKOPT). ---
+    // The socket driver fills `before` in-place; the returned optlen lands in res.
+    int before = -1;
+    socklen_t vlen = before.sizeof;
+    const getRes = runCmdSock(io, SOCKET_URING_OP_GETSOCKOPT, fd,
+        SOL_SOCKET, SO_REUSEADDR, &before, vlen);
+
+    // URING_CMD itself, or the socket sub-command, may be absent on older
+    // kernels — treat those as a clean SKIP rather than a hard failure.
+    if (getRes == -EINVAL || getRes == -EOPNOTSUPP || getRes == -ENOSYS)
+    {
+        writefln("SKIP: IORING_OP_URING_CMD / SOCKET_URING_OP_GETSOCKOPT unsupported (errno %d)",
+            -getRes);
+        return 0;
+    }
+    if (getRes < 0)
+    {
+        stderr.writefln("uring_cmd getsockopt failed: errno %d", -getRes);
+        return 1;
+    }
+    // On success, getsockopt reports the option length (sizeof(int)) in res.
+    if (getRes != cast(int) before.sizeof)
+    {
+        stderr.writefln("unexpected getsockopt optlen: res=%d (expected %d)",
+            getRes, cast(int) before.sizeof);
+        return 1;
+    }
+
+    // --- 2) Flip SO_REUSEADDR on through the ring (SOCKET_URING_OP_SETSOCKOPT). ---
+    int on = 1;
+    const setRes = runCmdSock(io, SOCKET_URING_OP_SETSOCKOPT, fd,
+        SOL_SOCKET, SO_REUSEADDR, &on, on.sizeof);
+    if (setRes < 0)
+    {
+        stderr.writefln("uring_cmd setsockopt failed: errno %d", -setRes);
+        return 1;
+    }
+
+    // --- 3) Read it back to confirm the write took effect (round-trip proof). ---
+    int after = -1;
+    const getRes2 = runCmdSock(io, SOCKET_URING_OP_GETSOCKOPT, fd,
+        SOL_SOCKET, SO_REUSEADDR, &after, vlen);
+    if (getRes2 < 0)
+    {
+        stderr.writefln("uring_cmd getsockopt (after set) failed: errno %d", -getRes2);
+        return 1;
+    }
+    if (after == 0)
+    {
+        stderr.writefln("SO_REUSEADDR still off after uring_cmd setsockopt (got %d)", after);
+        return 1;
+    }
+
+    writefln("ok: IORING_OP_URING_CMD socket passthrough — getsockopt SO_REUSEADDR=%d, "
+        ~ "setsockopt=1, re-read=%d (all through the ring)", before, after);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/uring-cmd-socket.d
+++ b/docs/research/async-io/io-uring/examples/uring-cmd-socket.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_uring_cmd_socket"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/examples/waitid.d
+++ b/docs/research/async-io/io-uring/examples/waitid.d
@@ -1,0 +1,155 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "io_uring_waitid"
+    dependency "during" version="~>0.5.0"
+    targetPath "build"
++/
+/**
+ * `io_uring` — asynchronously reap a child process (`IORING_OP_WAITID`, Linux 6.7).
+ *
+ * Before 6.7, the only way to reap a child without blocking a thread was to
+ * juggle `SIGCHLD` handlers or poll `waitid(WNOHANG)` in your event loop.
+ * `IORING_OP_WAITID` folds the reap into the ring like any other op: you submit
+ * a `WAITID` SQE naming the child, and the completion fires when the child
+ * changes state. No signal plumbing, no busy-polling.
+ *
+ * This example forks a child that immediately exits with a known code, submits a
+ * `prepWaitid(P_PID, childpid, &siginfo, WEXITED, 0)`, waits for the CQE, and
+ * verifies `res == 0` plus the `siginfo_t` the kernel filled in (`si_code ==
+ * CLD_EXITED`, `si_status ==` the child's exit code). Modeled on the `during`
+ * library's own `tests/waitid.d`.
+ *
+ * Companion to the io_uring chronology:
+ * see docs/research/async-io/io-uring/timeline.md
+ * § "6.7 — Futex, waitid, read-multishot (January 2024)".
+ *
+ * Run with: `dub run --single waitid.d`
+ *
+ * Portability: if the running kernel has no `io_uring`, or lacks `IORING_OP_WAITID`
+ * (kernel < 6.7), the program prints a `SKIP:` line and exits 0 so it stays green
+ * in CI regardless of the host kernel.
+ */
+module io_uring_waitid;
+
+import during;
+
+import std.stdio : writefln, stderr;
+
+import core.sys.linux.errno : EINVAL, EOPNOTSUPP, ENOSYS;
+import core.sys.posix.signal : siginfo_t;
+import core.sys.posix.sys.wait : waitpid;
+import core.sys.posix.unistd : fork, _exit;
+
+// idtype_t values from <sys/wait.h>. druntime doesn't expose these portably, so
+// we hardcode the well-known constants.
+private enum P_PID = 1;
+
+// `options` bits from <sys/wait.h>. `WEXITED` is mandatory for waitid(2): it asks
+// to wait for children that have terminated.
+private enum WEXITED = 0x00000004;
+
+// si_code value the kernel sets for a normally-exited child (from <bits/siginfo-consts.h>).
+private enum CLD_EXITED = 1;
+
+// The exit code our child reports; we verify it round-trips through siginfo_t.
+private enum int childExitCode = 42;
+
+int main()
+{
+    Uring io;
+    const setupRet = io.setup(8);
+    if (setupRet < 0)
+    {
+        writefln("SKIP: io_uring_setup failed (errno %d) — io_uring unavailable on this host", -setupRet);
+        return 0;
+    }
+
+    // Probe up front: on a kernel older than 6.7 `IORING_OP_WAITID` is unknown and
+    // we should skip cleanly rather than fork a child we'd have to reap by hand.
+    const probe = io.probe();
+    if (cast(bool) probe && !probe.isSupported(Operation.WAITID))
+    {
+        writefln("SKIP: IORING_OP_WAITID unsupported on this kernel (needs Linux >= 6.7)");
+        return 0;
+    }
+
+    // Fork the child *after* the ring is up. The child exits immediately with a
+    // known code; the parent reaps it asynchronously through the ring.
+    const pid = fork();
+    if (pid < 0)
+    {
+        stderr.writefln("fork failed: errno %d", -pid);
+        return 1;
+    }
+    if (pid == 0)
+        _exit(childExitCode); // child path — never returns.
+
+    // The kernel writes the reaped child's status into this struct. It must stay
+    // alive (and addressable) until the completion arrives, hence a plain stack local.
+    siginfo_t info;
+
+    // Place the WAITID SQE: wait on this specific pid (P_PID), accept terminated
+    // children (WEXITED), and have the kernel fill `&info` with the child status.
+    io.putWith!(
+        (ref SubmissionEntry e, int p, siginfo_t* infop)
+        {
+            e.prepWaitid(P_PID, cast(uint) p, infop, WEXITED, 0);
+            e.user_data = 1;
+        })(pid, &info);
+
+    const submitted = io.submit(1);
+    if (submitted < 0)
+    {
+        stderr.writefln("submit failed: errno %d", -submitted);
+        // Avoid leaving a zombie behind on the error path.
+        int status;
+        waitpid(pid, &status, 0);
+        return 1;
+    }
+
+    // Block for the single completion. Bounded: exactly one CQE is expected.
+    io.wait(1);
+    const res = io.front.res;
+    io.popFront();
+
+    // Some kernels surface "op unknown" only at completion time. Treat the
+    // canonical unsupported errnos as a SKIP, reaping the child synchronously so
+    // we don't leak a zombie.
+    if (res == -EINVAL || res == -EOPNOTSUPP || res == -ENOSYS)
+    {
+        int status;
+        waitpid(pid, &status, 0);
+        writefln("SKIP: IORING_OP_WAITID rejected with errno %d (kernel < 6.7?)", -res);
+        return 0;
+    }
+
+    if (res < 0)
+    {
+        stderr.writefln("WAITID completed with error: errno %d", -res);
+        int status;
+        waitpid(pid, &status, 0);
+        return 1;
+    }
+
+    // The kernel reaped the child for us and populated `info`.
+    // For a WEXITED reap, si_code is CLD_EXITED and si_status is the raw exit code.
+    if (info.si_code != CLD_EXITED || info.si_status != childExitCode)
+    {
+        stderr.writefln("siginfo mismatch: si_code=%d (want %d), si_status=%d (want %d)",
+            info.si_code, CLD_EXITED, info.si_status, childExitCode);
+        return 1;
+    }
+
+    // Confirm the child really is gone — a second waitpid should find no such child.
+    int status;
+    const wp = waitpid(pid, &status, 0);
+    if (wp > 0)
+    {
+        stderr.writefln("child %d was NOT reaped by IORING_OP_WAITID (waitpid returned it)", pid);
+        return 1;
+    }
+
+    writefln("ok: IORING_OP_WAITID reaped child %d asynchronously (si_code=CLD_EXITED, exit code %d)",
+        pid, info.si_status);
+    return 0;
+}

--- a/docs/research/async-io/io-uring/examples/waitid.d
+++ b/docs/research/async-io/io-uring/examples/waitid.d
@@ -2,6 +2,7 @@
 /+ dub.sdl:
     name "io_uring_waitid"
     dependency "during" version="~>0.5.0"
+    platforms "linux"
     targetPath "build"
 +/
 /**

--- a/docs/research/async-io/io-uring/features.md
+++ b/docs/research/async-io/io-uring/features.md
@@ -38,6 +38,8 @@ Per-request `fget`/`fput` reference counting and per-request page pinning (`get_
 
 A proactor that re-registers nothing pays `fget`/`fput` plus a GUP on every single op. Registering the listening/connected sockets and a slab of I/O buffers up front turns each subsequent SQE into a pointer-free index lookup. Resource _tags_ give the loop a safe-reclaim signal, and _sparse_ + _FILE_ALLOC_RANGE_ let `accept`/`open` return **direct descriptors** that never enter the process fd table at all — see [FIXED_FD_INSTALL](#fixed_fd_install) for moving a direct descriptor back into the regular table when an external API needs a real fd. Compare Glommio's and Tokio's buffer-pool strategies in [`../glommio.md`](../glommio.md) and [`../tokio.md`](../tokio.md).
 
+> **Worked examples.** [`read-write-fixed.d`][ex-rwfixed] round-trips a payload through a registered (fixed) buffer with `WRITE_FIXED`/`READ_FIXED`; [`registered-files.d`][ex-regfiles] reads a file by fixed-file table index with `IOSQE_FIXED_FILE`.
+
 ---
 
 ## Provided buffers and buffer rings
@@ -72,6 +74,8 @@ With `IOU_PBUF_RING_INC` (Linux 6.12), the app registers a few very large buffer
 
 Buffer rings are _the_ idiom for high-fan-in servers: combined with [multishot recv](#multishot-operations) the loop arms one SQE per socket and lets the kernel deliver data into freshly-picked buffers indefinitely, with no userspace round-trip to re-provide memory. Incremental consumption further cuts the buffer count for streaming reads. liburing's `proxy.c` example drives multishot recv off a buffer ring (`io_uring_buf_ring`). See [`liburing/examples/proxy.c`].
 
+> **Worked example.** [`provided-buf-ring.d`][ex-pbufring] registers an `io_uring_buf` ring and issues a buffer-selecting `RECV` against it.
+
 ---
 
 ## Multishot operations
@@ -101,6 +105,8 @@ A **multishot** SQE is armed once and produces _many_ CQEs over its lifetime, ea
 ### Why it matters
 
 Multishot is what turns `io_uring` from "batched syscalls" into a genuine **event source**. One armed `ACCEPT_MULTISHOT` SQE replaces an `accept` loop; one `RECV_MULTISHOT` + buffer ring replaces an epoll-`recv` dance. The loop's steady-state submission rate drops toward zero — it only re-arms when an op terminates. This is the closest `io_uring` gets to the green-thread "park until ready" model of Go's netpoller ([`../go-netpoller.md`](../go-netpoller.md)) or Loom ([`../../algebraic-effects/java-loom.md`](../../algebraic-effects/java-loom.md)), while staying completion-based. See [`liburing/man/io_uring_multishot.7`].
+
+> **Worked examples.** [`multishot-accept.d`][ex-msaccept] serves multiple loopback connections from a single armed `ACCEPT` (each CQE carries `CQEFlags.MORE`); [`multishot-recv.d`][ex-msrecv] arms one `RECV` posting a CQE per segment into provided-ring buffers; [`read-multishot.d`][ex-readms] does repeated reads from a pipe into provided-ring buffers with `READ_MULTISHOT`; [`multishot-timeout.d`][ex-mstimeout] arms one `TIMEOUT_MULTISHOT` recurring timer.
 
 ---
 
@@ -132,6 +138,8 @@ Four orthogonal polling strategies, each trading CPU for latency in a different 
 ### Why it matters
 
 SQPOLL is the headline "syscall-free" mode — at the cost of a dedicated, busy-spinning core. NAPI busy-poll is the network-latency analogue and is what lets an `io_uring` server beat a `recvmsg`-on-epoll server on p99 under load (see `napi-busy-poll-server.c`). Hybrid IOPOLL is the pragmatic default for NVMe-class storage where pure IOPOLL's spin cost is unjustified. An event-loop author must treat these as mutually-constrained: SQPOLL forbids `IORING_SETUP_SQ_REWIND`, and `DEFER_TASKRUN`-style single-issuer modes interact with how completions are delivered. See [`liburing/examples/napi-busy-poll-server.c`].
+
+> **Worked examples.** [`sqpoll.d`][ex-sqpoll] submits a `NOP` with no `io_uring_enter` syscall via the `IORING_SETUP_SQPOLL` kernel thread; [`napi.d`][ex-napi] configures NAPI busy-poll with `IORING_REGISTER_NAPI`.
 
 ---
 
@@ -171,6 +179,8 @@ The notification machinery is `struct io_notif_data` (`notif.c`), built atop the
 
 Zero-copy is where `io_uring` decisively diverges from epoll: epoll can tell you a socket is readable, but you still `recv` into a kernel buffer and copy. ZCRX cuts the copy entirely for line-rate ingest, and `SEND_ZC` does the same for egress — at the cost of a **two-phase completion model** the event loop must understand (a send "completes" twice). Designs that hide this (Tokio, Seastar — [`../seastar.md`](../seastar.md)) must keep the buffer alive until the `F_NOTIF` CQE. See [`liburing/examples/send-zerocopy.c`] and [`liburing/examples/zcrx.c`], and the kernel's [io_uring zero copy Rx][zcrx-doc] document.
 
+> **Worked examples.** [`send-zc.d`][ex-sendzc] performs a zero-copy `SEND_ZC` over loopback and asserts the transfer-CQE → notification-CQE pattern; [`recv-zc.d`][ex-recvzc] does zero-copy receive via a registered ZCRX interface queue (SKIPs without a capable NIC).
+
 ---
 
 ## Linked SQEs, drains, and link timeouts
@@ -196,6 +206,8 @@ Zero-copy is where `io_uring` decisively diverges from epoll: epoll can tell you
 ### Why it matters
 
 Links let the loop fuse `accept → recv`, `connect → send`, or `openat → read → close` into one submission, so a whole protocol step costs one `io_uring_enter`. Crucially, **a direct-descriptor `accept` linked to a `recv`** never surfaces the fd to userspace at all. The trade-off is rigidity: a link chain is a fixed DAG decided at submission time — it cannot branch on a result. Higher-level effect systems express the same dependency dynamically instead (see [`../../algebraic-effects/ocaml-eio.md`](../../algebraic-effects/ocaml-eio.md)). See [`liburing/man/io_uring_linked_requests.7`].
+
+> **Worked examples.** [`linked-sqes.d`][ex-linked] chains a write to an `fsync` with `IOSQE_IO_LINK`, showing write-before-`fsync` ordering and `-ECANCELED` failure propagation; [`timeout-link-timeout.d`][ex-timeout] uses a `LINK_TIMEOUT` to cancel a never-ready poll; [`cqe-skip.d`][ex-cqeskip] suppresses a successful op's CQE in a link with `IOSQE_CQE_SKIP_SUCCESS`.
 
 ---
 
@@ -225,6 +237,8 @@ Links let the loop fuse `accept → recv`, `connect → send`, or `openat → re
 
 `msg_ring` is `io_uring`'s answer to "how do N event loops talk to each other" — a work-stealing or sharded-acceptor design (think one acceptor thread fanning connections to worker rings) needs exactly this. Registered ring fds remove the per-`enter` file-table contention that otherwise dominates threaded programs. Glommio and Monoio ([`../glommio.md`](../glommio.md), [`../monoio.md`](../monoio.md)) build their thread-per-core models on these.
 
+> **Worked examples.** [`msg-ring.d`][ex-msgring] posts a `u64` from one ring into another — the cross-core wakeup primitive; [`registered-ring-fd.d`][ex-regringfd] registers the ring fd so `io_uring_enter` skips per-call `fdget`/`fdput`.
+
 ---
 
 ## Futex operations
@@ -249,6 +263,8 @@ Links let the loop fuse `accept → recv`, `connect → send`, or `openat → re
 ### Why it matters
 
 Futex-on-ring is the bridge between the I/O world and the _concurrency-primitive_ world. An event loop can now wait on a condition variable or an async mutex as just another SQE, so a fiber blocked on a lock and a fiber blocked on a socket sit in the same CQ. This is the building block several async runtimes use for cross-task signaling; cf. how effect-based runtimes model blocking ([`../effects-and-event-loops.md`](../effects-and-event-loops.md)). See LWN's [futex wait/wake][lwn-futex] writeup.
+
+> **Worked examples.** [`futex.d`][ex-futex] parks a ring on a 32-bit private futex with `IORING_OP_FUTEX_WAIT`, woken by a legacy `futex(2)` wake; [`futex-waitv.d`][ex-futexv] waits on a vector of futexes with `FUTEX_WAITV`.
 
 ---
 
@@ -277,6 +293,8 @@ Two cancellation surfaces. **Asynchronous** cancellation is an SQE (`IORING_OP_A
 ### Why it matters
 
 Structured concurrency (timeouts, "cancel the loser of a race", graceful shutdown) is only as good as the cancellation primitive underneath it. `CANCEL_FD` lets a loop tear down _all_ operations on a closing socket in one SQE; `CANCEL_OP` + `CANCEL_ALL` enables policy-level cancellation. The synchronous register variant is the clean way to drain a ring before freeing it. This is the low-level counterpart to the cancellation scopes in Eio and Loom ([`../../algebraic-effects/ocaml-eio.md`](../../algebraic-effects/ocaml-eio.md), [`../../algebraic-effects/java-loom.md`](../../algebraic-effects/java-loom.md)). See [`liburing/man/io_uring_cancelation.7`].
+
+> **Worked examples.** [`async-cancel.d`][ex-cancel] cancels an in-flight poll by its `user_data` and observes the `-ECANCELED` completion; [`sync-cancel.d`][ex-synccancel] cancels an in-flight poll synchronously with `IORING_REGISTER_SYNC_CANCEL`.
 
 ---
 
@@ -317,6 +335,8 @@ Plus `IORING_CQE_F_SOCK_NONEMPTY` (`io_uring.h:540`) — set on a recv CQE when 
 
 The networking ops are the reason `io_uring` exists for server authors. BUNDLE in particular is a throughput multiplier — one `recv` SQE can drain several buffers' worth of data, and one `send` SQE can flush a whole scatter list, cutting CQE count under bursty load. Compared to the readiness-only model exposed to Go's netpoller or libuv ([`../libuv.md`](../libuv.md)), these are _completion_ ops: the data is already moved when the CQE lands.
 
+> **Worked examples.** [`tcp-echo.d`][ex-tcp] drives a loopback `ACCEPT`+`CONNECT`+`SEND`+`RECV` round-trip through a single ring; [`sendmsg-recvmsg.d`][ex-sendmsg] passes a file descriptor over a unix socket with `SCM_RIGHTS` via `SENDMSG`/`RECVMSG`; [`socket-bind-listen.d`][ex-socketbl] drives a full async `SOCKET` + `BIND` + `LISTEN` lifecycle through the ring.
+
 ---
 
 ## File and filesystem operations
@@ -340,6 +360,8 @@ The networking ops are the reason `io_uring` exists for server authors. BUNDLE i
 ### Why it matters
 
 Having `statx`, `renameat`, and `unlinkat` on the ring means a tool like a build system can issue _thousands_ of filesystem ops in a batch with one syscall — the workload that motivates Glommio's storage focus. `READV_FIXED`/`WRITEV_FIXED` (see [registered buffers](#registered--fixed-files-and-buffers)) and `IOPOLL` together give the lowest-latency `O_DIRECT` path available on Linux. `PIPE` returning direct descriptors closes a loop: you can build a pipe, splice through it, and never touch the fd table.
+
+> **Worked examples.** [`openat-statx-close.d`][ex-openat] chains `OPENAT`→`STATX`→`READ`→`CLOSE` asynchronously; [`splice-tee.d`][ex-splicetee] does a zero-copy `SPLICE` between pipes and a `TEE` duplication; [`fs-mutations.d`][ex-fsmut] performs async `MKDIRAT`/`SYMLINKAT`/`LINKAT`/`RENAMEAT`/`UNLINKAT` directory mutations.
 
 ---
 
@@ -373,6 +395,8 @@ Ops: `IORING_OP_TIMEOUT`, `IORING_OP_TIMEOUT_REMOVE`, `IORING_OP_LINK_TIMEOUT`.
 
 Every event loop needs timers: I/O deadlines, periodic heartbeats, scheduler quanta. Doing them as SQEs keeps timers in the _same_ completion stream as I/O, so there is one wait point, not two. `min_timeout` is the subtle but high-value knob — it lets a latency-tolerant loop sleep just long enough to coalesce a batch of CQEs, trading a few microseconds of latency for far fewer wakeups. Link timeouts (above) reuse this machinery to bound any other op.
 
+> **Worked examples.** [`timeout-link-timeout.d`][ex-timeout] fires a standalone relative `TIMEOUT` (completing with `-ETIME`) and a `LINK_TIMEOUT`; [`multishot-timeout.d`][ex-mstimeout] arms one `TIMEOUT_MULTISHOT` recurring timer; [`clock-min-timeout.d`][ex-clock] selects the wait clock with `IORING_REGISTER_CLOCK` and uses a min-timeout batched wait.
+
 ---
 
 ## `uring_cmd` passthrough
@@ -402,6 +426,8 @@ Every event loop needs timers: I/O deadlines, periodic heartbeats, scheduler qua
 
 `uring_cmd` is what lets `io_uring` reach _outside_ the generic VFS/socket API — userspace NVMe drivers (SPDK-style) and fine-grained socket introspection (`SIOCINQ` to size the next recv, TX timestamps for latency measurement) all flow through it without bloating the opcode enum. For an event loop it means device- and protocol-specific fast paths can be added without a kernel ABI change. The socket-command path is exercised by liburing's test suite (`test/socket-io-cmd.c`, `test/socket-getsetsock-cmd.c`) rather than the `examples/` programs.
 
+> **Worked example.** [`uring-cmd-socket.d`][ex-uringcmd] does socket `getsockopt`/`setsockopt` through the `URING_CMD` passthrough channel.
+
 ---
 
 ## FIXED_FD_INSTALL {#fixed_fd_install}
@@ -418,6 +444,8 @@ Every event loop needs timers: I/O deadlines, periodic heartbeats, scheduler qua
 
 Direct descriptors are strictly faster (no fd-table lock), so a high-performance loop wants to live in that world. But some libraries demand a real `int fd`. `FIXED_FD_INSTALL` is the bridge that keeps the fast path fast while remaining interoperable — see the [registered files](#registered--fixed-files-and-buffers) discussion of direct descriptors.
 
+> **Worked example.** [`direct-descriptors.d`][ex-directfd] opens into a fixed-file slot, uses it by index, then `FIXED_FD_INSTALL`s it back to a real fd.
+
 ---
 
 ## epoll integration ops
@@ -432,6 +460,8 @@ Two ops let `io_uring` and epoll coexist during migration: `IORING_OP_EPOLL_CTL`
 ### Why it matters
 
 These are _bridging_ ops. A large codebase built around an epoll fd (or a library that exposes only an epoll fd) can be folded into an `io_uring` loop incrementally: register the epoll fd, arm `EPOLL_WAIT` as one SQE, and the epoll readiness stream merges into the CQ. It is the pragmatic on-ramp from a reactor design ([`../libuv.md`](../libuv.md)) to a proactor.
+
+> **Worked example.** [`epoll-wait.d`][ex-epollwait] folds a legacy epoll set into the ring with `IORING_OP_EPOLL_WAIT`.
 
 ---
 
@@ -461,6 +491,8 @@ The right pattern for portable code is `IORING_REGISTER_QUERY` (new) falling bac
 ### Why it matters
 
 `RESIZE_RINGS` means a loop can react to load without dropping connections; `MEM_REGION` enables the registered-wait-argument optimization (passing the wait timeout/sigmask by index instead of by copy each `enter`); `RESTRICTIONS` + `PERSONALITY` are the security story for letting an untrusted plugin submit on a shared ring. `QUERY`/`PROBE` are non-negotiable for any library that targets a range of kernels — the feature set above spans 5.6 → 7.x and **must** be detected, not assumed. See [`./timeline.md`](./timeline.md) for the version map.
+
+> **Worked examples.** [`probe.d`][ex-probe] uses `IORING_REGISTER_PROBE` to print which opcodes the running kernel supports; [`restrictions.d`][ex-restrict] sandboxes a ring to a whitelist of opcodes via `IORING_REGISTER_RESTRICTIONS` + `R_DISABLED`; [`resize-rings.d`][ex-resize] grows a live ring's SQ/CQ with `IORING_REGISTER_RESIZE_RINGS`; [`cqe-mixed.d`][ex-cqemixed] reaps mixed 16- and 32-byte CQEs with `IORING_SETUP_CQE_MIXED`; [`sqe-mixed.d`][ex-sqemixed] issues mixed 64/128-byte SQEs + `NOP128` with `IORING_SETUP_SQE_MIXED`; [`sq-rewind.d`][ex-sqrewind] rewinds the SQ tail to re-submit unconsumed SQEs with `IORING_SETUP_SQ_REWIND`.
 
 ---
 
@@ -531,3 +563,39 @@ For a multi-tenant or sandboxed deployment, BPF filtering lets the host express 
 [liburing/man/io_uring_multishot.7]: https://github.com/axboe/liburing/blob/master/man/io_uring_multishot.7
 [liburing/man/io_uring_linked_requests.7]: https://github.com/axboe/liburing/blob/master/man/io_uring_linked_requests.7
 [liburing/man/io_uring_cancelation.7]: https://github.com/axboe/liburing/blob/master/man/io_uring_cancelation.7
+[ex-rwfixed]: ./examples/read-write-fixed.d
+[ex-regfiles]: ./examples/registered-files.d
+[ex-pbufring]: ./examples/provided-buf-ring.d
+[ex-msaccept]: ./examples/multishot-accept.d
+[ex-msrecv]: ./examples/multishot-recv.d
+[ex-readms]: ./examples/read-multishot.d
+[ex-mstimeout]: ./examples/multishot-timeout.d
+[ex-sqpoll]: ./examples/sqpoll.d
+[ex-napi]: ./examples/napi.d
+[ex-sendzc]: ./examples/send-zc.d
+[ex-recvzc]: ./examples/recv-zc.d
+[ex-linked]: ./examples/linked-sqes.d
+[ex-timeout]: ./examples/timeout-link-timeout.d
+[ex-cqeskip]: ./examples/cqe-skip.d
+[ex-msgring]: ./examples/msg-ring.d
+[ex-regringfd]: ./examples/registered-ring-fd.d
+[ex-futex]: ./examples/futex.d
+[ex-futexv]: ./examples/futex-waitv.d
+[ex-cancel]: ./examples/async-cancel.d
+[ex-synccancel]: ./examples/sync-cancel.d
+[ex-tcp]: ./examples/tcp-echo.d
+[ex-sendmsg]: ./examples/sendmsg-recvmsg.d
+[ex-socketbl]: ./examples/socket-bind-listen.d
+[ex-openat]: ./examples/openat-statx-close.d
+[ex-splicetee]: ./examples/splice-tee.d
+[ex-fsmut]: ./examples/fs-mutations.d
+[ex-clock]: ./examples/clock-min-timeout.d
+[ex-uringcmd]: ./examples/uring-cmd-socket.d
+[ex-directfd]: ./examples/direct-descriptors.d
+[ex-epollwait]: ./examples/epoll-wait.d
+[ex-probe]: ./examples/probe.d
+[ex-restrict]: ./examples/restrictions.d
+[ex-resize]: ./examples/resize-rings.d
+[ex-cqemixed]: ./examples/cqe-mixed.d
+[ex-sqemixed]: ./examples/sqe-mixed.d
+[ex-sqrewind]: ./examples/sq-rewind.d

--- a/docs/research/async-io/io-uring/timeline.md
+++ b/docs/research/async-io/io-uring/timeline.md
@@ -40,6 +40,8 @@ This is the foundation every surveyed library targets as its baseline (read/writ
 
 > **Worked examples.** [`nop.d`][ex-nop] walks the minimal setup → submit → wait → CQE cycle; [`read-write-fixed.d`][ex-rwfixed] round-trips a payload through a registered (fixed) buffer; [`poll-add.d`][ex-poll] arms a one-shot `POLL_ADD`. All three are runnable `during` demos.
 
+> **Worked examples.** [`registered-files.d`][ex-regfiles] reads a file by fixed-file table index with `IOSQE_FIXED_FILE`; [`sqpoll.d`][ex-sqpoll] submits a `NOP` with no `io_uring_enter` syscall via the `IORING_SETUP_SQPOLL` kernel thread.
+
 ## 5.2 — Sync file range (July 2019)
 
 - `IORING_OP_SYNC_FILE_RANGE` — async `sync_file_range(2)`. (`io_uring_enter.2`: "Available since 5.2".)
@@ -52,6 +54,8 @@ This is the foundation every surveyed library targets as its baseline (read/writ
 - Linked SQEs (`IOSQE_IO_LINK`): the ability to chain dependent SQEs so the next starts only after the previous succeeds; the man page records this submission-side feature "Available since 5.3".
 
 > **Worked example.** [`linked-sqes.d`][ex-linked] chains a write to an `fsync` on the same fd with `IOSQE_IO_LINK`, showing the kernel-guaranteed write-before-`fsync` ordering and the failure-propagation (`-ECANCELED`) semantics of linked SQEs.
+
+> **Worked example.** [`sendmsg-recvmsg.d`][ex-sendmsg] passes a file descriptor over a unix socket with `SCM_RIGHTS` via `SENDMSG`/`RECVMSG`.
 
 ## 5.4 — Timeouts and single mmap (November 2019)
 
@@ -102,6 +106,8 @@ All marked "Available since 5.6" in `io_uring_enter.2`; the [LWN growth article]
 - `IORING_OP_PROVIDE_BUFFERS` / `IORING_OP_REMOVE_BUFFERS` — the application hands the kernel a pool of buffers; recv-style ops pick one via `IOSQE_BUFFER_SELECT`. (Both "since 5.7".) This is the precursor to the far more efficient ring-provided buffers of 5.19.
 - `IORING_FEAT_FAST_POLL` — internally arms a poll and retries, so an op like `RECVMSG` on a socket no longer needs an async worker thread to block. (`io_uring_setup.2`: "Available since 5.7"; corroborated by [man7][man7-enter].) A major latency/scaling win that effectively makes `io_uring` a competitive readiness reactor as well as a completion proactor.
 
+> **Worked example.** [`splice-tee.d`][ex-splicetee] does a zero-copy `SPLICE` between pipes and a `TEE` duplication.
+
 ## 5.8 — Tee (August 2020)
 
 - `IORING_OP_TEE` — async `tee(2)`. (`io_uring_enter.2`: "Available since 5.8".)
@@ -117,6 +123,8 @@ All marked "Available since 5.6" in `io_uring_enter.2`; the [LWN growth article]
 - `IORING_REGISTER_RESTRICTIONS` — sandbox a ring by whitelisting which opcodes/registrations/SQE flags are permitted. (`io_uring_register.2`: "Available since 5.10".)
 - `IORING_FEAT_EXT_ARG` groundwork (finalized 5.11).
 
+> **Worked example.** [`restrictions.d`][ex-restrict] sandboxes a ring to a whitelist of opcodes via `IORING_REGISTER_RESTRICTIONS` + `IORING_SETUP_R_DISABLED`.
+
 ## 5.11 — Filesystem mutation ops, SQPOLL without root (February 2021)
 
 - `IORING_OP_SHUTDOWN` — async `shutdown(2)`.
@@ -126,6 +134,8 @@ All marked "Available since 5.6" in `io_uring_enter.2`; the [LWN growth article]
 All "Available since 5.11" (`io_uring_enter.2`).
 
 **Features**: `IORING_FEAT_EXT_ARG` — `io_uring_enter(2)` accepts an extended argument struct (a `timespec` timeout for `GETEVENTS`), "since kernel 5.11". **SQPOLL policy change**: the man pages note that _before 5.11_ SQPOLL required registered files and root; _in 5.11_ registration is no longer required and SQPOLL is usable as non-root with `CAP_SYS_NICE` (further relaxed in 5.13). Also `IORING_OP_ASYNC_CANCEL` gains `IORING_ASYNC_CANCEL_ALL`-style behavior ("since 5.11" in the cancel discussion).
+
+> **Worked example.** [`fs-mutations.d`][ex-fsmut] performs async `MKDIRAT`/`SYMLINKAT`/`LINKAT`/`RENAMEAT`/`UNLINKAT` directory mutations.
 
 ## 5.12 — Files-update by index, native workers (April 2021)
 
@@ -154,9 +164,13 @@ All "Available since 5.15" (`io_uring_enter.2`). `io_uring` **direct descriptors
 
 **Registration**: `IORING_REGISTER_IOWQ_MAX_WORKERS` — cap the number of bounded/unbounded async workers. (`io_uring_register.2`: "Available since 5.15".)
 
+> **Worked example.** [`direct-descriptors.d`][ex-directfd] opens into a fixed-file slot, uses it by index, then `FIXED_FD_INSTALL`s it back to a real fd.
+
 ## 5.17 — CQE skip, faster cancel (March 2022)
 
 - `IORING_FEAT_CQE_SKIP` — `IOSQE_CQE_SKIP_SUCCESS` lets a successful SQE produce _no_ CQE (errors still post one). (`io_uring_setup.2`: "Available since 5.17"; git: enum value lands in the 5.17 merge window.) A throughput win for fire-and-forget links.
+
+> **Worked example.** [`cqe-skip.d`][ex-cqeskip] suppresses a successful op's CQE in a link with `IOSQE_CQE_SKIP_SUCCESS`.
 
 ## 5.18 — Ring-fd registration, msg-ring, linked-file (May 2022)
 
@@ -164,6 +178,8 @@ All "Available since 5.15" (`io_uring_enter.2`). `io_uring` **direct descriptors
 - `IORING_SETUP_SUBMIT_ALL` — submit all SQEs even if one errors. (`io_uring_setup.2`: "since 5.18".)
 - `IORING_REGISTER_RING_FDS` / `IORING_UNREGISTER_RING_FDS` + `IORING_REGISTER_USE_REGISTERED_RING` — register the ring fd itself so `io_uring_enter(2)` need not pass a real fd. (`io_uring_register.2`: "Available since 5.18".)
 - `IORING_FEAT_LINKED_FILE` — defer file assignment in a link chain until the request actually runs. (`io_uring_setup.2`: "since" — git: enum value first in `v5.18`.)
+
+> **Worked examples.** [`msg-ring.d`][ex-msgring] posts a `u64` from one ring into another — the cross-core wakeup primitive; [`registered-ring-fd.d`][ex-regringfd] registers the ring fd so `io_uring_enter` skips per-call `fdget`/`fdput`.
 
 ## 5.19 — Buffer rings, zero-copy groundwork, big SQE/CQE (July 2022)
 
@@ -180,6 +196,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 
 > **Worked examples.** [`multishot-accept.d`][ex-msaccept] serves multiple loopback connections from a single armed accept SQE (each CQE carries `CQEFlags.MORE`); [`provided-buf-ring.d`][ex-pbufring] registers an `io_uring_buf` ring and issues a buffer-selecting `RECV`.
 
+> **Worked example.** [`uring-cmd-socket.d`][ex-uringcmd] does socket `getsockopt`/`setsockopt` through the `URING_CMD` passthrough channel.
+
 ## 6.0 — Zero-copy send, single-issuer, sync cancel (October 2022)
 
 - `IORING_OP_SEND_ZC` — zero-copy `send`; the data is pinned and a second "notification" CQE (`IORING_CQE_F_NOTIF`) fires when the kernel is done with the buffer. (`io_uring_enter.2`: "Available since 6.0". Git: enum value first in `v6.0`.)
@@ -190,6 +208,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 **Registration**: `IORING_REGISTER_SYNC_CANCEL` (synchronous cancel from userspace; "Available since 6.0"), `IORING_REGISTER_FILE_ALLOC_RANGE` (reserve a sub-range of the direct-descriptor table; "Available since 6.0").
 
 > **Worked example.** [`send-zc.d`][ex-sendzc] performs a zero-copy `SEND_ZC` over loopback and asserts the two-CQE pattern: a transfer-result CQE (`CQEFlags.MORE`) followed by a separate notification CQE (`CQEFlags.NOTIF`).
+
+> **Worked examples.** [`multishot-recv.d`][ex-msrecv] arms one `RECV` posting a CQE per segment into provided-ring buffers; [`sync-cancel.d`][ex-synccancel] cancels an in-flight poll synchronously with `IORING_REGISTER_SYNC_CANCEL`.
 
 ## 6.1 — Zero-copy sendmsg, deferred task-run (December 2022)
 
@@ -227,6 +247,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 
 > **Worked example.** [`futex.d`][ex-futex] parks a ring on a 32-bit private futex with `IORING_OP_FUTEX_WAIT` and is woken by a helper thread issuing a legacy `futex(2)` wake on the same word.
 
+> **Worked examples.** [`waitid.d`][ex-waitid] asynchronously reaps a child process with `IORING_OP_WAITID`; [`read-multishot.d`][ex-readms] does repeated reads from a pipe into provided-ring buffers with `READ_MULTISHOT`; [`futex-waitv.d`][ex-futexv] waits on a vector of futexes with `FUTEX_WAITV`.
+
 ## 6.8 — Fixed-fd install, pbuf status (March 2024)
 
 - `IORING_OP_FIXED_FD_INSTALL` — convert a registered (direct) descriptor back into a normal process fd. (`io_uring_enter.2`: "Available since 6.8"; git: enum first in `v6.8`.)
@@ -237,6 +259,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 - `IORING_OP_FTRUNCATE` — async `ftruncate(2)`. (`io_uring_enter.2`: "Available since 6.9"; git: enum first in `v6.9`.)
 - `IORING_REGISTER_NAPI` / `IORING_UNREGISTER_NAPI` — configure NAPI busy-polling for network completions, trading CPU for latency. (`io_uring_register.2`: "Available since 6.9".)
 
+> **Worked example.** [`napi.d`][ex-napi] configures NAPI busy-poll with `IORING_REGISTER_NAPI`.
+
 ## 6.10 — Send/recv bundles (July 2024)
 
 - `IORING_FEAT_RECVSEND_BUNDLE` — bundle multiple buffers into a single send/recv using provided-buffer rings (`io_uring_prep_send_bundle(3)` etc.). (Git: the `IORING_FEAT_RECVSEND_BUNDLE` define is first contained in tag `v6.10`.)
@@ -245,6 +269,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 
 - `IORING_OP_BIND` — async `bind(2)`. (Git: enum first in `v6.11`; `io_uring_enter.2`: "Available since 6.11".)
 - `IORING_OP_LISTEN` — async `listen(2)`. (Git: enum first in `v6.11`; "Available since 6.11".)
+
+> **Worked example.** [`socket-bind-listen.d`][ex-socketbl] drives a full async `SOCKET` + `BIND` + `LISTEN` lifecycle through the ring.
 
 ## 6.12 — Clock source, buffer cloning, min-timeout (November 2024)
 
@@ -255,6 +281,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 
 > **Forward-dated boundary.** Everything from here on (`6.13+`) carries 2025–2026 commit dates _in this checkout's git tree_. The markers are read directly from `liburing 2.15` man pages and `git tag --contains` in the v7.1-rc6 tree; treat them as "as observed here," since they post-date widely-distributed reference material.
 
+> **Worked example.** [`clock-min-timeout.d`][ex-clock] selects the wait clock with `IORING_REGISTER_CLOCK` and uses a min-timeout batched wait.
+
 ## 6.13 — Ring resize, mem regions, hybrid iopoll (≈ January 2025, per tree)
 
 - `IORING_REGISTER_RESIZE_RINGS` — grow/shrink the SQ/CQ rings of a live ring without tearing it down. (`io_uring_register.2`: "Available since kernel 6.13"; git: first in `v6.13`.)
@@ -262,6 +290,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 - `IORING_REGISTER_SEND_MSG_RING` ("Available since kernel 6.13").
 - `IORING_SETUP_HYBRID_IOPOLL` — a hybrid of interrupt-driven and busy-poll completions, used with `IORING_SETUP_IOPOLL`. (Git: `IORING_SETUP_HYBRID_IOPOLL` first in `v6.13`.)
 - `IORING_REGISTER_CLONE_BUFFERS` gains offset/destination-range support ("6.13 added support for specifying the offsets…").
+
+> **Worked example.** [`resize-rings.d`][ex-resize] grows a live ring's SQ/CQ with `IORING_REGISTER_RESIZE_RINGS`.
 
 ## 6.15 — Zero-copy receive, epoll-wait, vectored fixed, query (≈ May 2025, per tree)
 
@@ -273,6 +303,8 @@ A large networking/throughput release in this tree:
 - `IORING_REGISTER_ZCRX_IFQ` — register the zero-copy RX interface queue that `RECV_ZC` consumes. (`io_uring_register.2`: "Available since kernel 6.15"; git: enum value first in `v6.15`.) A later `IORING_REGISTER_ZCRX_CTRL` control op is documented alongside it.
 - `IORING_REGISTER_QUERY` — a structured capability-query registration op (a successor/companion to `IORING_REGISTER_PROBE`). **Discrepancy flagged:** `liburing 2.15`'s `io_uring_register.2` marks it "Available since kernel 6.15", but in this tree the enum value `IORING_REGISTER_QUERY` is **not** present in `v6.15`; it is added by commit `c265ae75f900` ("`io_uring`: introduce `io_uring` querying", Sept 2025), whose first containing tag is **`v6.18`**. Treat the kernel availability as **6.18**, not 6.15.
 
+> **Worked examples.** [`epoll-wait.d`][ex-epollwait] folds a legacy epoll set into the ring with `IORING_OP_EPOLL_WAIT`; [`recv-zc.d`][ex-recvzc] does zero-copy receive via a registered ZCRX interface queue (SKIPs without a capable NIC).
+
 ## 6.16 — Async pipe (≈ July 2025, per tree)
 
 - `IORING_OP_PIPE` — async `pipe2(2)`; can create normal _or_ direct (fixed) descriptor pairs, writing the read/write ends into a two-element array. (`io_uring_enter.2`: "Available since 6.16"; git: enum first in `v6.16`.)
@@ -282,6 +314,8 @@ A large networking/throughput release in this tree:
 ## 6.18 — Mixed-size CQE (≈ November 2025, per tree)
 
 - `IORING_SETUP_CQE_MIXED` — a ring may carry a mix of 16-byte and 32-byte CQEs, transparently, instead of committing to `CQE32` for the whole ring. (`io_uring_setup.2`: "Available since 6.18"; git: `IORING_SETUP_CQE_MIXED` first in `v6.18`.)
+
+> **Worked example.** [`cqe-mixed.d`][ex-cqemixed] reaps mixed 16- and 32-byte CQEs from one ring with `IORING_SETUP_CQE_MIXED`.
 
 ## 6.19 — Mixed-size SQE and 128-byte opcodes (≈ February 2026, per tree)
 
@@ -293,9 +327,13 @@ A large networking/throughput release in this tree:
 
 > **Marker accuracy note.** The `liburing 2.15` `io_uring_enter.2` text labels `IORING_OP_NOP128` and `IORING_OP_URING_CMD128` "Available since 6.19". In this tree the `v6.19` tag does exist and contains the commit, so the man-page marker is internally consistent. There is no `6.x → 7.0` _skip_: the sequence is `… 6.18 → 6.19 → 7.0 → 7.1`. Anyone reading this against a _public_ kernel (≤ 6.13 as of early 2025) will not find these opcodes.
 
+> **Worked example.** [`sqe-mixed.d`][ex-sqemixed] issues mixed 64/128-byte SQEs + `NOP128` with `IORING_SETUP_SQE_MIXED` (needs ≥6.19).
+
 ## 7.0 — SQ rewind (≈ April 2026, per tree)
 
 - `IORING_SETUP_SQ_REWIND` — used with `IORING_SETUP_NO_SQARRAY`, allows the SQ tail to be rewound (re-submission of not-yet-consumed SQEs). (`io_uring_setup.2`: "Available since 7.0"; git: `IORING_SETUP_SQ_REWIND` first in `v7.0`.)
+
+> **Worked example.** [`sq-rewind.d`][ex-sqrewind] rewinds the SQ tail to re-submit unconsumed SQEs with `IORING_SETUP_SQ_REWIND` (needs ≥7.0).
 
 ## 7.1-rc6 — Current checkout (development, ≈ May 2026)
 
@@ -376,24 +414,49 @@ and degrades to a `SKIP` (exit 0) on kernels that lack it, so the whole set stay
 the 5.1 baseline up to a bleeding-edge tree. Run them all with `ci --example-files`, or one at
 a time with `dub run --single <file>`.
 
-| Example                                | Since     | Demonstrates                                              |
-| -------------------------------------- | --------- | --------------------------------------------------------- |
-| [`nop.d`][ex-nop]                      | 5.1       | Minimal setup → submit → wait → CQE cycle                 |
-| [`read-write-fixed.d`][ex-rwfixed]     | 5.1       | Registered (fixed) buffers via `WRITE_FIXED`/`READ_FIXED` |
-| [`poll-add.d`][ex-poll]                | 5.1       | One-shot `POLL_ADD` readiness on a pipe                   |
-| [`linked-sqes.d`][ex-linked]           | 5.3       | `IOSQE_IO_LINK` write→`fsync` ordering                    |
-| [`timeout-link-timeout.d`][ex-timeout] | 5.4 / 5.5 | `TIMEOUT` (`-ETIME`) and `LINK_TIMEOUT` cancelling a poll |
-| [`tcp-echo.d`][ex-tcp]                 | 5.5 / 5.6 | Loopback `ACCEPT`+`CONNECT`+`SEND`+`RECV` on one ring     |
-| [`async-cancel.d`][ex-cancel]          | 5.5       | `ASYNC_CANCEL` of an in-flight poll by `user_data`        |
-| [`openat-statx-close.d`][ex-openat]    | 5.6       | Async `OPENAT`→`STATX`→`READ`→`CLOSE` chain               |
-| [`probe.d`][ex-probe]                  | 5.6       | `IORING_REGISTER_PROBE` per-opcode capability table       |
-| [`multishot-accept.d`][ex-msaccept]    | 5.19      | Multishot `ACCEPT` (`CQEFlags.MORE` keeps it armed)       |
-| [`provided-buf-ring.d`][ex-pbufring]   | 5.19      | Ring-provided buffers (`PBUF_RING`) selecting a `RECV`    |
-| [`send-zc.d`][ex-sendzc]               | 6.0       | Zero-copy `SEND_ZC` transfer-CQE → notification-CQE       |
-| [`defer-taskrun.d`][ex-defer]          | 6.1       | `SINGLE_ISSUER`+`DEFER_TASKRUN`+`COOP_TASKRUN` setup      |
-| [`multishot-timeout.d`][ex-mstimeout]  | 6.4       | `IORING_TIMEOUT_MULTISHOT` recurring timer                |
-| [`futex.d`][ex-futex]                  | 6.7       | Async `FUTEX_WAIT` woken by a legacy `futex(2)` wake      |
-| [`pipe.d`][ex-pipe]                    | 6.16      | `IORING_OP_PIPE` pipe-pair creation through the ring      |
+| Example                                | Since     | Demonstrates                                                         |
+| -------------------------------------- | --------- | -------------------------------------------------------------------- |
+| [`nop.d`][ex-nop]                      | 5.1       | Minimal setup → submit → wait → CQE cycle                            |
+| [`read-write-fixed.d`][ex-rwfixed]     | 5.1       | Registered (fixed) buffers via `WRITE_FIXED`/`READ_FIXED`            |
+| [`poll-add.d`][ex-poll]                | 5.1       | One-shot `POLL_ADD` readiness on a pipe                              |
+| [`registered-files.d`][ex-regfiles]    | 5.1       | Read a file by fixed-file index with `IOSQE_FIXED_FILE`              |
+| [`sqpoll.d`][ex-sqpoll]                | 5.1       | `NOP` with no `io_uring_enter` via the `SQPOLL` kernel thread        |
+| [`linked-sqes.d`][ex-linked]           | 5.3       | `IOSQE_IO_LINK` write→`fsync` ordering                               |
+| [`sendmsg-recvmsg.d`][ex-sendmsg]      | 5.3       | Pass an fd over a unix socket (`SCM_RIGHTS`) via `SENDMSG`/`RECVMSG` |
+| [`timeout-link-timeout.d`][ex-timeout] | 5.4 / 5.5 | `TIMEOUT` (`-ETIME`) and `LINK_TIMEOUT` cancelling a poll            |
+| [`tcp-echo.d`][ex-tcp]                 | 5.5 / 5.6 | Loopback `ACCEPT`+`CONNECT`+`SEND`+`RECV` on one ring                |
+| [`async-cancel.d`][ex-cancel]          | 5.5       | `ASYNC_CANCEL` of an in-flight poll by `user_data`                   |
+| [`openat-statx-close.d`][ex-openat]    | 5.6       | Async `OPENAT`→`STATX`→`READ`→`CLOSE` chain                          |
+| [`probe.d`][ex-probe]                  | 5.6       | `IORING_REGISTER_PROBE` per-opcode capability table                  |
+| [`splice-tee.d`][ex-splicetee]         | 5.7       | Zero-copy `SPLICE` between pipes and `TEE` duplication               |
+| [`restrictions.d`][ex-restrict]        | 5.10      | Sandbox a ring via `REGISTER_RESTRICTIONS` + `R_DISABLED`            |
+| [`fs-mutations.d`][ex-fsmut]           | 5.11      | Async `MKDIRAT`/`SYMLINKAT`/`LINKAT`/`RENAMEAT`/`UNLINKAT`           |
+| [`direct-descriptors.d`][ex-directfd]  | 5.15      | Open into a fixed slot, then `FIXED_FD_INSTALL` back to a real fd    |
+| [`cqe-skip.d`][ex-cqeskip]             | 5.17      | Suppress a successful op's CQE with `IOSQE_CQE_SKIP_SUCCESS`         |
+| [`msg-ring.d`][ex-msgring]             | 5.18      | Post a `u64` from one ring into another (cross-core wakeup)          |
+| [`registered-ring-fd.d`][ex-regringfd] | 5.18      | Register the ring fd so `io_uring_enter` skips `fdget`/`fdput`       |
+| [`multishot-accept.d`][ex-msaccept]    | 5.19      | Multishot `ACCEPT` (`CQEFlags.MORE` keeps it armed)                  |
+| [`provided-buf-ring.d`][ex-pbufring]   | 5.19      | Ring-provided buffers (`PBUF_RING`) selecting a `RECV`               |
+| [`uring-cmd-socket.d`][ex-uringcmd]    | 5.19      | Socket `getsockopt`/`setsockopt` via `URING_CMD` passthrough         |
+| [`send-zc.d`][ex-sendzc]               | 6.0       | Zero-copy `SEND_ZC` transfer-CQE → notification-CQE                  |
+| [`multishot-recv.d`][ex-msrecv]        | 6.0       | Multishot `RECV` posting a CQE per segment into provided buffers     |
+| [`sync-cancel.d`][ex-synccancel]       | 6.0       | Synchronous cancel of a poll via `REGISTER_SYNC_CANCEL`              |
+| [`defer-taskrun.d`][ex-defer]          | 6.1       | `SINGLE_ISSUER`+`DEFER_TASKRUN`+`COOP_TASKRUN` setup                 |
+| [`multishot-timeout.d`][ex-mstimeout]  | 6.4       | `IORING_TIMEOUT_MULTISHOT` recurring timer                           |
+| [`futex.d`][ex-futex]                  | 6.7       | Async `FUTEX_WAIT` woken by a legacy `futex(2)` wake                 |
+| [`waitid.d`][ex-waitid]                | 6.7       | Async child-process reap with `IORING_OP_WAITID`                     |
+| [`read-multishot.d`][ex-readms]        | 6.7       | Repeated pipe reads into provided buffers via `READ_MULTISHOT`       |
+| [`futex-waitv.d`][ex-futexv]           | 6.7       | Wait on a vector of futexes with `FUTEX_WAITV`                       |
+| [`napi.d`][ex-napi]                    | 6.9       | Configure NAPI busy-poll with `REGISTER_NAPI`                        |
+| [`socket-bind-listen.d`][ex-socketbl]  | 6.11      | Async `SOCKET` + `BIND` + `LISTEN` lifecycle through the ring        |
+| [`clock-min-timeout.d`][ex-clock]      | 6.12      | Select the wait clock (`REGISTER_CLOCK`) + min-timeout wait          |
+| [`resize-rings.d`][ex-resize]          | 6.13      | Grow a live ring's SQ/CQ with `REGISTER_RESIZE_RINGS`                |
+| [`epoll-wait.d`][ex-epollwait]         | 6.15      | Fold a legacy epoll set into the ring with `EPOLL_WAIT`              |
+| [`recv-zc.d`][ex-recvzc]               | 6.15      | Zero-copy receive via a registered ZCRX interface queue              |
+| [`pipe.d`][ex-pipe]                    | 6.16      | `IORING_OP_PIPE` pipe-pair creation through the ring                 |
+| [`cqe-mixed.d`][ex-cqemixed]           | 6.18      | Reap mixed 16- and 32-byte CQEs with `SETUP_CQE_MIXED`               |
+| [`sqe-mixed.d`][ex-sqemixed]           | 6.19      | Mixed 64/128-byte SQEs + `NOP128` with `SETUP_SQE_MIXED`             |
+| [`sq-rewind.d`][ex-sqrewind]           | 7.0       | Rewind the SQ tail to re-submit SQEs with `SETUP_SQ_REWIND`          |
 
 ---
 
@@ -455,3 +518,28 @@ a time with `dub run --single <file>`.
 [ex-mstimeout]: ./examples/multishot-timeout.d
 [ex-futex]: ./examples/futex.d
 [ex-pipe]: ./examples/pipe.d
+[ex-regfiles]: ./examples/registered-files.d
+[ex-sqpoll]: ./examples/sqpoll.d
+[ex-sendmsg]: ./examples/sendmsg-recvmsg.d
+[ex-splicetee]: ./examples/splice-tee.d
+[ex-restrict]: ./examples/restrictions.d
+[ex-fsmut]: ./examples/fs-mutations.d
+[ex-directfd]: ./examples/direct-descriptors.d
+[ex-cqeskip]: ./examples/cqe-skip.d
+[ex-msgring]: ./examples/msg-ring.d
+[ex-regringfd]: ./examples/registered-ring-fd.d
+[ex-uringcmd]: ./examples/uring-cmd-socket.d
+[ex-msrecv]: ./examples/multishot-recv.d
+[ex-synccancel]: ./examples/sync-cancel.d
+[ex-waitid]: ./examples/waitid.d
+[ex-readms]: ./examples/read-multishot.d
+[ex-futexv]: ./examples/futex-waitv.d
+[ex-napi]: ./examples/napi.d
+[ex-socketbl]: ./examples/socket-bind-listen.d
+[ex-clock]: ./examples/clock-min-timeout.d
+[ex-resize]: ./examples/resize-rings.d
+[ex-epollwait]: ./examples/epoll-wait.d
+[ex-recvzc]: ./examples/recv-zc.d
+[ex-cqemixed]: ./examples/cqe-mixed.d
+[ex-sqemixed]: ./examples/sqe-mixed.d
+[ex-sqrewind]: ./examples/sq-rewind.d

--- a/docs/research/async-io/io-uring/timeline.md
+++ b/docs/research/async-io/io-uring/timeline.md
@@ -38,6 +38,8 @@ The kernel exposes a feature the moment its commit lands in a merge window; the 
 
 This is the foundation every surveyed library targets as its baseline (read/write/fsync + poll). See [Tokio's][doc-tokio] and Glommio's backends in the matrix below.
 
+> **Worked examples.** [`nop.d`][ex-nop] walks the minimal setup → submit → wait → CQE cycle; [`read-write-fixed.d`][ex-rwfixed] round-trips a payload through a registered (fixed) buffer; [`poll-add.d`][ex-poll] arms a one-shot `POLL_ADD`. All three are runnable `during` demos.
+
 ## 5.2 — Sync file range (July 2019)
 
 - `IORING_OP_SYNC_FILE_RANGE` — async `sync_file_range(2)`. (`io_uring_enter.2`: "Available since 5.2".)
@@ -49,11 +51,15 @@ This is the foundation every surveyed library targets as its baseline (read/writ
 - `IORING_OP_SENDMSG` / `IORING_OP_RECVMSG` — async `sendmsg(2)`/`recvmsg(2)`. (`io_uring_enter.2`: "Available since 5.3".)
 - Linked SQEs (`IOSQE_IO_LINK`): the ability to chain dependent SQEs so the next starts only after the previous succeeds; the man page records this submission-side feature "Available since 5.3".
 
+> **Worked example.** [`linked-sqes.d`][ex-linked] chains a write to an `fsync` on the same fd with `IOSQE_IO_LINK`, showing the kernel-guaranteed write-before-`fsync` ordering and the failure-propagation (`-ECANCELED`) semantics of linked SQEs.
+
 ## 5.4 — Timeouts and single mmap (November 2019)
 
 - `IORING_OP_TIMEOUT` — a timeout that completes after N completions or a wall-clock interval. (`io_uring_enter.2`: "Available since 5.4".)
 - `IORING_FEAT_SINGLE_MMAP` — SQ and CQ rings can share one `mmap`, cutting setup from three `mmap` calls to two. (`io_uring_setup.2`: "Available since kernel 5.4".)
 - A historical note in several `io_uring_prep_*` man pages: "Very early kernels (5.4 and earlier) required state to be stable" before submission — an early-era constraint relaxed by `IORING_FEAT_SUBMIT_STABLE` (5.5).
+
+> **Worked example.** [`timeout-link-timeout.d`][ex-timeout] fires a standalone relative `TIMEOUT` (completing with `-ETIME`) and then uses a `LINK_TIMEOUT` (5.5) to cancel a never-ready poll.
 
 ## 5.5 — Accept/connect, cancel, link-timeout (January 2020)
 
@@ -68,6 +74,8 @@ A pivotal release for networking and control flow:
 All five are marked "Available since 5.5" in `io_uring_enter.2`, matching the [LWN growth article][lwn-growth] inventory.
 
 **Features**: `IORING_FEAT_NODROP` (the kernel stops silently dropping CQEs on overflow; "since kernel 5.5"), `IORING_FEAT_SUBMIT_STABLE` (SQE data may be mutated immediately after submission; "since kernel 5.5"). (The `IORING_REGISTER_FILES_SKIP` skip-semantics for `IORING_REGISTER_FILES_UPDATE` arrive later — `io_uring_register.2` marks them "since 5.12", and the define is first present in the `v5.12` kernel; see 5.12 below.)
+
+> **Worked examples.** [`tcp-echo.d`][ex-tcp] drives a loopback `ACCEPT`+`CONNECT`+`SEND`+`RECV` round-trip through a single ring; [`async-cancel.d`][ex-cancel] cancels an in-flight poll by its `user_data` and observes the `-ECANCELED` completion.
 
 ## 5.6 — The filesystem/syscall expansion (March 2020)
 
@@ -85,6 +93,8 @@ The largest single-release opcode batch — `io_uring` stops being "just block I
 All marked "Available since 5.6" in `io_uring_enter.2`; the [LWN growth article][lwn-growth] enumerates the same set.
 
 **Features**: `IORING_FEAT_CUR_PERSONALITY` ("since kernel 5.6"). **Registration**: `IORING_REGISTER_PROBE` (runtime opcode capability probing — _the_ portable feature-detection mechanism, "since 5.6"), `IORING_REGISTER_PERSONALITY` / `IORING_UNREGISTER_PERSONALITY`, `IORING_REGISTER_EVENTFD_ASYNC` (all "since 5.6").
+
+> **Worked examples.** [`openat-statx-close.d`][ex-openat] chains `OPENAT`→`STATX`→`READ`→`CLOSE` asynchronously, feeding each op's result fd into the next; [`probe.d`][ex-probe] uses `IORING_REGISTER_PROBE` to print which opcodes the running kernel supports.
 
 ## 5.7 — Splice, provided buffers, fast poll (May 2020)
 
@@ -168,6 +178,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 
 **Setup**: `IORING_SETUP_COOP_TASKRUN` (don't IPI the target task for completion task-work; "Available since 5.19"), `IORING_SETUP_TASKRUN_FLAG` (surface `IORING_SQ_TASKRUN` so userspace knows to reap; "since 5.19"), `IORING_SETUP_SQE128` (128-byte SQEs, required by some `URING_CMD` users like NVMe passthrough; "since 5.19"), `IORING_SETUP_CQE32` (32-byte CQEs; "since 5.19").
 
+> **Worked examples.** [`multishot-accept.d`][ex-msaccept] serves multiple loopback connections from a single armed accept SQE (each CQE carries `CQEFlags.MORE`); [`provided-buf-ring.d`][ex-pbufring] registers an `io_uring_buf` ring and issues a buffer-selecting `RECV`.
+
 ## 6.0 — Zero-copy send, single-issuer, sync cancel (October 2022)
 
 - `IORING_OP_SEND_ZC` — zero-copy `send`; the data is pinned and a second "notification" CQE (`IORING_CQE_F_NOTIF`) fires when the kernel is done with the buffer. (`io_uring_enter.2`: "Available since 6.0". Git: enum value first in `v6.0`.)
@@ -177,10 +189,14 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 
 **Registration**: `IORING_REGISTER_SYNC_CANCEL` (synchronous cancel from userspace; "Available since 6.0"), `IORING_REGISTER_FILE_ALLOC_RANGE` (reserve a sub-range of the direct-descriptor table; "Available since 6.0").
 
+> **Worked example.** [`send-zc.d`][ex-sendzc] performs a zero-copy `SEND_ZC` over loopback and asserts the two-CQE pattern: a transfer-result CQE (`CQEFlags.MORE`) followed by a separate notification CQE (`CQEFlags.NOTIF`).
+
 ## 6.1 — Zero-copy sendmsg, deferred task-run (December 2022)
 
 - `IORING_OP_SENDMSG_ZC` — the `msghdr` form of zero-copy send. (`io_uring_enter.2`: "Available since 6.1". Git: enum value first in `v6.1`.)
 - `IORING_SETUP_DEFER_TASKRUN` — defer completion task-work until the app calls `io_uring_enter(2)` with `IORING_ENTER_GETEVENTS`; requires `SINGLE_ISSUER`. (`io_uring_setup.2`: "Available since 6.1".) Together with `COOP_TASKRUN` this is the latency/syscall-batching configuration most high-performance libraries adopt (see Glommio/monoio in the matrix).
+
+> **Worked example.** [`defer-taskrun.d`][ex-defer] sets up a ring with `SINGLE_ISSUER | DEFER_TASKRUN | COOP_TASKRUN` and reaps a `NOP` and a relative `TIMEOUT` through the `GETEVENTS`-driven deferred task-run path.
 
 ## 6.3 — Registered-ring registration (April 2023)
 
@@ -189,6 +205,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 ## 6.4 — Multishot timeout (June 2023)
 
 - `IORING_TIMEOUT_MULTISHOT` (a `timeout_flags` bit on `IORING_OP_TIMEOUT`) — a repeating timer that posts a CQE per interval. (Git: the `IORING_TIMEOUT_MULTISHOT` define is first contained in tag `v6.4`.)
+
+> **Worked example.** [`multishot-timeout.d`][ex-mstimeout] arms one `MULTISHOT` timeout, collects three recurring `-ETIME` ticks (each with `CQEFlags.MORE`), then stops the repeats with an `ASYNC_CANCEL`.
 
 ## 6.5 — No-mmap setup (August 2023)
 
@@ -206,6 +224,8 @@ A second pivotal release (alongside 5.5 and 5.6) — it lands the modern high-th
 - `IORING_OP_WAITID` — async `waitid(2)`; a parent gets a CQE on child state change instead of blocking. (Git: enum first in `v6.7`; [LWN][lwn-waitid].) See the 6.5 discrepancy note above.
 - `IORING_OP_FUTEX_WAIT` / `IORING_OP_FUTEX_WAKE` / `IORING_OP_FUTEX_WAITV` — async `futex(2)` operations; `FUTEX_WAIT` mirrors `FUTEX_WAIT_BITSET`. (`io_uring_enter.2`: "Available since 6.7"; [LWN futex coverage][lwn-futex].)
 - `IORING_OP_READ_MULTISHOT` — repeatedly read from a pollable fd into ring-provided buffers, one CQE per chunk. (`io_uring_enter.2`: "Available since 6.7"; git: enum first in `v6.7`.)
+
+> **Worked example.** [`futex.d`][ex-futex] parks a ring on a 32-bit private futex with `IORING_OP_FUTEX_WAIT` and is woken by a helper thread issuing a legacy `futex(2)` wake on the same word.
 
 ## 6.8 — Fixed-fd install, pbuf status (March 2024)
 
@@ -256,6 +276,8 @@ A large networking/throughput release in this tree:
 ## 6.16 — Async pipe (≈ July 2025, per tree)
 
 - `IORING_OP_PIPE` — async `pipe2(2)`; can create normal _or_ direct (fixed) descriptor pairs, writing the read/write ends into a two-element array. (`io_uring_enter.2`: "Available since 6.16"; git: enum first in `v6.16`.)
+
+> **Worked example.** [`pipe.d`][ex-pipe] creates a pipe pair through the ring with `IORING_OP_PIPE`, then round-trips a byte through the new read/write ends.
 
 ## 6.18 — Mixed-size CQE (≈ November 2025, per tree)
 
@@ -346,6 +368,35 @@ Legend for libraries: **Tok**=Tokio (`tokio-uring`), **Glo**=Glommio, **Mon**=mo
 
 ---
 
+## Worked examples
+
+Each row links a runnable, standalone [`during`][during]-based D program in the `examples/`
+directory next to this file. Every example demonstrates its feature against the _live_ kernel
+and degrades to a `SKIP` (exit 0) on kernels that lack it, so the whole set stays green from
+the 5.1 baseline up to a bleeding-edge tree. Run them all with `ci --example-files`, or one at
+a time with `dub run --single <file>`.
+
+| Example                                | Since     | Demonstrates                                              |
+| -------------------------------------- | --------- | --------------------------------------------------------- |
+| [`nop.d`][ex-nop]                      | 5.1       | Minimal setup → submit → wait → CQE cycle                 |
+| [`read-write-fixed.d`][ex-rwfixed]     | 5.1       | Registered (fixed) buffers via `WRITE_FIXED`/`READ_FIXED` |
+| [`poll-add.d`][ex-poll]                | 5.1       | One-shot `POLL_ADD` readiness on a pipe                   |
+| [`linked-sqes.d`][ex-linked]           | 5.3       | `IOSQE_IO_LINK` write→`fsync` ordering                    |
+| [`timeout-link-timeout.d`][ex-timeout] | 5.4 / 5.5 | `TIMEOUT` (`-ETIME`) and `LINK_TIMEOUT` cancelling a poll |
+| [`tcp-echo.d`][ex-tcp]                 | 5.5 / 5.6 | Loopback `ACCEPT`+`CONNECT`+`SEND`+`RECV` on one ring     |
+| [`async-cancel.d`][ex-cancel]          | 5.5       | `ASYNC_CANCEL` of an in-flight poll by `user_data`        |
+| [`openat-statx-close.d`][ex-openat]    | 5.6       | Async `OPENAT`→`STATX`→`READ`→`CLOSE` chain               |
+| [`probe.d`][ex-probe]                  | 5.6       | `IORING_REGISTER_PROBE` per-opcode capability table       |
+| [`multishot-accept.d`][ex-msaccept]    | 5.19      | Multishot `ACCEPT` (`CQEFlags.MORE` keeps it armed)       |
+| [`provided-buf-ring.d`][ex-pbufring]   | 5.19      | Ring-provided buffers (`PBUF_RING`) selecting a `RECV`    |
+| [`send-zc.d`][ex-sendzc]               | 6.0       | Zero-copy `SEND_ZC` transfer-CQE → notification-CQE       |
+| [`defer-taskrun.d`][ex-defer]          | 6.1       | `SINGLE_ISSUER`+`DEFER_TASKRUN`+`COOP_TASKRUN` setup      |
+| [`multishot-timeout.d`][ex-mstimeout]  | 6.4       | `IORING_TIMEOUT_MULTISHOT` recurring timer                |
+| [`futex.d`][ex-futex]                  | 6.7       | Async `FUTEX_WAIT` woken by a legacy `futex(2)` wake      |
+| [`pipe.d`][ex-pipe]                    | 6.16      | `IORING_OP_PIPE` pipe-pair creation through the ring      |
+
+---
+
 ## Cross-references
 
 - Mechanics of each primitive: [io_uring features][doc-features].
@@ -387,3 +438,20 @@ Legend for libraries: **Tok**=Tokio (`tokio-uring`), **Glo**=Glommio, **Mon**=mo
 [doc-tokio]: ../tokio.md
 [doc-asio]: ../boost-asio.md
 [doc-eio]: ../../algebraic-effects/ocaml-eio.md
+[during]: ../d-landscape.md
+[ex-nop]: ./examples/nop.d
+[ex-rwfixed]: ./examples/read-write-fixed.d
+[ex-poll]: ./examples/poll-add.d
+[ex-linked]: ./examples/linked-sqes.d
+[ex-timeout]: ./examples/timeout-link-timeout.d
+[ex-tcp]: ./examples/tcp-echo.d
+[ex-cancel]: ./examples/async-cancel.d
+[ex-openat]: ./examples/openat-statx-close.d
+[ex-probe]: ./examples/probe.d
+[ex-msaccept]: ./examples/multishot-accept.d
+[ex-pbufring]: ./examples/provided-buf-ring.d
+[ex-sendzc]: ./examples/send-zc.d
+[ex-defer]: ./examples/defer-taskrun.d
+[ex-mstimeout]: ./examples/multishot-timeout.d
+[ex-futex]: ./examples/futex.d
+[ex-pipe]: ./examples/pipe.d


### PR DESCRIPTION
## What

Adds **41 runnable, standalone D example programs** that demonstrate the Linux `io_uring` features catalogued in the async-I/O research survey, built on the [`during`](https://code.dlang.org/packages/during)`~>0.5.0`. Each example lives under `docs/research/async-io/io-uring/examples/` and is cross-linked from both the [`timeline.md`](docs/research/async-io/io-uring/timeline.md) chronology (per-kernel-version callouts + a "Worked examples" index table) and the [`features.md`](docs/research/async-io/io-uring/features.md) feature taxonomy (per-category "Worked example(s)" callouts).

## The contract — green on any kernel

Every example follows the same shape: **probe the running kernel → demonstrate the feature on a live ring → `SKIP` and `exit 0` when the feature (or `io_uring` itself) is unavailable.**
It returns non-zero only on a genuine, unexpected syscall failure. This means the whole set:

- **genuinely exercises** each feature on a capable host (this was developed on a 6.18 box),
- stays **green on older CI runners** (`ubuntu-latest`, ~6.8–6.11) by skipping newer ops,
- and lets the three forward-dated entries (`SQE_MIXED`/`NOP128` 6.19, `SQ_REWIND` 7.0) plus the hardware-gated `RECV_ZC`/ZCRX compile and `SKIP` cleanly below their kernel/NIC.

`ci --example-files` only checks exit codes, so this contract is exactly what keeps CI stable.

## CI integration

`feat(ci)`: `trackedStandaloneExampleFiles()` now enumerates `docs/research/async-io/io-uring/examples/*.d` alongside the existing `core-cli` demos (factored into a documented `standaloneExampleGlobs()` seam), so the existing `ci --example-files --fail-fast` step in `.github/workflows/ci.yml` runs all of them with no further wiring.

## Coverage (41 examples)

Foundational & pivotal (16): `nop`, `read-write-fixed`, `poll-add`, `linked-sqes`, `timeout-link-timeout`, `tcp-echo`, `async-cancel`, `openat-statx-close`, `probe`, `multishot-accept`, `provided-buf-ring`, `send-zc`, `defer-taskrun`, `multishot-timeout`, `futex`, `pipe`.

Notable features (25): `msg-ring`, `registered-files`, `sqpoll`, `multishot-recv`, `waitid`, `sync-cancel`, `splice-tee`, `napi`, `cqe-skip`, `direct-descriptors`, `restrictions`, `registered-ring-fd`, `sendmsg-recvmsg` (SCM_RIGHTS fd-passing), `socket-bind-listen`, `read-multishot`, `futex-waitv`, `fs-mutations`, `epoll-wait`, `resize-rings`, `clock-min-timeout`, `uring-cmd-socket`, `cqe-mixed`, `recv-zc`, `sqe-mixed`, `sq-rewind`.

## Verification

- `ci --example-files` → **41/41 pass** (the exact CI command).
- Each example confirmed to genuinely demonstrate its feature (not skip) on a capable kernel; forward-dated/hardware-gated ones print a precise `SKIP` reason.
- VitePress build, `lychee`, `prettier`, and `editorconfig-checker` all pass; example links are build-safe via the existing `ignoreDeadLinks: [/\.d$/]` rule.

## Notes

- Examples depend on the published `during ~>0.5.0` from the DUB registry (fetched + cached in CI), so no vendored code.
- Example files carry the `#!/usr/bin/env dub` shebang and are committed executable (`100755`), matching the `core-cli` examples convention.
