### PR TITLE
build(nix): Replace `nixpkgs#dub` (1.39) with `dlang-nix#dub-1_43_0-alpha-5efed36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,7 +144,7 @@
           "crate2nix"
         ],
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1767714506,
@@ -176,7 +176,7 @@
           "crate2nix_stable"
         ],
         "git-hooks": "git-hooks_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1767714506,
@@ -251,7 +251,7 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nix-test-runner": "nix-test-runner",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
@@ -406,22 +406,23 @@
           "flake-compat"
         ],
         "flake-parts": [
-          "mcl-nixos-modules",
           "flake-parts"
         ],
-        "nixpkgs": "nixpkgs_4"
+        "git-hooks-nix": [
+          "git-hooks-nix"
+        ],
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1744296746,
-        "narHash": "sha256-x9rQjZceKcCte+gZcy0EmrNw5WEXVpP130w2YIVLEnw=",
+        "lastModified": 1780686322,
+        "narHash": "sha256-z/SNKqzpOy0LGN6WMS/DQDhaa8VUviszmTnhVALA4Fs=",
         "owner": "PetarKirov",
         "repo": "dlang.nix",
-        "rev": "e7c6c25978f5ec0a7b8ebae703dad3460d7fcceb",
+        "rev": "a4d19998321619b3e94ed70ffbb5c8685733cd52",
         "type": "github"
       },
       "original": {
         "owner": "PetarKirov",
-        "ref": "feat/build-dub-package",
         "repo": "dlang.nix",
         "type": "github"
       }
@@ -1090,7 +1091,9 @@
         "devenv": "devenv",
         "devshell": "devshell_3",
         "disko": "disko",
-        "dlang-nix": "dlang-nix",
+        "dlang-nix": [
+          "dlang-nix"
+        ],
         "ethereum-nix": "ethereum-nix",
         "fenix": "fenix",
         "flake-compat": "flake-compat_3",
@@ -1624,11 +1627,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765186076,
-        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {
@@ -1672,6 +1675,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1769433173,
         "narHash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=",
         "owner": "NixOS",
@@ -1682,22 +1701,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1794,6 +1797,7 @@
     },
     "root": {
       "inputs": {
+        "dlang-nix": "dlang-nix",
         "flake-parts": [
           "mcl-nixos-modules",
           "flake-parts"

--- a/flake.nix
+++ b/flake.nix
@@ -21,21 +21,15 @@
       };
     };
   };
-
   outputs =
-    inputs@{ flake-parts, mcl-nixos-modules, ... }:
+    inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         inputs.git-hooks-nix.flakeModule
-
         ./nix/packages/default.nix
         ./nix/checks/pre-commit.nix
+        ./nix/shells/default.nix
       ];
       systems = import inputs.systems;
-      perSystem =
-        { config, pkgs, ... }:
-        {
-          devShells.default = import ./nix/shells/default.nix { inherit config pkgs; };
-        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         inputs.git-hooks-nix.flakeModule
+        ./nix/d-toolchain.nix
         ./nix/packages/default.nix
         ./nix/checks/pre-commit.nix
         ./nix/shells/default.nix

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,9 @@
 {
   inputs = {
-    mcl-nixos-modules.url = "github:metacraft-labs/nixos-modules";
+    mcl-nixos-modules = {
+      url = "github:metacraft-labs/nixos-modules";
+      inputs.dlang-nix.follows = "dlang-nix";
+    };
 
     nixpkgs.follows = "mcl-nixos-modules/nixpkgs-unstable";
     flake-parts.follows = "mcl-nixos-modules/flake-parts";
@@ -8,6 +11,15 @@
     git-hooks-nix.follows = "mcl-nixos-modules/git-hooks-nix";
 
     systems.url = "github:nix-systems/triplet";
+
+    dlang-nix = {
+      url = "github:PetarKirov/dlang.nix";
+      inputs = {
+        flake-compat.follows = "mcl-nixos-modules/flake-compat";
+        flake-parts.follows = "flake-parts";
+        git-hooks-nix.follows = "git-hooks-nix";
+      };
+    };
   };
 
   outputs =

--- a/nix/d-toolchain.nix
+++ b/nix/d-toolchain.nix
@@ -2,12 +2,13 @@
 #
 # For each system it:
 #
-#   1. Applies a nixpkgs overlay that replaces `ldc` and `dmd` with the
-#      platform-corrected variants (`_module.args.pkgs`), so *every* consumer
-#      — directly and through `buildDubPackage`, whose `compiler`/`dub` default
-#      to `pkgs.ldc`/`pkgs.dub` — resolves the same toolchain. That consistency
-#      is the whole point: the dev shell, the `ci` package and the example
-#      derivations can no longer drift onto a different `ldc` than each other.
+#   1. Applies a nixpkgs overlay that replaces `ldc`, `dmd` and `dub` with the
+#      project-pinned, platform-corrected variants (`_module.args.pkgs`), so
+#      *every* consumer — directly and through `buildDubPackage`, whose
+#      `dub`/`compiler` default to `pkgs.dub`/`pkgs.ldc` — resolves the same
+#      toolchain. That consistency is the whole point: the dev shell, the `ci`
+#      package and the example derivations can no longer drift onto a different
+#      `dub` or `ldc` than each other.
 #
 #   2. Derives the dev-shell/packaging metadata (package list, env vars, NOFILE
 #      cap) from the overlaid package set and exports it under
@@ -18,6 +19,7 @@
   perSystem =
     {
       system,
+      inputs',
       pkgs,
       ...
     }:
@@ -81,6 +83,8 @@
               # a C23 keyword unknown to the D parser).  Only needed when stdenv
               # is GCC-based; on macOS stdenv already uses clang.
               dmd = if prev.stdenv.cc.isGNU then prev.dmd.override { stdenv = prev.gcc14Stdenv; } else prev.dmd;
+
+              dub = inputs'.dlang-nix.packages.dub-1_43_0-alpha-5efed36;
             }
           )
         ];

--- a/nix/d-toolchain.nix
+++ b/nix/d-toolchain.nix
@@ -1,52 +1,118 @@
-{ pkgs }:
-let
-  inherit (pkgs) lib;
-  inherit (pkgs.stdenv) isDarwin isx86_64;
-
-  cleanLdcConfig = lib.pipe "${pkgs.ldc}/etc/ldc2.conf" [
-    builtins.readFile
-    (lib.splitString "\n")
-    (lib.filter (line: !(lib.hasInfix "/lib/clang/" line && lib.hasInfix "/lib/darwin" line)))
-    lib.concatLines
-    (pkgs.writeText "ldc2-clean.conf")
-  ];
-
-  ldc =
-    if isDarwin then
-      pkgs.writeShellScriptBin "ldc2" ''
-        exec ${pkgs.ldc}/bin/ldc2 -conf=${cleanLdcConfig} "$@"
-      ''
-    else
-      pkgs.ldc;
-
-  # DMD 2.110's ImportC cannot parse GCC 15's stddef.h (`nullptr` is a
-  # C23 keyword unknown to the D parser).  Only needed when stdenv is
-  # GCC-based; on macOS stdenv already uses clang.
-  dmd = if pkgs.stdenv.cc.isGNU then pkgs.dmd.override { stdenv = pkgs.gcc14Stdenv; } else pkgs.dmd;
-
-  clangUnwrapped = pkgs.clangStdenv.cc.cc;
-in
+# The project's D toolchain, as a flake-parts module.
+#
+# For each system it:
+#
+#   1. Applies a nixpkgs overlay that replaces `ldc` and `dmd` with the
+#      platform-corrected variants (`_module.args.pkgs`), so *every* consumer
+#      — directly and through `buildDubPackage`, whose `compiler`/`dub` default
+#      to `pkgs.ldc`/`pkgs.dub` — resolves the same toolchain. That consistency
+#      is the whole point: the dev shell, the `ci` package and the example
+#      derivations can no longer drift onto a different `ldc` than each other.
+#
+#   2. Derives the dev-shell/packaging metadata (package list, env vars, NOFILE
+#      cap) from the overlaid package set and exports it under
+#      `legacyPackages.d-toolchain`. Other modules consume it via
+#      `config.legacyPackages.d-toolchain.*`.
+{ inputs, ... }:
 {
-  inherit ldc dmd;
-  inherit (pkgs) dub dtools;
+  perSystem =
+    {
+      system,
+      pkgs,
+      ...
+    }:
+    {
+      _module.args.pkgs = import inputs.nixpkgs {
+        inherit system;
+        overlays = [
+          (
+            final: prev:
+            let
+              inherit (prev) lib;
+              inherit (prev.stdenv) isDarwin;
 
-  packages = [
-    ldc
-    pkgs.dub
-    pkgs.dtools
-  ]
-  ++ lib.optionals (isx86_64) [
-    dmd
-  ];
+              cleanLdcConfig = lib.pipe "${prev.ldc}/etc/ldc2.conf" [
+                builtins.readFile
+                (lib.splitString "\n")
+                (lib.filter (line: !(lib.hasInfix "/lib/clang/" line && lib.hasInfix "/lib/darwin" line)))
+                lib.concatLines
+                (prev.writeText "ldc2-clean.conf")
+              ];
+            in
+            {
+              # On Darwin, ldc2.conf ships a lib-dirs entry pointing at a
+              # compiler-rt path that does not exist in the Nix store, yielding
+              # a spurious `ld: warning: directory not found`. Re-point both
+              # drivers at the cleaned config via a wrapper. Because this overlay
+              # replaces `pkgs.ldc` package-set-wide, the result must stay a
+              # *complete* ldc — dub builds link against `${ldc}/lib`
+              # (druntime/phobos) and may invoke `ldmd2` — so we `symlinkJoin`
+              # the real package and only wrap the two drivers, rather than
+              # substituting a bare `ldc2` shim.
+              ldc =
+                if isDarwin then
+                  prev.symlinkJoin {
+                    name = "ldc-${prev.ldc.version}";
+                    paths = [ prev.ldc ];
+                    nativeBuildInputs = [ prev.makeWrapper ];
+                    postBuild = ''
+                      for drv in ldc2 ldmd2; do
+                        wrapProgram "$out/bin/$drv" --add-flags "-conf=${cleanLdcConfig}"
+                      done
+                    '';
+                    meta = prev.ldc.meta // {
+                      mainProgram = "ldc2";
+                    };
+                  }
+                else
+                  prev.ldc;
 
-  env = lib.optionalAttrs isDarwin {
-    CC = "${clangUnwrapped}/bin/clang";
-    CXX = "${clangUnwrapped}/bin/clang++";
-    SDKROOT = "${pkgs.apple-sdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
-    MACOSX_DEPLOYMENT_TARGET = "14.0";
-  };
+              # Build `dtools` (rdmd, dustmite, …) against the *unwrapped* ldc.
+              # Its check phase (`test_rdmd`) copies `ldmd2` into a temp dir and
+              # execs it, which trips over the Darwin wrapper above ("Permission
+              # denied"), and the tool bundle gains nothing from our cleaned
+              # config. A bare `prev.dtools` would not help: nixpkgs `by-name`
+              # packages bind `callPackage` to the *final* package set, so
+              # `prev.dtools` already resolves `ldc` to the wrapper — the `ldc`
+              # argument has to be overridden back to the plain package.
+              dtools = prev.dtools.override { ldc = prev.ldc; };
 
-  # Caps open-file limit so D's std.process.fork() child doesn't overflow
-  # when casting rlim_cur to int (phobos bug with unlimited NOFILE).
-  nofileLimit = 131072;
+              # DMD 2.110's ImportC cannot parse GCC 15's stddef.h (`nullptr` is
+              # a C23 keyword unknown to the D parser).  Only needed when stdenv
+              # is GCC-based; on macOS stdenv already uses clang.
+              dmd = if prev.stdenv.cc.isGNU then prev.dmd.override { stdenv = prev.gcc14Stdenv; } else prev.dmd;
+            }
+          )
+        ];
+      };
+
+      legacyPackages.d-toolchain =
+        let
+          inherit (pkgs) lib;
+          inherit (pkgs.stdenv) isDarwin isx86_64;
+
+          clangUnwrapped = pkgs.clangStdenv.cc.cc;
+        in
+        {
+          packages = [
+            pkgs.ldc
+            pkgs.dub
+            pkgs.dtools
+          ]
+          ++ lib.optionals (isx86_64) [
+            pkgs.dmd
+          ];
+
+          env = lib.optionalAttrs isDarwin {
+            CC = "${clangUnwrapped}/bin/clang";
+            CXX = "${clangUnwrapped}/bin/clang++";
+            SDKROOT = "${pkgs.apple-sdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
+            MACOSX_DEPLOYMENT_TARGET = "14.0";
+          };
+
+          # Caps open-file limit so D's std.process.fork() child doesn't overflow
+          # when casting rlim_cur to int (phobos bug with unlimited NOFILE).
+          nofileLimit = 131072;
+        };
+    };
 }

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -7,7 +7,7 @@
   perSystem =
     { config, pkgs, ... }:
     let
-      dToolchain = import ../d-toolchain.nix { inherit pkgs; };
+      inherit (config.legacyPackages) d-toolchain;
 
       fs = lib.fileset;
       root = ../..;
@@ -50,7 +50,7 @@
         # that sharing explicit instead of having `examples.nix` reach
         # into a sibling sub-package's dir to grab the file.
         dubLock = fromRoot "nix/dub-lock.json";
-        compiler = dToolchain.ldc;
+        compiler = pkgs.ldc;
 
         nativeBuildInputs = [
           pkgs.makeWrapper
@@ -82,8 +82,8 @@
           let
             path = lib.makeBinPath [
               pkgs.git
-              dToolchain.dub
-              dToolchain.ldc
+              pkgs.dub
+              pkgs.ldc
             ];
             setEnv = lib.cli.toGNUCommandLineShell {
               mkOption = name: value: [
@@ -91,7 +91,7 @@
                 name
                 value
               ];
-            } dToolchain.env;
+            } d-toolchain.env;
           in
           ''
             install -Dm755 build/${finalAttrs.pname} $out/bin/${finalAttrs.pname}
@@ -107,7 +107,7 @@
               wrapProgram $out/bin/${finalAttrs.pname} \
                 --prefix PATH : ${path} \
                 ${setEnv} \
-                --run 'ulimit -n ${toString dToolchain.nofileLimit} 2>/dev/null || true'
+                --run 'ulimit -n ${toString d-toolchain.nofileLimit} 2>/dev/null || true'
             '';
 
         meta = {

--- a/nix/packages/examples.nix
+++ b/nix/packages/examples.nix
@@ -3,8 +3,6 @@
   perSystem =
     { pkgs, ... }:
     let
-      dToolchain = import ../d-toolchain.nix { inherit pkgs; };
-
       fs = lib.fileset;
       root = ../..;
       fromRoot = lib.path.append root;
@@ -82,7 +80,7 @@
           # an additional dependency, that dep needs to be added to the
           # shared lockfile or split out into its own.
           dubLock = fromRoot "nix/dub-lock.json";
-          compiler = dToolchain.ldc;
+          compiler = pkgs.ldc;
 
           # The unpacked source is read-only by default; dub needs to write
           # build artifacts into the package's `targetPath "build"` directory.
@@ -97,7 +95,7 @@
 
             dub build \
               --single ${info.fileBase}.d \
-              --compiler=${lib.getExe dToolchain.ldc} \
+              --compiler=${lib.getExe pkgs.ldc} \
               --skip-registry=all \
               --build=release
 

--- a/nix/shells/default.nix
+++ b/nix/shells/default.nix
@@ -1,40 +1,51 @@
-{ config, pkgs }:
-let
-  inherit (pkgs) lib;
-  dToolchain = import ../d-toolchain.nix { inherit pkgs; };
+{
+  perSystem =
+    {
+      config,
+      pkgs,
+      inputs',
+      ...
+    }:
+    let
+      inherit (pkgs) lib;
+      dToolchain = import ../d-toolchain.nix { inherit pkgs; };
 
-  envExports = lib.concatStringsSep "\n" (
-    lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") dToolchain.env
-  );
-in
-pkgs.mkShell {
-  packages = [
-    # devshell niceties
-    pkgs.figlet
-
-    # Pre-commit hooks
-    pkgs.prek
-
-    # Used by :test-utils package
-    pkgs.delta
-
-    # Profiling
-    pkgs.tracy
-    pkgs.capstone
-
-    pkgs.mold
-
-    # Documentation site
-    pkgs.nodejs
-    # CI helper (markdown examples, standalone examples, link maintenance)
-    config.packages.ci
-  ]
-  ++ dToolchain.packages;
-
-  shellHook = ''
-    ${envExports}
-    export GITHUB_TOKEN="$(gh auth token)"
-    figlet 'sparkles : *'
-  ''
-  + config.pre-commit.installationScript;
+      envExports = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") dToolchain.env
+      );
+      mkSparklesShell =
+        greeting:
+        pkgs.mkShell {
+          packages = [
+            # Pre-commit hooks
+            pkgs.prek
+            # Used by :test-utils package
+            pkgs.delta
+            # Profiling
+            pkgs.tracy
+            pkgs.capstone
+            pkgs.mold
+            # Documentation site
+            pkgs.nodejs
+            # CI helper (markdown examples, standalone examples, link maintenance)
+            config.packages.ci
+          ]
+          ++ lib.optional greeting pkgs.figlet
+          ++ dToolchain.packages;
+          shellHook = ''
+            ${envExports}
+            export GITHUB_TOKEN="$(gh auth token)"
+            ${lib.optionalString greeting "figlet 'sparkles : *'"}
+          ''
+          + config.pre-commit.installationScript;
+        };
+    in
+    {
+      devShells = {
+        # Quiet shell for non-interactive use (LLM agents, scripts, CI).
+        default = mkSparklesShell false;
+        # Full shell for interactive use — adds the figlet greeting on entry.
+        full = mkSparklesShell true;
+      };
+    };
 }

--- a/nix/shells/default.nix
+++ b/nix/shells/default.nix
@@ -3,15 +3,14 @@
     {
       config,
       pkgs,
-      inputs',
       ...
     }:
     let
       inherit (pkgs) lib;
-      dToolchain = import ../d-toolchain.nix { inherit pkgs; };
+      inherit (config.legacyPackages) d-toolchain;
 
       envExports = lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") dToolchain.env
+        lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") d-toolchain.env
       );
       mkSparklesShell =
         greeting:
@@ -31,7 +30,7 @@
             config.packages.ci
           ]
           ++ lib.optional greeting pkgs.figlet
-          ++ dToolchain.packages;
+          ++ d-toolchain.packages;
           shellHook = ''
             ${envExports}
             export GITHUB_TOKEN="$(gh auth token)"


### PR DESCRIPTION
Replace `nixpkgs#dub` (1.39.0) with `dlang-nix#dub-1.43.0-alpha-5efed36`, and
route the whole D toolchain through a `pkgs` overlay so it stays consistent.

