### PR TITLE
docs: ANSI output blocks + interactive terminal-grid cell explorer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,11 @@ insert_final_newline = unset
 [*.md]
 indent_size = unset
 
+# Also disable charset checking for markdown files in `docs/` as they can
+# contain ```ansi code blocks with raw ANSI escape codes (non-printable chars)
+[docs/**.md]
+charset = unset
+
 # The Make deep-dive embeds real Makefile recipes in fenced code blocks, and
 # Make requires literal tabs — so disable indent-style checking for that file.
 [docs/research/monorepo-tooling/make/index.md]

--- a/docs/.vitepress/theme/components/TerminalCellGrid.vue
+++ b/docs/.vitepress/theme/components/TerminalCellGrid.vue
@@ -1,0 +1,279 @@
+<script setup lang="ts">
+// Terminal-grid presentation for the cell explorer. Given the flat list of
+// grapheme-cluster cells produced by TextCellViz (via spk_segment), lay them out
+// on a real monospace terminal grid: each cluster occupies one cell whose width
+// (1 or 2 columns) comes from its leading scalar, zero-width clusters fold into
+// the preceding cell (kitty's "add the code point to the previous cell"), a line
+// break (LF/CR/CRLF/LS/PS) starts a new row, and the line wraps to a new row once
+// a cluster no longer fits in `cols` columns.
+//
+// Per-cell details (glyph, code points, width, row, col) surface through a
+// GUI-inspector tooltip that follows the cursor on hover and pins on click.
+import { computed, ref, onMounted, onUnmounted } from 'vue';
+
+type Cell = { glyph: string; width: number; cps: string[] };
+type PlacedCell = {
+  glyph: string;
+  width: number;
+  cps: string[];
+  row: number;
+  col: number;
+  zero: boolean;
+  key: number;
+};
+
+const props = defineProps<{ cells: Cell[]; cols: number }>();
+
+// Walk the clusters like a terminal cursor: advance by each cluster's width,
+// wrap at `cols`, and absorb zero-width clusters into the previous cell.
+const placed = computed<PlacedCell[]>(() => {
+  const cols = Math.max(1, props.cols);
+  const out: PlacedCell[] = [];
+  let row = 0;
+  let col = 0;
+  let key = 0;
+  for (const c of props.cells) {
+    // A line break (LF/CR/CRLF/LS/PS) ends the current row like a terminal cursor.
+    if (/[\n\r\u2028\u2029]/.test(c.glyph)) {
+      row++;
+      col = 0;
+      continue;
+    }
+    if (c.width === 0) {
+      const prev = out[out.length - 1];
+      if (prev && !prev.zero) {
+        prev.cps = prev.cps.concat(c.cps);
+        continue;
+      }
+      // A leading zero-width cluster with nothing to attach to gets its own
+      // marker slot (rendered narrow, never advances past one column).
+      out.push({ ...c, cps: [...c.cps], row, col, zero: true, key: key++ });
+      continue;
+    }
+    if (col + c.width > cols) {
+      row++;
+      col = 0;
+    }
+    out.push({ ...c, cps: [...c.cps], row, col, zero: false, key: key++ });
+    col += c.width;
+  }
+  return out;
+});
+
+const rows = computed(() =>
+  placed.value.reduce((m, c) => Math.max(m, c.row + 1), 0),
+);
+
+const hovered = ref<PlacedCell | null>(null);
+const pinned = ref<PlacedCell | null>(null);
+const pointer = ref({ x: 0, y: 0 });
+
+const active = computed(() => pinned.value ?? hovered.value);
+
+function onCellEnter(cell: PlacedCell, e: MouseEvent) {
+  hovered.value = cell;
+  pointer.value = { x: e.clientX, y: e.clientY };
+}
+function onCellMove(e: MouseEvent) {
+  pointer.value = { x: e.clientX, y: e.clientY };
+}
+function onCellLeave() {
+  hovered.value = null;
+}
+function onCellClick(cell: PlacedCell, e: MouseEvent) {
+  e.stopPropagation();
+  pinned.value = pinned.value?.key === cell.key ? null : cell;
+}
+function onDocClick() {
+  pinned.value = null;
+}
+
+onMounted(() => document.addEventListener('click', onDocClick));
+onUnmounted(() => document.removeEventListener('click', onDocClick));
+</script>
+
+<template>
+  <div class="tcv-term-wrap">
+    <div
+      class="tcv-term"
+      :style="{
+        '--cols': props.cols,
+        '--rows': rows,
+        gridTemplateColumns: `repeat(${props.cols}, var(--cell-w))`,
+      }"
+    >
+      <div
+        v-for="c in placed"
+        :key="c.key"
+        class="tcv-tcell"
+        :class="{
+          wide: c.width === 2,
+          zero: c.zero,
+          pinned: pinned?.key === c.key,
+        }"
+        :style="{
+          gridColumn: `${c.col + 1} / span ${Math.max(c.width, 1)}`,
+          gridRow: c.row + 1,
+        }"
+        @mouseenter="onCellEnter(c, $event)"
+        @mousemove="onCellMove"
+        @mouseleave="onCellLeave"
+        @click="onCellClick(c, $event)"
+      >
+        <span class="tcv-tglyph">{{ c.glyph }}</span>
+      </div>
+    </div>
+
+    <div
+      v-if="active"
+      class="tcv-inspector"
+      :style="{ left: pointer.x + 14 + 'px', top: pointer.y + 14 + 'px' }"
+    >
+      <div class="tcv-insp-head">
+        <span class="tcv-insp-glyph">{{ active.glyph }}</span>
+        <span v-if="pinned" class="tcv-insp-pin">📌 pinned</span>
+      </div>
+      <dl class="tcv-insp-rows">
+        <div>
+          <dt>width</dt>
+          <dd>{{ active.width }}</dd>
+        </div>
+        <div>
+          <dt>row</dt>
+          <dd>{{ active.row }}</dd>
+        </div>
+        <div>
+          <dt>col</dt>
+          <dd>{{ active.col }}</dd>
+        </div>
+        <div>
+          <dt>cp</dt>
+          <dd class="tcv-insp-cps">
+            <span v-for="cp in active.cps" :key="cp" class="tcv-insp-cp">{{
+              cp
+            }}</span>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tcv-term-wrap {
+  margin-top: 1rem;
+}
+.tcv-term {
+  /* Size each cell to the monospace character box so box-drawing glyphs span the
+    whole cell and connect across borders: --cell-w is the column advance
+    (≈ 0.6em for a monospace font) and --cell-h is the matching 1em line box.
+    Keep --cell-w in sync with CELL_REM in TextCellViz.vue (the column-fit cap). */
+  --cell-w: 0.8rem;
+  --cell-h: calc(var(--cell-w) / 0.6);
+  position: relative;
+  display: grid;
+  grid-auto-rows: var(--cell-h);
+  width: calc(var(--cols) * var(--cell-w) + 1px);
+  border: 1px solid var(--vp-c-divider);
+  /* The glyph fills the cell (font-size = line box, line-height 1), so adjacent
+    box-drawing strokes meet with no padding between them. */
+  font-family: var(--vp-font-family-mono);
+  font-size: var(--cell-h);
+  line-height: 1;
+  /* Draw the full terminal grid (including empty cells) as a background so the
+    horizontal/vertical lines show through transparent cells. */
+  background-image:
+    linear-gradient(var(--vp-c-divider) 1px, transparent 1px),
+    linear-gradient(90deg, var(--vp-c-divider) 1px, transparent 1px);
+  background-size: var(--cell-w) var(--cell-h);
+  background-position: -1px -1px;
+}
+.tcv-tcell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--cell-h);
+  cursor: pointer;
+  background: transparent;
+}
+.tcv-tcell:hover {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: -2px;
+  z-index: 1;
+}
+.tcv-tcell.pinned {
+  outline: 2px solid var(--vp-c-brand-1);
+  outline-offset: -2px;
+  background: var(--vp-c-brand-soft);
+  z-index: 1;
+}
+.tcv-tcell.wide {
+  background: var(--vp-c-brand-soft);
+}
+.tcv-tcell.zero {
+  opacity: 0.6;
+  background: var(--vp-c-bg-mute);
+}
+.tcv-tglyph {
+  font: inherit;
+  line-height: 1;
+  /* A cluster can render as several glyphs (e.g. a base + an inapplicable
+    modifier); keep them on one line instead of wrapping/stacking in the cell. */
+  white-space: nowrap;
+}
+
+.tcv-inspector {
+  position: fixed;
+  z-index: 9999;
+  min-width: 9rem;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  background-color: var(--vp-c-bg-elv);
+  box-shadow: var(--vp-shadow-3);
+  pointer-events: none;
+}
+.tcv-insp-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+.tcv-insp-glyph {
+  font-family: var(--vp-font-family-mono);
+  font-size: 1.6rem;
+  line-height: 1;
+}
+.tcv-insp-pin {
+  font-size: 0.65rem;
+  color: var(--vp-c-text-2);
+}
+.tcv-insp-rows {
+  margin: 0;
+  display: grid;
+  gap: 0.15rem 0;
+  font-size: 0.78rem;
+}
+.tcv-insp-rows > div {
+  display: flex;
+  gap: 0.5rem;
+}
+.tcv-insp-rows dt {
+  width: 3rem;
+  color: var(--vp-c-text-3);
+}
+.tcv-insp-rows dd {
+  margin: 0;
+  font-family: var(--vp-font-family-mono);
+  color: var(--vp-c-text-1);
+}
+.tcv-insp-cps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 0.35rem;
+}
+.tcv-insp-cp {
+  white-space: nowrap;
+}
+</style>

