### PR TITLE
docs(research): parsing survey wave 3 — the D landscape + sparkles:parsing proposal

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -310,6 +310,14 @@ export default withMermaid(
               ],
             },
             {
+              text: 'Parsing (proposal)',
+              collapsed: true,
+              items: [
+                { text: 'Design Proposal', link: '/specs/parsing/' },
+                { text: 'Delivery Plan', link: '/specs/parsing/PLAN' },
+              ],
+            },
+            {
               text: 'Versions',
               collapsed: false,
               items: [
@@ -470,6 +478,10 @@ export default withMermaid(
                 {
                   text: 'Comparison & Synthesis',
                   link: '/research/parsing/comparison',
+                },
+                {
+                  text: 'The D Landscape',
+                  link: '/research/parsing/d-landscape',
                 },
               ],
             },

--- a/docs/research/parsing/comparison.md
+++ b/docs/research/parsing/comparison.md
@@ -277,9 +277,13 @@ survey suggests the design center for an allocation-conscious D parsing toolkit:
   re-serializable CST (e.g. a formatter) — otherwise a plain AST is lighter. Incremental
   is an architecture to adopt deliberately for an editor, never to retrofit.
 
-A future `d-landscape.md` (Pegged, `std.experimental.lexer`, the in-tree parsers) and a
-milestoned proposal are deferred; this section is the design-lessons sketch the survey
-currently supports.
+These design lessons are cashed in two follow-on documents: the **[D parsing
+landscape][d-landscape]** surveys what D itself offers (Pegged, the dmd/libdparse/sdc
+hand-written front-ends, mir-ion/asdf, pry) and pinpoints the gap — no maintained, `@nogc`,
+zero-copy ordered-choice combinator — that a Sparkles toolkit fills; and the
+**[`sparkles:parsing` proposal](../../specs/parsing/index.md)** (+ its
+[milestones](../../specs/parsing/PLAN.md)) turns the sketch above into a concrete,
+bottom-up design over the existing [`sparkles.base.text`][base-text] readers.
 
 ---
 
@@ -329,6 +333,7 @@ recovery ladder — trace to Knuth 1965, Earley 1970, Ford 2002/2004, Valiant 19
 [combine]: ./rust-combine.md
 [angstrom]: ./ocaml-angstrom.md
 [fparsec]: ./fsharp-fparsec.md
+[d-landscape]: ./d-landscape.md
 [v-parsing]: https://github.com/PetarKirov/sparkles/blob/main/libs/versions/src/sparkles/versions/parsing.d
 [cli-args]: https://github.com/PetarKirov/sparkles/blob/main/libs/core-cli/src/sparkles/core_cli/args.d
 [base-text]: https://github.com/PetarKirov/sparkles/blob/main/libs/base/src/sparkles/base/text/package.d

--- a/docs/research/parsing/d-landscape.md
+++ b/docs/research/parsing/d-landscape.md
@@ -1,0 +1,318 @@
+# The D parsing landscape
+
+The survey's inward turn: what the **D ecosystem itself** offers for parsing, mapped onto
+the [taxonomy][umbrella] the cross-ecosystem deep-dives established, and read against
+Sparkles' allocation-conscious (`@nogc`/`@safe`) needs. Where the other pages ask "how does
+Rust/Haskell/C++ do it," this one asks "what can a D project reach for today, and what is
+missing" — the evidence base for the [Sparkles parsing proposal][proposal]. Every project
+below is grounded against a **locally pinned** checkout under `$REPOS/dlang/`
+(`$REPOS = /home/petar/code/repos`; per-claim verification lives in the survey's internal
+grounding tree, which the published pages do not link).
+
+**Last reviewed:** July 3, 2026
+
+---
+
+## The landscape at a glance
+
+D's parsing story has four strong pillars and one conspicuous gap. The pillars: a
+**compile-time PEG generator** ([Pegged][pegged-repo]), a **production hand-written
+front-end** for D itself (three of them — [libdparse][libdparse-repo], [dmd][dmd-repo],
+[sdc][sdc-repo]), a **world-class `@nogc`/SIMD serialization stack**
+([mir-ion][mir-ion-repo]/[asdf][asdf-repo]), and solid **range-based structured-data
+parsers** ([dxml][dxml-repo], [D-YAML][dyaml-repo], [sdlite][sdlite-repo]). The gap: **no
+modern, maintained, `@nogc` zero-copy _ordered-choice combinator_** ([nom][nom]/[winnow]
+style) and **no recovering parser** ([chumsky]-style) — the two designs the survey
+identifies as the [Sparkles design center][comparison-fit].
+
+| Project                       | Category (survey link)                  | Grammar / approach                                | Compile-time?    | `@nogc` / zero-copy             | Maturity (dub score) |
+| ----------------------------- | --------------------------------------- | ------------------------------------------------- | ---------------- | ------------------------------- | -------------------- |
+| [Pegged][pegged-repo]         | [PEG generator][peg] (cf. [pest])       | PEG string → parser via `mixin`; `ParseTree`      | **Yes** (CTFE)   | ✗ (GC `ParseTree`)              | Flagship, 4.1        |
+| [libdparse][libdparse-repo]   | [Hand-written RD][top-down] + lexer-gen | vendored `std.experimental.lexer` + RD → AST      | tables at CT     | perf-tuned (pools), not `@nogc` | Backbone, **4.9**    |
+| [dmd][dmd-repo]               | [Hand-written RD][top-down]             | reference D lexer + RD parser → AST               | no               | `core.stdc`/betterC-leaning     | Reference            |
+| [sdc][sdc-repo]               | [Hand-written RD][top-down]             | independent RD over a `TokenRange`; `ambiguous.d` | no               | perf-oriented                   | Independent          |
+| [pry][pry-repo]               | [Parser combinator][nom]                | `Stream`-over-ranges combinators; TLV             | CT-specialized   | Stream/zero-copy-leaning        | Stale-ish, 2.1       |
+| [mir-ion][mir-ion-repo]       | [SIMD / data-parallel][simdjson]        | Ion/JSON/YAML/MsgPack (de)serialization engine    | CT introspection | **`@nogc`**, SIMD, zero-copy    | Active, 3.3          |
+| [asdf][asdf-repo]             | [SIMD / data-parallel][simdjson]        | fast JSON + compact IR; SSE4.2                    | CT introspection | cache-oriented, low-alloc       | Active, 4.0          |
+| [JSONiopipe][jsoniopipe-repo] | Streaming ([Angstrom][angstrom]-like)   | pull tokenizer over an `iopipe` char stream       | no               | streaming, no required DOM      | Niche                |
+| [`std.json`][stdjson]         | Built-in DOM (baseline)                 | GC `JSONValue` DOM                                | no               | ✗ (GC; RED at-scale warning)    | Stdlib               |
+| [dxml][dxml-repo]             | Pull (StAX)                             | range-based StAX pull + optional DOM              | no               | `@safe`, slicing, some `@nogc`  | Active, 4.6          |
+| [D-YAML][dyaml-repo]          | Hand-written (spec-heavy)               | PyYAML-derived YAML 1.1 parser                    | no               | slicing input reuse             | Active, **4.9**      |
+| [sdlite][sdlite-repo]         | Range-based (config)                    | SDLang parser/generator; pool allocator           | no               | pooled GC, low overhead         | Active, 3.8          |
+
+<sub>dub scores are the registry's 0–5 popularity/quality signal at review time; "compile-time?"
+distinguishes _parsing at CT_ (Pegged) from _tables/reflection generated at CT_ (libdparse,
+mir). Per-cell sources are recorded in the survey's internal grounding tree.</sub>
+
+---
+
+## Compile-time PEG generation — Pegged
+
+[Pegged][pegged-repo] (Philippe Sigaud; Boost) is D's flagship parser generator and the
+ecosystem's headline demonstration of _metaprogramming as a parser generator_ — the D
+answer to [pest]/ANTLR, but with a twist no runtime generator has: it can run the parser
+**at compile time**. You write a PEG as a string, pass it to `grammar`, and `mixin` the
+result:
+
+```d
+import pegged.grammar;
+
+mixin(grammar(`
+Arithmetic:
+    Term     < Factor (Add / Sub)*
+    Add      < "+" Factor
+    Factor   < Primary (Mul / Div)*
+    Primary  < Parens / Number / Variable
+    Number   < ~([0-9]+)
+    Variable <- identifier
+`));
+```
+
+The generated `Arithmetic` parser then works _both_ ways ([`README.md`][pegged-repo]):
+
+```d
+enum parseTree1 = Arithmetic("1 + 2 - (3*x-5)*6");   // Parsing at compile-time
+auto parseTree2 = Arithmetic(" 0 + 123 - 456 ");     // ...and at runtime too
+```
+
+It implements the full [PEG][peg] operator set (ordered choice `/`, `*`/`+`/`?`, syntactic
+predicates `&`/`!`), supports semantic actions and a `dynamic/` runtime-grammar variant, and
+generates packrat-style memoizing recursive-descent parsers. The cost is the one the
+[PEG/packrat theory][peg] predicts and that matters for Sparkles: the output is a
+**GC-allocated `ParseTree`** — Pegged is _not_ `@nogc` (the latest commit is literally "use
+GC allocated slice instead of always alloca on stack"). It is the right tool for a
+throwaway DSL or a compile-time grammar, the wrong tool for an allocation-bounded hot path.
+The historical alternative, `ctpg` (youkei's Compile-Time Parser Generator), predates Pegged
+with the same CTFE idea but is effectively abandoned.
+
+---
+
+## The D-language front-ends — three hand-written recursive-descent parsers
+
+The most instructive data point in the D landscape is that the D _language itself_ is
+parsed, in production, by **three independent hand-written recursive-descent parsers** — not
+one of them generated. This is the same lesson the [top-down][top-down] page draws from
+GCC/Clang/rustc: nobody _generates_ a production language parser.
+
+- **[libdparse][libdparse-repo]** (dlang-community; dub score **4.9**, the highest in the
+  space) — "Library for lexing and parsing D source code" ([`README.md`][libdparse-repo]).
+  It is the ecosystem's backbone: **DCD, D-Scanner, dfmt, dfix** all parse D through it.
+  Two-stage: a lexer built on a **compile-time lexer generator** feeding a hand-written RD
+  parser (`src/dparse/parser.d`) that builds an AST. Its lexer is where
+  **`std.experimental.lexer`** actually lives — the generator was **removed from Phobos**
+  and the canonical copy is now vendored at
+  [`src/std/experimental/lexer.d`][libdparse-lexer], documented as "a range-based
+  compile-time _lexer generator_" driven by `staticTokens`/`dynamicTokens`/`tokenHandlers`
+  declarations. The lexer uses SSE4.2 (`core.cpuid : sse42`) and a rollback/stack-buffer
+  allocator for speed — perf-conscious, though not a blanket `@nogc`.
+- **[dmd][dmd-repo]** (Walter Bright / D Language Foundation; Boost) — the **reference**
+  implementation. `compiler/src/dmd/lexer.d` "converts source code into lexical tokens" and
+  `compiler/src/dmd/parse.d` "takes a token stream from the lexer, and parses it into an
+  abstract syntax tree" ([spec-linked][dmd-repo] to `dlang.org/spec/{lex,grammar}.html`). It
+  leans on `core.stdc` and is written in a betterC-friendly style — the authoritative D
+  grammar, hand-written throughout.
+- **[sdc][sdc-repo]** (Amaury "deadalnix" Séchet; MIT; built on `libd`) — an **independent
+  from-scratch** D compiler. Its parser (`src/d/parser/`) is RD over a `TokenRange`, and its
+  standout file `ambiguous.d` confronts head-on the thing that makes D genuinely hard to
+  parse — the type/expression/identifier ambiguity. `parseAmbiguous` is documented as
+  ["Branch to the right code depending if we have a type, an expression or an
+  identifier"][sdc-ambiguous] and drives a mode-parameterized disambiguation, a concrete
+  worked example of the [general-parsing][general] problem of local ambiguity handled inside
+  a deterministic RD parser.
+
+For Sparkles the takeaway is direct: the [hand-written scannerless RD][top-down] the repo
+already uses for [version schemes][v-parsing] is exactly what D's own toolchain does for a
+_much_ harder grammar. The proposal builds on that grain, not against it.
+
+---
+
+## Parser combinators — pry (and the gap)
+
+[pry][pry-repo] (Dmitry Olshansky — the `std.regex` author; BSL-1.0) is D's most serious
+parser-combinator library and the closest local analogue to [nom]/[winnow]. It is
+explicitly pragmatic: "the focus of development is pragmatic qualities such as achieving
+performance on par with handwritten parsers" ([`README.md`][pry-repo]), with generic input
+via a thin **`Stream`** wrapper over D ranges, compile-time-specialized building blocks
+("one of a set of values", "given value"), and support for **TLV** (type-length-value)
+binary formats. Architecturally it is the D design the survey most wants for an `@nogc`
+combinator — but its last release is **2024** (v0.7.0), it is small, and it never grew the
+zero-copy/`@nogc`-by-construction discipline of [nom]/[flatparse]. Other combinator attempts
+(`sdpc`, `parsed`, `pushdown`) are one-off and low-signal. **This is the gap:** D has no
+maintained, `@nogc`, zero-copy ordered-choice combinator, and none with [chumsky]-style
+error recovery.
+
+---
+
+## High-performance JSON & serialization — the mir stack, asdf, JSONiopipe
+
+D's answer to [simdjson][simdjson] + [serde](https://serde.rs) is the **mir** stack, and it
+is genuinely world-class — but it is a **serialization** framework, not a general parsing
+toolkit. `mir-algorithm` ships the `@nogc` substrate: `mir.serde` "implements common
+de/serialization routines" and `mir.parse` is billed as "@nogc and nothrow Parsing
+Utilities" ([Apache-2.0][mir-algo-repo], Ilia Ki / Symmetry Investments). The actual
+parsers sit on top:
+
+- **[mir-ion][mir-ion-repo]** — a "serialization engine [that] supports Text and binary
+  [Ion](http://amzn.github.io/ion-docs), JSON, MsgPack, YAML" and more ([`README.md`][mir-ion-repo]).
+  Amazon Ion is the core model; JSON/YAML/CSV are frontends. SIMD-optimized, `@nogc`-friendly,
+  and driven by heavy compile-time introspection-based (de)serialization — the D design that
+  most resembles [simdjson][simdjson] (SIMD) fused with [serde](https://serde.rs)
+  (derive-based mapping). It is the high-performance successor to asdf.
+- **[asdf][asdf-repo]** — the original libmir fast JSON: "a cache oriented string based JSON
+  representation … specially geared towards transforming high volumes of JSON dataframes"
+  ([`README.md`][asdf-repo]), SSE4.2-accelerated, built at Tamedia for click-stream
+  processing. Its "Simple Document Format" is a compact binary intermediate — a
+  [simdjson-tape][simdjson]-adjacent idea.
+- **[JSONiopipe][jsoniopipe-repo]** (Steven Schveighoffer) — the streaming outlier, the D
+  cousin of [Angstrom][angstrom]/attoparsec: "a streaming parser, which can be applied to
+  any iopipe of character type … the entire data does not need to be held in memory for
+  parsing" and "there is no required intermediate format" ([`README.md`][jsoniopipe-repo]),
+  with an optional DOM. Pull/lazy, low-allocation, JSON5-capable.
+
+The stdlib baseline is [`std.json`][stdjson], and it is honest about its limits — the module
+header carries a red warning that its GC `JSONValue` DOM, "at the range of hundreds of
+megabytes … is known to cause and exacerbate GC problems … try replacing it with a stream
+parser" ([`std/json.d`][stdjson]). It is the correctness-first baseline every faster D JSON
+parser is measured against. (`hipjson` is a newer SIMD-DOM attempt; niche.)
+
+---
+
+## Structured-data & config parsers
+
+- **[dxml][dxml-repo]** (Jonathan M Davis) — "a library … for parsing XML 1.0 [whose] parser
+  is a range-based [StAX parser](https://en.wikipedia.org/wiki/StAX), but … also has support
+  for generating a DOM" ([`README.md`][dxml-repo]). `@safe`, pure-D, slicing over the input;
+  the clean **pull-parser** design point in D.
+- **[D-YAML][dyaml-repo]** (dlang-community; dub score 4.9) — the canonical D YAML, PyYAML-derived
+  (~YAML 1.1), a spec-heavy hand-written parser with slicing input reuse.
+- **[sdlite][sdlite-repo]** (Sönke Ludwig) — "a lightweight SDLang parser/generator … providing
+  a range based API. While the parser still uses the GC … it uses a very efficient pool based
+  allocation scheme that has very low computation and memory overhead" ([`README.md`][sdlite-repo]).
+  The modern SDLang parser (SDLang is dub's own recipe format; dub bundles its own copy).
+  Supersedes the older `sdlang-d`.
+
+A few adjacent points worth a line: **[d_tree_sitter][dtreesitter]** provides D FFI bindings
+to the [tree-sitter][tree-sitter] C runtime — the D path to incremental parsing without
+reimplementing it; **[httparsed][httparsed]** is a `@nogc`/betterC HTTP/1 request-response
+parser (picohttpparser-style), a nice small proof that `@nogc` parsing is idiomatic in D;
+and **cerealed** is a compile-time-introspection _binary_ serialization library (the D
+`cereal`), parsing-adjacent but not a grammar parser.
+
+---
+
+## The in-tree Sparkles parsers — the baseline
+
+Sparkles already hand-parses several small languages, and they set the idiom the
+[proposal][proposal] must fit:
+
+- **Version schemes** ([`sparkles.versions.parsing`][v-parsing] + `schemes/`) — hand-written
+  **scannerless recursive descent** over a `scope const(char)[]` cursor. The engine
+  `parseSemVerShaped` walks a scheme's components with `static foreach` (design-by-introspection
+  over the scheme struct), advancing the slice and a byte offset in lockstep; the node-semver
+  range grammar is a second, deeper RD layer. Entry points are `@safe pure nothrow @nogc`, and
+  the result type is `Expected!(T, ParseError, NoGcHook)` — no exceptions, structured
+  `(code, offset)` errors, fail-fast.
+- **The `@nogc` text substrate** ([`sparkles.base.text`][base-text]) — `readers.d` provides
+  **zero-copy, cursor-advancing** primitives (`readInteger`, `skipSpaces`, `tryConsume`,
+  `readUntil`) that take `ref scope const(char)[]` and advance only on success, returning
+  slices into the input; `writers.d` mirrors them for output ranges (`SmallBuffer`); `errors.d`
+  defines the shared `ParseError`/`ParseErrorCode`/`Expected` vocabulary. Documented as
+  "mechanism, not policy" — the ideal foundation for a combinator layer.
+- **CLI arguments** ([`sparkles.core_cli.args`][cli-args]) — the pragmatic exception: a
+  compile-time UDA (`@CliOption`) wrapper around Phobos `std.getopt`, which uses **GC +
+  exceptions**. Explicitly _not_ the `@nogc`/`Expected` idiom; a candidate to migrate onto the
+  proposed toolkit.
+- **Terminal VT sequences** (`sparkles:ghostty`) — delegated to the C `libghostty-vt` engine
+  via ImportC; Sparkles owns no D-side VT state machine.
+
+---
+
+## Synthesis — the gap Sparkles fills
+
+Map the D landscape onto the survey's taxonomy and the shape is clear:
+
+| Survey category                  | D's strongest option                      | Fit for an `@nogc` Sparkles parser                          |
+| -------------------------------- | ----------------------------------------- | ----------------------------------------------------------- |
+| [PEG generator][peg]             | [Pegged][pegged-repo] (compile-time)      | ✗ GC `ParseTree`; great for DSLs, wrong for hot paths       |
+| [Hand-written RD][top-down]      | dmd / libdparse / sdc                     | ✓ the grain Sparkles already follows (version schemes)      |
+| [Combinator][nom]                | [pry][pry-repo] (stale)                   | ✗ no maintained `@nogc`, zero-copy combinator exists        |
+| [SIMD / high-perf][simdjson]     | [mir-ion][mir-ion-repo]/[asdf][asdf-repo] | ✓ but _serialization_, not general parsing; heavyweight dep |
+| Streaming ([Angstrom][angstrom]) | [JSONiopipe][jsoniopipe-repo]             | ~ iopipe-coupled; JSON-specific                             |
+| [Recovering][chumsky]            | — (none)                                  | ✗ no D parser offers [chumsky]-style recovery               |
+
+D has a strong compile-time generator (but GC-bound), a proven hand-written-RD tradition
+(D-specific), and a world-class `@nogc`/SIMD _serialization_ stack (mir) — yet **nothing in
+the middle**: no small, maintained, `@nogc`, zero-copy **ordered-choice combinator** over
+`const(char)[]` slices, and no **error-recovering** parser. That middle is exactly where
+Sparkles' needs sit (version constraints, config, CLI, small DSLs), exactly what the existing
+[`sparkles.base.text`][base-text] readers are shaped to support, and exactly the
+[design center the comparison identifies][comparison-fit]: zero-copy scannerless RD in the
+[nom]/[winnow] mold, zero-allocation validators ([flatparse]'s proof), a [Pratt][pratt] loop
+for constraint grammars, and `Expected!(T, E)` results. The
+[Sparkles parsing proposal][proposal] cashes this in.
+
+---
+
+## Sources
+
+Every project characterization is grounded against a locally pinned checkout under
+`$REPOS/dlang/` (pinned SHAs and per-claim verification are recorded in the survey's internal
+grounding tree, `docs/research/parsing/grounding/`, which the published pages do not link).
+Primary artifacts: the project READMEs and source trees named inline (Pegged `README.md`; libdparse `README.md`
+
+- vendored `src/std/experimental/lexer.d`; dmd `compiler/src/dmd/{lexer,parse}.d`; sdc
+  `src/d/parser/ambiguous.d`; pry `README.md`; mir-algorithm `source/mir/{serde,parse}.d`;
+  mir-ion & asdf `README.md`; JSONiopipe `README.md`; Phobos `std/json.d`; dxml/D-YAML/sdlite
+  `README.md`), plus the in-tree Sparkles sources.
+
+<!-- References -->
+
+<!-- Within-tree: survey -->
+
+[umbrella]: ./index.md
+[concepts]: ./concepts.md
+[comparison]: ./comparison.md
+[comparison-fit]: ./comparison.md#where-a-sparkles-parser-would-fit
+[peg]: ./theory/peg-packrat.md
+[top-down]: ./theory/top-down.md
+[general]: ./theory/general-parsing.md
+[pratt]: ./theory/pratt-precedence.md
+[incremental]: ./theory/incremental.md
+[pest]: ./pest.md
+[nom]: ./rust-nom.md
+[winnow]: ./rust-winnow.md
+[chumsky]: ./rust-chumsky.md
+[flatparse]: ./haskell-flatparse.md
+[simdjson]: ./simdjson.md
+[angstrom]: ./ocaml-angstrom.md
+[tree-sitter]: ./tree-sitter.md
+
+<!-- The proposal this page feeds -->
+
+[proposal]: ../../specs/parsing/index.md
+
+<!-- D ecosystem (external) -->
+
+[pegged-repo]: https://github.com/PhilippeSigaud/Pegged
+[libdparse-repo]: https://github.com/dlang-community/libdparse
+[libdparse-lexer]: https://github.com/dlang-community/libdparse/blob/master/src/std/experimental/lexer.d
+[dmd-repo]: https://github.com/dlang/dmd/blob/master/compiler/src/dmd/parse.d
+[sdc-repo]: https://github.com/snazzy-d/sdc
+[sdc-ambiguous]: https://github.com/snazzy-d/sdc/blob/master/src/d/parser/ambiguous.d
+[pry-repo]: https://github.com/DmitryOlshansky/pry-parser
+[mir-algo-repo]: https://github.com/libmir/mir-algorithm
+[mir-ion-repo]: https://github.com/libmir/mir-ion
+[asdf-repo]: https://github.com/libmir/asdf
+[jsoniopipe-repo]: https://github.com/schveiguy/jsoniopipe
+[stdjson]: https://github.com/dlang/phobos/blob/master/std/json.d
+[dxml-repo]: https://github.com/jmdavis/dxml
+[dyaml-repo]: https://github.com/dlang-community/D-YAML
+[sdlite-repo]: https://github.com/s-ludwig/sdlite
+[dtreesitter]: https://github.com/aminya/d-tree-sitter
+[httparsed]: https://github.com/tchaloupka/httparsed
+
+<!-- In-tree Sparkles sources -->
+
+[v-parsing]: https://github.com/PetarKirov/sparkles/blob/main/libs/versions/src/sparkles/versions/parsing.d
+[base-text]: https://github.com/PetarKirov/sparkles/blob/main/libs/base/src/sparkles/base/text/package.d
+[cli-args]: https://github.com/PetarKirov/sparkles/blob/main/libs/core-cli/src/sparkles/core_cli/args.d

--- a/docs/research/parsing/grounding/_sources.md
+++ b/docs/research/parsing/grounding/_sources.md
@@ -58,6 +58,32 @@ Wave 2 — SIMD / data-parallel + combinators (added 2026-07-03):
 `$REPOS/zig/zig/lib/std/zig/tokenizer.zig` checkout. Hyperscan paper:
 `papers/parsing/wang-2019-hyperscan-nsdi.pdf`, NSDI 2019, 19 pp.)
 
+Wave 3 — D landscape (added 2026-07-03). All under `$REPOS/dlang/`:
+
+| Repo          | Path                                     | Pinned SHA   | As of      |
+| ------------- | ---------------------------------------- | ------------ | ---------- |
+| asdf          | `$REPOS/dlang/asdf`                      | `8b33521`    | 2025-11-07 |
+| mir-ion       | `$REPOS/dlang/mir/mir-ion`               | `a5c2a78`    | 2025-11-07 |
+| D-YAML        | `$REPOS/dlang/dlang-community/D-YAML`    | `09aeac1`    | 2026-01-24 |
+| sdlite        | `$REPOS/dlang/sdlite`                    | `b33048b`    | 2025-10-14 |
+| jsoniopipe    | `$REPOS/dlang/jsoniopipe`                | `36abd4f`    | 2026-06-14 |
+| Pegged        | `$REPOS/dlang/Pegged`                    | `c351440`    | 2025-08-01 |
+| libdparse     | `$REPOS/dlang/dlang-community/libdparse` | `ce770e4`    | 2026-05-10 |
+| dxml          | `$REPOS/dlang/dxml`                      | `6c25b3d`    | 2025-08-20 |
+| pry           | `$REPOS/dlang/pry-parser`                | `ae4c017`    | 2024-04-24 |
+| mir-algorithm | `$REPOS/dlang/mir/mir-algorithm`         | `2da2123`    | 2026-02-04 |
+| mir-core      | `$REPOS/dlang/mir/mir-core`              | `4397b03`    | 2026-02-24 |
+| cerealed      | `$REPOS/dlang/cerealed`                  | `3340ea8`    | 2026-05-09 |
+| dmd           | `$REPOS/dlang/dmd`                       | `e6baf47458` | 2026-07-03 |
+| sdc           | `$REPOS/dlang/sdc`                       | `611d70ad`   | 2026-03-16 |
+| phobos        | `$REPOS/dlang/phobos`                    | `6be6c3809`  | 2026-06-29 |
+
+Wave-3 grounding notes: `std.experimental.lexer` was **removed from Phobos**; the canonical
+copy is vendored inside libdparse at `src/std/experimental/lexer.d`. `mir-algorithm` ships
+only the `mir.serde`/`mir.parse` framework + `JsonAlgebraic` — the actual SIMD parsers are
+`asdf`/`mir-ion`. The three D-language front-ends: `dmd` (`compiler/src/dmd/{lexer,parse}.d`),
+`libdparse` (`src/dparse/{lexer,parser}.d`), `sdc` (`src/d/parser/` incl. `ambiguous.d`).
+
 In-repo docs/manuals to use for quote-grounding: bison `doc/bison.texi`; menhir
 `doc/` + `CHANGES.md`; tree-sitter `docs/src/`; nom/winnow/chumsky/pest `doc/` + `README` +
 `src/`; the Haskell libs' `.cabal`/`CHANGELOG`/`src` + Haddocks in-tree. For wave 2:

--- a/docs/research/parsing/grounding/d-landscape.md
+++ b/docs/research/parsing/grounding/d-landscape.md
@@ -1,0 +1,71 @@
+# Grounding ledger — `d-landscape.md`
+
+Claim-by-claim verification of `docs/research/parsing/d-landscape.md` against **local**
+pinned checkouts under `$REPOS/dlang/` (SHAs in [`_sources.md`](./_sources.md), wave-3
+table). `$REPOS = /home/petar/code/repos`. All quotes read directly during the 2026-07-03
+wave-3 pass.
+
+Status key: ✓ verified verbatim/exact · ≈ accurate paraphrase / abridged-but-faithful ·
+⚠ discrepancy · ◯ opinion/interpretation · 🌐 web/secondary (dub scores, download stats).
+
+| #   | Claim                                                                                                                                                                                                           | Type         | Source (local + locator)                                                                                   | Status |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------- | ------ |
+| 1   | Pegged: "Parsing Expression Grammar (PEG) generator"; Boost; Philippe Sigaud                                                                                                                                    | fact         | `Pegged/dub.json` (description, license, authors)                                                          | ✓      |
+| 2   | The `mixin(grammar(\`Arithmetic: …\`))` example                                                                                                                                                                 | QUOTE-code   | `Pegged/README.md`                                                                                         | ✓      |
+| 3   | Parse both ways: `enum parseTree1 = Arithmetic(...)` (compile-time) + runtime `auto parseTree2 = …`                                                                                                             | QUOTE-code   | `Pegged/README.md` ("Parsing at compile-time" / "at runtime too")                                          | ✓      |
+| 4   | Pegged is **not `@nogc`** — GC `ParseTree`; latest commit "use GC allocated slice instead of always alloca"                                                                                                     | fact         | `Pegged` git log HEAD `c351440` (2025-08-01)                                                               | ✓      |
+| 5   | ctpg = historical CTFE generator (youkei), abandoned                                                                                                                                                            | fact         | 🌐 registry/GitHub (not locally cloned)                                                                    | 🌐     |
+| 6   | libdparse: "Library for lexing and parsing D source code"                                                                                                                                                       | QUOTE        | `dlang-community/libdparse/README.md:3`                                                                    | ✓      |
+| 7   | Backbone of DCD/D-Scanner/dfmt/dfix (they depend on it)                                                                                                                                                         | fact         | dlang-community/{D-Scanner,dfmt,dfix} `dub.json` deps on `dparse`                                          | ≈      |
+| 8   | `std.experimental.lexer` **removed from Phobos**, vendored in libdparse; "range-based compile-time _lexer generator_"                                                                                           | QUOTE + fact | `phobos/std/experimental/` (no `lexer.d`); `libdparse/src/std/experimental/lexer.d:1-6`                    | ✓      |
+| 9   | libdparse lexer uses SSE4.2 + rollback/stack-buffer allocator                                                                                                                                                   | fact         | `libdparse/src/dparse/lexer.d` (`core.cpuid : sse42`); `src/dparse/rollback_allocator.d`                   | ✓      |
+| 10  | dmd `lexer.d` "converts source code into lexical tokens"; `parse.d` "takes a token stream from the lexer, and parses it into an abstract syntax tree"                                                           | QUOTE        | `dmd/compiler/src/dmd/lexer.d:2`, `parse.d:2`                                                              | ✓      |
+| 11  | dmd Walter Bright / D Language Foundation, Boost; spec-linked; `core.stdc`/betterC-leaning                                                                                                                      | fact         | `dmd/.../lexer.d` header (Copyright/License/Specification lines + `import core.stdc.*`)                    | ✓      |
+| 12  | sdc: independent from-scratch D compiler, MIT, based on `libd`                                                                                                                                                  | fact         | `sdc/README.md` (title, "based on libd", "released under the MIT license")                                 | ✓      |
+| 13  | sdc `parseAmbiguous`: "Branch to the right code depending if we have a type, an expression or an identifier" over a `TokenRange`                                                                                | QUOTE        | `sdc/src/d/parser/ambiguous.d:16-23`                                                                       | ✓      |
+| 14  | pry: "performance on par with handwritten parsers"; `Stream`-over-ranges; CT-specialized; TLV                                                                                                                   | QUOTE + fact | `pry-parser/README.md:5-12`                                                                                | ✓      |
+| 15  | pry last release 2024 (v0.7.0), stale-ish; BSL-1.0                                                                                                                                                              | fact         | `pry-parser` git log HEAD `ae4c017` (2024-04-24); `dub.sdl` license                                        | ✓      |
+| 16  | mir.serde "implements common de/serialization routines"; mir.parse "@nogc and nothrow Parsing Utilities"; Apache-2.0, Ilia Ki / Symmetry Investments                                                            | QUOTE        | `mir/mir-algorithm/source/mir/serde.d:2`, `mir/parse.d:2-6`                                                | ✓      |
+| 17  | mir-ion: "serialization engine supports Text and binary Ion, JSON, MsgPack, YAML"                                                                                                                               | QUOTE        | `mir/mir-ion/README.md` ("# Mir Ion" section)                                                              | ✓      |
+| 18  | mir-ion SIMD-optimized, `@nogc`-friendly, CT-introspection (de)serialization; successor to asdf                                                                                                                 | fact         | `mir-ion` README + `source/` (SIMD in mir-algorithm; introspection-driven)                                 | ≈      |
+| 19  | asdf: "a cache oriented string based JSON representation … specially geared towards transforming high volumes of JSON dataframes"; SSE4.2; Tamedia                                                              | QUOTE        | `asdf/README.md` ("# A Simple Document Format")                                                            | ✓      |
+| 20  | JSONiopipe: "a streaming parser, which can be applied to any iopipe of character type … the entire data does not need to be held in memory"; "no required intermediate format"; optional DOM                    | QUOTE        | `jsoniopipe/README.md` (Design Overview)                                                                   | ✓      |
+| 21  | `std.json` RED warning: GC `JSONValue`, "at the range of hundreds of megabytes … known to cause and exacerbate GC problems … try replacing it with a stream parser"                                             | QUOTE        | `phobos/std/json.d:8-10`                                                                                   | ✓      |
+| 22  | dxml: "range-based [StAX parser] … but … also has support for generating a DOM"; `@safe`, XML 1.0                                                                                                               | QUOTE        | `dxml/README.md:3-7`                                                                                       | ✓      |
+| 23  | D-YAML: canonical D YAML, PyYAML-derived (~YAML 1.1), slicing input reuse; dub 4.9                                                                                                                              | fact         | `dlang-community/D-YAML` README/source; score 🌐                                                           | ≈      |
+| 24  | sdlite: "a lightweight SDLang parser/generator … range based API. While the parser still uses the GC … it uses a very efficient pool based allocation scheme that has very low computation and memory overhead" | QUOTE        | `sdlite/README.md:1-7`                                                                                     | ✓      |
+| 25  | d_tree_sitter = D FFI to tree-sitter; httparsed = `@nogc`/betterC HTTP; cerealed = binary serialization                                                                                                         | fact         | 🌐 (d_tree_sitter/httparsed not cloned); `cerealed/dub.sdl` local                                          | ≈/🌐   |
+| 26  | In-tree: `parseSemVerShaped` scannerless RD, `static foreach` DbI, `@safe pure nothrow @nogc`, `Expected!(T, ParseError, NoGcHook)`                                                                             | fact         | `libs/versions/src/sparkles/versions/schemes/semver.d:707`; `parsing.d`; verified via wave-3 Explore agent | ✓      |
+| 27  | In-tree: `base.text.readers` zero-copy cursor-advancing (`ref scope const(char)[]`), "mechanism, not policy"                                                                                                    | fact         | `libs/base/src/sparkles/base/text/{readers,errors}.d`                                                      | ✓      |
+| 28  | In-tree: `core_cli.args` = compile-time UDA wrapper around `std.getopt` (GC + exceptions)                                                                                                                       | fact         | `libs/core-cli/src/sparkles/core_cli/args.d`                                                               | ✓      |
+| 29  | In-tree: VT parsing delegated to C `libghostty-vt` via ImportC                                                                                                                                                  | fact         | `libs/ghostty/src/sparkles/ghostty/{c.c,package.d}`                                                        | ✓      |
+| 30  | dub **scores** (Pegged 4.1, libdparse 4.9, dxml 4.6, pry 2.1, mir-ion 3.3, asdf 4.0, D-YAML 4.9, sdlite 3.8)                                                                                                    | figure       | 🌐 code.dlang.org registry (as of review)                                                                  | 🌐     |
+| 31  | Catalog table + synthesis table + "the gap" thesis                                                                                                                                                              | synth        | derived from rows above                                                                                    | ◯      |
+
+## Discrepancies
+
+None. Every inline blockquote was read directly from the pinned checkout this session
+(README/source headers). The one thing to watch: dub **scores** and download counts (rows
+5, 23, 25, 30) are registry figures, not repo facts — flagged 🌐; they are popularity signals,
+not load-bearing claims.
+
+## Web-fallback / not-locally-groundable
+
+- **dub scores / download stats** — code.dlang.org registry (row 30); the registry category
+  browse is JS-rendered/flaky, so scores are point-in-time signals.
+- **ctpg** (row 5), **d_tree_sitter** / **httparsed** (row 25) — mentioned but **not cloned**;
+  characterized from the registry/GitHub, marked 🌐/≈, not asserted from a local tree.
+- **libdparse adopter list** (row 7) and **mir-ion successor-to-asdf / SIMD** (row 18),
+  **D-YAML PyYAML lineage** (row 23) — accurate paraphrases from README/deps + ecosystem
+  knowledge, marked ≈.
+
+## Opinion (◯)
+
+- "the gap Sparkles fills" thesis, the fit-for-`@nogc` column, and the catalog framing —
+  legitimate survey synthesis; every cell traces to a verified row or an existing
+  [comparison.md] Sparkles-fit conclusion.
+
+**Net:** 0 discrepancies. Every project's headline quote is verbatim from its pinned local
+checkout (Pegged mixin/compile-time, libdparse + vendored lexer provenance, dmd lexer/parse
+headers, sdc `ambiguous.d`, pry, mir serde/parse + mir-ion/asdf, JSONiopipe, `std.json` RED
+warning, dxml, sdlite). Only dub scores and the three uncloned brief-mentions are secondary.

--- a/docs/research/parsing/grounding/index.md
+++ b/docs/research/parsing/grounding/index.md
@@ -59,6 +59,7 @@ Web is fallback-only. This tree is internal QA evidence — excluded from the Vi
 | rust-combine            | [rust-combine.md](./rust-combine.md)                       | full | 0   | downloads        | ✅ B7  |
 | ocaml-angstrom          | [ocaml-angstrom.md](./ocaml-angstrom.md)                   | full | 0   | httpaf/RWO       | ✅ B7  |
 | fsharp-fparsec          | [fsharp-fparsec.md](./fsharp-fparsec.md)                   | full | 0   | reputation       | ✅ B7  |
+| d-landscape             | [d-landscape.md](./d-landscape.md)                         | full | 0   | dub scores       | ✅ B8  |
 
 ## Master discrepancy register
 
@@ -198,9 +199,21 @@ notes (all flagged 🌐 per ledger; none asserted as tree facts).
 [ocaml-angstrom]: ./ocaml-angstrom.md
 [fsharp-fparsec]: ./fsharp-fparsec.md
 
-## Status: all 36 pages grounded (7 batches). 44 discrepancies (R8–R51, all from B1–B5);
+### Batch 8 (wave 3 — D landscape, 2026-07-03)
 
-wave-2 B6 + B7 added
+**Zero discrepancies.** The [`d-landscape.md`](./d-landscape.md) page's every project quote
+was read directly from a locally pinned checkout under `$REPOS/dlang/` this session (Pegged
+`mixin(grammar)`/compile-time; libdparse "Library for lexing and parsing D source code" + the
+vendored `std.experimental.lexer` provenance; dmd `lexer.d`/`parse.d` headers; sdc
+`ambiguous.d`; pry; mir `serde.d`/`parse.d` + mir-ion/asdf READMEs; JSONiopipe; `std.json`'s
+RED GC warning; dxml; sdlite). Web-attested only: **dub scores/download counts** and the three
+brief-mention uncloned projects (ctpg, d_tree_sitter, httparsed) — all flagged 🌐/≈, none
+asserted as tree facts. The `docs/specs/parsing/` proposal is design, not a research claim, so
+it carries no ledger; its prior-art links resolve to real survey pages.
+
+## Status: all 37 pages grounded (8 batches). 44 discrepancies (R8–R51, all from B1–B5);
+
+wave-2 B6 + B7 + wave-3 B8 added
 
 0 substantive. All minor — quote-precision, citation-locator, version/attribution. No fabricated _facts_
 beyond R8/R23 quote-padding and R26/R39/R45–R47 quote-sourcing. Proceed to Phase 3 (apply fixes).

--- a/docs/research/parsing/index.md
+++ b/docs/research/parsing/index.md
@@ -226,13 +226,17 @@ this review; treat 2023–2026 tool entries as current-as-of-review.</sub>
   in [pest][pest] / [chumsky][chumsky].
 - **"I'm designing the Sparkles parser."** [comparison][comparison] → [rust-nom][nom]
   (zero-copy, `@nogc`-shaped) + [rust-chumsky][chumsky] (recovery) → [peg-packrat][peg]
-  (the space cost) → [pratt-precedence][pratt] (the expression engine).
+  (the space cost) → [pratt-precedence][pratt] (the expression engine) → the
+  **[D landscape][d-landscape]** (what D offers + the gap) → the
+  **[`sparkles:parsing` proposal](../../specs/parsing/index.md)** (the design).
 
 ### Synthesis
 
 - **[Concepts & vocabulary][concepts]** — the shared glossary + the parser-landscape table.
 - **[Theory umbrella][theory]** — the classical algorithm spine, end to end.
 - **[Comparison][comparison]** — the head-to-head matrix, the consensus, the trade-offs, and where a Sparkles parser fits.
+- **[D landscape][d-landscape]** — the inward turn: what the D ecosystem offers for parsing,
+  and the `@nogc`-combinator gap the [`sparkles:parsing` proposal](../../specs/parsing/index.md) fills.
 
 ---
 
@@ -294,6 +298,7 @@ official docs); the authoritative artifacts behind this index's classifications 
 <!-- Within-tree: synthesis -->
 
 [comparison]: ./comparison.md
+[d-landscape]: ./d-landscape.md
 
 <!-- Sparkles source -->
 

--- a/docs/specs/parsing/PLAN.md
+++ b/docs/specs/parsing/PLAN.md
@@ -1,0 +1,111 @@
+# `sparkles:parsing` — Delivery Plan
+
+_Audience: contributors implementing the toolkit. Execution-only — milestones, dependencies,
+verification, deferrals. For the design rationale and prior-art justification read the
+[proposal](./index.md); for the evidence base read the
+[parsing survey](../../research/parsing/index.md)._
+
+> [!NOTE]
+> **Status: proposal.** This is a milestoned _plan_ for a library that does not exist yet.
+> It is deliberately incremental: each milestone is independently useful, builds bottom-up on
+> the existing [`sparkles.base.text`](https://github.com/PetarKirov/sparkles/blob/main/libs/base/src/sparkles/base/text/package.d)
+> substrate, and can stop early — Sparkles gets value at M2 (combinators + Pratt) without
+> ever needing M4. Nothing here should be built ahead of a real in-repo client that needs it.
+
+## 1. Milestone overview
+
+| #      | Deliverable                                                                                              | Prior art                   | Depends on |
+| ------ | -------------------------------------------------------------------------------------------------------- | --------------------------- | ---------- |
+| **M0** | `ParseResult!T` + the leaf-parser convention over `base.text.readers` (formalise the existing idiom)     | [nom] · in-tree             | —          |
+| **M1** | Ordered-choice combinators (`seq`/`alt`/`many`/`opt`/`sepBy`/`map` + predicates), attribute-inferring    | [PEG][peg] · [nom]/[winnow] | M0         |
+| **M2** | [Pratt][pratt] expression engine (binding-power loop); **first client:** version-constraint grammar      | [pratt][pratt]              | M0, M1     |
+| **M3** | Error posture: fail-fast default + opt-in `cut` + opt-in [chumsky]-style recovery (partial + error list) | [flatparse] · [chumsky]     | M0–M2      |
+| **M4** | _(deferred)_ Optional lossless/CST view — only if a re-serializable-tree client appears                  | [red-green][incremental]    | M1–M3      |
+
+M0 formalises what [`parseSemVerShaped`][v-parsing] already does implicitly. M1 is the bulk.
+M2 is where Sparkles first gains something it lacks today (a reusable constraint parser). M3
+is a per-client policy, not new core. M4 is deferred and may never be built.
+
+## 2. Per-milestone detail
+
+Each milestone's outcome is: the relevant modules compiling `@safe pure nothrow @nogc` where
+the leaf parsers allow, unit-tested (silly, feature modules — not `package.d`), a runnable
+`[Output]` README example, and DDoc per [AGENTS.md](../../guidelines/AGENTS.md). All new code
+lives in a new `libs/parsing/` sub-package (mirroring the eight existing ones) or, if it stays
+small, under `libs/base/src/sparkles/base/text/` beside the readers it extends — decide at M0.
+
+### M0 — core result + leaf convention
+
+- Define `ParseResult!T` as `Expected!(T, ParseError, NoGcHook)` (alias the existing
+  `ParseExpected!T` from [`errors.d`][base-text]) and the parser shape
+  `ParseResult!T delegate(ref scope const(char)[])` / a `Parser` concept (`isParser!P`).
+- Wrap the [`readers.d`][base-text] primitives (`readInteger`, `skipSpaces`, `tryConsume`,
+  `readUntil`) as canonical leaf parsers; confirm advance-on-success semantics are uniform.
+- **No new parsing power** — this is the vocabulary M1 composes.
+
+### M1 — ordered-choice combinators
+
+- `seq(p...)`, `alt(p...)` / `choice` (first-match [PEG][peg] ordered choice), `many`/`many1`,
+  `opt`, `sepBy`/`sepBy1`, `map`/`mapErr`, `peek`, `notFollowedBy`. Let attributes **infer**
+  (do not force `@safe`/`@nogc` on the templates — see [AGENTS § safety attributes](../../guidelines/AGENTS.md#safety-attributes--annotate-non-templates-infer-on-templates)).
+- Accumulate into `SmallBuffer`, never `appender`; **no memoization**.
+- Verify a `()`-returning validator allocates nothing (a `@nogc` unittest is the proof).
+
+### M2 — Pratt engine + first real client
+
+- A table-free binding-power loop (`prattParse!(prefix, infix)`) per [pratt-precedence][pratt].
+- **First client:** re-express a version-constraint grammar (node-semver-style `>=1.2 <2.0 || ^3`)
+  with M1 combinators + M2 Pratt, and validate it against the existing
+  [`sparkles.versions`](https://github.com/PetarKirov/sparkles/blob/main/libs/versions/src/sparkles/versions/parsing.d)
+  range parsers (same accept/reject set). This is the milestone that proves the toolkit earns
+  its place.
+
+### M3 — error posture
+
+- Fail-fast is the default (an `err` short-circuits). Add `cut(p)` (commit — a failure after
+  `cut` is unrecoverable, the [flatparse]/[nom] error vs failure split). Add an opt-in
+  recovering combinator that returns `(partial value, ParseError[])` for user-facing grammars,
+  modelled on [chumsky]'s `ParseResult`. Recovery is opt-in per parser, never global.
+
+### M4 — deferred: lossless view
+
+- Only if a client needs a re-serializable CST (e.g. a config formatter): a lossless node type
+  that records byte spans + trivia, borrowing the [red-green][incremental] position-free-node
+  idea. Do **not** build speculatively.
+
+## 3. Verification
+
+- **Per milestone:** `dub test :parsing` (or `:base`) green; a `@nogc` unittest proving the
+  zero-allocation property (M0/M1); the M2 client matching `sparkles.versions`' accept/reject
+  set on a shared corpus; a runnable README `[Output]` example verified by
+  `nix run .#ci -- --verify`.
+- **Idiom conformance:** `@safe pure nothrow @nogc` on leaf/non-template code; attributes
+  inferred on combinator templates; `Expected` (no exceptions in the `@nogc` path); tests in
+  feature modules, not `package.d` (the silly gotcha).
+- **Docs:** the toolkit gets a `docs/libs/parsing/` Diátaxis tree when it lands; this
+  `docs/specs/parsing/` pair (proposal + plan) becomes its design-history reference.
+
+## 4. Deferrals / non-goals
+
+Per the [proposal §4](./index.md#4-non-goals-and-why): no SIMD by default (use [mir-ion]/[asdf]
+if a megabyte-JSON need appears), no incremental/query machinery (Sparkles parses once), no
+CTFE grammar DSL à la [Pegged] (hand-written RD is the survey's evidence-backed default). This
+plan builds the small `@nogc` combinator + Pratt layer that D lacks
+([the gap](../../research/parsing/d-landscape.md#synthesis--the-gap-sparkles-fills)) — nothing more.
+
+<!-- References -->
+
+[survey]: ../../research/parsing/index.md
+[comparison]: ../../research/parsing/comparison.md
+[peg]: ../../research/parsing/theory/peg-packrat.md
+[pratt]: ../../research/parsing/theory/pratt-precedence.md
+[incremental]: ../../research/parsing/theory/incremental.md
+[nom]: ../../research/parsing/rust-nom.md
+[winnow]: ../../research/parsing/rust-winnow.md
+[flatparse]: ../../research/parsing/haskell-flatparse.md
+[chumsky]: ../../research/parsing/rust-chumsky.md
+[mir-ion]: ../../research/parsing/d-landscape.md
+[asdf]: ../../research/parsing/d-landscape.md
+[Pegged]: ../../research/parsing/d-landscape.md
+[base-text]: https://github.com/PetarKirov/sparkles/blob/main/libs/base/src/sparkles/base/text/package.d
+[v-parsing]: https://github.com/PetarKirov/sparkles/blob/main/libs/versions/src/sparkles/versions/schemes/semver.d

--- a/docs/specs/parsing/index.md
+++ b/docs/specs/parsing/index.md
@@ -1,0 +1,148 @@
+# `sparkles:parsing` — Design Proposal
+
+_Audience: contributors and coding agents evaluating whether/how to build a Sparkles
+parsing toolkit. This document is a **proposal**, not a normative spec — it states what to
+build and why, grounded in the [parsing survey](../../research/parsing/index.md). For the
+milestoned delivery plan see [PLAN.md](./PLAN.md); for the cross-ecosystem evidence base see
+the [survey](../../research/parsing/index.md), its [capstone][comparison], and the
+[D-ecosystem landscape][d-landscape]._
+
+## 1. Why
+
+Sparkles already hand-parses several small languages — [version schemes][v-parsing], CLI
+arguments, terminal VT sequences — each `@nogc`/`@safe`, each hand-rolled from scratch over
+the [`sparkles.base.text`][base-text] readers. The [parsing survey](../../research/parsing/index.md)
+was written to answer whether a **reusable** parsing layer would serve those cases better,
+and what shape it should take. Its two load-bearing conclusions:
+
+1. **The cross-ecosystem [design center][comparison]** for an allocation-conscious parser is
+   **zero-copy, scannerless recursive descent** ([nom]/[winnow]) with **zero-allocation
+   validators** ([flatparse]'s proof), a [Pratt][pratt] expression loop, and `Expected!(T, E)`
+   results — _not_ SIMD ([yyjson] shows careful scalar wins), _not_ incremental (that earns
+   its keep only under an editor re-parse contract), _not_ a table generator.
+2. **The [D landscape][d-landscape] has a gap exactly there.** D has a compile-time PEG
+   generator ([Pegged] — but GC-bound), a hand-written-RD tradition (dmd/libdparse/sdc — but
+   D-specific), and a world-class `@nogc`/SIMD _serialization_ stack (mir-ion/asdf) — but **no
+   maintained, `@nogc`, zero-copy ordered-choice combinator** and **no recovering parser**.
+
+`sparkles:parsing` fills that gap: a small combinator layer over the existing `base.text`
+readers, in the idiom the repo already uses.
+
+## 2. What — the design center
+
+Each decision below cites the prior-art page it reifies and the in-tree code it builds on.
+None of it contradicts the [comparison's Sparkles-fit sketch][comparison] — it operationalises it.
+
+- **Zero-copy, scannerless recursive descent over `const(char)[]`.** No separate lexer, no
+  generated tables; the input slice _is_ the cursor. This is what [nom]/[winnow] do and what
+  [`parseSemVerShaped`][v-parsing] already does in-tree. Parsers are values of the form
+  `ParseResult!T function(ref scope const(char)[])` (advance-on-success), composing directly
+  with the [`base.text.readers`][base-text] primitives (`readInteger`, `skipSpaces`,
+  `tryConsume`, `readUntil`).
+- **Ordered-choice combinators (a PEG-shaped internal DSL).** `seq`, `choice`/`alt` (first
+  match wins — [PEG][peg] ordered choice, unambiguous by construction), `many`/`many1`,
+  `opt`, `sepBy`, `map`, plus syntactic predicates (`peek`/`notFollowedBy`). Combinators are
+  ordinary D values ([embedded-combinator interface][comparison-interface]); attributes
+  **infer** so `@nogc`/`@safe`/`pure`/`nothrow` propagate from the caller's leaf parsers.
+- **Zero-allocation by construction.** A parser returning `void`/a slice must run with **no
+  heap allocation** — the property [flatparse] proves a combinator API can have and the one
+  most relevant to Sparkles (validating a version string, a CLI token). `SmallBuffer`
+  replaces `appender` where accumulation is unavoidable; **no packrat memoization by default**
+  ([the space cost][peg] is the wrong default; reserve it for a measured hot spot).
+- **A [Pratt][pratt] expression engine.** A table-free, `O(n)` binding-power loop for any
+  operator/constraint grammar Sparkles needs (version constraints `>=1.2 <2.0 || ^3`, filter
+  expressions). Drops into the recursive-descent shell exactly as the survey's
+  [pratt-precedence][pratt] page describes.
+- **`Expected!(T, ParseError, NoGcHook)` results, failure-vs-error split.** Reuse the
+  existing [`errors.d`][base-text] vocabulary verbatim. The [flatparse]/[nom] **failure**
+  (control-flow, backtrackable) vs **error** (unrecoverable, `cut`) distinction maps onto
+  `Expected`: an ordinary parse miss is a recoverable `err`; a committed-path failure short-
+  circuits. `parseOk`/`parseErr` are the constructors.
+- **Error posture chosen per use, up front.** Fail-fast by default (validating a version
+  string); opt-in [chumsky]-style **recovery** (a partial value + an error list) for the
+  user-facing cases (config, a REPL) — an architecture decision made at parser-construction
+  time, never retrofitted ([comparison §4][comparison-recovery]).
+
+## 3. What it builds on (reuse, don't reinvent)
+
+- [`sparkles.base.text.readers`][base-text] — the zero-copy cursor primitives are the leaf
+  parsers; combinators are the glue. `readers.d` is documented as "mechanism, not policy" —
+  this toolkit _is_ the policy layer.
+- [`sparkles.base.text.errors`][base-text] — `ParseError`/`ParseErrorCode`/`ParseExpected`/
+  `parseOk`/`parseErr`/`NoGcHook` already exist and are the result vocabulary.
+- [`sparkles.base.smallbuffer`](../../libs/base/index.md) — the `@nogc` output range.
+- The [`expected`](../../guidelines/idioms/expected/index.md) idiom — `Expected!(T, E)` chaining
+  (`map`/`andThen`/`orElse`) is how parsers compose without exceptions.
+- [`parseSemVerShaped`][v-parsing] — the existing scannerless-RD exemplar; the version schemes
+  are the first real client and the migration test.
+
+## 4. Non-goals (and why)
+
+- **No SIMD by default.** [yyjson] reaches GB/s with careful scalar ANSI C and _no_ SIMD;
+  [simdjson]-class vectorization is a measured optimization for large, hot, structured inputs
+  (megabytes of JSON), which Sparkles does not parse. If such a need appears, the mir stack
+  ([mir-ion]/[asdf]) already exists — depend on it, don't rebuild it.
+- **No incremental / query machinery.** [tree-sitter]/[rust-analyzer]/[Roslyn]/[`rustc`][rustc]/[Lezer]
+  earn their persistent-tree + dependency-graph overhead only under an **editor** contract
+  (re-parse on every keystroke). Sparkles' inputs are parse-once. The one borrowable idea is a
+  [red-green][incremental] lossless view — and only if a future use wants a re-serializable
+  CST (a formatter); a plain AST is lighter otherwise. See [the incremental theory page][incremental].
+- **No CTFE grammar DSL (à la [Pegged]).** A string-mixin grammar generator is powerful but
+  GC-shaped and compile-time-heavy; the survey's evidence is that production parsers are
+  hand-written RD ([top-down], and D's own dmd/libdparse/sdc). Reach for a grammar DSL only on
+  a measured need for a large external grammar.
+- **Not a replacement for `std.getopt`/mir/Pegged.** This is a small `@nogc` toolkit for
+  Sparkles' own small languages, not a general parsing framework.
+
+## 5. Prior-art map
+
+Where each design decision comes from in the survey (the evidence, not re-derived here):
+
+| Decision                                  | Prior art (survey page)                          | What to borrow                                               |
+| ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------ |
+| Zero-copy scannerless RD over slices      | [nom] · [winnow]                                 | slice cursor, no allocator on the recognizer path            |
+| Ordered-choice combinators (unambiguous)  | [PEG/packrat][peg] · [pest]                      | ordered choice `/`, predicates; skip packrat default         |
+| Zero-allocation validators                | [flatparse]                                      | failure/error split; `()`-returning parsers allocate nothing |
+| Pratt expression engine                   | [pratt-precedence][pratt]                        | binding-power loop for constraints                           |
+| `Expected` results, fail-fast vs recover  | [flatparse] · [chumsky]                          | error posture as an up-front architecture choice             |
+| Table-free hand-written lexer (if needed) | [Zig tokenizer][zig]                             | character-class state machine, zero-alloc                    |
+| Stay batch (reject incremental)           | [incremental theory][incremental] · [comparison] | the editor-contract boundary                                 |
+| Don't reach for SIMD                      | [yyjson] · [simdjson]                            | scalar-first; vectorize only measured hot paths              |
+
+The milestones that build this — bottom-up, each reusing the `base.text` substrate — are in
+[PLAN.md](./PLAN.md).
+
+<!-- References -->
+
+<!-- Survey pages -->
+
+[survey]: ../../research/parsing/index.md
+[comparison]: ../../research/parsing/comparison.md#where-a-sparkles-parser-would-fit
+[comparison-interface]: ../../research/parsing/index.md#by-interface-model
+[comparison-recovery]: ../../research/parsing/comparison.md
+[d-landscape]: ../../research/parsing/d-landscape.md
+[peg]: ../../research/parsing/theory/peg-packrat.md
+[top-down]: ../../research/parsing/theory/top-down.md
+[pratt]: ../../research/parsing/theory/pratt-precedence.md
+[incremental]: ../../research/parsing/theory/incremental.md
+[pest]: ../../research/parsing/pest.md
+[nom]: ../../research/parsing/rust-nom.md
+[winnow]: ../../research/parsing/rust-winnow.md
+[flatparse]: ../../research/parsing/haskell-flatparse.md
+[chumsky]: ../../research/parsing/rust-chumsky.md
+[simdjson]: ../../research/parsing/simdjson.md
+[yyjson]: ../../research/parsing/yyjson.md
+[mir-ion]: ../../research/parsing/d-landscape.md#high-performance-json--serialization--the-mir-stack-asdf-jsoniopipe
+[asdf]: ../../research/parsing/d-landscape.md#high-performance-json--serialization--the-mir-stack-asdf-jsoniopipe
+[Pegged]: ../../research/parsing/d-landscape.md#compile-time-peg-generation--pegged
+[zig]: ../../research/parsing/zig-tokenizer.md
+[tree-sitter]: ../../research/parsing/tree-sitter.md
+[rust-analyzer]: ../../research/parsing/rust-analyzer.md
+[Roslyn]: ../../research/parsing/roslyn.md
+[Lezer]: ../../research/parsing/lezer.md
+[rustc]: ../../research/parsing/rustc-queries.md
+
+<!-- In-tree Sparkles sources -->
+
+[base-text]: https://github.com/PetarKirov/sparkles/blob/main/libs/base/src/sparkles/base/text/package.d
+[v-parsing]: https://github.com/PetarKirov/sparkles/blob/main/libs/versions/src/sparkles/versions/schemes/semver.d

--- a/lychee.exclude
+++ b/lychee.exclude
@@ -70,3 +70,9 @@
 # parsing/theory/pratt-precedence.md): a slow academic host that times out for
 # automated checkers (12 timeouts, 0 real errors in a local run); valid citation.
 ^https?://(www\.)?engr\.mun\.ca/
+# cgit.git.savannah.gnu.org (GNU Bison source-tree browse links, cited in
+# parsing/bison-yacc.md): the Savannah cgit server intermittently returns 502 Bad
+# Gateway to automated checkers (6/6 links 502'd in one CI run, all transient); the
+# links are valid canonical source citations, so exclude the flaky host rather than
+# rot-pin each tree URL.
+^https?://cgit\.git\.savannah\.gnu\.org/


### PR DESCRIPTION
## Parsing survey — wave 3: the D landscape + the Sparkles proposal

Follows wave 2 (#77, merged). This closes the loop the survey was built for: it turns the
survey **inward** to D's own ecosystem, then cashes in the accumulated Sparkles-fit
conclusions as a concrete, milestoned design proposal. Two commits, `docs:build` green.

### `docs/research/parsing/d-landscape.md` — what D offers for parsing
A grounded catalog mapping D's parsing options onto the survey taxonomy:

- **Compile-time PEG** — Pegged (`mixin(grammar(...))`; parses at CT *and* runtime; but GC-bound).
- **Three hand-written D-language front-ends** — dmd (reference), libdparse (the tooling
  backbone, and where `std.experimental.lexer` lives after being *removed from Phobos*), and
  sdc (deadalnix's independent compiler; `ambiguous.d` handles D's type/expr ambiguity). The
  trio reinforces the survey's finding: production language parsers are hand-written RD.
- **`@nogc`/SIMD serialization** — the mir-ion/asdf stack (D's simdjson+serde answer),
  JSONiopipe (streaming), and `std.json` (the GC baseline with its own at-scale warning).
- **Config/structured** — dxml (StAX), D-YAML, sdlite.
- **Synthesis — the gap:** D has a CT generator, a hand-written-RD tradition, and a
  world-class serde stack — but **no maintained, `@nogc`, zero-copy ordered-choice
  combinator** and **no recovering parser**. That gap is where Sparkles fits.

### `docs/specs/parsing/` — the `sparkles:parsing` proposal
`index.md` (design) + `PLAN.md` (milestones M0→M4 + non-goals). Each decision cross-links the
prior-art page it reifies and the in-tree code it builds on: zero-copy scannerless RD over
`sparkles.base.text.readers`, ordered-choice combinators, zero-allocation validators
(flatparse's proof), a Pratt loop for version constraints, `Expected!(T, E)` results, opt-in
chumsky-style recovery — with explicit, survey-grounded non-goals (no SIMD, no incremental,
no CTFE grammar DSL).

### Grounding & integration
- **Batch-8 grounding ledger** (`grounding/d-landscape.md`), **0 substantive discrepancies** —
  every D-project quote read directly from a locally pinned checkout. `_sources.md` pins 15 D
  repos (5 newly cloned: asdf, mir-ion, D-YAML, sdlite, jsoniopipe).
- `comparison.md` §"Where a Sparkles parser would fit" now points at both docs (was
  "deferred"); wired into `index.md`'s reading path + the VitePress sidebar (D Landscape under
  Parsing; the proposal under Specs).

> Review notes: `lychee` + `verify-md-examples` were skipped at commit time (per the
> research-docs guidance) and left to CI. Survey pages deliberately do **not** link the
> `srcExclude`d `grounding/` tree. The two commits are atomic (content+proposal / grounding)
> and each builds green.

https://claude.ai/code/session_018ZrCUXiMoUV1pVvUcw56sS