## Commits

- **build(flake.nix/inputs): Add `dlang-nix`** — new flake input providing
  pinned `dub` builds.
- **refactor(nix): Convert nix/shells/default.nix to a proper flake-parts module.**
- **refactor(nix): make d-toolchain a flake-parts module with a pkgs overlay** —
  `nix/d-toolchain.nix` becomes a flake-parts module that (1) applies a nixpkgs
  overlay replacing `ldc`/`dmd` with the platform-corrected variants
  (`_module.args.pkgs`), so every consumer — directly and via `buildDubPackage`,
  whose `compiler`/`dub` default to `pkgs.ldc`/`pkgs.dub` — sees the same
  toolchain; and (2) exports dev-shell/packaging metadata under
  `legacyPackages.d-toolchain`, consumed via `config.legacyPackages.d-toolchain.*`.
- **build(nix): Upgrade `dub`: `1.39.0` -> `dub-1.43.0-alpha-5efed36`** — override
  `dub` in that overlay so the whole package set (including `buildDubPackage`'s
  default `dub`) uses the pinned build.

## Verification

- `nix flake check --no-build` passes.
- `nix build .#ci` succeeds; the refactor commit builds on its own with
  nixpkgs `dub-1.39.0` (bisectable), the final commit with `dub-1.43.0-alpha`.