### PR TITLE
build: shrink ci + devShell closures (DMD) and make the compiler matrix effective

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
 
       - name: Build and test with dub
         run: ci --test --fail-fast
+        env:
+          # `ci` embeds dmd (small closure); honour the matrix compiler for the
+          # test suite so the ldc2/dmd dimensions are actually exercised. Both
+          # are on PATH via the `default` dev shell.
+          DC: ${{ matrix.DC }}
 
       - name: Build and run examples
         run: ci --example-files --fail-fast

--- a/apps/ci/src/app.d
+++ b/apps/ci/src/app.d
@@ -1122,8 +1122,14 @@ private int runDubTestsMode(bool failFast)
         const header = styledText(i"{dim $(progress)} {cyan $(pkgName)} {dim › dub test :$(pkgName)}");
 
         mkdirRecurse(buildPath(repoRoot, pkg, "build"));
-        auto result = executeLogged(
-            ["dub", "--root", repoRoot, "test", ":" ~ pkgName], "test " ~ pkgName);
+        // Honour `$DC` so the sub-package tests use the CI matrix's compiler
+        // (the dev shell provides both dmd and ldc). Example verification keeps
+        // `ci`'s own embedded compiler; only the test suite is compiler-matrixed.
+        auto testCmd = ["dub", "--root", repoRoot, "test", ":" ~ pkgName];
+        const dc = environment.get("DC", "");
+        if (dc.length)
+            testCmd ~= "--compiler=" ~ dc;
+        auto result = executeLogged(testCmd, "test " ~ pkgName);
 
         auto outputLines = result.output.lineSplitter
             .map!(l => l.to!string)

--- a/apps/ci/src/app.d
+++ b/apps/ci/src/app.d
@@ -668,8 +668,8 @@ private size_t totalMemoryGiB()
 }
 
 /// Executes every example concurrently, returning results in input order.