--- a/docs/.vitepress/theme/components/TextCellViz.vue
+++ b/docs/.vitepress/theme/components/TextCellViz.vue
@@ -87,14 +87,8 @@ onMounted(async () => {
 <template>
   <div class="tcv">
     <div class="tcv-controls">
-      <input
-        v-model="input"
-        class="tcv-input"
-        spellcheck="false"
-        @input="update"
-        aria-label="text to measure"
-      />
       <div class="tcv-presets">
+        Examples:
         <button
           v-for="p in presets"
           :key="p.label"
@@ -107,6 +101,13 @@ onMounted(async () => {
           {{ p.label }}
         </button>
       </div>
+      <input
+        v-model="input"
+        class="tcv-input"
+        spellcheck="false"
+        @input="update"
+        aria-label="text to measure"
+      />
     </div>
 
     <p v-if="status" class="tcv-status">{{ status }}</p>
@@ -161,6 +162,7 @@ onMounted(async () => {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
+  align-items: center;
 }
 .tcv-preset {
   font-size: 0.8rem;

--- a/docs/.vitepress/theme/components/TextCellViz.vue
+++ b/docs/.vitepress/theme/components/TextCellViz.vue
@@ -5,12 +5,17 @@
 // clusters and show each one over the terminal cells it occupies.
 //
 // SSR-safe: all WebAssembly/DOM work happens in onMounted (client only).
-import { ref, onMounted } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
+import TerminalCellGrid from './TerminalCellGrid.vue';
+
+// Column width in rem; keep in sync with `--cell-w` in TerminalCellGrid.vue.
+// Small enough that ~45+ columns fit the component width without overflowing.
+const CELL_REM = 0.8;
 
 type Cell = { glyph: string; width: number; cps: string[] };
 
 const presets: { label: string; value: string }[] = [
-  { label: 'mixed', value: 'aÁ世\u{1F1FA}\u{1F1F8}कि❤️' },
+  { label: 'mixed', value: 'aÁ世\u{1F1FA}\u{1F1F8}कि❤️' },
   {
     label: 'flags',
     value: '\u{1F1FA}\u{1F1F8}\u{1F1EF}\u{1F1F5}\u{1F1EB}\u{1F1F7}',
@@ -18,14 +23,70 @@ const presets: { label: string; value: string }[] = [
   { label: 'ZWJ family', value: '\u{1F469}‍\u{1F467}' },
   { label: 'Devanagari', value: 'नमस्ते' },
   { label: 'CJK', value: '世界終わり' },
-  { label: 'emoji + VS', value: '❤️\u{1F600}\u{1F3FD}' },
+  { label: 'emoji + VS', value: '❤️\u{1F44D}\u{1F3FD}' },
+  { label: 'multiline', value: 'hello\n世界\n❤️ok' },
+  {
+    // The `drawBox` grand-tour frame from libs/core-cli/examples/unicode-box.d.
+    // Joiners / variation selector / rocket are escaped so they're auditable.
+    label: 'box drawing',
+    value:
+      '╭──╼ Grand tour 世界 \u{1F680} ╾───────────────────────╮\n' +
+      '│ CJK 世界, emoji \u{1F469}\u200D\u{1F467} \u2764\uFE0F, and a clickable styled │\n' +
+      '│ link — all wrapped and streamed together.     │\n' +
+      '╰───────────────────────────────────────────────╯',
+  },
 ];
 
 const input = ref(presets[0].value);
 const cells = ref<Cell[]>([]);
 const total = ref(0);
 const status = ref('loading…');
+const mode = ref<'cards' | 'grid'>('cards');
+const cols = ref(16);
+const truncated = ref(false);
 let exp: any = null;
+
+// Max grapheme clusters we segment per update. The wasm scratch buffer keeps the
+// input in [0, 40000) and the output triples from 40000, leaving room for ~2100
+// triples; this cap stays well within that while covering multi-line inputs.
+const MAX_CELLS = 512;
+
+// Cap the column count to what fits the component's content width, so a grid row
+// never overflows the TextCellViz box. `availPx` tracks the measured content-box
+// width (kept current by a ResizeObserver); `maxCols` is the resulting ceiling.
+const rootEl = ref<HTMLElement | null>(null);
+const availPx = ref(0);
+let ro: ResizeObserver | null = null;
+
+function rootFontPx() {
+  if (typeof window === 'undefined') return 16;
+  return parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+}
+
+const maxCols = computed(() => {
+  const cellPx = CELL_REM * rootFontPx();
+  // -1 leaves room for the grid container's 1px border.
+  return Math.max(4, Math.floor((availPx.value - 1) / cellPx));
+});
+
+// Only ever clamp down: shrinking the viewport pulls the slider in, but widening
+// it just raises the ceiling without moving the user's chosen value.
+watch(maxCols, m => {
+  if (cols.value > m) cols.value = m;
+});
+
+onMounted(() => {
+  if (!rootEl.value || typeof ResizeObserver === 'undefined') return;
+  // Seed synchronously (content width = clientWidth minus the 1rem×2 padding) so
+  // maxCols is correct before the first preset click, then keep it live.
+  availPx.value = rootEl.value.clientWidth - 2 * rootFontPx();
+  ro = new ResizeObserver(entries => {
+    availPx.value = entries[0].contentRect.width;
+  });
+  ro.observe(rootEl.value);
+});
+
+onUnmounted(() => ro?.disconnect());
 
 function withBase(p: string) {
   const base = (import.meta as any).env?.BASE_URL ?? '/';
@@ -42,7 +103,8 @@ function update() {
   }
   new Uint8Array(exp.memory.buffer).set(bytes, p);
   const outP = (p + 40000) & ~3;
-  const n = exp.spk_segment(p, bytes.length, outP, 64);
+  const n = exp.spk_segment(p, bytes.length, outP, MAX_CELLS);
+  truncated.value = n >= MAX_CELLS;
   const o = new Uint32Array(exp.memory.buffer, outP, n * 3);
   const dec = new TextDecoder();
   const out: Cell[] = [];
@@ -61,6 +123,34 @@ function update() {
   cells.value = out;
   total.value = sum;
   status.value = '';
+}
+
+// Visible width (in cells) of the widest line — the sum of cluster widths per
+// line, line breaks resetting the run. Used to fit the grid to a preset.
+function widestLineWidth(list: Cell[]): number {
+  const lineBreak = /[\n\r\u2028\u2029]/;
+  let max = 0;
+  let cur = 0;
+  for (const c of list) {
+    if (lineBreak.test(c.glyph)) {
+      if (cur > max) max = cur;
+      cur = 0;
+    } else {
+      cur += c.width;
+    }
+  }
+  return cur > max ? cur : max;
+}
+
+// Choosing a preset sizes the grid to its widest line, so it shows on one row
+// (clamped to what fits the component — see maxCols).
+function applyPreset(value: string) {
+  input.value = value;
+  update();
+  cols.value = Math.min(
+    maxCols.value,
+    Math.max(4, widestLineWidth(cells.value)),
+  );
 }
 
 onMounted(async () => {
@@ -85,7 +175,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="tcv">
+  <div ref="rootEl" class="tcv">
     <div class="tcv-controls">
       <div class="tcv-presets">
         Examples:
@@ -93,24 +183,54 @@ onMounted(async () => {
           v-for="p in presets"
           :key="p.label"
           class="tcv-preset"
-          @click="
-            input = p.value;
-            update();
-          "
+          @click="applyPreset(p.value)"
         >
           {{ p.label }}
         </button>
       </div>
-      <input
+      <textarea
         v-model="input"
         class="tcv-input"
+        rows="2"
         spellcheck="false"
         @input="update"
         aria-label="text to measure"
-      />
+      ></textarea>
+    </div>
+
+    <div class="tcv-view-controls">
+      <div class="tcv-modes" role="group" aria-label="presentation mode">
+        <button
+          class="tcv-mode"
+          :class="{ active: mode === 'cards' }"
+          @click="mode = 'cards'"
+        >
+          Cards
+        </button>
+        <button
+          class="tcv-mode"
+          :class="{ active: mode === 'grid' }"
+          @click="mode = 'grid'"
+        >
+          Terminal grid
+        </button>
+      </div>
+      <label v-if="mode === 'grid'" class="tcv-cols">
+        columns
+        <input
+          v-model.number="cols"
+          type="range"
+          min="4"
+          :max="maxCols"
+          aria-label="terminal columns"
+        />
+        <span class="tcv-cols-val">{{ cols }}</span>
+      </label>
     </div>
 
     <p v-if="status" class="tcv-status">{{ status }}</p>
+
+    <TerminalCellGrid v-else-if="mode === 'grid'" :cells="cells" :cols="cols" />
 
     <div v-else class="tcv-grid">
       <div
@@ -131,6 +251,9 @@ onMounted(async () => {
     <p v-if="!status" class="tcv-total">
       <code>visibleWidth</code> = {{ total }} cell{{ total === 1 ? '' : 's' }} ·
       {{ cells.length }} cluster{{ cells.length === 1 ? '' : 's' }}
+      <span v-if="truncated" class="tcv-trunc"
+        >· showing first {{ MAX_CELLS }} clusters</span
+      >
     </p>
   </div>
 </template>
@@ -157,6 +280,8 @@ onMounted(async () => {
   border-radius: 6px;
   background: var(--vp-c-bg);
   color: var(--vp-c-text-1);
+  resize: vertical;
+  line-height: 1.4;
 }
 .tcv-presets {
   display: flex;
@@ -174,6 +299,49 @@ onMounted(async () => {
 }
 .tcv-preset:hover {
   border-color: var(--vp-c-brand-1);
+}
+.tcv-view-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 0.75rem;
+}
+.tcv-modes {
+  display: inline-flex;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.tcv-mode {
+  font-size: 0.8rem;
+  padding: 0.25rem 0.6rem;
+  border: none;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+}
+.tcv-mode + .tcv-mode {
+  border-left: 1px solid var(--vp-c-divider);
+}
+.tcv-mode:hover {
+  color: var(--vp-c-brand-1);
+}
+.tcv-mode.active {
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}
+.tcv-cols {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--vp-c-text-2);
+}
+.tcv-cols-val {
+  font-family: var(--vp-font-family-mono);
+  min-width: 1.5rem;
+  color: var(--vp-c-text-1);
 }
 .tcv-grid {
   display: flex;
@@ -228,5 +396,8 @@ onMounted(async () => {
   margin-top: 0.75rem;
   color: var(--vp-c-text-2);
   font-size: 0.9rem;
+}
+.tcv-trunc {
+  color: var(--vp-c-warning-1, var(--vp-c-text-3));
 }
 </style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -60,9 +60,14 @@
   --vp-font-family-base:
     'Inter', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  /* Fira Code first (ligatures), with Nerd Font families so glyphs in the
+    Private Use Area (Powerline, devicons, box-drawing extras) resolve via the
+    browser's per-glyph fallback. Like the other families here, these are not
+    web-loaded — they apply where installed and degrade to the next entry. */
   --vp-font-family-mono:
-    'JetBrains Mono', ui-monospace, 'Menlo', 'Monaco', 'Consolas',
-    'Liberation Mono', 'Courier New', monospace;
+    'FiraCode Nerd Font Mono', 'Fira Code', 'Symbols Nerd Font Mono',
+    'Symbols Nerd Font', 'JetBrains Mono', ui-monospace, 'Menlo', 'Monaco',
+    'Consolas', 'Liberation Mono', 'Courier New', monospace;
 }
 
 /* -- Headings: Space Grotesk with refined tracking ----------------------- */

--- a/docs/guidelines/idioms/expected/index.md
+++ b/docs/guidelines/idioms/expected/index.md
@@ -61,7 +61,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 Success: quiet
 Error: Unknown verbosity level
 ```
@@ -121,7 +121,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 Successes: [1, 3, 5]
 Items: [[1], [], [3], [], [5]]
 ```
@@ -190,7 +190,7 @@ Expected!(int, string) validate(int i)
 }
 ```
 
-```[Output]
+```ansi
 42: Success
 invalid: Invalid age: Unexpected 'i' when converting from type string to type int
 ```
@@ -247,7 +247,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 Mapped: 42
 ```
 
@@ -311,7 +311,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 Eager Value: 100
 Lazy Expression: 100
 Lazy Delegate: 100
@@ -368,7 +368,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 Success: 21
 ```
 
@@ -445,7 +445,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 Value: 42
 Error offset: 5
 ```

--- a/docs/guidelines/move-semantics/index.md
+++ b/docs/guidelines/move-semantics/index.md
@@ -105,7 +105,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 foo(s)           = 2
 foo(__rvalue(s)) = 1
 ```
@@ -175,7 +175,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 copyCtor=1 moveCtor=1 copyAss=1 moveAss=1
 ```
 
@@ -291,7 +291,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 *t.p=5 moveCtor=1 copyCtor=0 g.p is null=true
 ```
 
@@ -347,7 +347,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 u.t.i=2 v.t.i=3
 ```
 
@@ -390,7 +390,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 moves=3
 ```
 
@@ -430,7 +430,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 a.p is null=true *b.p=5
 ```
 
@@ -545,7 +545,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 a.p is null=true *b.p=7
 ```
 
@@ -608,7 +608,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 MoveC: move=true copy=false
 CopyC: move=false copy=true
 Postblit: postblit=true

--- a/docs/libs/base/how-to/log-with-core-logger.md
+++ b/docs/libs/base/how-to/log-with-core-logger.md
@@ -50,7 +50,7 @@ void main()
 [ {{_}} | Δt {{_}} | Δtᵢ {{_}} | WRN | {{_}} ]: Latency spike: 230ms on db-01.prod
 -->
 
-```[Output:ansi]
+```ansi
 [90m[ 15:22:40[39m | Δt [33m46.7µs[39m | Δtᵢ [33m46.7µs[39m | [90mTRC[39m | [2mbase_core_logger.d:14[22m ]: [1mApplication starting up[22m
 [90m[ 15:22:40[39m | Δt [33m119.7µs[39m | Δtᵢ [33m72.9µs[39m | [32mINF[39m | [2mbase_core_logger.d:15[22m ]: [1mListening on port [32m8080[39m[22m
 [90m[ 15:22:40[39m | Δt [33m167.3µs[39m | Δtᵢ [33m47.5µs[39m | [33mWRN[39m | [2mbase_core_logger.d:16[22m ]: [1mDisk usage above [33m80%[39m[22m

--- a/docs/libs/base/how-to/parse-text-readers.md
+++ b/docs/libs/base/how-to/parse-text-readers.md
@@ -86,7 +86,7 @@ void main()
 }
 ```
 
-```[Output:ansi]
+```ansi
 Parsed: [32mPoint(x: 10, y: 20)[39m
 [31mError: 1 at offset 0[39m
 ```

--- a/docs/libs/base/how-to/prettyprint-values.md
+++ b/docs/libs/base/how-to/prettyprint-values.md
@@ -29,7 +29,7 @@ void main()
 }
 ```
 
-```[Output:ansi]
+```ansi
 [35mUser[39m([96mname[39m: [32m"Alice"[39m, [96mage[39m: [34m30[39m, [96mroles[39m: [[32m"admin"[39m, [32m"developer"[39m])
 ```
 
@@ -58,7 +58,7 @@ void main()
 }
 ```
 
-```[Output:ansi]
+```ansi
 [[32m"Alice"[39m: [34m30[39m, [32m"Bob"[39m: [34m25[39m]
 ```
 
@@ -92,6 +92,6 @@ void main()
 }
 ```
 
-```[Output:ansi]
+```ansi
 [Point(x: 1, y: 2), Point(x: 3, y: 4)]
 ```

--- a/docs/libs/base/how-to/style-text-templates.md
+++ b/docs/libs/base/how-to/style-text-templates.md
@@ -36,7 +36,7 @@ void main()
 }
 ```
 
-```[Output:ansi]
+```ansi
 [31m[1mFatal Error: connection refused[22m[39m
 Status: [32m[1mOK[22m[39m | Service: [36mdatabase[39m
 ```
@@ -66,7 +66,7 @@ void main()
 }
 ```
 
-```[Output:ansi]
+```ansi
 Styled length: 23
 Plain length: 13
 ```
@@ -94,6 +94,6 @@ void main()
 }
 ```
 
-```[Output:ansi]
+```ansi
 Level: [35mdebug[39m
 ```

--- a/docs/libs/base/how-to/test-with-check-helpers.md
+++ b/docs/libs/base/how-to/test-with-check-helpers.md
@@ -56,7 +56,7 @@ void main()
 }
 ```
 
-```[Output:ansi]
+```ansi
 [32m✓ All tests passed successfully![39m
 ```
 

--- a/docs/libs/base/how-to/write-nogc-text.md
+++ b/docs/libs/base/how-to/write-nogc-text.md
@@ -39,7 +39,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 job=0042 rss=1.5KiB elapsed=1.5m
 ```
 

--- a/docs/libs/base/tutorial/getting-started.md
+++ b/docs/libs/base/tutorial/getting-started.md
@@ -96,7 +96,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 007 1.5s
 ready after 007 1.5s
 ```

--- a/docs/libs/versions/how-to/compare-and-sort.md
+++ b/docs/libs/versions/how-to/compare-and-sort.md
@@ -92,7 +92,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 parse error: unexpectedCharacter at offset 4
 order(a, b): 1
 latest: 2.0.0

--- a/docs/libs/versions/how-to/constrain-with-ranges.md
+++ b/docs/libs/versions/how-to/constrain-with-ranges.md
@@ -96,7 +96,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 1.5.0 in >=1.2.0 <2.0.0: true
 2.0.0 in >=1.2.0 <2.0.0: false
 1.9.9 in ^1.2.3: true

--- a/docs/libs/versions/how-to/handle-unknown-schemes.md
+++ b/docs/libs/versions/how-to/handle-unknown-schemes.md
@@ -85,7 +85,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 same-scheme compare null? false
   3.13.0a1 vs 4.0.0: -1
 cross-scheme compare null? true

--- a/docs/libs/versions/how-to/vers-and-purl-interop.md
+++ b/docs/libs/versions/how-to/vers-and-purl-interop.md
@@ -106,7 +106,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 typed as PypiVersion: 3.13.0a1
 type=pypi name=django ver=3.13.0a1
 parseVersAny ok: true

--- a/docs/libs/versions/tutorial/getting-started.md
+++ b/docs/libs/versions/tutorial/getting-started.md
@@ -142,9 +142,7 @@ void main()
 }
 ```
 
-Run it with `dub run --single tour.d`. You will see:
-
-```
+```ansi
 parsed: 1.4.2
 rc < release: true
   1.2.0-beta

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -74,6 +74,12 @@ void main()
 }
 ```
 
+```ansi
+[31mError: [39mSomething went wrong
+[32mSuccess: [39mOperation completed
+[33m[1mWarning[22m[39m
+```
+
 ### Compile-Time Builder
 
 For CTFE-compatible styling, use `stylizedTextBuilder`:
@@ -95,6 +101,10 @@ void main()
 }
 ```
 
+```ansi
+[31m[4m[1mImportant[22m[24m[39m
+```
+
 ## Styled Templates (IES)
 
 The `styled_template` module provides a template syntax for applying terminal styles using D's Interpolated Expression Sequences (IES).
@@ -112,6 +122,10 @@ void main()
     int cpu = 75;
     styledWriteln(i"CPU: {red $(cpu)%} Status: {green OK}");
 }
+```
+
+```ansi
+CPU: [31m75%[39m Status: [32mOK[39m
 ```
 
 ### Syntax Reference
@@ -172,6 +186,14 @@ void main()
 }
 ```
 
+```ansi
+[1m[3m[32mBold italic green text[39m[23m[22m
+[1mBold [31mbold+red[39m back to bold[22m
+[1m[31mBoth [39mjust bold[31m both again[39m[22m
+[2mmain.d:[22m [31m[1m3 errors[22m[39m
+Use {style text} syntax
+```
+
 ## Pretty Printing
 
 The `prettyprint` module formats any D type with syntax highlighting.
@@ -196,6 +218,11 @@ void main()
     int[] numbers = [1, 2, 3, 4, 5];
     writeln(prettyPrint(numbers, PrettyPrintOptions!void(useColors: false)));
 }
+```
+
+```ansi
+[35mServer[39m([96mhost[39m: [32m"localhost"[39m, [96mport[39m: [34m8080[39m, [96mssl[39m: [33mtrue[39m)
+[1, 2, 3, 4, 5]
 ```
 
 ### PrettyPrintOptions
@@ -259,14 +286,11 @@ void main()
 }
 ```
 
-Output:
-
-```text
+```ansi
 ╭────────┬─────────╮
-│ Name   │ Status  │
-├────────┼─────────┤
-│ web-01 │ Running │
-│ web-02 │ Stopped │
+│ [1mName[22m   │ [1mStatus[22m  │
+│ web-01 │ [32mRunning[39m │
+│ web-02 │ [31mStopped[39m │
 ╰────────┴─────────╯
 ```
 
@@ -289,9 +313,7 @@ void main()
 }
 ```
 
-Output:
-
-```text
+```ansi
 ╭──╼ My Box ╾───╮
 │ Line 1        │
 │ Line 2        │
@@ -318,9 +340,7 @@ void main()
 }
 ```
 
-Output:
-
-```text
+```ansi
 ╭──╼ Status ╾──────────────╮
 │ Processing...            │
 ╰──╼ Press Q to cancel ╾───╯
@@ -352,11 +372,8 @@ void main()
 }
 ```
 
-Output:
-
-```text
+```ansi
 ── Configuration ──
-
 ══════════════════════════════
          Main Section
 ══════════════════════════════
@@ -384,6 +401,11 @@ void main()
     // Styled clickable link (blue text)
     writeln(oscLink(text: "D Language", uri: "https://dlang.org", style: Style.blue));
 }
+```
+
+```ansi
+]8;;https://example.comExample]8;;
+]8;;https://dlang.org[34mD Language[39m]8;;
 ```
 
 #### API
@@ -432,14 +454,20 @@ void main()
 }
 ```
 
-Output:
+<!-- md-example-expected
+[ {{_}} | Δt {{_}} | Δtᵢ {{_}} | INF | loggerdemo.d:13 ]: Listening on port 8080
+[ {{_}} | Δt {{_}} | Δtᵢ {{_}} | WRN | loggerdemo.d:14 ]: Disk usage above 80%
+[ {{_}} | Δt {{_}} | Δtᵢ {{_}} | ERR | loggerdemo.d:15 ]: Connection to database lost
+[ {{_}} | Δt {{_}} | Δtᵢ {{_}} | CRT | loggerdemo.d:16 ]: Out of memory
+[ {{_}} | Δt {{_}} | Δtᵢ {{_}} | INF | loggerdemo.d:19 ]: Reconnected to db-01.prod:5432
+-->
 
-```text
-[ 14:32:01 | Δt 0ms   | Δtᵢ 0ms   | INF | app.d:17 ]: Listening on port 8080
-[ 14:32:01 | Δt 3ms   | Δtᵢ 3ms   | WRN | app.d:18 ]: Disk usage above 80%
-[ 14:32:01 | Δt 5ms   | Δtᵢ 2ms   | ERR | app.d:19 ]: Connection to database lost
-[ 14:32:01 | Δt 5ms   | Δtᵢ 0ms   | CRT | app.d:20 ]: Out of memory
-[ 14:32:01 | Δt 12ms  | Δtᵢ 7ms   | INF | app.d:23 ]: Reconnected to db-01.prod:5432
+```ansi
+[90m[ 22:24:12[39m | Δt [33m92.8µs[39m | Δtᵢ [33m92.8µs[39m | [32mINF[39m | [2mloggerdemo.d:13[22m ]: [1mListening on port 8080[22m
+[90m[ 22:24:12[39m | Δt [33m185.2µs[39m | Δtᵢ [33m92.4µs[39m | [33mWRN[39m | [2mloggerdemo.d:14[22m ]: [1mDisk usage above 80%[22m
+[90m[ 22:24:12[39m | Δt [33m225.5µs[39m | Δtᵢ [33m40.3µs[39m | [31mERR[39m | [2mloggerdemo.d:15[22m ]: [1mConnection to database lost[22m
+[90m[ 22:24:12[39m | Δt [33m266.7µs[39m | Δtᵢ [33m41.1µs[39m | [1m[31mCRT[39m[22m | [2mloggerdemo.d:16[22m ]: [1mOut of memory[22m
+[90m[ 22:24:12[39m | Δt [33m338.0µs[39m | Δtᵢ [33m71.3µs[39m | [32mINF[39m | [2mloggerdemo.d:19[22m ]: [1mReconnected to db-01.prod:5432[22m
 ```
 
 ### Features
@@ -484,6 +512,11 @@ void main()
     writeln(buf[]);  // "Hello World"
     writeln("On heap: ", buf.onHeap);  // false
 }
+```
+
+```ansi
+Hello World
+On heap: false
 ```
 
 ### Key Features

--- a/docs/research/vulkan/comparison.md
+++ b/docs/research/vulkan/comparison.md
@@ -530,7 +530,7 @@ void main() @safe
 }
 ```
 
-```[Output]
+```ansi
 sType pre-set:       true
 chain wired:         true
 created:             true

--- a/docs/research/window-system-integration/concepts.md
+++ b/docs/research/window-system-integration/concepts.md
@@ -153,7 +153,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 scancode  1 -> keysym Escape
 scancode 30 -> keysym a
 scancode 57 -> keysym space
@@ -259,7 +259,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 preferred_scale=120 -> scale=1.0000
 preferred_scale=180 -> scale=1.5000
 preferred_scale= 90 -> scale=0.7500
@@ -296,7 +296,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 wParam=0x00600060 -> dpiX=96 dpiY=96 scale=1.000
 wParam=0x00780078 -> dpiX=120 dpiY=120 scale=1.250
 wParam=0x00C000C0 -> dpiX=192 dpiY=192 scale=2.000
@@ -458,7 +458,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 wheel notch #1
 emitted 1 notch(es), remainder 30/120
 ```

--- a/docs/specs/base/text/index.md
+++ b/docs/specs/base/text/index.md
@@ -77,7 +77,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 cells [0..1)  a
 cells [1..3)  ❤️
 cells [3..5)  世
@@ -140,7 +140,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 bytes=61  width=1
 bytes=62  width=1
 bytes=ff  width=1
@@ -244,7 +244,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 A + combining acute    U+00C1(w1) -> cell width 1
 flag (RI + RI)         U+1F1FA(w2) U+1F1F8(w2) -> cell width 2
 Devanagari की           U+0915(w1) U+0940(w0) -> cell width 1
@@ -349,7 +349,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 U+0041 LATIN A           width=1
 U+002B PLUS (Sm)         width=1
 U+4E16 CJK (EAW W)       width=2
@@ -395,7 +395,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 A + combining acute    width=1
 CJK U+4E16             width=2
 flag (RI + RI)         width=2
@@ -455,7 +455,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 ╭─────────┬────────┬───────────────┬────────┬─────────────────┬───────────────┬───────────────╮
 │ cluster │ a      │ Á             │ 世     │ 🇺🇸              │ की             │ ❤️            │
 │ cells   │ [0,1)  │ [1,2)         │ [2,4)  │ [4,6)           │ [6,7)         │ [7,9)         │
@@ -508,7 +508,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 heart (bare)                   width=1
 heart + VS16                   width=2
 heart + VS15                   width=1
@@ -590,7 +590,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 PASS  a + acute          ÷ 0061 × 0301 ÷  clusters=[2]
 PASS  CRLF               ÷ 000D × 000A ÷  clusters=[2]
 PASS  CR | a             ÷ 000D ÷ 0061 ÷  clusters=[1, 1]
@@ -627,7 +627,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 cluster width=1  a
 escape  width=0  <esc>
 cluster width=2  世
@@ -675,7 +675,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 CJK @ width 4:
 世界
 世

--- a/docs/specs/base/text/test-cases.md
+++ b/docs/specs/base/text/test-cases.md
@@ -97,7 +97,7 @@ void main()
 }
 ```
 
-```[Output]
+```ansi
 PASS  ASCII 'A'                        width=1
 PASS  CJK U+4E16                       width=2
 PASS  Fullwidth U+FF21                 width=2


### PR DESCRIPTION
## Overview

Documentation-focused branch with two themes: (1) render single-file
recipe **output blocks as ANSI** so Shiki can colorize them, and (2) a
substantial upgrade to the interactive **cell explorer** on the
`sparkles.base.text` spec page — a new terminal-grid view with a
GUI-style inspector.

## Changes since `origin/main`

### `config(editorconfig)` — unset charset for `docs/**.md` (`a949d33`)
Stops the editorconfig charset rule from fighting markdown that embeds
ANSI/Unicode content.

### `docs` — ANSI language for recipe output blocks (`47b5ff2`)
Converts the expected-output blocks of D single-file recipes to
` ```ansi ` across the docs (guidelines, libs/base, libs/versions,
specs, research, overview…) so ANSI escapes are colorized and
highlighted via Shiki instead of shown as raw text.

### `improve(TextCellViz.vue)` — presets above the input (`b51b0ee`)
Moves the example/preset buttons above the input box in the cell
explorer for a clearer top-to-bottom flow.

### `feat(docs)` — terminal-grid presentation mode (`cbc6963`)
Adds a second, terminal-faithful view to the cell explorer alongside the
existing cards, extracted into a new `TerminalCellGrid.vue` child so
`TextCellViz` stays the wasm/data owner.

**New `TerminalCellGrid.vue`**
- Real monospace cell grid with horizontal/vertical grid lines. Cells
  are sized to the character box (column advance + 1em line box) so
  box-drawing glyphs span the cell and **connect across borders**.
- Terminal-cursor layout: width-2 clusters span two columns, zero-width
  clusters fold into the previous cell, and a line break
  (LF/CR/CRLF/LS/PS) starts a new row.
- **GUI-inspector tooltip**: follows the cursor on hover, pins on click,
  showing glyph, code points, width, and row/col.
- `white-space: nowrap` keeps a multi-glyph cluster on one line instead
  of stacking inside its cell.

**`TextCellViz.vue`**
- Cards / Terminal-grid toggle (Cards default) and a **columns slider**
  whose max is capped (via a `ResizeObserver`) to what fits the
  component width, so a row never overflows.
- Selecting a preset **auto-fits** the column count to its widest line.
- Input is now a **textarea** so newlines are preserved and drive the
  grid's row breaks; adds **multiline** and **box drawing** presets (the
  latter is the `drawBox` grand-tour frame from `unicode-box.d`).
- Raises the per-update segmentation cap 64 → 512 clusters (well within
  the wasm scratch buffer) with a "showing first N" note, so multi-line
  presets render in full.
- Fixes two degenerate example sequences surfaced by the grid view:
  `emoji + VS` used a skin-tone modifier on an invalid base (grinning
  face → two glyphs) — now a valid base (thumbs-up); the default
  `mixed` preset used a precomposed Á — now `A` + combining acute so the
  default view demonstrates a zero-width combining mark.

**`custom.css`**
- Leads `--vp-font-family-mono` with Fira Code + Nerd Font families so
  ligatures and PUA glyphs resolve via per-glyph fallback. Not
  web-loaded — degrades like the other named families (JetBrains Mono →
  system mono).

## Verification
- `vitepress build docs` passes; prettier + editorconfig pre-commit
  hooks pass.
- The cell explorer was driven in a real headless browser (DevTools
  protocol) and rendered offline with the exact component CSS:
  box-drawing connects at its 49-column width, the auto-fit picks the
  preset's widest line, the inspector follows/pins, and every preset was
  re-segmented against the real wasm to confirm clean clusters.
- The terminal-grid view is client-only (`<ClientOnly>` + `onMounted`),
  so SSR/build is unaffected.

> Note: Fira Code / Nerd Font glyphs only render for viewers who have the
> fonts installed (no `@font-face` yet) — happy to self-host the woff2s
> with `unicode-range` as a follow-up if desired.