-/// Each build is isolated via `--temp-build` (see `dubSingleFileCommand`), so the
-/// parallel `dub run`s never race on a shared dependency artifact.
+/// Each build runs in its own `DUB_HOME` (see `executeExample`), so the parallel
+/// `dub run`s never race on a shared dependency artifact.
 private ExecutionResult[] executeExamplesParallel(Example[] examples, string repoRoot)
 {
     auto results = new ExecutionResult[](examples.length);
@@ -903,8 +903,17 @@ ExecutionResult executeExample(in Example example, string repoRoot, size_t uniqu
         if (exampleDir.exists) rmdirRecurse(exampleDir);
     }
 
-    auto result = executeLogged(
-        dubSingleFileCommand("run", tmpFile, repoRoot), "run " ~ example.name);
+    // Give each example its own `DUB_HOME` so concurrent builds don't race.
+    // README examples depend on the in-repo `sparkles` package as `~master`,
+    // which dub rebuilds *in place and unlocked* on every `dub run` (it's a
+    // mutable branch version, never cached) — parallel builds then clobber the
+    // shared `libsparkles_*.a`. `--temp-build` only isolates the leaf
+    // single-file build, not this path dependency; a per-example home isolates
+    // it. Registry deps still resolve normally (dub locks its own fetches).
+    auto dubHome = buildPath(exampleDir, "dub-home");
+    auto cmd = ["/usr/bin/env", "DUB_HOME=" ~ dubHome]
+        ~ dubSingleFileCommand("run", tmpFile, repoRoot);
+    auto result = executeLogged(cmd, "run " ~ example.name);
 
     // Strip ANSI codes, then trim trailing whitespace from each line
     // so output matches what pre-commit hooks produce in markdown files.

--- a/libs/versions/src/sparkles/versions/operations.d
+++ b/libs/versions/src/sparkles/versions/operations.d
@@ -122,17 +122,13 @@ if (hasSemVerComponents!T)
 
 /**
 The npm caret operator: `^1.2.3` admits every version `>= 1.2.3` and
-`< 2.0.0` (compatible within the major). Requires the SemVer triple.
-
-A clear compile-time diagnostic fires for a scheme without the triple.
+`< 2.0.0` (compatible within the major). Constrained to schemes with the
+SemVer triple (`hasSemVerComponents!V`); other schemes don't match, so
+`caret` is a compile error for them — build the range explicitly instead.
 */
 Ranges!V caret(V)(in V v) @safe
+if (hasSemVerComponents!V)
 {
-    static assert(hasSemVerComponents!V,
-        "caret/tilde require components beginning [\"major\",\"minor\",\"patch\"] "
-        ~ "(hasSemVerComponents!V). " ~ V.stringof
-        ~ " has no SemVer triple; build the range explicitly instead.");
-
     const upper = bumpComponent!(V, 0)(v); // next major, minor/patch zeroed
     return Ranges!V.between(stripExtras(v), upper);
 }
@@ -142,12 +138,8 @@ The npm tilde operator: `~1.2.3` admits every version `>= 1.2.3` and
 `< 1.3.0` (compatible within the minor). Requires the SemVer triple.
 */
 Ranges!V tilde(V)(in V v) @safe
+if (hasSemVerComponents!V)
 {
-    static assert(hasSemVerComponents!V,
-        "caret/tilde require components beginning [\"major\",\"minor\",\"patch\"] "
-        ~ "(hasSemVerComponents!V). " ~ V.stringof
-        ~ " has no SemVer triple; build the range explicitly instead.");
-
     const upper = bumpComponent!(V, 1)(v); // next minor, patch zeroed
     return Ranges!V.between(stripExtras(v), upper);
 }

--- a/lychee.ci.exclude
+++ b/lychee.ci.exclude
@@ -40,6 +40,14 @@
 # the Bison manual's LALR algorithm/GLR/precedence chapters)
 ^https?://(www\.)?gnu\.org/software/bison/
 ^https?://(www\.)?gnu\.org/licenses/gpl-faq\.html
+# lists.gnu.org (info-gnu release announcements) times out under GitHub Actions'
+# concurrency (live + 200 locally; monorepo-tooling/make/index.md cites the
+# GNU Make 4.4 / 4.4.1 release announcements)
+^https?://lists\.gnu\.org/
+# docs.dagger.io resets the connection ("Connection reset by peer") for GitHub
+# Actions' shared IPs — same pattern as web.archive.org, retries don't help
+# (live + 200 locally; monorepo-tooling/dagger/index.md cites the Dagger docs)
+^https?://docs\.dagger\.io/
 # dickgrune.com (Parsing Techniques, 1st & 2nd editions) times out under GitHub
 # Actions' concurrency (live + 200 locally; cited across parsing/theory/*.md)
 ^https?://(www\.)?dickgrune\.com/

--- a/nix/checks/pre-commit.nix
+++ b/nix/checks/pre-commit.nix
@@ -29,7 +29,9 @@ in
         let
           inherit (config.pre-commit.settings) enabledPackages package configFile;
         in
-        pkgs.mkShell {
+        # No C toolchain needed to lint — mkShellNoCC keeps the default stdenv's
+        # cc/binutils out of the shell's own closure.
+        pkgs.mkShellNoCC {
           packages = enabledPackages ++ [ package ];
           shellHook = ''
             ln -fvs ${configFile} .pre-commit-config.yaml

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -9,6 +9,12 @@
     let
       inherit (config.legacyPackages) d-toolchain;
 
+      # `ci` runs a D compiler to build the examples, so it lands in ci's
+      # runtime closure (and every consumer's — pre-commit devShell, lint CI).
+      # Prefer DMD on x86_64-linux: no LLVM backend, so ~half LDC's closure.
+      # DMD only targets x86_64/i686-linux + x86_64-darwin; keep LDC elsewhere.
+      ciCompiler = if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then pkgs.dmd else pkgs.ldc;
+
       fs = lib.fileset;
       root = ../..;
       fromRoot = lib.path.append root;
@@ -51,19 +57,19 @@
         # that sharing explicit instead of having `examples.nix` reach
         # into a sibling sub-package's dir to grab the file.
         dubLock = fromRoot "nix/dub-lock.json";
-        compiler = pkgs.ldc;
+        compiler = ciCompiler;
 
         nativeBuildInputs = [
           pkgs.makeWrapper
         ];
 
         # `ci` shells out to `dub run --single` / `dub build --single` at
-        # runtime, so the wrapped binary genuinely needs `ldc2` and `dub`
-        # on its PATH. By default `buildDubPackage` declares the compiler
+        # runtime, so the wrapped binary genuinely needs the D compiler and
+        # `dub` on its PATH. By default `buildDubPackage` declares the compiler
         # as a `disallowedReference` and runs `remove-references-to` in
         # `preFixup`, which would scrub the compiler path out of our
-        # wrapper script (turning `…ldc-1.41.0/bin` into the placeholder
-        # `…eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ldc-1.41.0/bin`). Clearing
+        # wrapper script (turning `…dmd-2.112.1/bin` into the placeholder
+        # `…eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-dmd-2.112.1/bin`). Clearing
         # `disallowedReferences` keeps the runtime closure honest.
         disallowedReferences = [ ];
 
@@ -84,7 +90,7 @@
             path = lib.makeBinPath [
               pkgs.git
               pkgs.dub
-              pkgs.ldc
+              ciCompiler
             ];
             # Render `--set NAME VALUE` triples for wrapProgram from the toolchain
             # env (non-empty on darwin: CC/CXX/SDKROOT/MACOSX_DEPLOYMENT_TARGET).


### PR DESCRIPTION
Shrinks the `ci` helper and pre-commit devShell closures by building `ci` with
DMD (no LLVM), and — as prerequisites — makes the CI compiler matrix actually
take effect and fixes the DMD-exposed issues along the way. Depends on the
merged dlang.nix work (static `dub`, scrubbed `dmd`) pinned on `main`.

## Commits (bisectable, prerequisites first)

1. **`fix(versions)`** — `caret`/`tilde` used a body `static assert` to reject
   non-SemVer schemes, which still instantiated `Ranges!V`/`Interval!V[]` during
   a speculative `__traits(compiles, …)` check; DMD fails to emit that
   instantiation's TypeInfo initializer (LDC is fine). A template constraint
   (`if (hasSemVerComponents!V)`) gates it at overload resolution instead.
2. **`fix(ci)`** — `ci --test` now honors `$DC` (`--compiler=$DC`) and the
   workflow sets `DC: ${{ matrix.DC }}`. The `ldc2`/`dmd` matrix dimensions were
   previously a no-op for the test suite; now each really builds with its
   compiler (the `default` dev shell provides both).
3. **`build(ci)`** — compile `ci` with DMD on x86_64-linux (no LLVM in its
   closure). Example verification uses the embedded DMD; the test suite is
   matrix-controlled (commit 2).
4. **`build(nix)`** — `mkShellNoCC` for the pre-commit devShell (drops the
   shell's own gcc-15 stdenv toolchain).
5. **`ci(lychee)`** — exclude `lists.gnu.org` + `docs.dagger.io`, which
   block/reset GitHub Actions' shared IPs (same pattern as the existing excluded
   hosts).
6. **`fix(ci)`** — isolate each markdown example's `DUB_HOME`. README examples
   depend on the in-repo `sparkles` as `~master`, which dub rebuilds in place and
   unlocked on every `dub run`; parallel builds raced on the shared
   `libsparkles_*.a`. A per-example home fixes it **without** serializing —
   `--temp-build` only isolates the leaf build, not this path dep. (DMD's fast
   compiles exposed a race LDC's slower builds hid.)

## Measured closures (x86_64-linux)

| | before | after |
| --- | --- | --- |
| `.#ci` | 1344 MiB | **875 MiB** — 0 llvm/ldc |
| pre-commit devShell | 1599 MiB | **1149 MiB** — no gcc-15/binutils |

## Verified

- Every sub-package builds & tests under **dmd** (base 250 / core-cli 84 /
  test-utils 4 / math 10 / versions 167) and **ldc2**.
- `DC=ldc2`/`DC=dmd` drive the right compiler; 54/54 standalone examples under dmd.
- `--verify --files '**.md'` under DMD at **full concurrency** — all 20 example
  groups pass across repeated runs (no serialization).

https://claude.ai/code/session_012HAgTH22facAUpS3fg18rB