### PR TITLE
docs(research): survey iroh's Rust stack for a native D port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -28,6 +28,7 @@ export default withMermaid(
     srcExclude: [
       '**/research/parsing/grounding/**',
       '**/research/units-of-measure/grounding/**',
+      '**/research/iroh/prompt.md',
     ],
 
     markdown: {
@@ -846,6 +847,101 @@ export default withMermaid(
                 {
                   text: 'Other Implementations',
                   link: '/research/algebraic-effects/other-implementations',
+                },
+              ],
+            },
+            {
+              text: 'Iroh (P2P / QUIC)',
+              link: '/research/iroh/',
+              collapsed: true,
+              items: [
+                {
+                  text: 'Concepts & Vocabulary',
+                  link: '/research/iroh/concepts',
+                },
+                {
+                  text: 'Foundations',
+                  collapsed: true,
+                  items: [
+                    {
+                      text: 'Identity & Cryptography',
+                      link: '/research/iroh/identity-crypto',
+                    },
+                    {
+                      text: 'Wire Formats & Serialization',
+                      link: '/research/iroh/wire-serialization',
+                    },
+                    {
+                      text: 'QUIC Transport (noq)',
+                      link: '/research/iroh/quic-transport',
+                    },
+                  ],
+                },
+                {
+                  text: 'Connectivity',
+                  collapsed: true,
+                  items: [
+                    {
+                      text: 'Endpoint & Protocol Router',
+                      link: '/research/iroh/endpoint',
+                    },
+                    {
+                      text: 'The Multipath Socket',
+                      link: '/research/iroh/socket',
+                    },
+                    {
+                      text: 'NAT Traversal & Address Discovery',
+                      link: '/research/iroh/nat-traversal',
+                    },
+                    {
+                      text: 'The Relay Protocol',
+                      link: '/research/iroh/relay',
+                    },
+                    {
+                      text: 'Address Lookup (Discovery)',
+                      link: '/research/iroh/discovery',
+                    },
+                    {
+                      text: 'Net Report & Interface Watching',
+                      link: '/research/iroh/net-report',
+                    },
+                  ],
+                },
+                {
+                  text: 'Data Protocols',
+                  collapsed: true,
+                  items: [
+                    {
+                      text: 'Blobs: Content-Addressed Transfer',
+                      link: '/research/iroh/blobs',
+                    },
+                    {
+                      text: 'BLAKE3 Verified Streaming (bao-tree)',
+                      link: '/research/iroh/bao-tree',
+                    },
+                    {
+                      text: 'Document Sync (iroh-docs)',
+                      link: '/research/iroh/docs-sync',
+                    },
+                    {
+                      text: 'Epidemic Broadcast (iroh-gossip)',
+                      link: '/research/iroh/gossip',
+                    },
+                  ],
+                },
+                {
+                  text: 'D Migration',
+                  collapsed: true,
+                  items: [
+                    {
+                      text: 'Tokio Concurrency Inventory',
+                      link: '/research/iroh/concurrency',
+                    },
+                    {
+                      text: 'D Architecture Migration',
+                      link: '/research/iroh/d-architecture-migration',
+                    },
+                  ],
                 },
               ],
             },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,6 +20,7 @@ export default withMermaid(
       /\/text-conformance\//,
       /\/libs\/base\/src\//,
       /\/libs\/wired\/bench\//,
+      /\/specs\/event-horizon\//,
     ],
 
     // The parsing and units-of-measure grounding ledgers are internal QA

--- a/docs/research/iroh/bao-tree.md
+++ b/docs/research/iroh/bao-tree.md
@@ -1,0 +1,704 @@
+# BLAKE3 Verified Streaming (`bao-tree`)
+
+The BLAKE3 hash tree, exposed as a codec: a pure-math library that turns a blob's content hash into an incrementally-verifiable stream, so a downloader detects a single corrupt byte after at most one 16 KiB chunk group — the algorithmic heart of [`iroh-blobs`][blobs].
+
+| Field               | Value                                                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate               | `bao-tree`                                                                                                                                                |
+| Version             | `0.16.0`                                                                                                                                                  |
+| Repository          | [`n0-computer/bao-tree`][repo]                                                                                                                            |
+| Documentation       | [docs.rs/bao-tree/0.16.0][docs] · [crates.io][crate]                                                                                                      |
+| ALPN(s)             | n/a — `bao-tree` is a codec, not a wire protocol; the transfer ALPN (`/iroh-bytes/4`) is defined by [`iroh-blobs`][blobs]                                 |
+| Approx. size (LoC)  | ≈5,600 (`src/`, excl. tests; ≈7,700 with tests)                                                                                                           |
+| Category            | Protocols                                                                                                                                                 |
+| Upstream spec/draft | [BLAKE3 spec][blake3-spec]; wire-compatible with the [`bao`][bao-crate] crate at block size 0 with a size prefix and a single range ([`lib.rs:196`][lib]) |
+| Author / MSRV       | Rüdiger Klaehn (n0); Rust 1.75; `MIT OR Apache-2.0`                                                                                                       |
+
+> [!NOTE]
+> This page covers only the `bao-tree` crate and the verified-streaming math. The
+> store that persists these trees to disk (`.obao4`/`.sizes4` files, the `redb`
+> catalog, partial-entry state machines, the download write path) lives one layer
+> up in [`iroh-blobs`][blobs]; its concurrency inventory is in
+> [Tokio Concurrency Inventory][concurrency].
+
+---
+
+## Overview
+
+### What it solves
+
+BLAKE3 is not merely a fast hash; internally it computes the digest as a binary
+Merkle tree over 1024-byte _chunks_, combining chunk chaining values pairwise up
+to a single root. `bao-tree` exposes that internal tree so it can be used for
+**verified streaming**: given only a blob's 32-byte root hash, a receiver can pull
+the blob (or an arbitrary subset of it) from an untrusted peer and verify each
+piece against the root _as it arrives_, aborting the moment a hash fails to match
+— before a single unverified byte is surfaced to the application.
+
+This is the property that makes content-addressed transfer safe over a hostile
+network: the hash _is_ the request, the answer is deterministic, and tampering is
+detected locally within a bounded window. The two problems `bao-tree` solves on
+top of raw BLAKE3 are:
+
+1. **Granularity.** Plain BLAKE3's tree bottoms out at 1024-byte chunks, so a
+   verified-streaming _outboard_ (the tree of interior hashes) would be roughly
+   `size/1024 * 64` bytes ≈ 6.25% of the payload. `bao-tree` makes the leaf
+   granularity a _runtime_ parameter — a `BlockSize` — so iroh can hash down to
+   16 KiB groups and cut the outboard 16× (see [Chunk groups](#chunk-groups-and-block-size)).
+2. **Range queries.** Instead of verifying only whole blobs or single prefixes,
+   `bao-tree` encodes an arbitrary sorted set of non-overlapping chunk ranges —
+   `[0..1000, 5000..6000]` in one query — interleaving exactly the interior hash
+   pairs needed to verify exactly those ranges against the root ([`lib.rs:224`][lib]).
+
+### Design philosophy
+
+The crate is a deliberately narrow, `no-io`-in-spirit codec. Its README states the
+compatibility contract that governs the whole design:
+
+> _"The network wire format for encoded data and slices is compatible with the bao
+> crate, except that this crate has builtin support for `runtime` configurable
+> chunk groups. … It also allows encoding not just single ranges but sets of
+> non-overlapping ranges."_ — [`README.md`][readme]
+
+The security guarantee it exists to provide is stated most crisply in the
+`iroh-blobs` design note that consumes it:
+
+> _"for every request, there is exactly one sequence of bytes that is the correct
+> answer. And the requester will notice if data is incorrect after at most 16 KiB
+> of data."_ — [`iroh-blobs/DESIGN.md:5`][design]
+
+Three consequences shape the API, and each matters directly for a D port:
+
+1. **The geometry is pure integer arithmetic.** Every node address, span, offset,
+   and outboard size is a closed-form bit trick over a `u64` node index — no
+   allocation, no I/O, `const fn` throughout ([`TreeNode`, `lib.rs:545`][lib]).
+   This layer is trivially `@safe pure nothrow @nogc` in D.
+2. **Hashing uses BLAKE3's _hazmat_ (hazardous-materials) API**, not the one-shot
+   `blake3::hash`. Verified streaming needs to hash a _subtree_ starting at a
+   non-zero chunk offset and combine chaining values with and without the ROOT
+   finalization flag — operations the safe API hides ([`hash_subtree`/`parent_cv`,
+   `lib.rs:235`][lib]). A D reimplementation must expose BLAKE3's chunk-counter
+   chaining values and parent-merge internals, not just the top-level digest (see
+   [Cryptography & identity](#cryptography--identity)).
+3. **I/O is a trait parameter, chosen at the call site.** The same traversal logic
+   backs a synchronous `Read`/`Write` path, a `tokio`-style async finite-state
+   machine, and a "mixed" sync-read/async-send path (three feature-gated modules
+   over one core), so the codec never dictates a runtime (see
+   [Concurrency & I/O model](#concurrency--io-model)).
+
+---
+
+## How it works
+
+### Chunks, chunk groups, and block size
+
+The atomic unit is the BLAKE3 chunk: `BLAKE3_CHUNK_SIZE = 1024` bytes
+([`tree.rs:119`][tree]). A `ChunkNum(u64)` counts chunks; a `BlockSize(u8)` is the
+base-2 log of the _chunk group_ size measured in chunks ([`tree.rs:121`][tree]):
+
+```rust
+// bao-tree/src/tree.rs:130 — log2(group bytes / 1024)
+pub struct BlockSize(pub(crate) u8);
+// BlockSize(0) => 1024 B (== a BLAKE3 chunk); BlockSize(4) => 16 * 1024 = 16 KiB
+pub const fn bytes(self) -> usize { BLAKE3_CHUNK_SIZE << self.0 }
+```
+
+iroh fixes the group size at 16 KiB for every blob:
+
+```rust
+// iroh-blobs/src/store/mod.rs:17 — "Block size used by iroh, 2^4*1024 = 16KiB"
+pub const IROH_BLOCK_SIZE: BlockSize = BlockSize::from_chunk_log(4);
+```
+
+n0 calls this **"n0-flavoured bao"**: interior hashes are stored and transmitted
+only down to 16 KiB granularity. Because the outboard has one 64-byte record per
+group boundary rather than per 1024-byte chunk, its size drops by a factor of 16
+versus classic bao — at the cost that ranges _below_ group granularity cannot be
+served straight from stored hashes and must be recomputed from data (see
+[the encoded slice](#the-encoded-slice-response-format)).
+
+### Node addressing: the in-order index
+
+A `BaoTree` is fully described by two fields — the geometry contains no data
+([`lib.rs:274`][lib]):
+
+```rust
+// bao-tree/src/lib.rs:274
+pub struct BaoTree {
+    size: u64,             // total bytes
+    block_size: BlockSize, // log2 of the chunk-group size
+}
+```
+
+Every node is a `TreeNode(u64)` whose value is its **in-order index** in the binary
+tree over chunks ([`lib.rs:545`][lib]). All node relationships are pure bit tricks
+on that index — no pointers, no allocation:
+
+| Property        | Formula                                             | Source              |
+| --------------- | --------------------------------------------------- | ------------------- |
+| `level()`       | `index.trailing_ones()` (0 for a leaf)              | [`lib.rs:612`][lib] |
+| `is_leaf()`     | `index & 1 == 0` (leaves are even)                  | [`lib.rs:618`][lib] |
+| `mid()`         | `ChunkNum(index + 1)`                               | [`lib.rs:601`][lib] |
+| `half_span()`   | `1 << level()`                                      | [`lib.rs:606`][lib] |
+| `chunk_range()` | `[mid - span, mid + span)` with `span = 1 << level` | [`lib.rs:738`][lib] |
+| `left_child()`  | `index - (1 << (level - 1))`                        | [`lib.rs:680`][lib] |
+| `right_child()` | `index + (1 << (level - 1))`                        | [`lib.rs:686`][lib] |
+| `root(chunks)`  | `ceil(chunks / 2).next_power_of_two() - 1`          | [`lib.rs:596`][lib] |
+
+Because the level is the count of trailing one-bits, a leaf (index even → zero
+trailing ones) has level 0, and the root sits at the highest power-of-two-minus-one
+index. Hash-validation errors carry the offending `TreeNode` (or `ChunkNum`) so a
+mismatch is positionally attributable ([`io/error.rs:10`][ioerror]).
+
+### The shifted tree
+
+Iterating a tree at a non-zero block size would waste work descending into
+sub-group nodes that carry no stored hash. `bao-tree` instead computes a **shifted
+tree** whose leaves _are_ the chunk groups, then maps shifted node indices back to
+real ones ([`lib.rs:319`][lib]):
+
+```rust
+// bao-tree/src/lib.rs:319 — BaoTree::shifted() (block_size == level)
+let shift = 10 + level;                       // bits per chunk group (16 KiB => 14)
+let full_blocks = size >> shift;
+let open_block  = ((size & ((1 << shift) - 1)) != 0) as u64;
+let blocks = (full_blocks + open_block).max(1); // a 0-byte blob still has 1 block
+let n = blocks.div_ceil(2);
+let root = n.next_power_of_two() - 1;          // shifted root node
+let filled_size = n + n.saturating_sub(1);      // total nodes in the shifted tree
+```
+
+Conversion between the two index spaces is a single bit operation:
+`subtract_block_size(n)` appends `n` trailing one-bits (`!(!x << n)`) to descend
+into a smaller block size; `add_block_size(n)` strips `n` trailing one-bits
+(`x >> n`, or `None` if the node has fewer than `n` of them, i.e. it is too small
+to exist in the coarser tree) ([`lib.rs:630`, `lib.rs:643`][lib]).
+
+### Hashing: subtrees and chaining values
+
+Two functions do all the cryptography, both via BLAKE3's `hazmat` module
+([`lib.rs:235`][lib]):
+
+```rust
+// bao-tree/src/lib.rs:235
+fn hash_subtree(start_chunk: u64, data: &[u8], is_root: bool) -> blake3::Hash {
+    if is_root {
+        blake3::hash(data)                          // whole blob fits one subtree
+    } else {
+        let mut hasher = blake3::Hasher::new();
+        hasher.set_input_offset(start_chunk * 1024); // subtree's chunk counter
+        hasher.update(data);
+        blake3::Hash::from(hasher.finalize_non_root()) // chaining value, no ROOT flag
+    }
+}
+
+// bao-tree/src/lib.rs:249
+fn parent_cv(left: &blake3::Hash, right: &blake3::Hash, is_root: bool) -> blake3::Hash {
+    if is_root { merge_subtrees_root(left, right, Mode::Hash) }
+    else       { merge_subtrees_non_root(left, right, Mode::Hash).into() }
+}
+```
+
+`hash_subtree` hashes a run of chunks as a subtree at a known chunk offset;
+`parent_cv` merges the two child chaining values into their parent's. The `is_root`
+flag is load-bearing security-critical state: only the single node covering the
+_entire_ blob is finalized with the ROOT flag, so a subtree hash can never be
+confused with a whole-blob hash (a length-extension / substitution defense inherited
+from BLAKE3's design).
+
+### The outboard: interior hashes on the side
+
+An **outboard** stores the interior tree separately from the data, "so that the data
+can be used as-is" ([`DESIGN.md:11`][design]). Each record is a 64-byte hash pair —
+left child chaining value ‖ right child chaining value ([`io/mod.rs:204`][iomod]):
+
+```rust
+// bao-tree/src/io/mod.rs:204 — one outboard record, 64 bytes
+pub(crate) fn combine_hash_pair(l: &blake3::Hash, r: &blake3::Hash) -> [u8; 64] {
+    let mut res = [0u8; 64];
+    res[0..32].copy_from_slice(l.as_bytes());  // left CV
+    res[32..64].copy_from_slice(r.as_bytes()); // right CV
+    res
+}
+```
+
+There is exactly one record per _branch node of the shifted tree_, so the record
+count is `blocks - 1` and `outboard_size = (blocks - 1) * 64` bytes
+([`lib.rs:439`][lib]). A blob of at most one chunk group has an outboard of size 0 —
+its root hash alone verifies the single leaf. Two nodes are deliberately _not_
+persisted ([`is_relevant_for_outboard`, `lib.rs:476`][lib]): anything below group
+level (no stored hash exists) and the **half-leaf** — a final leaf whose midpoint is
+at or beyond the blob size (a last group that is at most half full), whose "right"
+child is empty and whose hash equals its parent's expected value.
+
+`bao-tree` defines two on-disk layouts:
+
+- **Pre-order** (`PreOrderOutboard`) — the record for node `N` lives at byte
+  `pre_order_offset(N) * 64` ([`io/sync.rs:145`][iosync]), where `pre_order_offset`
+  counts left-subtree nodes minus set bits plus in-tree ancestors
+  ([`pre_order_offset_loop`, `lib.rs:796`][lib]). This is the layout of iroh's
+  `.obao4` files and inline outboards. Its doc comment fixes the wire contract:
+
+  > _"Caution: unlike the outboard implementation in the bao crate, this
+  > implementation does not assume an 8 byte size prefix."_ — [`io/outboard.rs:101`][iooutboard]
+
+- **Post-order** (`PostOrderOutboard`) — records at `post_order_offset(N) * 64`,
+  where offsets are `Stable` (fully left of the current size, never move) or
+  `Unstable` (shift as data is appended) ([`PostOrderOffset`, `lib.rs:283`][lib]).
+  Post-order is append-friendly for synchronizing growing files, but **iroh-blobs
+  uses only the pre-order layout on disk** — post-order is effectively legacy in the
+  iroh stack.
+
+### The encoded slice (response format)
+
+Given a query as `ChunkRanges` (`= range_collections::RangeSet2<ChunkNum>`, a sorted
+boundary set, [`lib.rs:224`][lib]), the encoder walks
+`ranges_pre_order_chunks_iter_ref(ranges, min_level)` — a pre-order traversal that
+emits, for each visited branch node whose range intersection is non-empty, a 64-byte
+`Parent` pair, and for each needed leaf a `Leaf` of chunk-group bytes (the last may
+be short) ([`lib.rs:370`][lib]; [`iter.rs`][iter]). The wire stream is those items
+concatenated in traversal order, prefixed by the blob size:
+
+```text
+n0-bao encoded slice for (root_hash, ranges):
+
+    size : u64  (little-endian, 8 bytes)          # EncodedItem::Size, first item
+    then, in pre-order over the requested ranges:
+      Parent : 32-byte left CV ‖ 32-byte right CV  # 64 bytes, one per branch node
+      Leaf   : up to 16384 data bytes              # last leaf = size - start_offset
+    ... recursing below group level only for partially-requested groups
+```
+
+The size prefix is `EncodedItem::Size(u64)` in the streaming path
+([`io/mixed.rs:87`][iomixed]) and a literal `size.to_le_bytes()` prepended by iroh's
+`create_n0_bao` helper ([`iroh-blobs/src/store/util.rs:430`][blobsutil]).
+
+Two subtleties make the format both compact and honest:
+
+- **Sub-group ranges recurse from data.** `ResponseIterRef` re-instantiates the tree
+  at `BlockSize::ZERO` with `min_full_level` set to the real block size, so a fully
+  requested group stops at group granularity, but a _partial_ group descends below
+  it ([`iter.rs:657`][iter]). For a partially-covered 16 KiB group the encoder calls
+  `encode_selected_rec`, which recomputes the sub-tree hashes from the data on the
+  fly and interleaves sub-group parent pairs plus only the needed 1024-byte chunks
+  ([`io/sync.rs:470`][iosync]) — even though those sub-group hashes were never stored.
+- **Ranges past EOF become size proofs.** Before traversal the query is
+  canonicalized by `truncate_ranges`: any boundary at or beyond the last chunk is
+  turned into an open range, so a request for a blob of _unknown_ size returns the
+  final chunk and the hashes that pin the total length ([`rec.rs:26`][rec]). This is
+  how a downloader learns and verifies a blob's size without trusting the sender's
+  claim.
+
+### Verified decode: the hash-stack machine
+
+Decoding is a pull-parser driven by a stack of _expected_ hashes. Its entire state
+is: the response iterator (which recomputes the same traversal from `(size,
+block_size, ranges)`), a hash stack seeded with the root, and the reader
+([`io/sync.rs:262`][iosync]):
+
+```rust
+// bao-tree/src/io/sync.rs:262
+pub struct DecodeResponseIter<'a, R> {
+    inner: ResponseIterRef<'a>,          // recomputes traversal; not trusted from the wire
+    stack: SmallVec<[blake3::Hash; 10]>, // expected hashes; pushed with the root
+    encoded: R,
+    buf: BytesMut,
+}
+```
+
+Per traversal item ([`io/sync.rs:313`][iosync]):
+
+- **Parent** → read exactly 64 bytes into `(l_hash, r_hash)`; pop the expected hash;
+  if `parent_cv(l_hash, r_hash, is_root) != expected`, fail with
+  `ParentHashMismatch(node)`; otherwise push `r_hash` then `l_hash` — but each side
+  only when the iterator's `right`/`left` flag says that child's range is non-empty
+  (so the stack holds exactly the hashes future items will consume, in order).
+- **Leaf** → read `size` bytes; pop the expected hash; if
+  `hash_subtree(start_chunk, data, is_root) != expected`, fail with
+  `LeafHashMismatch(start_chunk)`; otherwise surface the verified `Leaf`.
+
+Because a node's expected hash is on the stack _before_ its bytes are read, **every
+byte is checked against the root chain before it is handed to the application**, and
+corruption is localized to a single 16 KiB group. The async FSM keeps the identical
+state (`ResponseDecoderInner { iter, stack, encoded }`, [`io/fsm.rs:316`][iofsm]) but
+pushes children _before_ comparing the parent hash, "so that we could in principle
+continue" past a mismatch ([`io/fsm.rs:417`][iofsm]) — a minor ordering difference
+from the sync path, with no effect on what is accepted.
+
+The decode error set is small and positional ([`io/error.rs:10`][ioerror]):
+`ParentNotFound(TreeNode)` / `LeafNotFound(ChunkNum)` (EOF — the peer lacks that
+part of the tree/data), `ParentHashMismatch(TreeNode)` / `LeafHashMismatch(ChunkNum)`
+(tampering or corruption), and `Io`.
+
+### Partial trees and validation
+
+With the `validate` feature, `valid_ranges(outboard, data, ranges)` re-hashes chunk
+data against a _possibly incomplete_ outboard and yields the chunk ranges that
+verify ([`io/sync.rs:657`][iosync]). iroh-blobs uses this to reconstruct a partial
+blob's possession bitfield after a crash — the store can hold a half-downloaded blob
+whose outboard covers only the chunks it has, and later prove exactly which ranges
+are intact.
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+All multi-byte integers are little-endian; a "CV" is a 32-byte BLAKE3 chaining
+value. `bao-tree` defines four byte layouts, all built from the 64-byte hash pair:
+
+| Artifact                        | Layout                                                                                                               | Size / notes                                           |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Outboard record                 | `left CV (32) ‖ right CV (32)`                                                                                       | 64 bytes per shifted-tree branch node                  |
+| Pre-order outboard (`.obao4`)   | records concatenated in `pre_order_offset` order; **no header, no size prefix** ([`io/outboard.rs:101`][iooutboard]) | `(blocks - 1) * 64` bytes; `blocks = ceil(size/16384)` |
+| Post-order outboard             | records at `post_order_offset * 64`; legacy variant appends `size` as LE `u64`                                       | unused by the iroh store                               |
+| Encoded slice (n0-bao response) | `size: u64 LE`, then pre-order interleave of 64-byte parent pairs and leaf bytes (16384 per full group)              | recurses below group level only for partial groups     |
+
+The framing is _self-describing through the tree geometry_, not through length
+delimiters: a decoder that knows `(root, size, block_size, ranges)` recomputes the
+exact sequence of Parent/Leaf items and their sizes, so the wire carries only hashes
+and payload — no per-item tags or lengths. This is what makes the response for a
+given `(hash, ranges)` a single canonical byte string. Byte-level compatibility with
+the original `bao` crate holds only at block size 0, with a size prefix, and a single
+range ([`lib.rs:196`][lib]); iroh's block size 4 is intentionally its own dialect.
+
+Serialization of the higher-level currency types (`Bitfield`, `EntryState`,
+collection metadata) belongs to `iroh-blobs` and its `postcard` codec, covered in
+[Wire Formats & Serialization][wire] and [Blobs][blobs]; `bao-tree` itself defines
+only the four raw layouts above.
+
+### Cryptography & identity
+
+`bao-tree` is a pure consumer of BLAKE3; it implements no cipher, signature, or key
+exchange. Its cryptographic surface is exactly the `blake3` (1.8) `hazmat` API
+([`blake3::hazmat`][blake3-hazmat]): `Hasher::set_input_offset` +
+`finalize_non_root` for subtree chaining values, and `merge_subtrees_root` /
+`merge_subtrees_non_root` for parent merging with and without the ROOT flag
+([`lib.rs:235`][lib]). The security properties it inherits and relies on:
+
+- **Collision/second-preimage resistance of BLAKE3** — the root hash uniquely pins
+  the blob and every subtree, so "there is exactly one sequence of bytes that is the
+  correct answer" ([`DESIGN.md:5`][design]).
+- **Domain separation via the ROOT flag** — a subtree hash is finalized without the
+  ROOT flag and can never equal a whole-blob hash, defeating attempts to pass off an
+  interior subtree as a complete blob or to length-extend.
+- **Bounded detection window** — because the tree bottoms out at 16 KiB groups, a
+  corrupt or malicious byte is caught after at most one group's worth of data, before
+  it reaches the application.
+
+The "identity" in this subsystem is _content identity_: a blob's name is its BLAKE3
+root hash (`iroh_blobs::Hash`, a 32-byte wrapper). This is distinct from iroh's
+_endpoint_ identity, which is an Ed25519 public key (`EndpointId`) — see
+[Identity & Cryptography][identity]. The one place the two families meet is that both
+use 32-byte values and BLAKE3 appears on both sides (content hashing here; TLS
+transcript/key derivation there), but `bao-tree` neither knows nor cares about
+endpoints or signatures.
+
+### State machines & lifecycle
+
+The crate contains three explicit state machines, all pure:
+
+1. **Verified decode** — state = `(response-iterator position, hash stack)`, seeded
+   with the root; `Parent` pops → verifies → pushes right-then-left (gated by range
+   flags), `Leaf` pops → verifies; terminal when the iterator is exhausted
+   ([`io/sync.rs:313`][iosync], [`io/fsm.rs:390`][iofsm]). Errors are positional and
+   fatal to the stream.
+2. **Range-validated encode** — the mirror image: walk the traversal, `load` each
+   parent pair from the outboard, verify it against the same hash stack (so a
+   corrupt _local_ outboard is caught before it is sent), and write parent pairs and
+   leaf bytes; abort with `ParentHashMismatch` / `LeafHashMismatch` /
+   `SizeMismatch`, or `ParentWrite` / `LeafWrite` if the receiver hangs up
+   ([`io/sync.rs:417`][iosync], [`io/error.rs:91`][ioerror]).
+3. **Outboard construction** — a _post-order_ traversal of the data computes leaf
+   hashes then parent CVs bottom-up, writing them into a _pre-order_ outboard and
+   returning the root ([`outboard`, `io/sync.rs:534`][iosync]). This is the import /
+   "compute outboard" step; it reads the whole blob exactly once.
+
+None of these owns a socket, file, timer, or task — lifecycle is entirely "advance
+the state machine until the iterator is done or a hash fails." The durable
+lifecycle (partial → complete entries, crash recovery, `.bitfield` dirty markers)
+is imposed by the `iroh-blobs` store, not by `bao-tree`.
+
+### Dependencies & coupling
+
+| Dependency                   | Role                   | Port implication                                                                                                                                                                                                                      |
+| ---------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `blake3` (1.8, `hazmat`)     | load-bearing algorithm | Must expose chunk-counter CVs, `set_input_offset`, `finalize_non_root`, `merge_subtrees_{root,non_root}` — a full BLAKE3, not just one-shot hashing.                                                                                  |
+| `range-collections` (0.4.5)  | load-bearing algorithm | `RangeSet2<ChunkNum>` sorted-boundary sets with union/intersection and a zero-copy `split(mid)` on borrowed boundary slices ([`lib.rs:839`][lib]); the split-by-reference trick drives the whole traversal and must be reimplemented. |
+| `smallvec`                   | convenience            | Hash stacks are `SmallVec<[Hash; 10]>` — depth ≈ `log2(chunks)`; maps to `SmallBuffer!(Hash, 10)`.                                                                                                                                    |
+| `bytes`                      | zero-copy buffers      | `Leaf.data: Bytes`; maps to an owned/refcounted D buffer (`isOwnedIoBuf`) or a GC slice off the hot path.                                                                                                                             |
+| `self_cell`                  | convenience            | Owning iterator over `ChunkRanges` ([`iter.rs:682`][iter]); a D fiber or index-based iterator makes it moot.                                                                                                                          |
+| `positioned-io` / `iroh-io`  | I/O trait surface      | `ReadAt`/`WriteAt` pread/pwrite; io_uring positioned ops cover these natively.                                                                                                                                                        |
+| `futures-lite` (`tokio_fsm`) | async FSM plumbing     | Feature-gated; the fibered EH port needs neither.                                                                                                                                                                                     |
+| `genawaiter` (`validate`)    | generator streams      | `valid_ranges` uses a generator; a D fiber makes this trivial.                                                                                                                                                                        |
+
+Feature flags select the I/O flavor: `tokio_fsm` (the async FSM), `validate`
+(`valid_ranges`), `serde`, `experimental-mixed` (the sync-read/async-send path used
+by `iroh-blobs`'s `ExportBao`), and `fs`. iroh-blobs enables
+`experimental-mixed, tokio_fsm, validate, serde`.
+
+The coupling to the rest of the stack is thin and downward: `bao-tree` knows nothing
+about iroh; `iroh-blobs` couples _to_ it by fixing `IROH_BLOCK_SIZE = 4` and framing
+the n0-bao size prefix. This makes `bao-tree` the most self-contained, cleanly
+portable subsystem in the whole survey.
+
+### Concurrency & I/O model
+
+`bao-tree` has **no internal concurrency** — no threads, tasks, channels, locks, or
+timers. This is a finding, not an omission: the crate is a codec, and it pushes the
+I/O model entirely to the caller through three interchangeable front-ends over one
+traversal core:
+
+- **sync** (`io/sync.rs`) — blocking `std::io::Read`/`Write` + `ReadAt`/`WriteAt`.
+- **fsm** (`io/fsm.rs`, `tokio_fsm`) — a hand-rolled state machine whose `next()`
+  is `async` and returns the machine plus one item, so it drops into any executor.
+- **mixed** (`io/mixed.rs`, `experimental-mixed`) — synchronous positioned reads of
+  local data, `async` sends of `EncodedItem`s to a `Sender`, for the serve path.
+
+What the crate _is_ is **CPU-bound**: every Parent verifies a BLAKE3 parent merge
+and every Leaf hashes up to 16 KiB. A full verified decode or encode of an N-byte
+blob performs ≈ `N/16384` group hashes plus ≈ `N/16384` parent merges — pure compute
+with no yield points of its own. In the Rust stack this is masked because
+`iroh-blobs` runs it inside `tokio` tasks that `.await` between groups; the hashing
+still occupies a worker thread, and the store notably does its file I/O with
+blocking `std::fs` calls on a dedicated multi-thread runtime rather than offloading
+to `spawn_blocking` (see [Tokio Concurrency Inventory][concurrency]).
+
+### Mapping to event-horizon
+
+`bao-tree` is the friendliest subsystem for the [event-horizon][eh-spec] port: the
+geometry and both codec state machines are pure and translate almost line-for-line,
+while the crate's I/O-agnosticism collapses neatly onto a single tier-B byte-stream
+implementation. Two things need deliberate design — buffer ownership and, above all,
+the single-threaded implication of CPU-bound hashing.
+
+**The geometry ports to `@safe pure nothrow @nogc` verbatim.** `TreeNode` and its bit
+tricks have no I/O and no allocation:
+
+```rust
+// bao-tree/src/lib.rs:545 (Rust, verbatim shape)
+pub struct TreeNode(u64);
+impl TreeNode {
+    pub const fn level(&self) -> u32 { self.0.trailing_ones() }
+    pub const fn is_leaf(&self) -> bool { (self.0 & 1) == 0 }
+    pub fn left_child(&self) -> Option<Self> {
+        let offset = 1 << self.level().checked_sub(1)?;
+        Some(Self(self.0 - offset))
+    }
+}
+```
+
+```d
+// proposed / sketch — pure geometry, no runtime, no GC
+struct TreeNode
+{
+    ulong index;
+
+@safe pure nothrow @nogc const:
+    uint level() => cast(uint) trailingOnesCount(index); // popcnt on ~index low bits
+    bool isLeaf() => (index & 1) == 0;
+    ChunkNum mid() => ChunkNum(index + 1);
+
+    // left/right children exist only for branch nodes (level >= 1)
+    Nullable!TreeNode leftChild()
+    {
+        const lvl = level();
+        if (lvl == 0) return typeof(return).init;
+        return nullable(TreeNode(index - (1UL << (lvl - 1))));
+    }
+}
+```
+
+**The decoder is a pull parser, not an async task.** Under tier B a byte stream is a
+blocking-looking verb (`recv`/`readExact`) that parks the fiber and resumes on the
+terminal CQE, so the verified-decode state machine needs no `async`/`Future`
+coloring at all — it is a plain struct with a `SmallBuffer` hash stack that reads
+from any `isByteStream` source:
+
+```rust
+// bao-tree/src/io/sync.rs:262 (Rust, verbatim shape)
+pub struct DecodeResponseIter<'a, R> {
+    inner: ResponseIterRef<'a>,
+    stack: SmallVec<[blake3::Hash; 10]>,
+    encoded: R,
+    buf: BytesMut,
+}
+```
+
+```d
+// proposed / sketch — verified pull-decoder; hashing runs on the loop fiber
+struct BaoDecoder(Reader) if (isByteStream!Reader)
+{
+    ResponseIter        iter;   // recomputes traversal from (size, blockSize, ranges)
+    SmallBuffer!(Hash, 10) stack; // expected hashes, seeded with the root
+    Reader              encoded;
+
+    // Blocks the fiber on `encoded` (tier-B), verifies, returns one item.
+    IoResult!(Option!BaoContentItem) next()
+    {
+        auto step = iter.next();
+        if (step.isNull) return ok(Option!BaoContentItem.init); // Done
+        final switch (step.kind)
+        {
+            case Step.parent:
+                ubyte[64] pair = void;
+                if (auto e = encoded.readExact(pair[])) return e.propagate;
+                const expected = stack.popBack();
+                if (parentCv(pair[0 .. 32], pair[32 .. 64], step.isRoot) != expected)
+                    return err!(...)(ParentHashMismatch(step.node));
+                if (step.right) stack ~= Hash(pair[32 .. 64]);
+                if (step.left)  stack ~= Hash(pair[0 .. 32]);
+                return ok(some(BaoContentItem.parent(step.node, pair)));
+            case Step.leaf:
+                // read `step.size` bytes into an owned buffer, hashSubtree, verify, surface
+                ...
+        }
+    }
+}
+```
+
+Mapping table for the constructs that do and do not carry over:
+
+| Rust / bao-tree                                    | event-horizon                                                                                                  |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `TreeNode` bit tricks, `BaoTree::shifted`, offsets | Pure D `@safe pure nothrow @nogc` structs/functions — direct translation                                       |
+| `SmallVec<[blake3::Hash; 10]>` hash stack          | `SmallBuffer!(Hash, 10)` (depth ≈ `log2(chunks)`, never large)                                                 |
+| sync / fsm / mixed I/O front-ends                  | **one** tier-B implementation over `isByteStream` verbs — the three-flavor split disappears                    |
+| `Leaf.data: Bytes` (refcounted)                    | an owned buffer (`isOwnedIoBuf`) for the hot path; a refcounted immutable buffer where cheap sharing is wanted |
+| `range_collections::RangeSet2<ChunkNum>`           | must be reimplemented, incl. the zero-copy `split(mid)` on a borrowed boundary slice ([`lib.rs:839`][lib])     |
+| `genawaiter` generator in `valid_ranges`           | a fiber that yields verified ranges                                                                            |
+| BLAKE3 `hazmat` (CVs, ROOT flag)                   | **no equivalent yet** — the port must ship a full BLAKE3 with chunk-counter chaining values and parent merges  |
+
+**Single-threaded implication (flag this).** Under the default `single` topology
+there is one loop, one thread, and a started fiber is pinned to it for life; there is
+no `spawn_blocking` thread pool. A verified decode/encode of a multi-GiB blob is a
+long CPU-bound run of BLAKE3 that **executes on the loop fiber and will monopolize
+the loop** for the duration — starving every other connection, timer, and accept.
+The Rust stack hides this behind a multi-thread `tokio` runtime; the D port cannot.
+Two mitigations, in increasing order of effort:
+
+1. **Insert explicit checkpoints per 16 KiB group.** The traversal already has a
+   natural boundary at every Leaf; make `next()` a cancellation/yield point so a
+   long transfer cooperatively cedes the loop and honors deadlines
+   (`withDeadline`) and cancellation (a parked fiber resumes only at its terminal
+   CQE). This bounds latency without adding threads.
+2. **Optional worker topology for bulk hashing.** For import of very large local
+   files (outboard computation re-hashes the whole blob) or crash-recovery
+   `valid_ranges`, an opt-in `workStealing` topology or a dedicated hashing worker
+   keeps the accept loop responsive. This is the one place the port genuinely wants
+   more than one thread, and it is isolable because the hashing is pure and takes an
+   owned buffer in, a hash out — no shared mutable state to lock.
+
+Everything else about the crate is _better_ on event-horizon than on tokio: no
+`Send + Sync` tax on the pure structs, no runtime coloring across the three I/O
+flavors, and positioned reads/writes (`ReadAt`/`WriteAt`) become native io_uring
+read-at/write-at ops with registered fds rather than the store's blocking `std::fs`
+calls.
+
+---
+
+## Strengths
+
+- **Provable, incremental verification.** A single 32-byte root hash lets a receiver
+  verify arbitrary ranges of a blob from an untrusted peer, detecting tampering
+  within one 16 KiB group ([`DESIGN.md:5`][design]).
+- **Compact outboards.** Runtime-configurable chunk groups cut the interior-hash
+  overhead 16× at iroh's `BlockSize(4)` versus classic 1024-byte bao, while still
+  serving sub-group ranges by recomputing hashes from data.
+- **Range-set queries.** One request can ask for several disjoint ranges and get a
+  single canonical, minimal proof stream interleaving exactly the needed hashes.
+- **Canonical, delimiter-free framing.** The response for `(hash, ranges)` is a
+  single deterministic byte string; a decoder reconstructs all framing from the tree
+  geometry, so the wire carries only hashes and payload.
+- **Pure, self-contained core.** No I/O, concurrency, or allocation in the geometry
+  and codec state machines — the most cleanly portable subsystem in the survey, and
+  `no_std`-friendly in spirit.
+- **Size proofs for unknown-size blobs.** `truncate_ranges` turns past-EOF requests
+  into verified length proofs, so a downloader never trusts a sender's size claim.
+- **I/O-model-agnostic.** One traversal core backs sync, async-FSM, and mixed
+  front-ends via feature flags, so it drops into any runtime.
+
+## Weaknesses
+
+- **CPU-bound with no built-in yielding.** The codec hashes every byte and never
+  yields on its own; a naïve single-threaded host will stall on large transfers
+  (see [Mapping to event-horizon](#mapping-to-event-horizon)).
+- **Depends on BLAKE3's hazmat internals.** A reimplementation must expose
+  chunk-counter chaining values and parent-merge-with/without-ROOT, not just the
+  one-shot digest — a non-trivial slice of BLAKE3 to port correctly.
+- **Sub-group ranges cost recomputation.** Because hashes below 16 KiB are not
+  stored, serving a partial group re-hashes that group's data
+  ([`io/sync.rs:470`][iosync]) — cheaper storage, more serve-time CPU.
+- **Two outboard layouts, one used.** Post-order support and its `Stable`/`Unstable`
+  offset machinery are legacy within the iroh stack (iroh-blobs is pre-order only),
+  yet remain in the surface area a faithful port must understand.
+- **`experimental-mixed` is exactly that.** The serve path iroh-blobs relies on is
+  behind an experimental feature flag, so its API is not yet stable upstream.
+- **Non-trivial range algebra.** The zero-copy `split` on borrowed boundary slices
+  ([`lib.rs:839`][lib]) and `range_collections` semantics are load-bearing and must
+  be reimplemented precisely for byte-compatible proofs.
+
+## Key design decisions and trade-offs
+
+| Decision                                                                    | Rationale                                                                                     | Trade-off                                                                                          |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Runtime chunk groups (`BlockSize`), iroh fixes 16 KiB                       | 16× smaller outboards than 1024-byte bao; less metadata to store and transmit                 | Sub-group ranges can't be served from stored hashes — must recompute from data at serve time       |
+| Store the tree as a separate outboard, not interleaved                      | "data can be used as-is" ([`DESIGN.md:11`][design]); reflink/zero-copy export of the raw file | Two artifacts per blob to keep consistent; a partial download tracks data and outboard separately  |
+| BLAKE3 `hazmat` (subtree CVs + ROOT-flag merges)                            | Reuses BLAKE3's proven tree; ROOT-flag domain separation defeats subtree/whole-blob confusion | Ties the codec to hazardous internals; a port can't lean on the one-shot hash API                  |
+| In-order `u64` node index with pure bit tricks                              | No pointers/allocation; every relation is a `const fn`; error positions are attributable      | Two index spaces (real vs shifted) plus half-leaf special cases to get exactly right               |
+| Pre-order outboard, **no** size prefix ([`io/outboard.rs:101`][iooutboard]) | Append-agnostic, fixed offset per node; matches iroh's `.obao4` on-disk layout                | Diverges from the `bao` crate's prefixed format; compatibility only at block size 0 with a prefix  |
+| Canonical, geometry-derived framing (no length tags)                        | One deterministic byte string per `(hash, ranges)`; minimal wire; verifiable framing          | Decoder must independently recompute the traversal; a desync is unrecoverable, not resynchronizing |
+| Verify before surfacing (hash stack seeded with root)                       | Bad bytes caught within one 16 KiB group, before the app sees them                            | Every byte is hashed on the read path — pure CPU cost, no shortcut                                 |
+| I/O-agnostic core, three feature-gated front-ends                           | One traversal backs sync/async/mixed; the codec never dictates a runtime                      | Three code paths to maintain; `experimental-mixed` (the serve path) is unstable                    |
+
+---
+
+## Sources
+
+- [`n0-computer/bao-tree` — GitHub repository (v0.16.0)][repo]
+- [bao-tree on docs.rs (0.16.0)][docs] · [crates.io][crate]
+- [`bao-tree/README.md` — wire compatibility, chunk groups, range sets][readme]
+- [`bao-tree/src/lib.rs` — `BaoTree`/`TreeNode` geometry, `hash_subtree`/`parent_cv`, shifted tree, offsets][lib]
+- [`bao-tree/src/tree.rs` — `ChunkNum`, `BlockSize`, `BLAKE3_CHUNK_SIZE`][tree]
+- [`bao-tree/src/iter.rs` — pre/post-order iterators, `ResponseIterRef`, `BaoChunk`][iter]
+- [`bao-tree/src/rec.rs` — `truncate_ranges` (size proofs), `encode_selected_rec`][rec]
+- [`bao-tree/src/io/mod.rs` — `Parent`/`Leaf`/`BaoContentItem`, `combine_hash_pair`][iomod]
+- [`bao-tree/src/io/sync.rs` — sync encode/decode, outboard load/save, `DecodeResponseIter`][iosync]
+- [`bao-tree/src/io/fsm.rs` — async `ResponseDecoder` state machine][iofsm]
+- [`bao-tree/src/io/mixed.rs` — `EncodedItem`, `traverse_ranges_validated`][iomixed]
+- [`bao-tree/src/io/outboard.rs` — `PreOrderOutboard`/`PostOrderOutboard`, "no 8 byte size prefix"][iooutboard]
+- [`bao-tree/src/io/error.rs` — `DecodeError`/`EncodeError` (positional)][ioerror]
+- [`iroh-blobs/src/store/mod.rs` — `IROH_BLOCK_SIZE = 16 KiB`][blobsstore]
+- [`iroh-blobs/src/store/util.rs` — `create_n0_bao` size prefix][blobsutil]
+- [`iroh-blobs/DESIGN.md` — verified-streaming rationale, one-correct-answer guarantee][design]
+- [BLAKE3 specification (BLAKE3-team)][blake3-spec] · [`blake3::hazmat` API][blake3-hazmat] · [`bao` crate][bao-crate]
+- Related iroh pages: [Blobs: Content-Addressed Transfer][blobs] · [Identity & Cryptography][identity] · [Wire Formats & Serialization][wire] · [Tokio Concurrency Inventory][concurrency]
+
+<!-- References -->
+
+[repo]: https://github.com/n0-computer/bao-tree
+[docs]: https://docs.rs/bao-tree/0.16.0/bao_tree/
+[crate]: https://crates.io/crates/bao-tree
+[readme]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/README.md
+[lib]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/lib.rs
+[tree]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/tree.rs
+[iter]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/iter.rs
+[rec]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/rec.rs
+[iomod]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/io/mod.rs
+[iosync]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/io/sync.rs
+[iofsm]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/io/fsm.rs
+[iomixed]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/io/mixed.rs
+[iooutboard]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/io/outboard.rs
+[ioerror]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/io/error.rs
+[blobsstore]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/mod.rs
+[blobsutil]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/util.rs
+[design]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md
+[blake3-spec]: https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf
+[blake3-hazmat]: https://docs.rs/blake3/latest/blake3/hazmat/index.html
+[bao-crate]: https://github.com/oconnor663/bao
+[blobs]: ./blobs.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[concurrency]: ./concurrency.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md

--- a/docs/research/iroh/blobs.md
+++ b/docs/research/iroh/blobs.md
@@ -1,0 +1,472 @@
+# Blobs: Content-Addressed Transfer
+
+iroh's bulk-data plane: a request/response protocol that moves BLAKE3-addressed content over QUIC as _verified streams_ — every 16 KiB is checked against the tree hash before it is surfaced — backed by a crash-consistent on-disk store, a resumable multi-provider downloader, and a per-`ALPN` connection pool. This is the protocol a D port must reproduce byte-for-byte to interoperate with n0's network.
+
+| Field               | Value                                                                                                                                                                                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)            | `iroh-blobs` — modules `protocol`, `protocol::range_spec`, `get` (the `fsm`), `provider`, `hashseq`, `format::collection`, `store::fs`, `api::{remote, downloader, blobs}` — plus `iroh-util::connection_pool`, `irpc`, and [`bao-tree`][bao-tree] for the hash-tree math |
+| Version             | `iroh-blobs` **v0.103.0** (git `e82cbdcb`); `bao-tree` **v0.16.0**; `iroh-util` **v0.6.0** (`connection_pool`, crates.io-only); `irpc` **v0.17.0**; over `iroh` **v1.0.1** (`22cac742ca`) / `noq` tag `noq-v1.0.1`                                                        |
+| Repository          | [`n0-computer/iroh-blobs`][repo] · [`iroh-util`][util-repo] · [`irpc`][irpc-repo] · [`bao-tree`][bt-repo]                                                                                                                                                                 |
+| Documentation       | [docs.rs/iroh-blobs][docs] · [docs.rs/irpc][irpc-docs] · [docs.rs/bao-tree][bt-docs]                                                                                                                                                                                      |
+| ALPN(s)             | `/iroh-bytes/4` (`b"/iroh-bytes/4"`) — the transfer protocol; unchanged across the 0.x→1.0 rename ([`protocol.rs:406`][bp-alpn])                                                                                                                                          |
+| Approx. size (LoC)  | ≈14k across `iroh-blobs` (`protocol.rs` 1072, `range_spec.rs` 712, `get.rs` 992, `provider.rs` 708 + `events.rs` 716, `store/fs.rs` 2312 + `meta.rs` 976 + `bao_file.rs` 749 + …); plus `bao-tree` ≈5k, `irpc` ≈2.7k, `iroh-util` ≈1k                                     |
+| Category            | Protocols                                                                                                                                                                                                                                                                 |
+| Upstream spec/draft | No IETF draft; content addressing is [BLAKE3][blake3] verified streaming ("n0-flavoured bao", 16 KiB chunk groups). Rides QUIC [RFC 9000][rfc9000] via [`noq`][quic-transport]                                                                                            |
+
+> [!NOTE]
+> iroh 1.0 is a major restructure of the 0.x API and this crate rides on top of it: `NodeId` → `EndpointId`, `NodeAddr` → `EndpointAddr` (vocabulary in [Concepts][concepts]). Within blobs specifically, the 0.x `Store`/`Map` trait hierarchy is **gone** — a store is now "whatever handles the `Command` enum" over [`irpc`][concurrency]; the 0.x `downloader` with dial queues, retry backoff and request dedup is **gone**, replaced by a ~550-line orchestrator that pushed those concerns onto consumers; and `Collection` is no longer a protocol concept, just a [`HashSeq`](#hashseq-collections-and-the-hash-newtype) convention. `Collection`/`NodeAddr`-era folklore does not compile. The bao-tree _math_ — `TreeNode` addressing, outboard layout, the verified-decode stack machine — is described in [`bao-tree`][bao-tree]; this page covers the protocol, store, downloader and RPC seam that sit on top of it. This page is part of the [iroh survey][index].
+
+---
+
+## Overview
+
+### What it solves
+
+Given a 32-byte BLAKE3 [`Hash`](#hashseq-collections-and-the-hash-newtype), fetch the corresponding bytes from any peer that has them, verifying integrity incrementally so a lying or corrupt provider is caught within one 16 KiB chunk group — and do it _resumably_ (pick up where a previous partial download left off) and _from multiple providers_ (ask the next peer only for the ranges the previous one did not deliver). That is the whole job. The building blocks are:
+
+1. **A request/response wire protocol** (`ALPN = /iroh-bytes/4`) over iroh QUIC connections: one bidirectional stream per request. A [`GetRequest`](#request-types-and-the-chunkrangesseq-encoding) names a root hash plus a run-length-encoded set of chunk ranges per blob; the response is the size header followed by the BLAKE3 [`bao-tree`][bao-tree] slice for exactly those ranges.
+2. **A content-addressed store** that persists two artifacts per hash — the data and an _outboard_ (the interior BLAKE3 tree hashes) — with an inline-small-blobs optimization, a partial/complete entry state machine, and a crash-consistency discipline built around _never_ claiming to have data it cannot verify.
+3. **A resumable multi-provider [`Downloader`](#the-downloader-and-connectionpool)** that splits a hash-sequence download into per-child requests, runs them with bounded parallelism, and re-plans each attempt against local state; underneath it, a generic **[`ConnectionPool`](#the-connectionpool)** caches and idle-evicts one QUIC connection per remote per `ALPN`.
+4. **An [`irpc`][concurrency] actor/RPC seam** that unifies the in-process store API and the (optional) cross-process store RPC behind one request enum and typed channels.
+
+### Design philosophy
+
+Correctness dominates. The protocol module's opening doc comment ([`protocol.rs:10`][bp-integrity]):
+
+> _"Data integrity is considered more important than performance. Data will be validated both on the provider and getter side. A well behaved provider will never send invalid data."_
+
+The store's `DESIGN.md` restates the same principle as an availability invariant that governs the entire crash story ([`DESIGN.md:124`][design-crash]):
+
+> _"Losing a bit of data that has been written immediately before the crash is tolerable. But we don't ever want to have a situation after a crash where we think we have some data, but actually we are missing something about the data or the outboard that is needed to verify the data."_
+
+Three consequences shape everything below:
+
+1. **There is exactly one correct answer per request, and the requester verifies it.** Because the response geometry is fully determined by `(hash, size, ranges)`, "there is exactly one sequence of bytes that is the correct answer. And the requester will notice if data is incorrect after at most 16 KiB of data" ([`DESIGN.md:5`][design-integrity]). No delimiters, no per-blob framing metadata, no hashes in the response — the tree is self-describing.
+2. **Downloads must not touch the metadata database.** "An individual database update is very fast, but syncing the update to disk is extremely slow no matter how small the update is. So the secret to fast download speeds is to not touch the metadata database at all if possible" ([`DESIGN.md:61`][design-meta]). Syncing after each 16 KiB group would cap throughput at 3.2 MB/s ([`DESIGN.md:134`][design-fsync]); the store therefore batches metadata writes and persists per-hash bitfields only on clean shutdown, reconstructing them by re-hashing after a crash.
+3. **Chunk possession is monotone, so concurrent downloads commute.** "A chunk of a blob can only go from not present (all zeroes) to present … And this means that all changes due to syncing from a remote source commute, which makes dealing with concurrent downloads from multiple sources much easier" ([`DESIGN.md:112`][design-commute]). This is what makes the resumable multi-provider downloader sound.
+
+The crate is explicit that this generation is not yet hardened: "this version of iroh-blobs is not yet considered production quality. For now, if you need production quality, use iroh-blobs 0.35" ([`README.md:3`][bp-readme]).
+
+---
+
+## How it works
+
+### The transfer, end to end
+
+A getter holds an open QUIC [`Connection`][endpoint] to a provider that speaks `/iroh-bytes/4`. For each request it opens a **fresh bidirectional stream** ([`get.rs:239`][get-openbi]), postcard-serializes a [`Request`](#request-types-and-the-chunkrangesseq-encoding), writes it, and FINs the send half. The provider runs an `accept_bi` loop and spawns one task per accepted stream ([`provider.rs:305`][pv-accept]). Multiplexing many requests is free — you just open more streams: "Multiple requests just create multiple streams on the same connection, which is very cheap in QUIC" ([`protocol.rs:367`][bp-streams]).
+
+For a `Get`, the provider replies, per requested blob and in request order, with an **8-byte little-endian `u64` claimed size** followed by the [`bao-tree`][bao-tree] verified slice for the requested ranges: a pre-order interleave of **64-byte parent nodes** (left CV ‖ right CV) and **leaf chunk-group payloads** (≤ 16 KiB) ([`api/blobs.rs:1133`][ab-write] write side; [`get.rs:520`][get-header] size read). The getter decodes with bao-tree's `ResponseDecoder`, which reconstructs the _same_ traversal from `(size, ranges)` and validates every parent and leaf against a hash stack seeded with the root ([`bao-tree/io/fsm.rs:317`][bt-decoder]). Blob boundaries need no delimiter — geometry is fully determined by the size header plus the request.
+
+Missing data is signalled by an **early FIN**, not an error code: the getter maps `UnexpectedEof` at the size header to `NotFound` and mid-blob to `ChunkNotFound`/`ParentNotFound`/`LeafNotFound` purely by stream position ([`get.rs:495`][get-notfound]). Actual RESET codes are reserved for `ERR_PERMISSION`(1) / `ERR_LIMIT`(2) / `ERR_INTERNAL`(3) ([`protocol.rs:398`][bp-errcodes]).
+
+### Request types and the `ChunkRangesSeq` encoding
+
+The `Request` enum reserves stable postcard tags so `Push` and `GetMany` sit at 8 and 9 ([`protocol.rs:408`][bp-request]):
+
+```rust
+// iroh-blobs/src/protocol.rs:408 (tags: Get=0, Observe=1, Push=8, GetMany=9)
+pub enum Request {
+    Get(GetRequest),
+    Observe(ObserveRequest),
+    Slot2, Slot3, Slot4, Slot5, Slot6, Slot7,   // reserved; decode as InvalidData
+    Push(PushRequest),
+    GetMany(GetManyRequest),
+}
+
+pub struct GetRequest {
+    pub hash: Hash,             // blake3 root
+    pub ranges: ChunkRangesSeq, // element 0 = root; element n>0 = child n-1 of the HashSeq
+}
+```
+
+A `GetRequest` addresses a _tree of blobs_: element 0 is the root blob; element `n>0` addresses child `n-1` of the root interpreted as a [`HashSeq`](#hashseq-collections-and-the-hash-newtype). A trailing non-empty element **repeats forever**, which is how "give me the hash sequence and all of its children" is expressed without knowing the child count ([`range_spec.rs:165`][rs-inf]). The sibling request types: `GetManyRequest { hashes: Vec<Hash>, ranges }` is "identical to a `GetRequest` for a `HashSeq`, but the `HashSeq` is provided by the requester" as an explicit hash list ([`protocol.rs:579`][bp-getmany]); `PushRequest(GetRequest)` inverts direction (the getter _sends_ bao data after the request — disabled by default, see below); `ObserveRequest { hash, ranges }` subscribes to the provider's local bitfield for a hash ([`protocol.rs:616`][bp-observe]).
+
+The wire encoding of the range set is the protocol's one genuinely clever piece ([`protocol.rs:293`][bp-rangeseq]):
+
+> _"In the wire encoding of `ChunkRangesSeq`, `ChunkRanges` are encoded alternating intervals of selected and non-selected chunks. This results in smaller numbers that will result in fewer bytes on the wire when using the postcard encoding format that uses variable length integers."_
+
+Concretely, a `RangeSpec` is a `SmallVec<[u64; 2]>` of alternating span widths, starting _deselected_ at chunk 0; an odd element count means an open-ended selected tail ([`range_spec.rs:341`][rs-spec]). A `ChunkRangesSeq` is a `SmallVec` of `(offset-delta, RangeSpec)` tuples where deltas are between the _absolute indices at which the value changes_ ([`range_spec.rs:470`][rs-wire]). All ranges are in units of 1024-byte BLAKE3 chunks. From the crate's own hexdump tests ([`range_spec.rs:553`][rs-tests]):
+
+```text
+RangeSpec examples (span widths, alternating deselect/select from chunk 0):
+    empty            00
+    all (0..)        01 00        # one span of width 0 ⇒ selected from chunk 0
+    chunks 64..      01 40
+    chunks ..64      02 00 40     # deselect 0, select 64
+    {1..3} ∪ {9..13} 04 01 02 06 04
+
+Full GetRequest wire messages (tag ‖ 32-byte hash ‖ ChunkRangesSeq):
+    GetRequest::all(hash)   00 <hash*32> 01 00 01 00        # root + all children, forever
+    GetRequest::blob(hash)  00 <hash*32> 02 00 01 00 01 00  # (Δ0, all)(Δ1, empty) ⇒ root only
+```
+
+### Hashseq, collections, and the `Hash` newtype
+
+`Hash` is a `#[repr(transparent)]`-style newtype over `blake3::Hash` ([`hash.rs:14`][hash-newtype]); on the wire it is **32 raw bytes, no length prefix** (postcard `MaxSize = 32`). Its `Display` is 64-char lowercase hex, `FromStr` also accepts 52-char base32-nopad, and `fmt_short()` prints the first 5 bytes ([`hash.rs:151`][hash-parse]). The empty blob is a hard special case everywhere: `Hash::EMPTY` is the compile-time constant BLAKE3 hash of `b""` (`af1349b9…3262`), never stored, always "present", and the only hash for which a `size == 0` response is legal ([`hash.rs:25`][hash-empty]).
+
+A **`HashSeq`** is just a blob whose bytes are a raw concatenation of 32-byte hashes — `len % 32 == 0`, `get(i) = bytes[i*32 .. (i+1)*32]`, no header ([`hashseq.rs:54`][hashseq]). This is the only structural type the protocol knows beyond a raw blob; `BlobFormat` is `Raw | HashSeq`. A **`Collection`** is a _convention_ layered on top (not visible to the protocol): a `HashSeq` whose link 0 is the hash of a metadata blob `postcard(CollectionMeta { header: [u8;13] = b"CollectionV0.", names: Vec<String> })`, where `names[i]` labels `link[i+1]` ([`format/collection.rs:82`][collection]). Fetching a collection therefore reads child 0 (the metadata) before the payload children.
+
+Because the response never transmits hashes, **the getter must already know or derive every blob hash**: the root is known from the request, children are learned by decoding the `HashSeq` blob mid-transfer. The low-level FSM makes this a _caller_ obligation — `AtStartChild::next(hash)` takes the child hash as an argument ([`get.rs:418`][get-startchild]).
+
+### The provider pipeline
+
+`BlobsProtocol` implements iroh's `ProtocolHandler`; `accept` delegates to `handle_connection` ([`net_protocol.rs:86`][np]). Per connection: an interceptable `ClientConnected` event can reject the connection outright (`conn.close(code, reason)` with `b"limit"`/`b"permission"`/`b"internal"`, [`provider.rs:294`][pv-reject]); then the accept loop spawns `handle_stream` per request stream. Per stream: `read_request` → a per-request-type **event gate** → `into_writer` asserts the request stream is at EOF (extra bytes ⇒ `InvalidData`) → serve.
+
+`handle_get_impl` walks the requested ranges: offset 0 streams the root; offsets `>0` index into the `HashSeq`, which is **loaded fully into memory and assumed complete** (an explicit `todo`), and walking past the end of the sequence just stops the loop — not an error ([`provider.rs:429`][pv-getimpl]). Push is the mirror (`import_bao_reader` per non-empty range set) and is **disabled by default** via `EventMask::DEFAULT { push: RequestMode::Disabled }` ⇒ `ERR_PERMISSION` — the constants deliberately offer no "all-enabled" mask to avoid store-write misuse ([`provider/events.rs:189`][pe-pushdefault]). Observe streams length-prefixed `ObserveItem`s (full bitfield first, then diffs) until the remote STOPs the stream, driven by a `select!` on bitfield updates vs `writer.inner.stopped()` ([`provider.rs:627`][pv-observe]).
+
+All provider observability flows through an `EventSender` (an `irpc::Client` over a tokio mpsc) configured by a static `EventMask` with per-request-type modes (`None | Notify | Intercept | NotifyLog | InterceptLog | Disabled`, [`provider/events.rs:167`][pe-mask]). In `Intercept*` modes the provider awaits a oneshot verdict before serving. **Throttling, when enabled, is a blocking RPC round-trip per payload write** — i.e. once per ≤16 KiB chunk group: `transfer_progress` awaits a `Throttle { connection_id, request_id, size }` reply ([`provider/events.rs:282`][pe-throttle]). Elegant, but a latency multiplier on the hot path.
+
+### The store, on disk
+
+The `fs` store's root directory holds `blobs.db` (a [redb][redb] database) plus `data/` and `temp/` (temp must be on the same device for atomic renames). Per hash, in `data/`, hex-lowercase: `<hash>.data` (raw bytes), `<hash>.obao4` (pre-order outboard, block size 4, **no size prefix**), `<hash>.sizes4` (a `u64`-per-chunk-group size log), and `<hash>.bitfield` (possession + best-known size). The redb schema is four tables ([`meta/tables.rs:7`][tables]):
+
+| Table               | Key           | Value                                 |
+| ------------------- | ------------- | ------------------------------------- |
+| `blobs-0`           | `Hash` (32 B) | `EntryState` (postcard)               |
+| `tags-0`            | `Tag` (bytes) | `HashAndFormat`                       |
+| `inline-data-0`     | `Hash`        | `&[u8]` — complete blob bytes         |
+| `inline-outboard-0` | `Hash`        | `&[u8]` — complete pre-order outboard |
+
+An `EntryState` is `Complete { data_location, outboard_location } | Partial { size: Option<u64> }` ([`entry_state.rs:161`][entrystate]); `DataLocation` is `Inline | Owned(size) | External(Vec<PathBuf>, size)`. Inline thresholds default to **16 KiB for both data and outboard** ([`options.rs:71`][opts-inline]) — with those defaults, inline data implies no outboard is needed, and any needed outboard implies the data is on disk. `DESIGN.md`'s statement of the store's job ([`DESIGN.md:11`][design-job]):
+
+> _"The job of a blob store is to store two pieces of data per hash, the actual data itself and an `outboard` containing the BLAKE3 hash tree that connects each chunk of data to the root. Data and outboard are kept separate so that the data can be used as-is."_
+
+The per-hash in-memory state is a `BaoFileStorage` with states `Initial, Loading, NonExisting, PartialMem, Partial, Complete, Poisoned` ([`bao_file.rs:299`][baofile]). Fresh partial entries start as `PartialMem` (sparse memory buffers); when a write batch's max offset exceeds the inline threshold the state is persisted to `PartialFileStorage` (the three files, created _before_ the batch to avoid a large allocation on a write near the end of a huge file). When the bitfield reports the entry complete, storage converts to `CompleteStorage` (applying inline rules) and the db entry flips to `Complete`, queuing deletion of the now-redundant `.sizes4` and `.bitfield` files.
+
+**The metadata database is written in batches.** The db actor pulls one command, opens a read _or_ write redb transaction, then keeps draining _compatible_ commands into it (via a peekable receiver) until a batch limit (10000 reads / 1000 writes), a 1-second timer, or an incompatible command ([`meta.rs:785`][meta-batch]). File deletions collected during a write transaction execute only _after_ the metadata commits (the "file transaction"), and `ProtectHandle::protect` removes pending deletions for files a concurrent task just (re)created. This is the crash-consistency spine: **metadata commits first, file deletion second, file creation protected against racing deletes** ([`delete_set.rs:113`][deleteset]).
+
+**The bitfield is a dirty flag.** The `.bitfield` file (`blake3(payload) ‖ postcard(Bitfield)`) is written only on clean entity shutdown, after the data/outboard/sizes files are fsynced; on load it is read and immediately truncated to zero + fsync, so its mere validity is a "clean shutdown" marker ([`store/util.rs:218`][su-checksum]). A crash leaves it empty, and the bitfield is _reconstructed_ by re-hashing the data against the outboard. This is the concrete realization of design principle #2 — the store never fsyncs per chunk, so on the unhappy path it pays a full re-validation instead of ever trusting unverified data.
+
+**GC is mark-and-sweep** over a "protected" set ([`gc.rs:34`][gc]): mark = all tag targets ∪ all temp tags ∪ (for every non-raw root) the hashes enumerated by streaming the blob as a `HashSeq`; sweep = list all blobs and delete the non-live ones in batches of 100. There is no per-blob refcount — protection is `tags ∪ temp-tags ∪ hashseq-closure ∪ recently-touched` (every db update since the last GC re-inserts its hash into `protected`, shielding entries written mid-GC). `TempTag` holds a `Weak<dyn TagDrop>`; dropping it notifies the store, `leak()` makes it permanent for the process.
+
+### The store protocol is `irpc`, not a trait
+
+Every store implementation (fs, mem, readonly-mem) is an actor handling one `Command` enum, generated by irpc's `#[rpc_requests]` macro from a `Request` enum whose variants declare their channel shapes ([`api/proto.rs:90`][proto]):
+
+```rust
+// iroh-blobs/src/api/proto.rs:90 (excerpt) — the whole store protocol
+#[rpc_requests(message = Command, alias = "Msg", rpc_feature = "rpc")]
+pub enum Request {
+    #[rpc(rx = mpsc::Receiver<BaoContentItem>, tx = oneshot::Sender<Result<()>>)] ImportBao(..),
+    #[rpc(tx = mpsc::Sender<EncodedItem>)]                                        ExportBao(..),
+    #[rpc(tx = mpsc::Sender<Bitfield>)]                                           Observe(..),
+    #[rpc(tx = mpsc::Sender<AddProgressItem>)]                                    ImportBytes(..),
+    // … 23 variants total: ListBlobs, Batch, DeleteBlobs, tags, SyncDb, Shutdown …
+}
+```
+
+The public `Store` is a `#[repr(transparent)]` wrapper over `irpc::Client<proto::Request>` ([`api.rs:211`][api-store]). In-process this is a plain tokio channel send; with the `rpc` feature the same enum is served remotely over a localhost noq socket via `irpc::rpc::listen` / `Store::connect` ([`api.rs:250`][api-connect]). So the "RPC layer" is irpc: **commands are postcard-serializable messages paired with typed channels; the local path never serializes.** irpc's own stated goal ([`irpc/lib.rs:5`][irpc-goal]):
+
+> _"The main goal of this library is to provide an rpc framework that is so lightweight that it can be also used for async boundaries within a single process without any overhead, instead of the usual practice of a mpsc channel with a giant message enum where each enum case contains mpsc or oneshot backchannels."_
+
+### The `Downloader` and `ConnectionPool`
+
+`Downloader::new(store, endpoint)` spawns a detached actor and hands back an `irpc::Client<SwarmProtocol>` with two messages: `Download(DownloadRequest)` (server-streaming `DownloadProgressItem`s) and `WaitIdle` ([`api/downloader.rs:40`][dl-proto]). A `DownloadRequest` carries the request, an `Arc<dyn ContentDiscovery>` provider source, and a `SplitStrategy` — and it deliberately serializes to an error, making the call local-process-only by construction. `Store::downloader()` warns it "has internal state, so don't create it ad hoc but store it somewhere" ([`api.rs:241`][api-downloader]).
+
+The provider loop is strictly sequential and resumable ([`api/downloader.rs:484`][dl-execget]):
+
+> _"It will try each provider in order until it finds one that can fulfill the request. When trying a new provider, it takes the progress from the previous providers into account, so e.g. if the first provider had the first 10% of the data, it will only ask the next provider for the remaining 90%. This is fully sequential, so there will only be one request in flight at a time. … If the provider stream never ends, it will try indefinitely."_
+
+Per provider: emit `TryProvider` → `pool.get_or_connect(provider)` (lazy) → `remote.local_for_request(request)` computes a `LocalInfo` from store bitfields → if already complete, done → await the connection (failure ⇒ `ProviderFailed`, next) → `execute_get_sink(conn, local.missing(), …)` resumes from local state, shifting byte offsets by the pre-existing local bytes. There is **no retry, no backoff, no provider scoring, no dedup** in the downloader — the only built-in policy is `Shuffled` (randomize order); dedup and retry live in consumers such as iroh-docs' [`LiveActor`][docs-sync] (`queued_hashes` / `missing_hashes`). The `Split` path first fully fetches the root `HashSeq` blob sequentially, then fans out one `GetRequest` per child offset with **at most 32 parts in flight** (`buffered_unordered(32)`); a failed part emits one `DownloadError` progress item but does **not** cancel its siblings ([`api/downloader.rs:150`][dl-strategy]).
+
+Underneath sits a generic per-`(Endpoint, ALPN, Options)` **`ConnectionPool`** from the crates.io-only `iroh-util` crate ([`connection_pool.rs:1`][cp-doc]):
+
+> _"You create a connection pool for a specific ALPN and `Options`. Then the pool will manage connections for you. … It is important that you keep the `ConnectionRef` alive while you are using the connection."_
+
+Its `Options` are three numbers and a hook: `idle_timeout` (default **5 s**), `connect_timeout` (default **1 s**, explicitly _including_ time in the `on_connected` callback), `max_connections` (default **1024**), and an optional `on_connected` async callback (e.g. "hold this connection back until its path is direct") ([`connection_pool.rs:42`][cp-options]). The design is two-level actors: a main actor owns a `HashMap<EndpointId, mpsc::Sender>` of per-remote **connection actors** plus an idle LRU; each connection actor dials once, arms a `conn.closed()` watcher, and serves handed-out `ConnectionRef`s tracked by an atomic refcount. When the refcount hits zero it notifies the pool and arms a `sleep(idle_timeout)`; a fresh request clears the timer and reuses the connection (observable via `Connection::stable_id()`). A failed dial is **cached and re-served (cloned) to every queued waiter** until the pool unlists it (`PoolConnectError: Clone`, sources `Arc`-wrapped for exactly this). At `max_connections` the main actor evicts the oldest idle connection or answers `TooManyConnections`. Two quirks a port must note: the main actor **can never terminate** (its shared `Context` holds a clone of its own inbox sender, so `recv()` never sees all-senders-dropped, and there is no shutdown message), and there is **no request-level timeout** beyond the 1-second connect budget — a stalled established transfer is bounded only by QUIC idle mechanisms.
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+Two wire surfaces, both postcard-over-QUIC, both length-delimited by the stream or an explicit varint — never by an in-band frame header.
+
+**The blobs transfer protocol** (`/iroh-bytes/4`), one request per bidi stream:
+
+| Request   | Layout                                                            | Terminator                           |
+| --------- | ----------------------------------------------------------------- | ------------------------------------ |
+| `Get`     | `0x00` ‖ hash(32) ‖ `ChunkRangesSeq`                              | stream FIN (client drops the writer) |
+| `Observe` | `0x01` ‖ hash(32) ‖ `RangeSpec`                                   | explicit `finish()`                  |
+| `Push`    | `0x08` ‖ varint(len) ‖ `postcard(GetRequest)` ‖ bao push payload… | payload then FIN                     |
+| `GetMany` | `0x09` ‖ seq(hashes) ‖ `ChunkRangesSeq`                           | stream FIN                           |
+
+`Get`/`GetMany`/`Observe` read the tag byte then read-to-EOF (bounded by `MAX_MESSAGE_SIZE` = `1024 * 1024` = **1 MiB**, despite a stale "100MiB" comment); `Push` is varint-length-prefixed because the same stream then carries payload ([`protocol.rs:395`][bp-maxsize], [`protocol.rs:448`][bp-read]). The **response** for `Get`/`GetMany`, per non-empty blob in request order:
+
+```text
+u64 size            (8 bytes, little-endian, *claimed*, verified progressively)
+then bao items, pre-order over BaoTree::new(size, IROH_BLOCK_SIZE = BlockSize(4) = 16 KiB):
+    parent:  64 bytes = left_child_CV(32) ‖ right_child_CV(32)
+    leaf:    chunk-group payload, ≤ 16384 bytes (last group may be short)
+```
+
+The `Observe` response is repeated `varint(len) ‖ postcard(ObserveItem { size, ranges })` frames (full bitfield, then non-empty diffs). All multi-byte integers are postcard LEB128 varints (7 value bits/byte, MSB = continuation) — the crate ships its own 20-line varint reader ([`util/stream.rs:401`][stream-varint]), which a D port can lift verbatim. Note two subtleties flagged in recon: the same `Bitfield` data is encoded _two different ways_ (the store's custom flat `[size, boundaries…]` seq vs the wire `ObserveItem`'s derived struct), and `ObserveRequest.ranges` is transmitted but **ignored** by the provider (it streams all diffs regardless).
+
+**The store/downloader RPC** ([`irpc`][concurrency]) uses a second, simpler framing — `varint_u64(len) ‖ postcard(payload)` per message, one request per QUIC bidi stream, **no request IDs and no frame headers** (multiplexing is entirely QUIC's) — with a 16 MiB message cap and error codes `1` (max-size-exceeded) / `2` (invalid-postcard) ([`irpc/lib.rs:50`][irpc-framing]). It is only reachable behind the optional `rpc` feature and dials TLS server name `"localhost"` — it is a _cross-process-on-one-host_ control plane, not part of the p2p wire. A port can defer it entirely and lose no interop.
+
+On-disk formats (see [store, on disk](#the-store-on-disk)) are also postcard: `EntryState`, the `.bitfield` payload, and `CollectionMeta`. Because these are content-addressed and interop-relevant only for reusing an existing store directory, a port that starts from an empty store is free to choose its own on-disk layout — but adopting the `.data`/`.obao4`/`.sizes4`/`.bitfield` scheme byte-for-byte buys drop-in compatibility with n0 tooling. The tree math and the exact outboard byte layout are [`bao-tree`][bao-tree]'s remit.
+
+### Cryptography & identity
+
+Blobs owns **no key material and no handshake** — peer identity, TLS 1.3, and the `EndpointId` all belong to [`endpoint`][endpoint] / [`identity-crypto`][identity]. What lives here is _content_ cryptography: BLAKE3. Every byte the getter surfaces has been checked against a hash chained to the requested root, so a provider cannot substitute or corrupt data without detection within one 16 KiB group; the provider likewise validates on its side. The security-relevant details — chunk chaining values, the `set_input_offset` / `finalize_non_root` hazmat API, root vs non-root domain separation, the parent-CV merge — are the crypto core of [`bao-tree`][bao-tree] and are covered there; a D port needs a BLAKE3 implementation exposing those internals, not just the one-shot hash.
+
+Two identity-adjacent items are in scope. **`BlobTicket`** (`{EndpointAddr, BlobFormat, Hash}`) is the shareable "here is a blob and where to get it" token: its string form is the literal `"blob"` followed by lowercase base32-nopad of a postcard single-variant enum that preserves the legacy 0.x `NodeAddr` shape (endpoint id ‖ optional relay URL ‖ direct socket addrs ‖ format ‖ hash) ([`ticket.rs:39`][ticket]) — the same `Ticket` codec described in [`wire-serialization`][wire]. And the **size-honesty check**: a validated leaf that contains the final chunk must end exactly at the claimed size, so a remote cannot inflate work with a fake size claim ([`fs.rs:1140`][fs-importbao]) — a small but load-bearing integrity guard the D port must replicate.
+
+### State machines & lifecycle
+
+The subject is unusually FSM-dense; the port should treat each as a checklist.
+
+- **Get client typestate FSM** ([`get.rs` mod `fsm`][get-fsm], diagram `get_machine.drawio.svg`): `AtInitial → AtConnected → {AtStartRoot | AtStartChild | AtClosing} → AtBlobHeader → AtBlobContent →* AtEndBlob → {AtStartChild | AtClosing} → Stats`. It is an explicit _move-only_ typestate machine so a low-level API can be driven without async traits; a `Box<Misc>` (start time, counters, owned ranges iterator) is threaded through every state "so we don't have to memcpy it on every state transition" ([`get.rs:369`][get-misc]). `start_get_many` bypasses `AtInitial`/`AtConnected` and enters at `AtStartChild` (where the offset indexes `hashes` directly, no `-1`).
+- **Verified-decode stack machine** (in [`bao-tree`][bao-tree]): state is `(response-iterator position, hash stack)`; a Parent pops+verifies+pushes children (right then left, gated by range flags), a Leaf pops+verifies; errors are positional (`ParentHashMismatch(node)`, `LeafHashMismatch(chunk)`).
+- **Provider** — per connection: `client_connected` gate → `accept_bi` loop → spawn `handle_stream` per stream → `connection_closed` on loop exit. Per stream: `read_request` → per-type event gate → serve → `sync()` → `transfer_completed`, or on error `reset(code)` + `transfer_aborted`. **Per-request failure RESETs only the stream, never the connection** ([`provider.rs:372`][pv-dispatch]) — a stale doc paragraph claiming otherwise contradicts the code.
+- **Store `BaoFileStorage`** (`Initial → Loading → {Complete | Partial | NonExisting} …`, with `PartialMem → Partial → Complete` on writes and any I/O error → `Poisoned`) and **`EntryState`** (`∅ → Partial{None} → Partial{Some(size)} → Complete`, merged with a commutative union so concurrent updates commute — the on-disk face of design principle #3).
+- **Connection pool** — per connection: `Connecting → {Ready | Failed}`; `Ready ⇄ {InUse, Idle}`; `Idle → Draining` on the idle timer; `Draining → closed` (`conn.close(0, b"idle"/b"drop")`). Per pool entry: `Absent → Active → IdleListed → Evicted`.
+- **irpc `NoqSender`** — `Open ⇄ Closed` with _take-poisoning_: a dropped in-flight `send` future poisons the sender (and all clones), guaranteeing a frame is on the wire completely or not at all. This is a workaround for silent Rust cancellation; event-horizon's terminal-CQE cancellation makes it unnecessary (see below).
+
+Cleanup discipline matters: dropping a noq `SendStream` FINishes it gracefully (the get client depends on this — `drop(writer)` _is_ the end-of-request marker); the store persists the partial bitfield on entity shutdown; the pool closes connections in the connection actor's drain path.
+
+### Dependencies & coupling
+
+| Crate                       | Depth                                  | Port implication                                                                                                                                           |
+| --------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`bao-tree`][bao-tree] 0.16 | **load-bearing algorithm**             | `ResponseDecoder`, `BaoTree`, outboard layout, chunk math — every response byte. Full reimplementation (its own dossier).                                  |
+| `blake3` (hazmat)           | **load-bearing**                       | Chunk-counter CVs, `set_input_offset`, root/non-root finalize, parent merge. The crypto core.                                                              |
+| `postcard` 1.1              | **load-bearing wire codec**            | Enum tags, LEB128 varints, seq length prefixes, fixed byte arrays, options. A D port needs a postcard subset.                                              |
+| `range_collections` 0.4.6   | load-bearing (small)                   | `RangeSet2<ChunkNum>` sorted-boundary sets with union/intersection/difference/superset + serde-as-boundary-seq. ~200 lines.                                |
+| `redb` 4.1                  | infrastructure                         | Embedded ACID B-tree KV (4 tables, point get/insert/remove, ordered scan, snapshot iteration). D: LMDB via ImportC, SQLite, or a purpose-built table file. |
+| `irpc` 0.17                 | infrastructure (local) / wire (remote) | Locally = typed channels; replace with direct capability calls. Remote store RPC is optional.                                                              |
+| `iroh-util` 0.6 (pool)      | load-bearing                           | The entire `ConnectionPool`; no other in-tree connection cache. Must be reimplemented (~1k LoC).                                                           |
+| `iroh` (endpoint, streams)  | API surface                            | Maps to the [`endpoint`][endpoint] and [`socket`][socket] ports.                                                                                           |
+| `tokio` / `n0-future`       | runtime                                | mpsc/oneshot/watch/JoinSet/select/try_join → event-horizon (see below).                                                                                    |
+| `genawaiter`, `self_cell`   | convenience                            | Generator/owning-iterator sugar; subsumed by fibers and index-based iterators.                                                                             |
+
+The critical observation: the entire get/provider stack is **generic over two traits**, `SendStream` and `RecvStream` ([`util/stream.rs:14`][stream-traits]) — a `recv_bytes_exact` / `send_bytes` / `reset` / `stop` byte-stream abstraction. A D `isByteStream` capability slots in exactly where these generics sit, including the deterministic `SimNet` test double. This is the seam that makes the protocol portable without touching the transport.
+
+### Concurrency & I/O model
+
+The Rust code is aggressively actor-and-channel structured _because it targets a multi-threaded runtime_, and much of that structure is incidental complexity that a single-threaded proactor dissolves. The full inventory (with translation) lives in [`concurrency`][concurrency]; the shape:
+
+- **Protocol/get/provider layer**: one detached task per accepted request stream; a `select!` for the observe race (bitfield update vs remote STOP); a `try_join!` that concurrently feeds the store's `import_bao` while reading from the network; genawaiter generators for progress item streams. **No `spawn_blocking`, no `Mutex`/`RwLock`, no timers** — all timing (idle, keep-alive) lives in the [noq transport][quic-transport].
+- **Store**: a dedicated multi-threaded [tokio][tokio] runtime, a main actor + a db actor, and a per-hash _entity manager_ (≤1 entity actor per hash, pooled and recycled) whose only purpose is to serialize access across threads. The per-hash state cell is a `watch::Sender<BaoFileStorage>` that doubles as the `Observe` subscription. File I/O is **synchronous `std::fs` pread/pwrite done directly inside async tasks** — no `spawn_blocking` anywhere, long copies yield cooperatively ([store, on disk](#the-store-on-disk)).
+- **Downloader/pool**: detached actors, `JoinSet` of downloads (reaping is load-bearing — a documented leak class if skipped), `buffered_unordered(32)` bounded parallelism, `AtomicUsize + Notify` refcounting, `MaybeFuture` armable idle timers.
+
+The one **CPU cost that pins the loop thread**: outboard computation on import and bitfield reconstruction on crash recovery re-hash entire blobs, and `encode_ranges_validated` re-hashes on hot serving paths. Under tokio these yield per 16 KiB group; under a single-threaded loop they need explicit checkpoints or an optional worker.
+
+### Mapping to event-horizon
+
+The dominant finding: **most of the concurrency machinery is a tax on `Send + Sync` + work-stealing that [event-horizon][eh-spec]'s `single` topology refunds.** Per-hash serialization, the entity manager's pool/inbox/recycle apparatus, `Arc<Mutex<DeleteSet>>`, `AtomicUsize` refcounts, and the pool's owner-cycle "immortal actor" all exist to coordinate across threads. Under one loop per thread with fiber-affine tasks, they collapse to plain single-owner objects. Concretely, mapping [event-horizon vocabulary][async-io] onto the four subsystems:
+
+**1. The get FSM becomes straight-line fiber code.** The move-only typestate machine exists to drive a low-level API without async traits or lifetimes; a Tier-B fiber with blocking-looking verbs needs none of it. The whole get flow is one function: open stream → send request → per blob { read 8-byte size; loop: decode parent/leaf }. Keep the state _names_ as documentation checkpoints; the "who supplies the child hash" obligation becomes a delegate or an inversion where the driver owns the `HashSeq`.
+
+```rust
+// iroh-blobs/src/get.rs (fsm) — the low-level typestate, abbreviated
+let start = fsm::start(connection, request, Default::default());
+let connected = start.next().await?;
+let ConnectedNext::StartRoot(at_start) = connected.next().await? else { … };
+let header = at_start.next();
+let (mut content, size) = header.next().await?;         // AtBlobHeader → AtBlobContent
+loop {
+    match content.next().await {
+        BlobContentNext::More((next, item)) => { /* item = Parent|Leaf, verified */ content = next; }
+        BlobContentNext::Done(end_blob) => break end_blob,
+    }
+}
+```
+
+```d
+// proposed / sketch — Tier-B fiber over an `isByteStream` capability
+IoResult!Stats fetchBlob(Stream)(ref Stream s, in GetRequest req, ref Env env)
+{
+    s.sendAll(encodeRequest(req));      // parks on submit; ownership of Buf → kernel
+    s.finish();                          // graceful FIN == end-of-request marker
+    ubyte[8] hdr = s.recvExact!8();      // AtBlobHeader; EOF here ⇒ NotFound
+    immutable size = littleEndianU64(hdr);
+    auto dec = ResponseDecoder(req.hash, size, req.ranges);   // bao-tree stack machine
+    while (auto item = dec.pull(s))      // Parent(64B) | Leaf(≤16 KiB); verified before return
+        env.store.writeBatch(item);      // no try_join!: interleave in one fiber (below)
+    return dec.stats;
+}
+```
+
+**2. One fiber per request stream; connection = a `Scope` with error isolation.** iroh's provider deliberately does _not_ tear down the connection when one stream handler fails — the spawned task swallows the error and RESETs only that stream. Map to `spawnDaemon`/a child `Scope` per stream that converts failure into `reset(code)` + an event, **never** sibling cancellation. `Closed::ProviderTerminating` maps to scope-exit cleanup closing the connection. A cancelled get fiber must RESET/STOP its streams in an `onExit` hook.
+
+**3. Request gating and throttling become a capability row.** The 6-mode `EventMask` runtime dispatch is a Design-by-Introspection fit: an `isBlobEventSink` capability with optional methods (`interceptRequest`, `throttle`, `onTransferProgress`) detected by presence monomorphizes the whole thing — `EventMask::DEFAULT` = absent methods = zero cost. The throttle-as-blocking-call per 16 KiB is a natural fiber checkpoint (and a cancellation point). The observe server loop is `race(storeObserveNext, sendStreamStopped)`; the observe client is a fiber yielding bitfields. Both hit the **missing cross-fiber channel** (open issue O20): the Rust code already exposes the sink-shaped internals (`fetch_sink`, `execute_get_sink` take an `impl Sink<u64>`, [`api/remote.rs:341`][rm-missing]), so the port should make progress a `Sink`-style capability parameter and treat the channel-flavored wrappers as optional.
+
+**4. The store two-actor + entity-manager architecture collapses to one owner.** Under `single` topology the store is a plain object owning a `HashMap<Hash, handle>`; per-hash serialization comes for free from single-threaded ownership. Keep the _idea_ of a per-hash handle map with load-on-demand and idle eviction (a memory bound), drop the pool/inbox/recycle machinery. The `watch::Sender<BaoFileStorage>` — handle-as-observer-channel, the only structurally interesting tokio primitive here — has no direct equivalent; the natural design is a state struct plus an intrusive list of parked observer fibers, woken on every bitfield mutation:
+
+```rust
+// iroh-blobs/src/store/fs/bao_file.rs:530 — the per-hash cell IS the observer channel
+pub(crate) struct BaoFileHandle(pub(super) watch::Sender<BaoFileStorage>);
+// mutation: handle.send_if_modified(|s| { *s = s.write_batch(batch)?; changed });
+// Observe: subscribe() → forward every watch `changed()` as a Bitfield diff
+```
+
+```d
+// proposed / sketch — single-threaded cell + parked observers (no channel needed)
+struct BaoFileHandle
+{
+    BaoFileStorage state;
+    Waker[] observers;                   // fibers parked in `observe`
+    void writeBatch(in BaoBatch b) {     // plain mutation; no send_if_modified closure
+        if (state.apply(b))              // returns true if bitfield changed
+            foreach (ref w; observers) w.wake();
+    }
+}
+```
+
+Where the store touches disk, **event-horizon is strictly better than Rust here**: the write-batch path (leaves → `.data`, parents → `.obao4`, size slot → `.sizes4`) is a natural multi-op io_uring submission chain; `sync_all` is `IORING_OP_FSYNC`; ordering only matters versus the bitfield-persist fsync barrier, not within a batch. No dedicated runtime, no `spawn_blocking` — the whole "the fs store owns and manages its own tokio runtime" apparatus ([`fs.rs:50`][fs-runtime]) disappears. The db actor's transaction batching (amortize fsync across commands) stays valuable with any KV backend: one fiber owns the DB, drains its queue against an in-ring `TIMEOUT` deadline, commits batches.
+
+**The connection pool ports cleanly and _better_.** Model it as a struct owned by a `Scope`; per-connection actors are `Scope.spawn`ed fibers whose `onExit` runs `conn.close(0, "drop")`. The Rust `Context.owner` self-cycle and the no-shutdown-message gap — the reason its main actor is immortal — simply vanish. `ConnectionCounter`'s `AtomicUsize + Notify + Arc` becomes a plain `size_t` refcount plus a parked-fiber wakeup; `ConnectionRef` becomes a RAII handle (D struct with a dtor, or an `onExit`-registered release). The idle timer is a `withDeadline`-style cancellable sleep armed only when the refcount is zero. **Caveat**: event-horizon's `race` _cancels the losers_, whereas tokio's per-iteration `select!` keeps arms (the `conn.closed()` watcher, the inbox) alive across loop turns — so the port must structure each connection as one long-lived fiber blocking on a persistent composite (multishot-style subscription), not per-iteration races over freshly-created ops. Timeout semantics to preserve exactly: 1 s connect (including the `on_connected` hook), 5 s idle, 1024 cap, oldest-idle eviction, and error-caching for queued waiters.
+
+**The irpc seam is worth keeping; the macro is not.** The essential design — one serializable request enum + a per-variant `(Tx, Rx)` channel-type mapping + a message type = request ⊗ live channels — is a natural DbI fit: define the request structs, attach `Tx`/`Rx` as members/UDAs, and generate the message sum, the `From` conversions, and the remote dispatcher with `static foreach` over `__traits(allMembers)` — no proc-macro, and the **local path monomorphizes away entirely** into direct capability method calls, achieving the zero-overhead in-process goal irpc only approximates with channel sends. Remote channel halves are just framed stream loops — perfect Tier-B fiber material (a `recv` verb reading `varint + frame`, a `send` verb serializing into a `SmallBuffer` and `write_all`ing), with backpressure inherited from QUIC flow control. Cancellation maps _better_ than in Rust: irpc must poison senders on dropped futures because Rust cancellation is silent, but event-horizon cancels only at terminal CQEs, so a cancelled send fiber knows exactly how many bytes were submitted — the "frame fully sent or channel dead" invariant is cheap to uphold via the `interrupt` arm of `Cause`.
+
+**What has no equivalent and needs new design**: (a) the **cross-fiber channel** (O20) — needed for `Observe`/`GetProgress` streaming, the split-mode progress fan-in, and the pool/downloader inboxes; until it lands, single-owner fibers + direct calls cover request dispatch, but the many→one progress fan-in genuinely needs a small ring buffer with a parked-consumer wakeup. (b) **Buffer strategy** for cheaply-shared decoded leaves and `Bitfield` values (Rust's `bytes::Bytes`): plan a refcounted immutable buffer, or accept GC slices off the hot path. (c) A **`buffered_unordered(32)` equivalent** — a `Scope` plus a counting gate that admits the next part-fiber on each completion. What ports with zero friction: the postcard codec (`@nogc` reader/writer over `sparkles.base.text`-style primitives), the entire bao-tree math and decode stack machine (pure, `@safe pure nothrow @nogc`-able with `SmallBuffer` hash stacks), the `Bitfield`/`EntryState` algebra, and — if interop is wanted — the on-disk file layout byte-for-byte.
+
+---
+
+## Strengths
+
+- **Verified streaming with a 16 KiB detection bound.** Corruption or substitution is caught within one chunk group, on both sides, from a self-describing tree — no trust in the provider required.
+- **Monotone, commutative chunk possession.** Resumable and multi-provider downloads are _sound by construction_: any subset of ranges from any subset of providers composes to the same result. This is the single design choice that makes everything above the wire simple.
+- **A compact, varint-friendly range encoding.** Alternating selected/deselected spans keep numbers small, so even "the hash sequence and all its children, forever" is a handful of bytes.
+- **Transport-abstracted core.** The get/provider stack is generic over `SendStream`/`RecvStream`, so the protocol is testable against an in-memory network and composable with stream layers (e.g. compression) without touching QUIC.
+- **A principled crash story.** "Never think we have data we can't verify" yields a clean rule — fsync data/outboard, then a checksummed bitfield only on clean shutdown, reconstruct by re-hashing otherwise — that avoids per-chunk fsync (and its 3.2 MB/s ceiling) without ever risking phantom availability.
+- **A genuinely minimal RPC seam.** irpc's local path is near-free and its remote path is "just framed postcard over a QUIC stream," with QUIC providing all multiplexing and flow control.
+
+## Weaknesses
+
+- **Pre-production, by its own admission** ([`README.md:3`][bp-readme]); several rough edges are visible in-tree (a lying `MAX_MESSAGE_SIZE` comment, an apparently-dead `max_write_duration`, an "immortal" pool actor, a `todo` that loads whole hash sequences into memory and assumes them complete).
+- **Throttling is a synchronous RPC round-trip per 16 KiB** — correct but a latency multiplier on the hot serving path when enabled.
+- **The provider trusts hash-sequence completeness.** `handle_get_impl` loads the whole `HashSeq` into memory and indexes past-the-end silently ends the response rather than erroring — brittle for large or partial sequences.
+- **CPU-bound hashing is on the async thread.** Outboard computation, crash-recovery revalidation, and hot-path re-encoding re-hash whole blobs; only cooperative yields keep them from starving peers.
+- **The downloader is deliberately dumb.** No retry, backoff, scoring, or dedup — every consumer must re-implement those (iroh-docs does), and `SplitStrategy::None` is silently ignored for `GetMany`, which always fans out to 32.
+- **`ConnectionPool` lives in a crates.io-only crate with no in-tree home** and quirks (immortal main actor, 1 s connect timeout that includes hole-punching, no per-transfer timeout) that a port must consciously decide whether to reproduce.
+
+## Key design decisions and trade-offs
+
+| Decision                                                               | Rationale                                                                                            | Trade-off                                                                                                      |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| BLAKE3 verified streaming, 16 KiB chunk groups ("n0-flavoured bao")    | Incremental verification with a bounded detection window; 16× smaller outboards than 1 KiB bao       | Sub-group range requests must recompute sub-tree hashes on the fly; worst-case ~2 chunk groups overhead/range  |
+| One bidi QUIC stream per request; no in-band framing                   | QUIC gives cheap multiplexing, ordering, flow control; geometry is `(hash, size, ranges)`-determined | No response-level metadata; "not found" overloaded onto early FIN; no request IDs to correlate                 |
+| Alternating-span `ChunkRangesSeq` encoding                             | Minimizes varint sizes; "all children forever" expressible without a count                           | Non-obvious to read/debug; two different `Bitfield` encodings coexist                                          |
+| Responses carry no hashes                                              | Self-describing tree; nothing to spoof                                                               | Getter must know/derive every child hash (decode the `HashSeq` mid-transfer); a caller obligation in the FSM   |
+| Store never fsyncs per chunk; bitfield persisted only on clean exit    | Keeps download throughput high (avoids the 3.2 MB/s per-group-fsync ceiling)                         | A crash forces full re-hash reconstruction of the partial bitfield                                             |
+| Metadata batched; file-delete after metadata-commit; protect-on-create | "Don't touch the database if possible"; crash-consistent ordering                                    | Complex db-actor batching loop; a lost-on-crash window for large partial blobs                                 |
+| Store is an `irpc` `Request` enum, not a trait                         | One dispatch path for in-process and (optional) remote; local path never serializes                  | The store's whole surface is a message enum; behavior is implicit in the actor                                 |
+| Downloader has no retry/scoring/dedup; per-provider resume             | Keep it small; possession-commutativity makes naive resume correct                                   | Consumers must add dedup/retry; `SplitStrategy::None` ignored for `GetMany`; a stalled transfer has no timeout |
+| Per-`ALPN` `ConnectionPool` with idle eviction, cached dial errors     | Reuse expensive hole-punched connections; serialize "dial once, share result" without a lock         | Reuse is per-pool-per-ALPN (docs-sync dials separately); main actor never terminates; aggressive 1 s connect   |
+
+---
+
+## Sources
+
+- [`iroh-blobs` — GitHub repository (`v0.103.0`)][repo] · [docs.rs][docs]
+- [`iroh-blobs/src/protocol.rs` — `Request`, `GetRequest`, ALPN, `MAX_MESSAGE_SIZE`, error/close codes, `ChunkRangesSeq` doc][bp-request]
+- [`iroh-blobs/src/protocol/range_spec.rs` — `RangeSpec`/`ChunkRangesSeq` wire encoding + hexdump tests][rs-wire]
+- [`iroh-blobs/src/get.rs` — the get-client typestate `fsm`][get-fsm]
+- [`iroh-blobs/src/provider.rs` — accept loop, per-stream dispatch, observe server][pv-dispatch] · [`provider/events.rs` — `EventMask`, throttle, update channels][pe-mask]
+- [`iroh-blobs/src/hash.rs`][hash-newtype] · [`hashseq.rs`][hashseq] · [`format/collection.rs`][collection] · [`ticket.rs`][ticket] · [`util/stream.rs` (`SendStream`/`RecvStream`, varint)][stream-traits]
+- [`iroh-blobs/src/store/fs.rs` — main actor, import/export, disk layout][fs-mainactor] · [`store/fs/meta/tables.rs` (redb schema)][tables] · [`entry_state.rs`][entrystate] · [`bao_file.rs`][baofile] · [`store/util.rs` (checksummed bitfield)][su-checksum] · [`store/gc.rs`][gc]
+- [`iroh-blobs/src/api/proto.rs` — the store `Request` enum][proto] · [`api.rs` — `Store` = `irpc::Client`][api-store] · [`api/remote.rs` — `LocalInfo`/resume planner][rm-missing] · [`api/downloader.rs` — `Downloader`, split, provider loop][dl-execget]
+- [`iroh-blobs/DESIGN.md` — integrity, crash-consistency, commutativity][design-integrity] · [`README.md`][bp-readme]
+- [`iroh-util/src/connection_pool.rs` (`v0.6.0`) — pool `Options`, actors, idle eviction][cp-doc]
+- [`irpc/src/lib.rs` (`v0.17.0`) — channels, `Service`/`Channels`, `Client`, framing, `listen`][irpc-goal] · [docs.rs][irpc-docs]
+- [`bao-tree` (`v0.16.0`) — verified-streaming math (own dossier → [`bao-tree`][bao-tree])][bt-repo]
+- Related iroh pages: [`bao-tree`][bao-tree] · [`wire-serialization`][wire] · [`quic-transport`][quic-transport] · [`endpoint`][endpoint] · [`docs-sync`][docs-sync] · [`concurrency`][concurrency] · [`d-architecture-migration`][d-migration]
+
+<!-- References -->
+
+[repo]: https://github.com/n0-computer/iroh-blobs/tree/v0.103.0
+[docs]: https://docs.rs/iroh-blobs/0.103.0/iroh_blobs/
+[util-repo]: https://github.com/n0-computer/iroh-util/tree/v0.6.0
+[irpc-repo]: https://github.com/n0-computer/irpc/tree/v0.17.0
+[irpc-docs]: https://docs.rs/irpc/0.17.0/irpc/
+[bt-repo]: https://github.com/n0-computer/bao-tree/tree/v0.16.0
+[bt-docs]: https://docs.rs/bao-tree/0.16.0/bao_tree/
+[bp-alpn]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L406
+[bp-maxsize]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L395
+[bp-integrity]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L10
+[bp-rangeseq]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L293
+[bp-streams]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L367
+[bp-request]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L408
+[bp-getmany]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L579
+[bp-observe]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L616
+[bp-errcodes]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L398
+[bp-read]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs#L448
+[bp-readme]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/README.md#L3
+[rs-spec]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol/range_spec.rs#L341
+[rs-inf]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol/range_spec.rs#L165
+[rs-wire]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol/range_spec.rs#L470
+[rs-tests]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol/range_spec.rs#L553
+[get-fsm]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/get.rs
+[get-openbi]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/get.rs#L239
+[get-startchild]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/get.rs#L418
+[get-header]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/get.rs#L520
+[get-misc]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/get.rs#L369
+[get-notfound]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/get.rs#L495
+[hash-newtype]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/hash.rs#L14
+[hash-empty]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/hash.rs#L25
+[hash-parse]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/hash.rs#L151
+[hashseq]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/hashseq.rs#L54
+[collection]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/format/collection.rs#L82
+[ticket]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/ticket.rs#L39
+[stream-traits]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/util/stream.rs#L14
+[stream-varint]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/util/stream.rs#L401
+[np]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/net_protocol.rs#L86
+[pv-accept]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider.rs#L305
+[pv-reject]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider.rs#L294
+[pv-getimpl]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider.rs#L429
+[pv-dispatch]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider.rs#L372
+[pv-observe]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider.rs#L627
+[pe-mask]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider/events.rs#L167
+[pe-pushdefault]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider/events.rs#L189
+[pe-throttle]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider/events.rs#L282
+[ab-write]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api/blobs.rs#L1133
+[proto]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api/proto.rs#L90
+[api-store]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api.rs#L211
+[api-connect]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api.rs#L250
+[api-downloader]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api.rs#L241
+[rm-missing]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api/remote.rs#L341
+[dl-proto]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api/downloader.rs#L40
+[dl-strategy]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api/downloader.rs#L150
+[dl-execget]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api/downloader.rs#L484
+[fs-mainactor]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs.rs#L239
+[fs-runtime]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs.rs#L50
+[fs-importbao]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs.rs#L1140
+[tables]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs/meta/tables.rs#L7
+[meta-batch]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs/meta.rs#L785
+[entrystate]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs/entry_state.rs#L161
+[baofile]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs/bao_file.rs#L299
+[opts-inline]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs/options.rs#L71
+[deleteset]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs/delete_set.rs#L113
+[su-checksum]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/util.rs#L218
+[gc]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/gc.rs#L34
+[design-integrity]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md#L5
+[design-job]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md#L11
+[design-meta]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md#L61
+[design-commute]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md#L112
+[design-crash]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md#L124
+[design-fsync]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md#L134
+[cp-doc]: https://github.com/n0-computer/iroh-util/blob/v0.6.0/src/connection_pool.rs#L1
+[cp-options]: https://github.com/n0-computer/iroh-util/blob/v0.6.0/src/connection_pool.rs#L42
+[irpc-goal]: https://github.com/n0-computer/irpc/blob/v0.17.0/src/lib.rs#L5
+[irpc-framing]: https://github.com/n0-computer/irpc/blob/v0.17.0/src/lib.rs#L50
+[bt-decoder]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/io/fsm.rs#L317
+[blake3]: https://github.com/BLAKE3-team/BLAKE3
+[redb]: https://docs.rs/redb/4.1.0/redb/
+[rfc9000]: https://www.rfc-editor.org/rfc/rfc9000
+[bao-tree]: ./bao-tree.md
+[wire]: ./wire-serialization.md
+[quic-transport]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[identity]: ./identity-crypto.md
+[docs-sync]: ./docs-sync.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[concepts]: ./concepts.md
+[index]: ./index.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[async-io]: ../async-io/index.md
+[tokio]: ../async-io/tokio.md

--- a/docs/research/iroh/concepts.md
+++ b/docs/research/iroh/concepts.md
@@ -1,0 +1,485 @@
+# Concepts & Vocabulary
+
+The shared glossary the rest of this survey is written in: every load-bearing iroh 1.0 noun — `EndpointId`, `EndpointAddr`, `Ticket`, `ALPN`, `postcard`, the `Socket`/`Endpoint`/`Connection` layering, `path`/multipath, QUIC Address Discovery, NAT traversal, `address_lookup`, `Hash`/`bao`/`outboard`, `HashSeq`, `NamespaceId`/`AuthorId`/`Entry`, gossip `TopicId`, `relay`/home relay, `net_report` — defined once, grounded in a cited source line, and linked onward to the deep-dive that treats it in depth.
+
+**Last reviewed:** July 6, 2026
+
+> [!NOTE]
+> This is a _reference_ page, not a deep-dive: it fixes terminology and points at the
+> authoritative treatment, so the deep-dives can use a term without re-defining it. Every
+> definition here is pinned to iroh workspace **v1.0.1** (commit `22cac742ca`) and the
+> matching crate tags ([`iroh-blobs`][blobs] 0.103.0, [`iroh-docs`][docs-sync] 0.101.0,
+> [`iroh-gossip`][gossip] 0.101.0, [`noq`][quic] `noq-v1.0.1`, [`bao-tree`][bao] 0.16.0).
+> iroh 1.0 is a **major rename** of the 0.x API — see [The 1.0 rename cascade](#the-1-0-rename-cascade)
+> — so 0.x folklore (`NodeId`, `magicsock`, DISCO, STUN, `Collection`-as-protocol) does not
+> compile against this tree. Part of the [iroh survey][index].
+
+---
+
+## Why this page
+
+iroh's names are load-bearing. The single most consequential fact about the whole stack — that
+an endpoint's identity, address, and encryption root are the _same_ Ed25519 key — is expressed
+purely through the type aliasing `pub type EndpointId = PublicKey`, and reading the code without
+that in hand is a maze. The 1.0 restructure then renamed roughly a dozen of the most-used
+identifiers at once. This page is the decoder ring: it gives one grounded definition per term and
+a link to where the mechanics live, so a reader (or a D re-implementer) can move between deep-dives
+without re-deriving vocabulary each time.
+
+Terms are grouped by the layer they belong to, bottom-up: **identity & addressing** → **serialization
+& sharing** → **the connectivity layering** → **getting connected** → **content addressing (blobs)**
+→ **documents & gossip**. Two cross-cutting facts frame everything: the whole application stack
+serializes with one format ([`postcard`](#postcard)), and the whole connectivity stack is one
+[QUIC][quic] connection per peer carrying multiple [paths](#path-direct-vs-relay-and-multipath).
+
+---
+
+## The 1.0 rename cascade
+
+iroh 1.0 renamed the vocabulary wholesale and deleted two 0.x subsystems outright. A term on the
+left will not be found in the pinned tree; use the right.
+
+| 0.x term                       | 1.0 term                                                            | Note                                                                          |
+| ------------------------------ | ------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `NodeId`                       | [`EndpointId`](#endpointid-publickey-secretkey)                     | still an alias of `PublicKey` ([`key.rs`][key])                               |
+| `NodeAddr`                     | [`EndpointAddr`](#endpointaddr-transportaddr)                       | now an `id` + a unified `BTreeSet<TransportAddr>`                             |
+| `NodeTicket`                   | [`EndpointTicket`](#ticket-and-its-three-kinds)                     | old `node…` ticket strings are unparseable by 1.0                             |
+| `magicsock` / `MagicSock`      | the [socket][socket] layer / `Socket`                               | `pub(crate)`, restructured around `noq` multipath ([`socket.rs`][socket-doc]) |
+| `discovery` / `Discovery`      | [`address_lookup`](#address_lookup-pkarr-and-dns) / `AddressLookup` | a pure name→address directory ([`address_lookup.rs`][al-trait])               |
+| `DiscoveryItem` / `NodeInfo`   | `Item` / `EndpointInfo` / `EndpointData`                            | see [Address Lookup][discovery]                                               |
+| `DISCO` (UDP side-protocol)    | **gone** → in-QUIC [NAT traversal](#nat-traversal-holepunch) (QNT)  | no magic ping/pong packets on the wire                                        |
+| STUN                           | **gone** → [QUIC Address Discovery](#quic-address-discovery-qad)    | no STUN code anywhere in the tree                                             |
+| `netcheck`                     | [`net_report`](#net_report)                                         | same shape, QAD+HTTPS substrate ([`net_report.rs`][nr-doc])                   |
+| DERP                           | [relay](#relay-and-home-relay) (`iroh-relay`)                       | WebSocket packet-forwarder, revised                                           |
+| `Collection` (a protocol type) | a [`HashSeq`](#hashseq-and-collection) convention                   | no longer known to the wire protocol                                          |
+| `quinn`                        | [`noq`](#the-runtime-asyncudpsocket-seam)                           | n0's fork adding multipath / QAD / QNT ([`README.md`][noq-readme])            |
+
+---
+
+## Identity & addressing
+
+Everything an endpoint _is_ and everywhere it can be _reached_ hangs off one 32-byte Ed25519 key.
+The crate root states the dual role directly ([`iroh-base/src/key.rs`][key]):
+
+> _"Each endpoint in iroh has a unique identifier created as a cryptographic key. This can be used
+> to globally identify an endpoint. Since it is also a cryptographic key it is also the mechanism by
+> which all traffic is always encrypted for a specific endpoint only."_
+
+| Term                   | Definition                                                                                                                                                                                                                                       | Owning page · cite                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| `PublicKey`            | A `#[repr(transparent)]` newtype over the 32-byte compressed Edwards y-coordinate of an Ed25519 verifying key; `LENGTH = 32`. Verification is `verify_strict`, not the permissive `verify`.                                                      | [identity-crypto][identity] · [`key.rs`][key]        |
+| `EndpointId`           | The **same type**, `pub type EndpointId = PublicKey`. Convention: say `PublicKey` for crypto operations, `EndpointId` when naming an endpoint. Self-certifying — the name _is_ the verification key.                                             | [identity-crypto][identity] · [`key.rs`][key]        |
+| `SecretKey`            | The 32-byte Ed25519 **seed** wrapping `ed25519_dalek::SigningKey`, `ZeroizeOnDrop`. `public()` re-derives the `PublicKey`; the same secret signs relay, pkarr, and docs surfaces with no extra crypto.                                           | [identity-crypto][identity] · [`key.rs`][key]        |
+| `Signature`            | A 64-byte Ed25519 signature; on the wire it is 64 raw bytes, no length prefix.                                                                                                                                                                   | [identity-crypto][identity] · [`key.rs`][key]        |
+| `EndpointAddr`         | `EndpointAddr { id: EndpointId, addrs: BTreeSet<TransportAddr> }` — an id plus a set of location hints. Dialing by bare `id` (empty `addrs`) is legal; [address lookup](#address_lookup-pkarr-and-dns) fills the rest.                           | [wire][wire] · [`endpoint_addr.rs`][endpoint-addr]   |
+| `TransportAddr`        | The `#[non_exhaustive]` enum of one location hint: `Relay(RelayUrl)` (postcard tag 0), `Ip(SocketAddr)` (1), `Custom(CustomAddr)` (2). Derived `Ord` = `(variant index, payload)`, which _is_ the ticket byte order.                             | [wire][wire] · [`endpoint_addr.rs`][endpoint-addr]   |
+| `RelayUrl`             | A newtype over `Arc<Url>` naming a [relay](#relay-and-home-relay) server (e.g. `http://derp.me./`); it appears as `TransportAddr::Relay` and as an endpoint's [home relay](#relay-and-home-relay).                                               | [relay][relay] · [`endpoint_addr.rs`][endpoint-addr] |
+| `EndpointIdMappedAddr` | A **synthetic** IPv6 Unique-Local-Address (`fd15:70a:510b::/64`, dummy port `12345`) minted one-per-remote so [`noq`][quic], which only understands `SocketAddr`, can dial a peer that has no fixed IP. `struct EndpointIdMappedAddr(Ipv6Addr)`. | [socket][socket] · [`mapped_addrs.rs`][mapped]       |
+
+Two subtleties a reader trips on. First, an `EndpointId` **string** is 64-char lowercase hex by
+`Display` (the 0.x base32 `Display` is gone), though `FromStr` still accepts either hex or
+`BASE32_NOPAD`. Second, the `EndpointIdMappedAddr` is one of a family of "fake" ULA addresses the
+[socket][socket] uses to name non-IP destinations to QUIC — `RelayMappedAddr` and `CustomMappedAddr`
+are the siblings; the mapping table is append-only for process lifetime ([`mapped_addrs.rs`][mapped]).
+
+---
+
+## Serialization & sharing
+
+### `postcard`
+
+The **one** application-level serialization format across the whole stack — a compact,
+non-self-describing binary [`serde`][serde] encoding. There is no `protobuf`, no `bincode`, and no
+JSON on any hot path. The rules a codec must implement: unsigned integers are LEB128 varints
+(little-endian 7-bit groups, MSB = continuation); signed integers are zigzag-then-varint; a fixed
+`[u8; N]` (a key, a hash) is N raw bytes with **no** length prefix; an `enum` is a varint of the
+_declaration index_ then the payload; a struct is its fields concatenated in declaration order with
+no tags. Because nothing is self-describing, **the Rust declaration order _is_ the wire contract** —
+reordering a struct's fields is a silent wire break. A second varint dialect coexists: the
+[QUIC varint][rfc9000] (RFC 9000 §16, big-endian, 2-bit length tag) is used for relay frame types
+and QUIC-native fields; a port implements both and must never confuse them.
+Full byte-level treatment in [Wire Formats & Serialization][wire].
+
+### `ALPN`
+
+An **Application-Layer Protocol Negotiation** byte string ([RFC 7301][rfc7301]) chosen per protocol;
+every iroh connection is opened under one, and the accepting [protocol router][endpoint] dispatches
+on an exact-match of the bytes (the accept side picks the winner; connect-side order is irrelevant).
+The production registry:
+
+| `ALPN`           | Owner                    | Carries                                                            |
+| ---------------- | ------------------------ | ------------------------------------------------------------------ |
+| `/iroh-bytes/4`  | [`iroh-blobs`][blobs]    | content-addressed [blob](#blob-document-and-gossip-topic) transfer |
+| `/iroh-sync/1`   | [`iroh-docs`][docs-sync] | [document](#blob-document-and-gossip-topic) range-sync             |
+| `/iroh-gossip/1` | [`iroh-gossip`][gossip]  | epidemic broadcast on a [topic](#blob-document-and-gossip-topic)   |
+| `/iroh-qad/0`    | [`iroh-relay`][relay]    | [QUIC Address Discovery](#quic-address-discovery-qad) listener     |
+| `DUMBPIPEV0`     | `dumbpipe`               | raw byte pipe (example app)                                        |
+
+The full registry, hex, and citations are in [Wire Formats & Serialization][wire]. Note that `ALPN`
+is _not_ the TLS server name: the [SNI][identity] is a synthetic `base32(EndpointId).iroh.invalid`
+that carries the dialed id and buckets 0-RTT tickets per peer.
+
+### `Ticket` and its three kinds
+
+A **ticket** is the copy-pasteable string that bootstraps a connection: a `KIND` prefix plus the
+`BASE32_NOPAD` of a [`postcard`](#postcard) payload wrapped in a single-variant enum (so byte `0x00`
+opens every ticket, a one-byte version discriminant bought cheaply). The [`Ticket`][tickets-lib]
+trait leaves the byte format to the implementer but recommends `postcard`, which all three concrete
+tickets use.
+
+| Ticket           | `KIND`     | Payload                                                                                                                       | Cite                              |
+| ---------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `EndpointTicket` | `endpoint` | `EndpointId` + `BTreeSet<TransportAddr>` (the unified 1.0 address shape, `Variant1`)                                          | [`endpoint.rs`][tickets-endpoint] |
+| `BlobTicket`     | `blob`     | **legacy 0.x layout**: `EndpointId` + `Option<RelayUrl>` + `BTreeSet<SocketAddr>` + `BlobFormat` + [`Hash`](#hash-and-blake3) | [`ticket.rs`][blobs-ticket]       |
+| `DocTicket`      | `doc`      | a `Capability` (`Read` = a `NamespaceId`, or `Write` = a raw 32-byte `NamespaceSecret`) + `Vec<EndpointAddr>`                 | [`ticket.rs`][docs-ticket]        |
+
+Two hazards worth stating in the glossary. `BlobTicket` still ships the pre-1.0 address shape and
+**silently drops** `Custom` transports and all but the first relay on encode — a port cannot reuse
+one address encoder for all three. And a `DocTicket` whose `Capability` is `Write` embeds the
+document's raw secret key: **tickets are bearer credentials, not just addresses**.
+
+---
+
+## The connectivity layering
+
+Three objects sit in a strict stack, and confusing them is the most common vocabulary error. From
+bottom to top:
+
+| Object       | What it is                                                                                                                                                                                                                                                                                                                                                               | Owning page · cite                                |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
+| `Socket`     | The multipath **connectivity fabric** (ex-`magicsock`, `pub(crate)`). It presents [`noq`][quic] with a single object that _looks like one UDP socket_ (`noq::AsyncUdpSocket`) while fanning datagrams across IP, one relay, and custom transports, and owns [path](#path-direct-vs-relay-and-multipath) selection and [hole-punch](#nat-traversal-holepunch) scheduling. | [socket][socket] · [`socket.rs`][socket-doc]      |
+| `Endpoint`   | The public **front door**: a cheaply-clonable `Arc<EndpointInner>` over the QUIC stack + identity + a [protocol `Router`][endpoint]. Recommended one per application so all connections share peer-to-peer state.                                                                                                                                                        | [endpoint][endpoint] · [`endpoint.rs`][ep-single] |
+| `Connection` | **One QUIC connection** to one peer (over `noq::Connection`), typed `Connection<State>` for 0-RTT correctness. A single connection carries multiple concurrent [multipath paths](#path-direct-vs-relay-and-multipath).                                                                                                                                                   | [endpoint][endpoint] · [`quic-transport`][quic]   |
+
+The `Endpoint` doc comment fixes the "one per application" convention ([`endpoint.rs`][ep-single]):
+
+> _"It is recommended to only create a single instance per application. This ensures all the
+> connections made share the same peer-to-peer connections to other iroh endpoints, while still
+> remaining independent connections."_
+
+### The `Runtime` / `AsyncUdpSocket` seam
+
+The seam between the QUIC state machine and its host is the single most important interface for a
+port. [`noq`][quic] is **sans-io**: `noq-proto` is pure protocol logic with no clock and no sockets,
+and the async `noq` crate reaches the outside world through four traits — `Runtime` (`new_timer`,
+`spawn`, `wrap_udp_socket`, `now`), `AsyncUdpSocket` (`create_sender`, `poll_recv`, `local_addr`),
+`UdpSender` (`poll_send`), and `AsyncTimer`. iroh plugs its multipath `Socket` in as an
+`AsyncUdpSocket` via `new_with_abstract_socket` (so `wrap_udp_socket` is dead code — the QUIC stack
+never touches a raw UDP fd), and drives every timer/task through `Runtime`. That trait object is
+exactly what a D port replaces with an [event-horizon][eh-spec] capability row + `Scope`, and the
+sans-io core it fronts is what makes the port tractable at all ([`noq/src/runtime/mod.rs`][noq-runtime]).
+
+### `path` (direct vs relay) and multipath
+
+A **path** in iroh 1.0 is a QUIC-Multipath path, not a mode. The decisive change from 0.x: there is
+no separate "relay mode" any more — **the relay and every direct address are concurrent multipath
+paths on one connection**, and "upgrading from relay to direct" is just flipping a path's QUIC
+`PathStatus` from `Backup` to `Available` and letting [`noq`][quic] route ([`socket.rs`][socket-doc]).
+
+- A **direct path** is a hole-punched UDP 4-tuple between the two peers (see [NAT traversal](#nat-traversal-holepunch)).
+- A **relay path** carries the same encrypted QUIC datagrams through a [relay](#relay-and-home-relay) server by `EndpointId`.
+- Internally [`noq`][quic] separates a `PathId` (a multipath **packet-number space**: its own packet
+  numbers, ACK state, loss timers) from a `PathData` (the **4-tuple in use**: RTT, congestion
+  controller, MTU); one `PathId` can migrate across 4-tuples. Scheduling is a strict two-tier
+  priority — lowest-`PathId` validated `Available` path wins; `Backup` paths carry data only when no
+  `Available` path exists.
+
+iroh configures **8** concurrent paths, a **5 s** heartbeat, and a **15 s** per-path idle timeout;
+smarter selection (RTT-weighting, sticky failover) lives in the [socket][socket]'s per-remote actor,
+above `noq`.
+
+---
+
+## Getting connected
+
+Four subsystems cooperate to turn a bare `EndpointId` into a working direct path. STUN and the DISCO
+UDP side-protocol of 0.x are **both gone** — every mechanism below rides inside QUIC or over HTTPS.
+
+### QUIC Address Discovery (QAD)
+
+The **STUN replacement**: the peer at the other end of a QUIC connection tells you the source
+`SocketAddr` it observes for you, in an `OBSERVED_ADDRESS` frame. It is negotiated by the transport
+parameter `ObservedAddr = 0x9f81a176` (role ∈ {send-only, receive-only, both}) and carried by frames
+`ObservedIpv4Addr = 0x9f81a6` / `ObservedIpv6Addr = 0x9f81a7` ([`noq-proto`][quic],
+[`transport_parameters.rs`][noq-tp]). iroh consumes it two ways: **dedicated relay QAD servers**
+(ALPN `/iroh-qad/0` on UDP port `7842`) that [`net_report`](#net_report) probes to learn its own
+public address, and **in-band on every regular connection**. Because the probe rides the very socket
+whose mapping it measures, the discovered address is a valid direct-path candidate. Draft:
+[draft-seemann-quic-address-discovery][draft-qad]. See [NAT Traversal][nat] and [Net Report][net-report].
+
+### NAT traversal (holepunch)
+
+iroh punches through NATs **entirely inside QUIC**, via n0's own extension **QNT** — "inspired by
+[draft-seemann-quic-nat-traversal-02][draft-qnt], simplified to n0's own protocol". Both peers
+advertise their [QAD](#quic-address-discovery-qad)-learned reflexive addresses with
+`ADD_ADDRESS`/`REMOVE_ADDRESS`/`REACH_OUT` frames (block `0x3d7f90…0x3d7f94`), then fire off-path
+`PATH_CHALLENGE`/`PATH_RESPONSE` probes simultaneously so each NAT sees the inbound as a reply and
+installs a mapping (**simultaneous open**). A successful probe becomes a validated
+[multipath path](#path-direct-vs-relay-and-multipath). QNT requires multipath and negotiates via
+transport parameter `N0NatTraversal = 0x3d7f91120401` (value = max advertised addresses); roles are
+fixed by the QUIC client/server side, not by who is behind NAT. iroh allows **32** QNT addresses.
+The engine is [sans-io][async-io]; orchestration lives in the [socket][socket] per-remote actor. Full
+treatment in [NAT Traversal & Address Discovery][nat].
+
+### `address_lookup`, pkarr, and DNS
+
+**`address_lookup`** (what 0.x called _discovery_) is the directory that maps an `EndpointId` to
+transport addresses — deliberately _not_ the dialer. The [`AddressLookup`][al-trait] trait is
+asymmetric: `publish` is fire-and-forget, `resolve` is a cancellable multi-result stream. Its doc
+comment ([`address_lookup.rs`][al-trait]):
+
+> _"Publishes the given `EndpointData` to the Address Lookup mechanism. This is fire and forget,
+> since the `Endpoint` can not wait for successful publishing."_
+
+Two nouns name the _how_, not the _what_:
+
+- **pkarr** — _Public-Key Addressable Resource Records_: the self-authenticating record format. An
+  endpoint's addressing info is packed as an RFC 1035 DNS reply packet, wrapped in a [BEP-44][bep44]
+  mutable-item encoding, signed by the `SecretKey`. The 1104-byte layout is a 32-byte public key, a
+  64-byte signature, an 8-byte microsecond timestamp, then a `≤1000`-byte DNS packet
+  ([`iroh-dns/src/pkarr.rs`][dns-pkarr]). Any party
+  can verify; only the key-holder can mint a newer (monotonic-timestamp) record. iroh vendors the
+  format (~400 lines) rather than depending on the upstream `pkarr` crate.
+- **DNS** — one _transport_ for pkarr records: the same signed DNS packet is served under a
+  z-base-32 domain label, so resolvers can cache it. The `N0` preset pairs a `PkarrPublisher`
+  (publish over HTTP) with a `DnsAddressLookup` (resolve over cheap, cacheable DNS).
+
+The default publisher filter is `relay_only()` — raw IPs are not leaked to a public pkarr server
+unless the operator opts in. Full treatment in [Address Lookup (Discovery)][discovery].
+
+### `relay` and home relay
+
+A **relay** is a public, always-reachable server that both peers connect to and that forwards opaque
+already-encrypted QUIC datagrams between them by destination `EndpointId` — a revised DERP. It is
+simultaneously the _rendezvous_ (a fixed address both peers can reach) and the _fallback data path_
+(a [relay path](#path-direct-vs-relay-and-multipath) until direct hole-punching succeeds). It never
+sees plaintext ([`iroh-relay/src/lib.rs`][relay-lib]):
+
+> _"The relay server helps establish connections by temporarily routing encrypted traffic until a
+> direct, P2P connection is feasible. Once this direct path is set up, the relay server steps back,
+> and the data flows directly between devices."_
+
+The data plane is binary WebSocket messages over HTTP(S) (so it runs unmodified in a browser); the
+relay binary also co-hosts the [QAD](#quic-address-discovery-qad) endpoint. A node's **home relay**
+is the single lowest-latency relay it camps on, chosen by [`net_report`](#net_report) with hysteresis
+to prevent flapping between near-equal servers. Full treatment in [The Relay Protocol][relay].
+
+### `net_report`
+
+The **connectivity-sensing report** (descendant of Tailscale's `netcheck`): it answers "what does the
+network look like from here right now" — is UDP working over IPv4/IPv6, what public `SocketAddr` does
+the world assign me (`global_v4`/`global_v6`), is the NAT mapping endpoint-dependent (symmetric,
+which defeats naive hole-punching), which relay is the [home relay](#relay-and-home-relay), and is a
+captive portal intercepting traffic ([`report.rs`][nr-report]). In 1.0 its only probes are
+[QAD](#quic-address-discovery-qad) (over the _main_ endpoint) and HTTPS; STUN and ICMP are gone. It
+also owns two sibling inputs — `netwatch` (interface/route watching + the rebindable `UdpSocket`) and
+`portmapper` (UPnP/PCP/NAT-PMP). Full treatment in [Net Report][net-report].
+
+---
+
+## Content addressing (blobs)
+
+### `Hash` and BLAKE3
+
+A `Hash` is a 32-byte newtype over `blake3::Hash` — the content address at the heart of
+[blobs][blobs]. On the wire it is 32 raw bytes, no length prefix; `Display` is 64-char lowercase hex,
+`FromStr` also accepts 52-char base32-nopad. `Hash::EMPTY` (the BLAKE3 hash of `b""`) is a hard
+special case: never stored, always "present", the only hash for which a zero-size response is legal
+([`hash.rs`][blobs-hash]). The **hash is the request**: because response geometry is fully determined
+by `(hash, size, ranges)`, there is exactly one correct byte sequence per request, and tampering is
+detected locally.
+
+### `bao`, `outboard`, and `ChunkRanges`
+
+BLAKE3 internally hashes a blob as a binary Merkle tree over 1024-byte chunks; **[`bao-tree`][bao]**
+exposes that tree as a **verified-streaming codec**, so a receiver holding only the 32-byte root can
+pull an arbitrary subset from an untrusted peer and verify each piece _as it arrives_, aborting the
+moment a hash mismatches — "the requester will notice if data is incorrect after at most 16 KiB of
+data" ([`iroh-blobs/DESIGN.md`][design-integrity]).
+
+| Term                             | Definition                                                                                                                                                                                                                                                   | Cite                                             |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| `bao` / bao-tree                 | The verified-streaming format (wire-compatible with the `bao` crate at block size 0), extended with runtime-configurable chunk groups and multi-range queries.                                                                                               | [bao-tree][bao] · [`tree.rs`][bt-tree]           |
+| `outboard`                       | The tree of **interior** BLAKE3 hashes (64-byte parent chaining-value pairs) stored/transmitted separately from the data, so ranges can be verified without re-hashing the whole blob.                                                                       | [bao-tree][bao] · [`tree.rs`][bt-tree]           |
+| `BlockSize` / chunk group        | The runtime leaf granularity, `log2(group bytes / 1024)`. iroh fixes `IROH_BLOCK_SIZE = BlockSize::from_chunk_log(4)` = **16 KiB** ("n0-flavoured bao"), cutting the outboard 16× versus per-1024-byte-chunk classic bao.                                    | [bao-tree][bao] · [`tree.rs`][bt-tree]           |
+| `ChunkRanges` / `ChunkRangesSeq` | A run-length-encoded sorted set of non-overlapping chunk ranges (units of 1024-byte chunks) selecting exactly which parts of a blob (or hash-sequence) to fetch and verify. Encoded as alternating deselect/select span widths for small `postcard` varints. | [blobs][blobs] · [`protocol.rs`][blobs-protocol] |
+
+### `HashSeq` and `Collection`
+
+A **`HashSeq`** is the only structural type the [blobs][blobs] protocol knows beyond a raw blob: a
+blob whose bytes are a raw concatenation of 32-byte hashes (`len % 32 == 0`, `get(i)` = bytes
+`[i*32 .. (i+1)*32]`, no header) ([`hashseq.rs`][hashseq]). `BlobFormat` is therefore just
+`Raw | HashSeq`. A **`Collection`** is a _convention_ layered on top (invisible to the protocol): a
+`HashSeq` whose link 0 is the hash of a metadata blob whose `postcard`-encoded `CollectionMeta`
+carries a `header: [u8; 13]` = `b"CollectionV0."` and a list of `names`, so `names[i]` labels
+`link[i+1]` — a named directory of blobs
+([`format/collection.rs`][collection]). In 0.x `Collection` was a protocol concept; in 1.0 it is only
+this convention.
+
+---
+
+## Documents & gossip
+
+### `blob`, `document`, and gossip `topic`
+
+The three application protocols name three different data shapes:
+
+| Term             | Data shape                                                                                                                                         | ALPN             | Owning page            |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ---------------------- |
+| **blob**         | An immutable, content-addressed byte sequence named by its [`Hash`](#hash-and-blake3).                                                             | `/iroh-bytes/4`  | [blobs][blobs]         |
+| **document**     | A multi-writer, eventually-consistent key–value map (a _replica_) of signed `(namespace, author, key)` [entries](#namespaceid-authorid-and-entry). | `/iroh-sync/1`   | [docs-sync][docs-sync] |
+| **gossip topic** | A `TopicId` — a 32-byte identifier naming one independent broadcast swarm and its membership + broadcast state machines.                           | `/iroh-gossip/1` | [gossip][gossip]       |
+
+Gossip is a **control-plane** transport (default per-message ceiling **4096 bytes**): documents ride
+it to fan out change notifications, and bulk content moves through blobs.
+
+### `NamespaceId`, `AuthorId`, and `Entry`
+
+A [document][docs-sync]'s identity model is three Ed25519-keyed nouns:
+
+- **`NamespaceId`** — a `[u8; 32]` newtype over an Ed25519 public key that names the document. Its
+  secret, `NamespaceSecret`, is the **write capability for the whole document**.
+- **`AuthorId`** — a `[u8; 32]` public-key newtype naming a writer; its secret `Author` is an
+  authorship proof. Any number of authors may write the same key.
+- **`Entry`** — the unit of state: `Entry { id: RecordIdentifier, record: Record }`, where
+  `RecordIdentifier` is the triple `(NamespaceId, AuthorId, key-bytes)` and `Record { len, hash,
+timestamp }` is a metadata _pointer_ (the content bytes live in [blobs][blobs], fetched by
+  `hash`). A `SignedEntry` carries **two** Ed25519 signatures over one canonical payload — one by the
+  author, one by the namespace ([`sync.rs`][docs-sync-rs], [`keys.rs`][docs-keys]).
+
+Conflicts resolve last-writer-wins (timestamp, then content `hash`); a **deletion is an empty
+entry** (`Hash::EMPTY`, `len == 0`), itself a signed, replicated fact. Peers converge by
+range-based set reconciliation — recursively fingerprinting ranges of the ordered key space and
+descending only where fingerprints disagree.
+
+### HyParView and Plumtree
+
+The two classic algorithms [gossip][gossip] composes, each a faithful implementation of a Leitão et
+al. paper:
+
+- **HyParView** — the **membership** protocol ([DSN 2007][hyparview]). Each node keeps a small
+  `active_view` (size 5) of peers it holds live bidirectional connections to, plus a larger
+  `passive_view` (size 30) address book it draws from to heal the active view after a failure.
+  Random walks (`ForwardJoin`, `Shuffle`) diffuse membership across the swarm.
+- **Plumtree** — the **broadcast** protocol ([SRDS 2007][plumtree]). Each active neighbor is either
+  _eager_ (receives full payloads) or _lazy_ (receives only a `blake3` message-id announcement,
+  `IHave`). The eager set forms a low-redundancy spanning tree that carries each payload once per
+  edge; the lazy set is a backstop that repairs gaps and continually re-optimizes the tree toward
+  lowest latency by promoting a lazy peer to eager whenever it supplies a missing message.
+
+Both run as one pure, IO-less state machine per topic ([`proto.rs`][g-proto]), driven over per-peer
+[`noq`][quic] QUIC connections by the `net/` actor — the sans-io shape a D port drives directly on
+[event-horizon][eh-spec] fibers.
+
+---
+
+## Terms at a glance
+
+| Term                                 | One line                                                                  | Page                        |
+| ------------------------------------ | ------------------------------------------------------------------------- | --------------------------- |
+| `EndpointId` / `PublicKey`           | 32-byte Ed25519 key; the self-certifying endpoint name = verification key | [identity-crypto][identity] |
+| `SecretKey`                          | 32-byte Ed25519 seed; signs TLS, relay, pkarr, docs                       | [identity-crypto][identity] |
+| `EndpointAddr`                       | `id` + `BTreeSet<TransportAddr>` location hints                           | [wire][wire]                |
+| `TransportAddr`                      | one hint: `Relay` \| `Ip` \| `Custom`                                     | [wire][wire]                |
+| `RelayUrl`                           | URL of a relay server                                                     | [relay][relay]              |
+| `EndpointIdMappedAddr`               | synthetic ULA so QUIC can dial a non-IP peer                              | [socket][socket]            |
+| `postcard`                           | the one non-self-describing binary wire codec                             | [wire][wire]                |
+| `ALPN`                               | per-protocol negotiation byte string; router dispatch key                 | [endpoint][endpoint]        |
+| `Ticket`                             | base32 shareable string; `endpoint` / `blob` / `doc`                      | [wire][wire]                |
+| `Socket`                             | multipath fabric under QUIC (ex-`magicsock`)                              | [socket][socket]            |
+| `Endpoint`                           | public front door; one per app                                            | [endpoint][endpoint]        |
+| `Connection`                         | one QUIC connection to one peer, multi-path                               | [endpoint][endpoint]        |
+| `Runtime` / `AsyncUdpSocket`         | the sans-io host seam a D port replaces                                   | [quic][quic]                |
+| path / multipath                     | a QUIC-Multipath path; relay & direct are concurrent paths                | [quic][quic]                |
+| QUIC Address Discovery               | STUN replacement; `OBSERVED_ADDRESS` frame                                | [nat-traversal][nat]        |
+| NAT traversal (QNT)                  | in-QUIC simultaneous-open hole-punch                                      | [nat-traversal][nat]        |
+| `address_lookup`                     | `EndpointId` → addresses directory                                        | [discovery][discovery]      |
+| pkarr                                | self-authenticating signed-DNS-packet record format                       | [discovery][discovery]      |
+| relay / home relay                   | encrypted-datagram forwarder / lowest-latency relay                       | [relay][relay]              |
+| `net_report`                         | connectivity-sensing report (ex-`netcheck`)                               | [net-report][net-report]    |
+| `Hash` / BLAKE3                      | 32-byte content address                                                   | [blobs][blobs]              |
+| bao / `outboard`                     | verified-streaming tree / stored interior hashes                          | [bao-tree][bao]             |
+| `ChunkRanges`                        | RLE sorted set of chunk ranges to fetch/verify                            | [blobs][blobs]              |
+| `HashSeq` / `Collection`             | concatenated-hashes blob / named-directory convention                     | [blobs][blobs]              |
+| `NamespaceId` / `AuthorId` / `Entry` | doc identity + signed `(ns, author, key)` fact                            | [docs-sync][docs-sync]      |
+| HyParView / Plumtree                 | membership / eager-lazy broadcast                                         | [gossip][gossip]            |
+
+---
+
+## Sources
+
+- [`iroh-base/src/key.rs`][key] — `PublicKey` / `EndpointId` / `SecretKey` / `Signature`
+- [`iroh-base/src/endpoint_addr.rs`][endpoint-addr] — `EndpointAddr`, `TransportAddr`
+- [`iroh/src/socket/mapped_addrs.rs`][mapped] — `EndpointIdMappedAddr` and the ULA scheme
+- [`iroh/src/socket.rs`][socket-doc] · [`iroh/src/endpoint.rs`][ep-single] — the `Socket`/`Endpoint` layering
+- [`noq/src/runtime/mod.rs`][noq-runtime] — the `Runtime` / `AsyncUdpSocket` seam
+- [`noq-proto/src/transport_parameters.rs`][noq-tp] — QAD / MP / QNT transport parameters
+- [`iroh-tickets/src/endpoint.rs`][tickets-endpoint] · [`iroh-blobs/src/ticket.rs`][blobs-ticket] · [`iroh-docs/src/ticket.rs`][docs-ticket] — the three tickets
+- [`iroh-blobs/src/protocol.rs`][blobs-protocol] · [`hash.rs`][blobs-hash] · [`hashseq.rs`][hashseq] · [`format/collection.rs`][collection] — `Hash`, `ChunkRangesSeq`, `HashSeq`, `Collection`
+- [`bao-tree/src/tree.rs`][bt-tree] — `BlockSize`, chunk groups, outboard math
+- [`iroh-docs/src/sync.rs`][docs-sync-rs] · [`keys.rs`][docs-keys] — `NamespaceId` / `AuthorId` / `Entry`
+- [`iroh-gossip/src/proto.rs`][g-proto] — the sans-io HyParView + Plumtree state machine
+- [`iroh/src/address_lookup.rs`][al-trait] · [`iroh-dns/src/pkarr.rs`][dns-pkarr] — `address_lookup`, pkarr
+- [`iroh-relay/src/lib.rs`][relay-lib] · [`iroh/src/net_report/report.rs`][nr-report] — relay, `net_report`
+- Deep-dives: [Identity & Cryptography][identity] · [Wire Formats & Serialization][wire] · [QUIC Transport][quic] · [Endpoint & Protocol Router][endpoint] · [The Multipath Socket][socket] · [NAT Traversal & Address Discovery][nat] · [The Relay Protocol][relay] · [Address Lookup][discovery] · [Net Report][net-report] · [Blobs][blobs] · [`bao-tree`][bao] · [Document Sync][docs-sync] · [Gossip][gossip] · [Tokio Concurrency Inventory][concurrency] · [D Architecture Migration][d-migration]
+- Cross-tree: [event-horizon SPEC][eh-spec] · [async-io survey][async-io]
+- External: [RFC 7301 (ALPN)][rfc7301] · [RFC 7250 (raw public keys)][rfc7250] · [RFC 9000 (QUIC)][rfc9000] · [BEP-44][bep44] · [`postcard`][serde-postcard] · [BLAKE3 spec][blake3-spec] · [HyParView paper][hyparview] · [Plumtree paper][plumtree] · [Range-Based Set Reconciliation][meyer] · [draft-seemann-quic-address-discovery][draft-qad] · [draft-seemann-quic-nat-traversal][draft-qnt]
+
+<!-- References -->
+
+[index]: ./index.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[quic]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[net-report]: ./net-report.md
+[blobs]: ./blobs.md
+[bao]: ./bao-tree.md
+[docs-sync]: ./docs-sync.md
+[gossip]: ./gossip.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[async-io]: ../async-io/index.md
+[key]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-base/src/key.rs
+[endpoint-addr]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-base/src/endpoint_addr.rs
+[mapped]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/mapped_addrs.rs
+[socket-doc]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs
+[ep-single]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L861
+[al-trait]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup.rs
+[dns-pkarr]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns/src/pkarr.rs
+[nr-doc]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs
+[nr-report]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/report.rs
+[relay-lib]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/lib.rs
+[noq-runtime]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq/src/runtime/mod.rs
+[noq-tp]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/transport_parameters.rs
+[noq-readme]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/README.md
+[tickets-lib]: https://github.com/n0-computer/iroh-tickets/blob/v1.0.0/src/lib.rs
+[tickets-endpoint]: https://github.com/n0-computer/iroh-tickets/blob/v1.0.0/src/endpoint.rs
+[blobs-ticket]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/ticket.rs
+[blobs-protocol]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs
+[blobs-hash]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/hash.rs
+[hashseq]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/hashseq.rs
+[collection]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/format/collection.rs
+[design-integrity]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md
+[bt-tree]: https://github.com/n0-computer/bao-tree/blob/v0.16.0/src/tree.rs
+[docs-sync-rs]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/sync.rs
+[docs-keys]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/keys.rs
+[docs-ticket]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/ticket.rs
+[g-proto]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/proto.rs
+[serde]: https://docs.rs/serde/latest/serde/
+[serde-postcard]: https://docs.rs/postcard/latest/postcard/
+[rfc7301]: https://datatracker.ietf.org/doc/html/rfc7301
+[rfc7250]: https://www.rfc-editor.org/rfc/rfc7250
+[rfc9000]: https://datatracker.ietf.org/doc/html/rfc9000
+[bep44]: https://www.bittorrent.org/beps/bep_0044.html
+[blake3-spec]: https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf
+[hyparview]: https://asc.di.fct.unl.pt/~jleitao/pdf/dsn07-leitao.pdf
+[plumtree]: https://asc.di.fct.unl.pt/~jleitao/pdf/srds07-leitao.pdf
+[meyer]: https://arxiv.org/abs/2212.13567
+[draft-qad]: https://datatracker.ietf.org/doc/draft-seemann-quic-address-discovery/
+[draft-qnt]: https://www.ietf.org/archive/id/draft-seemann-quic-nat-traversal-02.html

--- a/docs/research/iroh/concurrency.md
+++ b/docs/research/iroh/concurrency.md
@@ -1,0 +1,524 @@
+# Tokio Concurrency Inventory
+
+The complete map of the iroh stack's runtime concurrency — every long-lived task, channel, lock, `tokio::select!` loop, `spawn_blocking`, and timer — classified into what the **protocol demands** versus what is an **artifact of `Send + Sync` multithreading**, and translated construct-by-construct onto the single-threaded [`sparkles:event-horizon`][eh-spec] runtime.
+
+**Last reviewed:** July 6, 2026
+
+| Field                 | Value                                                                                                                                                                                                                                                                 |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crates surveyed       | `n0-future` 0.3.2, `n0-watcher` 1.0.0, `iroh` 1.0.1, `iroh-blobs` 0.103.0, `iroh-docs` 0.101.0, `iroh-gossip` 0.101.0, `iroh-util` 0.6.0, `irpc` 0.17.0, `iroh-metrics` 1.0.1                                                                                         |
+| Version pin           | iroh workspace **v1.0.1** (git `22cac742ca`)                                                                                                                                                                                                                          |
+| Repository            | [`n0-computer`][org] (GitHub org)                                                                                                                                                                                                                                     |
+| Documentation         | [docs.rs/n0-future][n0-future] · [docs.rs/n0-watcher][n0-watcher] · [docs.rs/irpc][irpc-docs]                                                                                                                                                                         |
+| ALPN(s)               | None — this subsystem is process-internal plumbing; the wire-bearing ALPNs belong to their own pages ([blobs][blobs], [gossip][gossip], [relay][relay])                                                                                                               |
+| Approx. size (LoC)    | Shim layer `n0-future` ~1490, `n0-watcher` ~1475, `iroh-util` `connection_pool` 866, `irpc` `lib.rs` 2663; plus the actor loops embedded across the five subsystem crates                                                                                             |
+| Runtime model         | `tokio` multi-threaded work-stealing, **plus two extra runtimes**: `iroh-blobs` builds its own multi-thread pool; `iroh-docs` builds a current-thread runtime on a bare `std::thread`                                                                                 |
+| Target runtime        | [`sparkles:event-horizon`][eh-spec] — single loop, completion-first (`io_uring`/kqueue/IOCP), fibers + algebraic effects, `single` topology default                                                                                                                   |
+| Category              | D migration                                                                                                                                                                                                                                                           |
+| Upstream spec / draft | None — these are `tokio`/`tokio-util` runtime primitives, not a protocol. The _absence_ of a spec is the finding: the concurrency architecture is convention, and a clean-room port is free to re-derive it from the protocol constraints (see [Analysis](#analysis)) |
+
+---
+
+## Overview
+
+### What it solves
+
+Every other page in this survey describes one subsystem's bytes and state machines. This page describes the **glue that runs them**: the tree of `tokio` tasks, the bounded channels between them, the locks that guard shared state, the `select!` loops that multiplex events, and the blocking work that escapes to dedicated threads. It is the direct input to [D Architecture Migration][d-arch] — before a single line of the port is written, the migration needs an exhaustive, cited census of what concurrency exists, why each piece exists, and which pieces evaporate when the whole thing moves from a `Send + Sync` work-stealing runtime to a single-threaded completion loop.
+
+The census answers three questions per construct:
+
+1. **Is it inherent to the protocol?** A relay reconnect backoff, a "cancel the losing probes once we have enough" race, or an idle-timeout on a per-remote actor must exist in _any_ implementation, single-threaded or not.
+2. **Is it a `Send + Sync` artifact?** An `Arc<Mutex<…>>`, an `AtomicU64`, a `papaya` lock-free map, or the intricate protocol that restarts a dying actor with its unprocessed inbox re-injected — these exist _only_ because tasks migrate across threads and shared state races. Under [event-horizon][eh-spec]'s default `single` topology they collapse to plain fields owned by one fiber.
+3. **Is it genuinely hard single-threaded?** CPU-bound BLAKE3 hashing on the loop thread and an embedded blocking database are neither pure protocol nor free to delete; they need explicit design.
+
+The catalog compares directly against the three async-I/O deep-dives it draws on: [Tokio][tokio-async] (the work-stealing model iroh is built on), and [Glommio][glommio] / [Monoio][monoio] (the thread-per-core, share-nothing stance event-horizon adopts instead).
+
+### Design philosophy
+
+The iroh stack is a **tree of single-consumer actors** connected by bounded `tokio::sync::mpsc` channels, with `oneshot` channels for request/reply, [`n0-watcher`][n0-watcher] "watchables" for last-value-wins state observation, and `CancellationToken` trees for shutdown. Almost every long-lived task is a `loop { tokio::select! { … } }` over an inbox, some event streams, some timers, a cancellation token, and a `JoinSet` of children it reaps. There is essentially **no shared-mutable-state concurrency on hot paths**: the locks that exist guard cold config or tiny bimaps, and the one lock-free structure (a `papaya`-backed `ConcurrentReadMap`) exists so the datagram path can find a per-remote actor's inbox sender without a round-trip through the socket actor.
+
+Two shim crates encode the philosophy. `n0-future` is a _re-export layer_ that abstracts task-spawn and time so the same code compiles for native `tokio` and for `wasm32-unknown-unknown` — its crate root is candid about why it exists:
+
+> _"Read up more on our challenges with rust's async: `https://www.iroh.computer/blog/async-rust-challenges-in-iroh`"_
+>
+> — [`n0-future/src/lib.rs:3`][n0-future]
+
+`n0-watcher` is the state-observation half, and its own doc comment states the last-value-wins design contract that the port must preserve because it is _public API_ (`iroh::Watcher` re-exports it):
+
+> _"A `Watchable` exists to keep track of a value which may change over time. It allows observers to be notified of changes to the value. The aim is to always be aware of the **last** value, not to observe *every* value change."_
+>
+> — [`n0-watcher/src/lib.rs:3-5`][n0-watcher]
+
+The architecture is not without self-criticism. The socket layer's core `Socket` handle carries a comment that reads as a design confession, and it is a useful warning for the port about where the module boundaries should be tightened:
+
+> _"Shared state between an awful lot of iroh subsystems. In particular both the `EndpointInner` as well as this actor itself have a copy. But also other subsystems that consequently have access to way to much state."_
+>
+> — [`iroh/src/socket.rs:1456-1459`][socket]
+
+---
+
+## The concurrency substrate: `n0-future` and `n0-watcher`
+
+Everything in the inventory is spelled in the vocabulary of these two crates, so they are the first thing to port.
+
+### `n0-future` — the task/time abstraction
+
+On native targets `n0-future::task` is _literally_ a re-export of `tokio`; there is no novel scheduling logic:
+
+```rust
+// n0-future/src/task.rs:4-9 — the entire native "abstraction"
+#[cfg(not(wasm_browser))]
+pub use tokio::spawn;
+#[cfg(not(wasm_browser))]
+pub use tokio::task::{AbortHandle, Id, JoinError, JoinHandle, JoinSet};
+#[cfg(not(wasm_browser))]
+pub use tokio_util::task::AbortOnDropHandle;
+```
+
+`n0-future::time` similarly re-exports `tokio::time::{sleep, timeout, interval, Instant, …}`. On `wasm_browser` both are reimplemented over `wasm_bindgen_futures::spawn_local` and `setTimeout`. The crate adds exactly **one** novel type, `MaybeFuture` — an optional future that polls `Pending` when `None` and resets itself to `None` after completing, whose documented purpose is to conditionally enable a `select!` arm:
+
+```rust
+// n0-future/src/maybe_future.rs:86-94
+#[derive(Default, Debug)]
+#[pin_project(project = MaybeFutureProj, project_replace = MaybeFutureProjReplace)]
+pub enum MaybeFuture<T> {
+    /// The state in which it wraps a future to be polled.
+    Some(#[pin] T),
+    /// The state in which there's no future set, and polling will always return [`Poll::Pending`]
+    #[default]
+    None,
+}
+```
+
+> _"One major use case for this is ergonomically disabling branches in a `tokio::select!`."_ — [`n0-future/src/maybe_future.rs:24`][n0-future]
+
+`MaybeFuture` appears throughout the socket actor and per-remote actor as an armable timer (a holepunch retry, a path-open deadline, a network-change backoff). Its behaviour is fully captured by "arm the in-ring `TIMEOUT` op only when the state says so" under event-horizon — there is no future to disable when the corresponding forwarder fiber simply is not running.
+
+### `n0-watcher` — `Watchable` / `Watcher`
+
+`Watchable<T>` holds `Arc<Shared<T>>` where `Shared` couples an `RwLock` over `{value, epoch}` with a waker `VecDeque` behind a `Mutex`:
+
+```rust
+// n0-watcher/src/lib.rs:96-99, 763-774
+pub struct Watchable<T> { shared: Arc<Shared<T>> }
+struct Shared<T> {
+    state: RwLock<State<T>>,      // { value: T, epoch: u64 }
+    wakers: Mutex<VecDeque<Waker>>,
+}
+```
+
+`set` compares the new value with `Eq`, bumps `epoch`, and wakes queued wakers **only when the value actually changed** ([`lib.rs:147-172`][n0-watcher]); `poll_updated` is the classic check-epoch → register-waker → re-check-epoch double-check against lost wakeups; dropping the last `Watchable` wakes all watchers so they observe `Disconnected` (modelled by `Weak` upgrade failure). The observer side is a poll-based trait with combinators:
+
+```rust
+// n0-watcher/src/lib.rs:230-284 (trimmed) — the Watcher trait
+pub trait Watcher: Clone {
+    type Value: Clone + Eq;
+    fn get(&mut self) -> Self::Value { self.update(); self.peek().clone() }
+    fn update(&mut self) -> bool;
+    fn peek(&self) -> &Self::Value;
+    fn is_connected(&self) -> bool;
+    fn poll_updated(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Disconnected>>;
+    fn updated(&mut self) -> NextFut<'_, Self> { … }
+    fn initialized<T, W>(&mut self) -> InitializedFut<'_, T, W, Self> where … { … }
+    fn stream(self) -> Stream<Self> where Self: Unpin { … }
+    fn map<T: Clone + Eq>(self, map: impl Fn(Self::Value) -> T + Send + Sync + 'static) -> Map<Self, T> { … }
+    fn or<W: Watcher>(self, other: W) -> Tuple<Self, W> { … }
+}
+```
+
+The `map` combinator additionally dedups the _mapped_ value, so a chain of watchers never spins. This is not an internal detail to paper over — the public `Endpoint::watch_addr` API is composed as `watch_addrs.or(watch_relay).map(…)` ([`endpoint.rs:1270-1284`][endpoint-src]), and `home_relay_status` / `net_report` are watchers too. Any D port exposes the same surface, so the semantics (last-value-wins, notify-on-change-only, `map`/`or`/`Join` combinators, `Disconnected` on drop) must be reproduced faithfully; see the [paired sketch](#mapping-to-event-horizon) below.
+
+---
+
+## Per-crate concurrency inventory
+
+The tables below are the census. Cites are `file:line` against the pinned revisions; capacities are **protocol policy** a port must carry over verbatim.
+
+### Long-lived tasks and actors
+
+| Actor / task                            | Spawn site                                                                             | Inbox(es) (cap)                                              | State owned                                                            | Shutdown mechanism                                                               |
+| --------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| socket `Actor` (1/endpoint)             | [`socket.rs:1098`][socket]                                                             | `ActorMessage` mpsc(256); `direct_addr_done` mpsc(8)         | `RemoteMap`, netmon watcher, re-stun interval, `DirectAddrUpdateState` | child of `at_endpoint_closed` token + `AbortOnDropHandle`; 100 ms grace          |
+| `RemoteStateActor` (1/remote)           | [`remote_state.rs:223`][remote-state] → `JoinSet` [`remote_map.rs:145`][remote-map]    | `RemoteStateMessage` mpsc(16)                                | per-remote paths, holepunch state, per-conn event streams (merged)     | shutdown token, inbox close, or **60 s idle**; leftover-message restart protocol |
+| `RelayActor` (1)                        | [`relay.rs:57`][relay-transport]                                                       | `RelayActorMessage` mpsc(256); `RelaySendItem` mpsc(256)     | `BTreeMap<RelayUrl, ActiveRelayHandle>`, `JoinSet<()>`                 | cancel token; 3 s bounded `close_all_active_relays`                              |
+| `ActiveRelayActor` (1/relay URL)        | [`actor.rs:1268`][relay-actor] → `JoinSet`                                             | prio mpsc(32), inbox mpsc(64), send mpsc(64)                 | relay TCP/WS client, ping tracker, 60 s inactivity sleep               | stop token (child); self-exit on inactivity unless home relay                    |
+| `reportgen::Actor` (1/report)           | [`reportgen.rs:141`][reportgen]                                                        | none (fans out); results mpsc(32)                            | probe `JoinSet` + captive-portal token                                 | `AbortOnDropHandle` drop = abort; 5 s overall timeout                            |
+| net-report run task (1/update)          | [`socket.rs:816`][socket]                                                              | —                                                            | owned mutex guard on `net_report::Client`                              | `token.run_until_cancelled` + 10 s `NET_REPORT_TIMEOUT`                          |
+| `Router` accept loop                    | [`protocol.rs:614`][protocol]                                                          | —                                                            | `JoinSet` of per-connection handler tasks                              | own `CancellationToken` + drop guard; ordered shutdown                           |
+| noq driver tasks (endpoint/conn)        | [`runtime.rs:90`][runtime]                                                             | —                                                            | quinn/noq internals                                                    | `TaskTracker` + shared cancel token                                              |
+| `PkarrPublisher` service                | `pkarr.rs:324`                                                                         | `n0-watcher` `updated()`                                     | republish sleep (5 min default)                                        | watcher disconnect                                                               |
+| relay server `relay_supervisor`         | [`server.rs:959`][relay-server]                                                        | `JoinSet` of services                                        | http/quic server handles                                               | first exit stops all                                                             |
+| relay server per-client `Actor`         | [`client.rs:146`][relay-server-client]                                                 | packets mpsc(512), messages mpsc(512)                        | client stream, ping tracker                                            | `done` token + `AbortOnDropHandle`                                               |
+| blobs FS store main actor               | [`fs.rs:1424`][blobs-fs] (own runtime)                                                 | cmds mpsc(100), fs-cmds mpsc(100)                            | `JoinSet`, `EntityManagerState` (pool 1024, inbox 32), temp tags       | inbox close; joins all tasks                                                     |
+| blobs `meta::Actor` (redb)              | [`fs.rs:667`][blobs-fs]                                                                | db cmds mpsc(100)                                            | redb `Database`, delete set                                            | inbox close / `Shutdown` cmd                                                     |
+| blobs entity actor (1/active hash)      | [`entity_manager.rs:612`][blobs-entity]                                                | per-entity mpsc(32)                                          | per-hash `FuturesUnordered` tasks                                      | recycled to pool on idle; `ShutdownAll`                                          |
+| blobs `DownloaderActor`                 | [`downloader.rs:400`][downloader]                                                      | `SwarmMsg` mpsc(32)                                          | `ConnectionPool`, `JoinSet`, idle waiters                              | inbox close (drains in-flight — downloads are _not_ aborted on drop)             |
+| blobs gc task                           | [`fs.rs:1427`][blobs-fs] / [`mem.rs:143`][blobs-mem]                                   | —                                                            | `sleep(interval)` loop                                                 | runtime/task drop                                                                |
+| blobs provider per-stream               | [`provider.rs:308`][blobs-provider]                                                    | —                                                            | one request/response stream                                            | connection close                                                                 |
+| pool `Actor` (iroh-util)                | [`connection_pool.rs:430`][conn-pool]                                                  | `ActorMessage` mpsc(100)                                     | `HashMap<EndpointId, mpsc::Sender>`, idle LRU, `FuturesUnordered`      | **immortal** — owner-sender cycle, no shutdown message                           |
+| pool connection actor (1/remote)        | [`connection_pool.rs:176`][conn-pool]                                                  | `RequestRef` mpsc(100)                                       | one QUIC `Connection`, `ConnectionCounter`, idle timer                 | main actor drops sender (idle timeout / conn close / eviction)                   |
+| docs `SyncHandle` actor                 | [`actor.rs:289`][docs-actor] (**bare `std::thread`** + current-thread rt + `LocalSet`) | `Action` `async_channel`(1024)                               | redb store, open replicas, reply-streamer `JoinSet`                    | `Shutdown` action / channel close; thread joined on last handle drop             |
+| docs `LiveActor`                        | [`engine.rs:126`][docs-engine]                                                         | `ToLiveActor` mpsc(64); replica events `async_channel`(1024) | 3 `JoinSet`s (connect/accept syncs, downloads), gossip state           | `Shutdown` msg, ordered                                                          |
+| gossip net `Actor` (1)                  | [`net.rs:206`][gossip-net]                                                             | local mpsc(16), rpc mpsc(64), in-events mpsc(1024)           | sans-IO `proto::State`, `TimerMap`, `Dialer` `JoinSet`, conn `JoinSet` | `Shutdown` msg or all handles dropped                                            |
+| gossip connection task (1/peer)         | [`net.rs:545`][gossip-net]                                                             | send queue mpsc(64)                                          | read: `FuturesUnordered` of stream reads; write: finish `JoinSet`      | connection close                                                                 |
+| gossip topic subscriber forwarder       | [`net.rs:933`][gossip-net]                                                             | `broadcast::Receiver`(256)                                   | —                                                                      | broadcast closed / receiver gone                                                 |
+| irpc `rpc::listen` accept loop          | [`irpc/lib.rs:2485`][irpc-lib]                                                         | —                                                            | `JoinSet` per accepted connection                                      | connection `ApplicationClosed(0)`                                                |
+| metrics `MetricsServer`/`Dumper`/`Push` | [`iroh-metrics/service.rs`][iroh-metrics]                                              | —                                                            | HTTP scrape / CSV / push-gateway loop                                  | `CancellationToken` + `AbortOnDropHandle`                                        |
+
+### Channels, by kind
+
+| Kind                        | Representative sites                                                                                                                        | Purpose                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `tokio::sync::mpsc` bounded | every actor inbox above; blobs request/progress streams; provider events channel                                                            | actor inboxes; capacity = backpressure or drop policy   |
+| `tokio::sync::oneshot`      | ~40 call sites: [`socket.rs:1325`][socket], [`remote_map.rs:266`][remote-map], blobs [`meta.rs`][blobs-meta], docs [`actor.rs`][docs-actor] | request/reply into actors                               |
+| `tokio::sync::watch`        | portmapper external-address ([`socket.rs:1509`][socket]); relay rate-limit live update; blobs per-blob storage state                        | last-value config/state propagation                     |
+| `tokio::sync::broadcast`    | per-connection path events, cap 8 (`path_watcher.rs:50`); gossip topic events, cap 256 ([`net.rs:824`][gossip-net])                         | multi-subscriber fan-out with `Lagged` on overflow      |
+| `tokio::sync::Notify`       | path-state change (`path_watcher.rs:134`); relay `clearable_timeout`; connection-pool `ConnectionCounter`                                   | edge-triggered wakeup without payload                   |
+| `async_channel` (MPMC)      | docs action inbox ([`actor.rs:274`][docs-actor]); replica event subscribers; replica events to `LiveActor` (cap 1024)                       | crosses the `std::thread` boundary; cloneable receivers |
+| `n0-watcher` `Watchable`    | net-report `(Option<Report>, UpdateReason)`; `DiscoveredDirectAddrs.addrs`; `HomeRelayWatch`; the public `Endpoint::watch_addr` API         | last-value-wins observation, including public API       |
+| `irpc` typed channel        | `Client<S>` local path = plain `tokio` mpsc/oneshot; remote path = `noq` bidi stream framed `varint-len ++ postcard`                        | the [RPC seam][irpc-docs] behind blobs/docs/gossip APIs |
+
+### Locks, and what they guard
+
+| Lock                                                                                        | Guards                                                 | Contention profile                               |
+| ------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------ |
+| `Mutex<Option<AbortOnDropHandle<()>>>` ([`socket.rs:209`][socket])                          | task handle for shutdown                               | once, at close                                   |
+| `Arc<AsyncMutex<net_report::Client>>` ([`socket.rs:712`][socket])                           | one-report-at-a-time gate (`try_lock_owned` as a flag) | never contended — used as a boolean              |
+| `AddrMap: Arc<std::sync::Mutex<AddrMapInner>>` ([`mapped_addrs.rs:330`][mapped-addrs])      | EndpointId/relay ↔ mapped-IPv6 bimaps                  | short critical sections on send/recv translation |
+| `ConcurrentReadMap` (papaya, lock-free, [`concurrent_read_map.rs:19`][concurrent-read-map]) | per-remote actor senders; single writer via `&mut`     | **hot read** on datagram dispatch                |
+| `path_watcher Mutex<State> + Notify`                                                        | per-conn path list + selected path                     | writer = `RemoteStateActor`, readers = API       |
+| address-lookup `Arc<RwLock<Vec<Box<dyn AddressLookup>>>>`                                   | service registry / cached data                         | cold                                             |
+| relay server `DashMap` ×2 ([`clients.rs`][relay-server])                                    | client registry + sent-to sets                         | per-packet lookup, sharded                       |
+| blobs `Arc<Mutex<DeleteSet>>`, `TempTagScope(Mutex<…>)`                                     | gc protection, temp tags                               | short                                            |
+| docs `ProviderNodes(Arc<std::sync::Mutex<HashMap>>)` ([`live.rs:899`][docs-live])           | live-sync provider map                                 | cold (only insert; never pruned)                 |
+| gossip `NodeMap = Arc<RwLock<BTreeMap>>`                                                    | gossip-learned addresses                               | cold + evict interval                            |
+| `n0-watcher` `RwLock<State> + Mutex<VecDeque<Waker>>`                                       | every watchable read/set                               | every `get`/`set`/poll                           |
+| metrics `Counter`/`Gauge` = `portable_atomic`, `Family = Arc<RwLock<…>>`                    | metric cells / label-set map                           | lock-free inc from any thread                    |
+
+### `select!` loops (arm count → purpose)
+
+| Site                                                        | Arms                                                                                                                                                                                                   | Notes                              |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| socket actor [`socket.rs:1519`][socket]                     | 10: shutdown / inbox / re-stun tick / local-addr watch / net-report watch / direct-addr-done / portmap watch / netmon watch / remote-map cleanup / `MaybeFuture` backoff                               | the endpoint's "main thread"       |
+| [`remote_state.rs:272`][remote-state]                       | 11, `biased`: shutdown / inbox / path events / NAT-addr events / conn-close futures / direct-addr watch / scheduled path open / scheduled holepunch / addr-lookup stream / upgrade tick / idle timeout | per-remote brain                   |
+| relay `actor.rs:1023` (`RelayActor`)                        | 5, `biased`: cancel / `JoinSet` reap / inbox / send channel (gated on in-flight send) / pending send future                                                                                            | backpressure by arm-gating         |
+| relay [`actor.rs:416/543/747`][relay-actor]                 | 6–8 each, `biased`: dialing / connected / sending FSM                                                                                                                                                  | three-phase connection FSM         |
+| net-report [`net_report.rs:560`][net-report-src]            | 3, `biased`: shutdown / v4 `JoinSet` / v6 `JoinSet`                                                                                                                                                    | QAD probe collection, early-cancel |
+| [`protocol.rs:528`][protocol]                               | 3, `biased`: cancel / `JoinSet` reap (break on panic) / accept                                                                                                                                         | `Router`                           |
+| relay server [`client.rs:348`][relay-server-client]         | 6, `biased`: done / client frame / packet queue / message queue / pong timeout / keepalive tick                                                                                                        | per-client io actor                |
+| blobs [`fs.rs:604`][blobs-fs]                               | 4: entity-manager tick / cmds / fs-cmds / `JoinSet` reap + idle-waiter flush                                                                                                                           | store main loop                    |
+| blobs [`downloader.rs:94/213`][downloader]                  | 2 + 3: inbox / `join_next`; progress / part results / `tx.closed()`                                                                                                                                    | swarm download + split driver      |
+| pool connection actor [`connection_pool.rs:226`][conn-pool] | 4, `biased`: inbox / `conn.closed()` / idle-stream / idle timer                                                                                                                                        | per-connection lifecycle           |
+| docs [`live.rs:245`][docs-live]                             | 6, `biased`: inbox / replica events / connect-sync / accept-sync / download `JoinSet` / gossip progress                                                                                                | sync coordinator                   |
+| gossip [`net.rs:383`][gossip-net]                           | 9, `biased`: local inbox / rpc inbox / command streams / addr updates / dialer / in-events / timers / conn `JoinSet` / forwarder `JoinSet`                                                             | the gossip event loop              |
+
+### `spawn_blocking`, dedicated threads, and dedicated runtimes
+
+| Site                              | What blocks                                                                                                                                                      | Why                                                             |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| relay server `main.rs:627`        | TLS key/cert load + parse at startup                                                                                                                             | **the only `spawn_blocking` in all five trees**                 |
+| blobs [`fs.rs:1400`][blobs-fs]    | dedicated multi-thread runtime `iroh-blob-store-N`                                                                                                               | blocking `std::fs` + redb + BLAKE3 hashing run **inline** on it |
+| docs [`actor.rs:289`][docs-actor] | dedicated `std::thread` "sync-actor" (current-thread rt + `LocalSet`)                                                                                            | blocking redb; async facade via `async_channel`                 |
+| CPU crypto                        | BLAKE3/bao `init_outboard` hashes 16 KiB groups inline between awaits ([`util.rs:308-330`][blobs-util]); explicit `yield_now().await` in 64 KiB–1 MiB copy loops | cooperative chunking instead of thread offload                  |
+| qlog sink                         | synchronous buffered file `write` under `Arc<Mutex<QlogStreamer>>` inside the noq connection's packet path ([`noq-proto/…/qlog.rs`][noq-qlog])                   | tracing writes on the datapath (feature-gated ZST when off)     |
+
+> [!IMPORTANT]
+> There is **zero `spawn_blocking` in `iroh-blobs`**. The 0.x folklore "iroh-blobs offloads file I/O with `spawn_blocking`" is false in v0.103.0: blocking `std::fs`, redb transactions, and BLAKE3 hashing all run _inline_ on a dedicated multi-thread runtime whose threads nothing else touches. This is the single most important fact for the port's throughput story — see [Mapping to event-horizon](#mapping-to-event-horizon).
+
+### Timers and intervals (steady state)
+
+| Timer                                                                          | Value                                     | Site                                  |
+| ------------------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------- |
+| re-stun (net-report refresh) interval                                          | random 20–26 s                            | [`socket.rs:2004`][socket]            |
+| `FULL_REPORT_INTERVAL`                                                         | 5 min                                     | [`net_report.rs:132`][net-report-src] |
+| `NET_REPORT_TIMEOUT` / `OVERALL_REPORT_TIMEOUT`                                | 10 s / 5 s                                | `defaults.rs`                         |
+| relay `PING_INTERVAL` / `RELAY_INACTIVE_CLEANUP_TIME` / `CONNECT_TIMEOUT`      | 15 s / 60 s / 10 s                        | [`actor.rs`][relay-actor]             |
+| holepunch retry / connection upgrade / actor idle                              | 5 s / 60 s / 60 s                         | [`remote_state.rs`][remote-state]     |
+| `HEARTBEAT_INTERVAL` / `PATH_MAX_IDLE_TIMEOUT` / `RELAY_PATH_MAX_IDLE_TIMEOUT` | 5 s / 15 s / 30 s                         | [`socket.rs:109`][socket]             |
+| pool `idle_timeout` / `connect_timeout`                                        | 5 s / **1 s** (incl. `on_connected` hook) | [`connection_pool.rs`][conn-pool]     |
+| pkarr republish                                                                | 5 min                                     | `pkarr.rs:146`                        |
+| docs `MAX_COMMIT_DELAY`                                                        | 500 ms                                    | [`actor.rs:36`][docs-actor]           |
+| gossip `TimerMap`                                                              | protocol-driven, earliest-sleep           | [`net/util.rs:400`][gossip-util]      |
+
+---
+
+## Pattern taxonomy: protocol-inherent vs `Send + Sync` artifact
+
+The whole point of the census is this split.
+
+**Inherent to the protocol** (must exist in any implementation):
+
+- Every timer in the table above; the [`ActiveRelayActor`][relay] connection FSM with exponential backoff (10 ms → 16 s, jittered, reset after an established Pong); the drop policies on relay datagram queues (the relay is best-effort by design); the "enough reports → cancel the rest" probe race in [net-report][net-report]; per-peer/per-connection concurrent I/O (multiple relays, multiple streams, dial-while-receiving); the idle-out of per-remote actors (a memory bound); watcher _semantics_ (last-value-wins, notify-on-change), which are public API; and ordered graceful shutdown.
+
+**Artifacts of `Send + Sync` multithreading** (vanish or simplify under `single` topology):
+
+- Every `Arc<Mutex/RwLock>`, `DashMap`, and `papaya` map becomes a plain field owned by the loop fiber. `AddrMap`, `ConcurrentReadMap`, and the relay `Clients` registry become ordinary hash maps.
+- Every `oneshot` request/reply becomes a direct call into the owning fiber's state, or a `fork`/`join`.
+- `Watchable`'s waker queue + epoch double-check (a lost-wakeup race) reduces to `struct { value; epoch; waiterList }` with no races possible.
+- The `AsyncMutex` used as a "report running" flag becomes a plain `bool`.
+- `AtomicBool`/`AtomicU64` (`ipv6_reported`, shutdown `closed`, task counters) become plain fields.
+- The **`RemoteStateActor` leftover-message restart protocol** ([`remote_map.rs:230-311`][remote-map]) — a genuinely intricate dance where a dying actor returns its unprocessed inbox and the map either removes its sender or restarts it with the messages re-injected — exists _only_ because the sender map's readers race with actor death across tasks. With one loop, "actor death" and "map cleanup" are atomic; the whole mechanism deletes.
+- The pool's **immortal main actor** ([`connection_pool.rs:315-319`][conn-pool]), which can never observe all-senders-dropped because its shared `Context` holds a clone of its own inbox sender — a design forced by detached spawning — is fixed for free by structural ownership: a `Scope`-owned struct's teardown is scope exit.
+- The dedicated runtime/thread for blobs and docs storage exists because blocking file/DB I/O must not stall the network runtime. Under event-horizon, _file_ I/O is native `io_uring` and needs no offload; what remains is the harder residue below.
+- The `TaskTracker` + `CancellationToken` wrapper that iroh retrofits around every noq/quinn driver task ([`runtime.rs`][runtime]) — a structured-concurrency retrofit over an unstructured spawner — becomes native: the D QUIC drivers are fibers in the endpoint's `Scope`, and scope exit _is_ the tracker. The entire `runtime.rs` file evaporates.
+
+**Genuinely hard single-threaded** (neither pure protocol nor free to delete):
+
+1. **CPU-bound BLAKE3/bao hashing during [verified streaming][bao-tree] and import.** Rust runs it inline on a _dedicated multi-thread runtime_ so the endpoint never stalls. A single event loop stalls **all** networking for the duration of a hash burst. The Rust code shows the mitigation shape — hash one 16 KiB chunk group per step with an await between groups, plus explicit `yield_now` in copy loops — but that only cooperates _within_ one runtime; it does not free the loop thread the way a second thread does.
+2. **Embedded blocking database** (redb, under blobs `meta` and docs storage): there is no `io_uring` story for an mmap-backed embedded KV store; it needs a worker thread with completion injection, or a redesign to an async-friendly store.
+
+Both are treated in [Mapping to event-horizon](#mapping-to-event-horizon) and are load-bearing inputs to the [D architecture migration][d-arch].
+
+---
+
+## Analysis
+
+### The tokio → event-horizon translation table
+
+Each pattern maps to a specific [event-horizon][eh-spec] construct or is flagged as a gap requiring new design. Section references are to [SPEC.md][eh-spec].
+
+| tokio / iroh pattern                               | event-horizon construct                                                                                                                                                     | Notes / gaps                                                                                                                       |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `tokio::spawn` + `JoinHandle`                      | `Scope.spawn` / `Scope.fork` → `JoinHandle.join` (§8.1)                                                                                                                     | outcome is `Outcome!(T, E)`; a `panic`/`Throwable` maps to `Cause.die`                                                             |
+| `AbortOnDropHandle`                                | child fiber in a scope; scope exit cancels (`spawnDaemon` + `sc.cancel`)                                                                                                    | drop-based abort becomes _structural_ — the owner scope's exit                                                                     |
+| `JoinSet<T>` + `join_next`                         | **no direct primitive** — build a `TaskSet` over the O20 channel: each child pushes `(id, Outcome)` on completion; `joinNext` = channel recv                                | `race` is wrong (it cancels losers). Needed by `RemoteMap`, `RelayActor`, `Router`, gossip, blobs, docs                            |
+| `CancellationToken` tree, `run_until_cancelled`    | `CancelContext` tree + `Scope.cancel(Interrupt)`; checkpoints deliver it (§8.2, §8.4)                                                                                       | the two-token `ShutdownState` (`at_close_start`, `at_endpoint_closed`) maps to two nested scopes                                   |
+| `token.drop_guard()`                               | `onExit` hook cancelling a child scope (LIFO, §8.1)                                                                                                                         | —                                                                                                                                  |
+| `tokio::select!` over event sources                | **not `race`** — one owner fiber blocking on a single **inbox channel** (O20), with one daemon fiber per event source forwarding into it                                    | tokio `select!` polls `&mut` futures _without cancelling them_; `race` cancels losers. This is the single most load-bearing gap    |
+| `mpsc::channel(n)` bounded                         | **GAP — [open-issue O20][eh-spec]** (no cross-fiber channel in v1)                                                                                                          | needs: bounded ring, sender-park-on-full, `trySend` for drop sites, `recvMany` batch drain, close semantics. Capacities are policy |
+| `oneshot`                                          | `fork` + `JoinHandle.join`; or a one-slot rendezvous (`isWaker` handle) inside the message                                                                                  | single-threaded — no atomics needed                                                                                                |
+| `tokio::sync::watch` / `n0-watcher` `Watchable`    | **no direct equivalent** — port `n0-watcher`'s semantics (they are public API): `struct Watchable(T) { T value; ulong epoch; WaiterList waiters; }`                         | `map`/`or`/`Join` are direct transliterations; `Disconnected` tied to scope/refcount lifetime                                      |
+| `broadcast::channel(n)` + `Lagged`                 | per-topic ring buffer + per-subscriber cursor; a subscriber > `n` behind gets `Lagged{missed}` and snaps to head                                                            | small library type over the watcher/waiter list                                                                                    |
+| `Notify`                                           | `isWaker` one-shot park/wake (§10.3)                                                                                                                                        | direct fit                                                                                                                         |
+| `time::interval` + `MissedTickBehavior`            | `repeat` driver with a `spaced` schedule (§10.4)                                                                                                                            | intervals that `reset()` on traffic (relay ping) need a re-armable timer: `cancel(h)` + `submitAfter`                              |
+| resettable `Sleep` (`inactive_timeout.reset`)      | keep an `OpHandle` to an in-ring `TIMEOUT`; reset = `cancel` + `submitAfter` (§5.3)                                                                                         | 5+ sites — worth a small `ResettableTimer` utility                                                                                 |
+| `MaybeFuture` in `select!`                         | conditionally-armed `TIMEOUT` op — arm only when state says so                                                                                                              | trivial once `select!` is an inbox: the forwarder fiber just is not running                                                        |
+| `timeout(d, fut)`                                  | `withDeadline` / `timeout` driver (§8.3, §10.4)                                                                                                                             | interrupt kind `deadline`                                                                                                          |
+| backon `ExponentialBuilder{10ms→16s, jitter}`      | `Schedule`: `exponential(10.msecs) & upTo(16.seconds)` + `jittered`, via `retry` (§10.4)                                                                                    | `retry` consumes only the `fail` channel — matches "reset backoff after established" needing a manual policy reset, as Rust does   |
+| `spawn_blocking` (1 site: TLS load)                | do it synchronously during startup, before the loop is hot                                                                                                                  | zero-cost                                                                                                                          |
+| blobs dedicated runtime / docs `std::thread`       | either strict cooperative chunking on the single loop (yield every N chunk groups — _measure_), or a second worker via `Topology.threadPerCore` + `postTo`/`MSG_RING` (§11) | **decision point** — `io_uring` removes the file-I/O half of the reason; the CPU-hash and embedded-DB halves remain                |
+| `TaskTracker` (quinn runtime wrapper)              | native QUIC drivers are fibers in the endpoint's scope; scope exit joins them (§8.1)                                                                                        | the entire `runtime.rs` evaporates                                                                                                 |
+| `papaya`/`DashMap` concurrent maps                 | plain `HashMap`-equivalents owned by the loop fiber                                                                                                                         | under `single`, cross-"task" reads are same-thread                                                                                 |
+| `PollSender` / manual `poll_recv` glue into quinn  | disappears — the D QUIC stack speaks tier-B verbs / tier-A callbacks directly                                                                                               | the poll-based seam is a Rust-ecosystem artifact                                                                                   |
+| `async_channel` MPMC across the storage thread     | if storage stays on-loop: plain O20 channel; if a second loop: `MSG_RING`-backed cross-ring channel                                                                         | only needed for the worker-offload design                                                                                          |
+| `irpc` local channel + `noq`-stream remote channel | direct capability calls in-process; framed tier-B fiber loops on the wire ([wire-serialization][wire])                                                                      | keep the request-enum _design_, drop the proc-macro; local path can monomorphize away entirely                                     |
+
+### Mapping to event-horizon
+
+Four themes dominate the port, in decreasing order of difficulty.
+
+**1. The missing cross-fiber channel (open-issue O20) is the load-bearing gap.** Event-horizon v1 has structured concurrency (`Scope`, `fork`, `JoinHandle`, `race`), cancellation (`CancelContext`, `withDeadline`), and one-shot park/wake (`isWaker`), but [no cross-fiber channel primitive][eh-spec] — the spec names it as a recognised gap. **Every actor in the inventory is an inbox loop**, so the port cannot proceed without a channel design. The needed shape is fully specified by the census: a bounded ring of `T` with sender-park-on-full for backpressure sites, `trySend` returning `Full` vs `Closed` for the _drop_ sites (relay datagram queues, the `try_send` network-change fan-out), a `recvMany` batch drain for the relay's 20-datagram `recv_many` batching, and close semantics (recv returns none when all senders drop). Because callers and the owning fiber share one thread under `single`, request/reply `oneshot` traffic can bypass the channel entirely — a direct method call plus a parked-fiber rendezvous is equivalent — but the _stream_ fan-ins (split-download progress, gossip topic events) genuinely need the queue.
+
+Critically, a tokio `select!` loop does **not** translate to `race`: `select!` polls its arms _without cancelling them_ across loop iterations, whereas event-horizon's `race` cancels the losers (§10.4). The faithful translation of every actor is one long-lived owner fiber blocking on a single inbox channel, fed by one daemon forwarder fiber per event source (a `sleep` fiber for a timer, a watcher fiber for a `Watchable`, a `TaskSet` for child completions). An `if guard` arm becomes "do not run that forwarder"; a `MaybeFuture` arm becomes "only arm that `TIMEOUT` when the state says so". Side by side:
+
+```rust
+// Rust — the socket actor's select! loop (trimmed), iroh/src/socket.rs:1519
+loop {
+    tokio::select! {
+        _ = shutdown_token.cancelled() => break,
+        Some(msg) = inbox.recv() => self.handle_message(msg),
+        _ = re_stun_timer.tick() => self.trigger_net_report(),
+        Ok(()) = local_addrs_watcher.updated() => self.on_local_addrs_change(),
+        // … 6 more arms: net-report watch, direct-addr-done, portmap, netmon,
+        //   remote-map cleanup, MaybeFuture backoff
+    }
+}
+```
+
+```d
+// PROPOSED / SKETCH — one owner fiber + forwarder daemons + one inbox (O20).
+// The `select!` collapses into a single blocking recv; every other source is a
+// daemon fiber that forwards a tagged message into the same inbox.
+void runSocketActor(ref RootScope sc, ref Env env, Chan!ActorEvent inbox)
+{
+    // Forwarders: each parks on ITS source and posts into the shared inbox.
+    sc.spawnDaemon({ repeat(sc, env.clock, spaced(restunInterval()),
+                            { inbox.send(ActorEvent.reStunTick); return ioOk(); }); });
+    sc.spawnDaemon({ foreach (v; localAddrsWatcher.updates)          // watcher fiber
+                         inbox.send(ActorEvent.localAddrs(v)); });
+    // … one daemon per net-report watch / portmap / netmon / remote-map cleanup
+
+    // The owner: no locks, no Arc — `RemoteMap` etc. are plain owned fields.
+    for (;;)
+    {
+        auto ev = inbox.recv();                 // parks; the ONLY multiplex point
+        if (ev.hasError) break;                 // all senders dropped ⇒ shutdown
+        final switch (ev.value.kind) with (ActorEvent.Kind)
+        {
+            case message:    handleMessage(ev.value.msg);       break;
+            case reStunTick: triggerNetReport();                break;
+            case localAddrs: onLocalAddrsChange(ev.value.addrs); break;
+            // …
+        }
+    }
+    // scope exit joins/cancels every forwarder daemon — no CancellationToken tree
+}
+```
+
+**2. `Watchable` is public API and must be ported faithfully — but drops all its synchronisation.** The single-threaded rewrite has no `Arc`, no `RwLock`, no waker `Mutex`; the lost-wakeup double-check is impossible because there is no concurrent poll:
+
+```rust
+// Rust — n0-watcher/src/lib.rs:96-99, 763-774 (the synchronised original)
+pub struct Watchable<T> { shared: Arc<Shared<T>> }
+struct Shared<T> {
+    state: RwLock<State<T>>,       // { value: T, epoch: u64 }
+    wakers: Mutex<VecDeque<Waker>>,
+}
+```
+
+```d
+// PROPOSED / SKETCH — single-thread Watchable; T must be equality-comparable.
+struct Watchable(T)
+if (__traits(compiles, (T a, T b) => a == b))
+{
+    private T value;
+    private ulong epoch;
+    private WaiterList waiters;              // intrusive list of isWaker handles
+
+    /// Dedup on equality (n0-watcher semantics): wake watchers only on change.
+    void set(T next)
+    {
+        if (next == value) return;
+        value = next;
+        epoch++;
+        waiters.wakeAll();                   // resume every parked watcher fiber
+    }
+
+    ref const(T) peek() const return => value;
+}
+
+/// Watcher.updated: park until the epoch advances past what we last saw.
+IoResult!T updated(Watcher)(ref Watcher w)      // proposed
+{
+    while (w.seenEpoch == w.src.epoch)
+        w.src.waiters.park(currentTask);         // no lost-wakeup race single-threaded
+    w.seenEpoch = w.src.epoch;
+    return ioOk(w.src.peek);
+}
+```
+
+The `map`/`or`/`Join` combinators are straight transliterations — they poll children and combine, adding no machinery — and `map`'s output-dedup must be kept or downstream watchers spin. `broadcast` + `Lagged` is the same waiter list plus a per-subscriber cursor. This machinery underpins the whole public watcher surface consumed by [socket][socket], [discovery][discovery], and [endpoint][endpoint].
+
+**3. `spawn_blocking` has no thread pool — and mostly does not need one.** Event-horizon exposes no blocking-work executor. Three of the census's five offload sites dissolve: the lone `spawn_blocking` (relay TLS load) runs synchronously at startup before the loop is hot; file I/O is native `io_uring`, so the _file-I/O_ justification for the blobs and docs dedicated runtimes disappears. What genuinely remains is CPU hashing and the embedded DB:
+
+- **BLAKE3/bao on the loop thread.** This is the one place where single-threading has a real throughput cost. A `read_at`/import of a large blob hashes megabytes; on one loop that stalls all networking for the burst. Two viable designs, both flagged for [bao-tree][bao-tree] and [blobs][blobs]: **(a)** enforce a `yieldNow` checkpoint every _N_ chunk groups (budgeted — a 1 MiB group is tens of microseconds of BLAKE3), accepting that hashing throughput and network latency are coupled; or **(b)** run the store on a second worker via `Topology.threadPerCore` and `LoopGroup.postTo`, harvesting results with `MSG_RING` completions (§11) — mirroring Rust's dedicated-runtime architecture exactly. The census shows Rust chose (b) for exactly this reason; the port's choice is a measured trade-off, not an obvious one.
+- **The redb-style embedded DB** under blobs `meta` and docs storage has no `io_uring` path (it is mmap + blocking syscalls). It needs a worker thread with completion injection, or a redesign to an on-loop async store. This is the residual reason the docs storage actor is a bare `std::thread` rather than a task.
+
+**4. Everything else is a simplification.** The `JoinSet`-reaping loops become a `TaskSet` built on the O20 channel (a spawn-wrapper fiber sends `(id, Outcome)` on completion; `joinNext` is a channel recv). The `CancellationToken` trees map onto `CancelContext` + `Scope.cancel`, with the two-token `ShutdownState` becoming two nested scopes. The [`irpc`][irpc-docs] seam keeps its essential design — one serializable request enum, a per-variant `(Tx, Rx)` channel mapping, a message type = request ⊗ live channels — but drops the proc-macro for D compile-time introspection (`static foreach` over `__traits(allMembers)`), and the _local_ path monomorphizes to direct capability calls, achieving the "zero overhead in-process" goal irpc only approximates. The gossip protocol core is already sans-IO (`InEvent`/`OutEvent`, a `BTreeMap` `TimerMap`, zero `tokio`), so the D port of the gossip logic is a state-machine _transliteration_, not an async rewrite — and the same sans-IO discipline in [noq-proto][quic] means the deterministic `Pair` conformance rig maps directly onto event-horizon's `TestClock` + `TestSched.advanceAndSettle`, giving the port test determinism that _exceeds_ upstream's (whose iroh-level tests fall back to `sleep(100–200ms)` settling waits).
+
+**One hazard survives the translation.** The docs `LiveActor` carries the warning that its self-send channel deadlocks if used from the actor's own methods:
+
+> _"Send messages to self. Note: Must not be used in methods called from `Self::run` directly to prevent deadlocks. Only clone into newly spawned tasks."_ — [`iroh-docs/src/engine/live.rs:157-159`][docs-live]
+
+The D equivalent — a fiber sending into its own full inbox — deadlocks identically. Inbox self-sends must be `trySend` or deferred; the single-threaded model removes the _lock_ hazards but not this _logical_ one. Likewise the bounded-channel _arm-gating_ trick (the `RelayActor` stops reading its input while its output is full, to preserve ordering and drop behaviour) must be reproduced deliberately: "park on send" gives the backpressure, but the gating that stops consuming upstream is a policy the port must re-implement.
+
+---
+
+## Strengths
+
+Assessed as a _porting target_ — how amenable the concurrency architecture is to a clean-room single-threaded reimplementation:
+
+- **Actor-per-subsystem with explicit inboxes** is the friendliest possible shape for a fiber port: each actor becomes one owner fiber, and its bounded inbox capacity is a documented policy constant to carry over verbatim.
+- **Minimal shared-mutable-state on hot paths.** The locks are almost all cold config or tiny bimaps; the one hot structure (`ConcurrentReadMap`) exists solely for cross-task datagram dispatch and simply becomes a field. Most of the census's synchronisation is _deletable_, not _translatable_.
+- **`n0-future` is a thin shim, not a runtime.** The native path is a re-export of `tokio`; the only novel type (`MaybeFuture`) has a trivial single-threaded equivalent. There is no bespoke scheduler to reverse-engineer.
+- **Sans-IO cores where it matters most.** [gossip][gossip]'s `proto/` and [noq-proto][quic]'s connection state machine are pure `InEvent`/`OutEvent` machines with zero `tokio`; they transliterate rather than rewrite, and they bring a ready-made deterministic test rig.
+- **Cancellation is already structured in intent.** `CancellationToken` trees, `AbortOnDropHandle`, `run_until_cancelled`, ordered graceful shutdown — the _design_ is structured concurrency retrofitted onto an unstructured spawner. Event-horizon's `Scope` provides natively what iroh assembles by hand, so the port is often _simpler_ than the original.
+
+## Weaknesses
+
+- **The channel gap (O20) blocks nearly everything.** Every actor is an inbox loop, so the port cannot start subsystem work before landing a cross-fiber channel design — the largest single prerequisite.
+- **CPU-bound BLAKE3/bao is a genuine single-thread hazard.** Rust hides it behind a dedicated multi-thread runtime; the port must choose between cooperative chunking (coupling hash throughput to network latency) and a second worker loop (reintroducing cross-loop plumbing). Neither is free.
+- **Embedded blocking databases have no completion-model home.** redb is mmap + blocking syscalls; there is no `io_uring` translation, only a worker thread or a store redesign.
+- **Some patterns look mappable but are not.** `tokio::select!` is _not_ `race`; a naive translation that cancels losers is a correctness bug. The distinction must be understood per loop.
+- **Backpressure semantics are subtle and load-bearing.** The relay's arm-gating, the many `try_send`-and-drop sites, and the docs self-send deadlock are policy that the "park on send" default does not reproduce automatically.
+- **Two extra runtimes encode assumptions.** blobs' multi-thread pool and docs' `std::thread` bake in "storage must never stall the network runtime" — an assumption a single-loop port must re-satisfy explicitly rather than inherit.
+
+## Key design decisions and trade-offs
+
+| Decision                                                                | Rationale                                                                                                                 | Trade-off                                                                                                                                                 |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tree of single-consumer actors over bounded `mpsc` (iroh)               | Isolates state per subsystem; backpressure and drop policy are explicit per channel                                       | Every subsystem needs a cross-fiber channel to port ([O20][eh-spec]) — the whole port waits on one primitive                                              |
+| Model actor `select!` as one owner fiber + forwarder daemons (port)     | Faithful to tokio's poll-without-cancel semantics; `race` would wrongly cancel losers                                     | One extra daemon fiber per event source; ordering across sources must be re-established via inbox tagging                                                 |
+| Delete all `Arc<Mutex>`/atomics/`papaya` under `single` topology (port) | Single-thread ownership removes every data race; no locks needed                                                          | Requires auditing each lock's _reason_ — a few (self-send deadlock, arm-gating) are logical, not just sync                                                |
+| Port `Watchable` semantics but drop its synchronisation (port)          | Last-value-wins observation is public API; the epoch double-check is a lost-wakeup guard that cannot fire single-threaded | Must preserve `Eq`-dedup on `set` and `map` or watchers spin; combinators are hand-transliterated                                                         |
+| Run BLAKE3/bao on the loop thread with cooperative yields (option A)    | No second thread, no cross-loop plumbing; matches event-horizon's `single` default                                        | Hash bursts couple to network latency; a large import visibly stalls I/O unless the yield budget is tuned                                                 |
+| Or run the store on a second worker loop with `MSG_RING` (option B)     | Mirrors Rust's dedicated runtime; keeps the network loop responsive during hashing                                        | Reintroduces cross-ring channels, `postTo`, and share-nothing message passing — the complexity `single` avoids                                            |
+| Keep the `irpc` request-enum design, drop the proc-macro (port)         | The seam (request ⊗ live channels, local/remote sum) is sound; D introspection generates it                               | The local path can monomorphize to direct calls — better than irpc's channel-send approximation — but the remote framed-stream loop must be built by hand |
+| No `spawn_blocking` executor in the target runtime                      | Startup blocking is done synchronously; file I/O is native `io_uring`                                                     | The embedded DB has no home — needs a worker thread with completion injection or a store redesign                                                         |
+| Structural scope teardown replaces `TaskTracker`/`AbortOnDropHandle`    | Scope exit joins/cancels children natively; the pool's immortal-actor bug is fixed for free                               | Requires re-expressing every detached spawn as a scoped child — a discipline, not a drop-in                                                               |
+
+---
+
+## Sources
+
+Primary sources (pinned revisions):
+
+- [`n0-future`][n0-future] 0.3.2 — `task.rs` (native = `tokio` re-export), `time.rs`, `maybe_future.rs`.
+- [`n0-watcher`][n0-watcher] 1.0.0 — `Watchable`/`Watcher`, epoch/waker machinery, combinators.
+- [`iroh`][socket] 1.0.1 — `socket.rs`, `socket/remote_map*.rs`, `socket/transports/relay*.rs`, `net_report*.rs`, `protocol.rs`, `runtime.rs`, `endpoint.rs`; [`iroh-relay`][relay-server] server actors.
+- [`iroh-blobs`][blobs-fs] 0.103.0 — FS/mem stores, `meta`/`entity_manager`, `api/downloader.rs`, `provider.rs`, `util.rs`.
+- [`iroh-docs`][docs-actor] 0.101.0 — `actor.rs` (bare-thread storage), `engine.rs`, `engine/live.rs`.
+- [`iroh-gossip`][gossip-net] 0.101.0 — `net.rs`, `net/util.rs` (sans-IO `proto::` core + `TimerMap`).
+- [`iroh-util`][conn-pool] 0.6.0 — `connection_pool.rs`, `access_limit.rs`.
+- [`irpc`][irpc-lib] 0.17.0 — typed-channel seam, `rpc::listen`, `NoqSender` framing.
+- [`iroh-metrics`][iroh-metrics] 1.0.1 and [`noq-proto`][noq-qlog] qlog — observability actors and the on-datapath qlog write.
+- Related surveys: [event-horizon SPEC][eh-spec]; async-I/O deep-dives [Tokio][tokio-async], [Glommio][glommio], [Monoio][monoio]; [algebraic effects][alg-effects].
+- Sibling iroh pages this census feeds: [survey umbrella][index], [concepts][concepts], [identity & cryptography][identity], [wire formats][wire], [QUIC transport][quic], [endpoint & router][endpoint], [socket][socket-page], [NAT traversal][nat], [relay][relay], [discovery][discovery], [net report][net-report], [blobs][blobs], [bao-tree][bao-tree], [docs sync][docs-sync], [gossip][gossip], and the capstone [D architecture migration][d-arch].
+
+<!-- References -->
+
+[org]: https://github.com/n0-computer
+[n0-future]: https://docs.rs/n0-future/0.3.2/n0_future/
+[n0-watcher]: https://docs.rs/n0-watcher/1.0.0/n0_watcher/
+[irpc-docs]: https://docs.rs/irpc/0.17.0/irpc/
+[iroh-metrics]: https://docs.rs/iroh-metrics/1.0.1/iroh_metrics/
+[socket]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs
+[remote-map]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map.rs
+[remote-state]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs
+[relay-transport]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports/relay.rs
+[relay-actor]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports/relay/actor.rs
+[concurrent-read-map]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/concurrent_read_map.rs
+[mapped-addrs]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/mapped_addrs.rs
+[net-report-src]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs
+[reportgen]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/reportgen.rs
+[protocol]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/protocol.rs
+[runtime]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/runtime.rs
+[endpoint-src]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs
+[relay-server]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/server.rs
+[relay-server-client]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/server/client.rs
+[blobs-fs]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs.rs
+[blobs-meta]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs/meta.rs
+[blobs-entity]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs/util/entity_manager.rs
+[blobs-mem]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/mem.rs
+[downloader]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/api/downloader.rs
+[blobs-provider]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/provider.rs
+[blobs-util]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/util.rs
+[docs-actor]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/actor.rs
+[docs-engine]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/engine.rs
+[docs-live]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/engine/live.rs
+[gossip-net]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/net.rs
+[gossip-util]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/net/util.rs
+[conn-pool]: https://github.com/n0-computer/iroh-util/blob/v0.6.0/src/connection_pool.rs
+[irpc-lib]: https://github.com/n0-computer/irpc/blob/v0.17.0/src/lib.rs
+[noq-qlog]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/qlog.rs
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[tokio-async]: ../async-io/tokio.md
+[glommio]: ../async-io/glommio.md
+[monoio]: ../async-io/monoio.md
+[alg-effects]: ../algebraic-effects/index.md
+[index]: ./index.md
+[concepts]: ./concepts.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[quic]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket-page]: ./socket.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[net-report]: ./net-report.md
+[blobs]: ./blobs.md
+[bao-tree]: ./bao-tree.md
+[docs-sync]: ./docs-sync.md
+[gossip]: ./gossip.md
+[d-arch]: ./d-architecture-migration.md

--- a/docs/research/iroh/d-architecture-migration.md
+++ b/docs/research/iroh/d-architecture-migration.md
@@ -1,0 +1,742 @@
+# D Architecture Migration
+
+The capstone of the iroh survey: the bridge from _how Rust iroh works_ to _how to
+build it in D on [`sparkles:event-horizon`][eh-spec]_. It distils the fifteen
+deep-dives into a per-subsystem port strategy, translates iroh's `tokio`
+work-stealing concurrency onto a single-threaded completion loop, names the runtime
+primitives event-horizon still owes the port, and lays out a layered build order —
+each milestone cross-linking the prior-art page it draws on.
+
+> [!NOTE]
+> This is the _synthesis_ leaf of the survey. It assumes the per-subsystem mechanics
+> ([the deep-dives](./index.md)) and the shared vocabulary ([concepts][concepts]) as
+> given, and cross-links rather than re-derives them. The exhaustive census of every
+> long-lived task, channel, lock, `select!` loop, and timer — with its
+> construct-by-construct `tokio`→event-horizon translation table — lives in
+> [Tokio Concurrency Inventory][concurrency]; this page builds the _plan_ on top of
+> that census. The event-horizon analogue of async-io's [comparison][async-comparison].
+
+**Last reviewed:** July 6, 2026
+
+---
+
+## Part 1 — The port at a glance
+
+A native D reimplementation of iroh 1.0 is, before anything else, a reimplementation
+of `noq` (n0's `quinn` fork) and a handful of protocol crates on top of it. The
+survey establishes the two facts that make the port tractable: the QUIC core, the
+gossip membership protocol, the docs range-reconciler, and the whole `bao-tree` codec
+are **sans-io** — pure `(now, event) → (effects, deadline)` state machines with no
+runtime baked in — and almost all of iroh's remaining concurrency is an _artifact_ of
+`tokio`'s `Send + Sync` work-stealing model that event-horizon's `single` topology
+refunds (see [Part 2](#part-2--the-concurrency-translation)).
+
+### 1.1 The dependency-impact table
+
+Each major Rust crate/subsystem, the D **strategy** that fits it, a rough **effort**
+(LoC where the deep-dive counted them; T-shirt size otherwise), and the
+event-horizon **primitives** it needs. Strategy legend: **native** = clean-room D
+reimplementation; **sans-io reuse** = keep the Rust _design_ (the value-type state
+machine) and re-house it on fibers, no line-for-line copy; **C-binding** = bind an
+existing C library via ImportC rather than reimplement; **from-scratch** = a new D
+component with no direct iroh analogue. The link cell points at the deep-dive.
+
+| Subsystem (Rust crate/module)                                       | Size (Rust)             | D strategy                                          | Key event-horizon primitives                                                                                                        | Deep-dive                                            |
+| ------------------------------------------------------------------- | ----------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| **Identity & crypto** (`iroh-base` `key.rs`, `iroh/src/tls`)        | ~1.2k + crypto          | native                                              | value structs; `Rng` capability; `SmallBuffer` codecs; `@safe pure nothrow @nogc`                                                   | [identity-crypto][identity]                          |
+| **Ed25519 / SHA-512 / BLAKE3** (dalek, `blake3`)                    | (library)               | native or C-binding                                 | `verify_strict` interop-exact; BLAKE3 `hazmat` (chunk-counter CVs, ROOT flag)                                                       | [identity-crypto][identity] · [bao-tree][bao-tree]   |
+| **Wire codec** (`postcard`, `iroh-tickets`, `iroh-base` addressing) | ~0.8k + codec           | native / from-scratch                               | CTFE `static foreach` over `tupleof`; LEB128 + QUIC-varint; `SmallBuffer`; `isOwnedIoBuf`                                           | [wire-serialization][wire]                           |
+| **QUIC core** (`noq-proto`)                                         | ~38.2k non-test         | sans-io reuse                                       | one fiber owning `Connection`; tier-B verbs; one in-ring `TIMEOUT`; `SumType` controllers; **O19** msghdr; `WallClock` + `Rng` caps | [quic-transport][quic]                               |
+| **TLS 1.3 + QUIC AEAD** (`rustls` + `ring`/`aws-lc-rs`)             | load-bearing            | C-binding **or** native (decision)                  | sans-io `Session` fed `CRYPTO` bytes; `PacketKey` with **`PathId`-aware** nonce                                                     | [identity-crypto][identity] · [quic-transport][quic] |
+| **`noq-udp`** (platform UDP: GSO/GRO/ECN/pktinfo)                   | ~10k with `noq`         | native (per-OS syscalls)                            | `sendTo`/`recvFrom` verbs; **O19** msghdr/cmsg; `BufRing`                                                                           | [quic-transport][quic]                               |
+| **Verified streaming** (`bao-tree`)                                 | ~5.6k                   | native (pure)                                       | `@safe pure nothrow @nogc` geometry; `SmallBuffer!(Hash,10)`; `isByteStream`; yield checkpoints                                     | [bao-tree][bao-tree]                                 |
+| **Endpoint & Router** (`iroh` `endpoint`/`protocol`/`runtime`)      | ~6.1k non-test          | native (policy shell)                               | `Scope`; capability row; DbI `Connection<State>`; `ProtocolMap` AA; `Watchable`; memoized completion cell                           | [endpoint][endpoint]                                 |
+| **Multipath socket** (`iroh` `socket`, ex-`magicsock`)              | ~8k non-test            | native                                              | per-transport recv fibers; multishot `BufRing`; plain `MappedAddrs`; `Watchable`; **O19**                                           | [socket][socket]                                     |
+| **NAT traversal / QAD / QNT** (`noq-proto`, `iroh` `remote_state`)  | ~2.6k                   | sans-io reuse + native                              | value `ClientState`/`ServerState`; in-ring `TIMEOUT`; `race`; `Chan!T`                                                              | [nat-traversal][nat]                                 |
+| **Relay** (`iroh-relay` + `iroh` relay transport)                   | ~12.3k + ~2.15k         | native (client first, server later)                 | WebSocket client; reconnect `Schedule`; TLS; `Chan!T` drop-queues                                                                   | [relay][relay]                                       |
+| **Discovery** (`iroh` `address_lookup`, `iroh-dns`, `-server`)      | ~5k client + ~4k server | native + C-binding (DNS)                            | HTTP client; DNS wire codec; ed25519 `SignedPacket`; monotonic-CAS publisher                                                        | [discovery][discovery]                               |
+| **Net report / netwatch / portmapper** (`net-tools`)                | ~10.5k                  | native + C-binding (iface enum)                     | per-OS interface watch; UPnP/PCP/NAT-PMP codecs; QAD probe; `Watchable`                                                             | [net-report][net-report]                             |
+| **Blobs** (`iroh-blobs`)                                            | ~14k                    | native                                              | tier-B fibers; `isByteStream`; per-hash handle map; io_uring file ops; `Chan!T`; hash offload (decision)                            | [blobs][blobs]                                       |
+| **Embedded KV store** (`redb`)                                      | (library)               | C-binding (LMDB) **or** from-scratch                | worker-thread-with-completion-injection **or** on-loop async store                                                                  | [blobs][blobs]                                       |
+| **Docs sync** (`iroh-docs`)                                         | ~9k non-test            | native + sans-io reuse (`ranger`)                   | pure range reconciler; `SyncStore` fiber; `isContentStatus` cap; `TestClock`                                                        | [docs-sync][docs-sync]                               |
+| **Gossip** (`iroh-gossip`)                                          | ~6.9k                   | sans-io reuse (`proto/` verbatim) + native (`net/`) | `GossipState` value type; `TimerMap`; broadcast + `Lagged`; `Scope`                                                                 | [gossip][gossip]                                     |
+| **RPC seam** (`irpc`)                                               | ~2.7k                   | keep design, drop macro                             | DbI request enum; local path monomorphizes to direct calls; framed tier-B fiber remote                                              | [concurrency][concurrency] · [blobs][blobs]          |
+| **Concurrency substrate** (`n0-future`, `n0-watcher`)               | ~3k shim                | native (mostly delete)                              | `Scope`/`fork`/`race`; port `Watchable` semantics faithfully (public API)                                                           | [concurrency][concurrency]                           |
+
+### 1.2 The four strategies, and the size budget
+
+The table clusters into four postures, in decreasing order of the ratio of _kept
+design_ to _rewritten code_:
+
+- **Sans-io reuse (the leverage).** `noq-proto`'s connection machine, `iroh-gossip`'s
+  `proto/` HyParView/Plumtree core, `iroh-docs`'s `ranger`, and `bao-tree`'s codec are
+  runtime-neutral by construction. The port keeps the algorithm and the value-type
+  shape verbatim and simply drives it from a fiber instead of a `tokio` task — the
+  `Arc<Mutex<State>>`, waker maps, `Notify`s, and self-wakes become _zero code_. The
+  `noq-proto` crate root is explicit that this is licensed:
+
+  > _"noq-proto contains a fully deterministic implementation of QUIC protocol logic.
+  > It contains no networking code and does not get any relevant timestamps from the
+  > operating system … or if you want to use a different event loop than the one tokio
+  > provides."_ — [`noq-proto/src/lib.rs:3-8`][noq-lib]
+
+- **Native reimplementation (the bulk).** The policy shells (endpoint/router, socket,
+  relay client, discovery, blobs, docs `net/`) are a few thousand lines each of D over
+  the sans-io cores. This is where iroh's identity model, its holepunching-tuned
+  defaults, its wire framing, and its lifecycle live — all portable, most of it
+  _simpler_ in D because event-horizon's `Scope` provides natively what iroh assembles
+  by hand.
+
+- **C-binding (the escape hatch).** Three subsystems can be bound rather than
+  rewritten: the **TLS 1.3 + QUIC-AEAD** engine (bind a C QUIC-crypto library exposing
+  the `PathId`-aware `PacketKey`, or reimplement a sans-io TLS 1.3), the **embedded KV
+  store** (LMDB via ImportC in place of `redb`), and **platform interface/route
+  enumeration** for net-report. Each is a decision the milestones flag, not a
+  foregone conclusion.
+
+- **From-scratch (the missing primitives).** A short list of runtime types
+  event-horizon v1 does not ship — a cross-fiber channel, a `Watchable`, a bounded
+  broadcast, a memoized completion cell — that _several_ subsystems need. These are
+  [Part 4](#part-4--the-primitives-event-horizon-still-owes-the-port) and the gate on
+  the whole port.
+
+The **size budget** is dominated by one rock. `noq-proto` alone is ~38k non-test
+lines with no external QUIC/CC/recovery library to lean on — BBRv3, Cubic, the pacer,
+DPLPMTUD, the reassembler, and the token machinery are all in-tree ([quic][quic]).
+Everything else combined — relay (~14k), net-tools (~10.5k), blobs (~14k), docs (~9k),
+gossip (~6.9k), bao-tree (~5.6k), discovery (~9k), socket (~8k), endpoint (~6.1k) — is
+the same order of magnitude _in aggregate_ as the single QUIC crate. The strategic
+consequence: **the QUIC core is the critical path**, and the milestones ([Part
+5](#part-5--the-layered-build-order)) are structured so that pure, testable value code
+(crypto, wire, bao-tree) and the missing runtime primitives land _before_ the QUIC
+core, so that when the big rock is being cut, its dependencies are already green.
+
+---
+
+## Part 2 — The concurrency translation
+
+iroh is a **tree of single-consumer actors** connected by bounded
+`tokio::sync::mpsc` channels, with `oneshot` for request/reply, [`n0-watcher`][concurrency]
+watchables for last-value-wins state, and `CancellationToken` trees for shutdown —
+almost every long-lived task a `loop { tokio::select! { … } }` over an inbox
+([concurrency][concurrency]). event-horizon inverts every one of those axes: one loop
+per thread, completion-first io_uring/kqueue/IOCP, fibers with structured concurrency,
+and — under the default `single` topology — **no cross-thread sharing at all**.
+
+### 2.1 `tokio` work-stealing → event-horizon single-thread thread-per-core
+
+| Axis          | iroh on `tokio`                                                   | port on event-horizon                                                                             |
+| ------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Scheduler     | multi-thread work-stealing; futures migrate across worker threads | one `Sched` per thread; a started fiber is **pinned for life** ([SPEC §11][eh-spec])              |
+| Shared state  | `Arc<Mutex/RwLock>`, `AtomicU64`, `papaya`/`DashMap` on hot paths | plain fields owned by the loop fiber; no atomics, no locks under `single`                         |
+| Task spawn    | `tokio::spawn` → `JoinHandle`; `AbortOnDropHandle`; `TaskTracker` | `Scope.spawn`/`fork` → `JoinHandle.join`; scope exit joins/cancels ([SPEC §8][eh-spec])           |
+| Multiplex     | `tokio::select!` (polls arms _without_ cancelling them)           | one owner fiber blocking on an **inbox channel**, fed by forwarder daemons                        |
+| Timers        | `tokio::time` `Sleep`/`interval`, one `AsyncTimer` per driver     | in-ring `TIMEOUT` ops; a single collapsed deadline per connection ([SPEC §5.3][eh-spec])          |
+| Blocking work | dedicated runtimes/threads; `spawn_blocking`                      | native io_uring file I/O; **no thread pool** (a hazard — [§2.3](#23-what-single-threading-costs)) |
+| I/O model     | readiness bridged to a sans-io core via wakers                    | completion-first: submit the op, resume the fiber on the terminal CQE                             |
+
+This is exactly the [Glommio][glommio]/[Monoio][monoio] thread-per-core, share-nothing
+stance, applied to a stack that was written for [Tokio][tokio]. The survey's central
+finding is that iroh's actor architecture is _friendly_ to this inversion, not hostile
+to it: each actor becomes one owner fiber, its documented bounded-inbox capacity
+becomes a policy constant to carry over verbatim, and its `CancellationToken` tree —
+"structured concurrency retrofitted onto an unstructured spawner" — is replaced by the
+`Scope` that event-horizon provides natively ([concurrency][concurrency]).
+
+### 2.2 What single-threading buys
+
+Under the `single` topology the entire "locks, and what they guard" and "channels, by
+kind" census ([concurrency][concurrency]) is mostly _deletable_, not merely
+_translatable_:
+
+- **No `Send + Sync` tax.** Per-shard state need not be `Send + Sync + 'static`; the
+  `Arc`/`Mutex`/`RwLock`/`AtomicU64` scaffolding evaporates. `AddrMap`,
+  `ConcurrentReadMap` (a `papaya` lock-free map that exists _only_ so the datagram path
+  can find a per-remote actor's inbox cross-thread), the relay `Clients` `DashMap`, and
+  the five `Arc`s in iroh's `TlsConfig` all become plain fields ([socket][socket],
+  [identity-crypto][identity]).
+- **No work-stealing overhead, no task migration.** A resumed fiber immediately submits
+  to its owner ring; op slots, buffers, and deadline timers are ring-local, so
+  cache-hot handoff replaces cross-core cache-coherency traffic ([SPEC §11][eh-spec]).
+- **`oneshot` request/reply becomes a direct call.** Because caller and owner share one
+  thread, `resolve_remote`/`register_connection`-style `mpsc(256) + oneshot`
+  round-trips collapse to a suspendable method call on the owning state object
+  ([endpoint][endpoint]).
+- **Whole mechanisms delete.** The `RemoteStateActor` _leftover-message restart
+  protocol_ — a dying actor returns its unprocessed inbox and the map either removes its
+  sender or restarts it with the messages re-injected — exists solely because the sender
+  map's readers race with actor death across tasks; single-threaded, "actor death" and
+  "map cleanup" are atomic and the whole dance vanishes. The connection pool's
+  **immortal main actor** (which can never observe all-senders-dropped because it holds
+  a clone of its own inbox sender) is fixed for free by structural scope ownership. The
+  `runtime.rs` `TaskTracker` wrapper around every noq driver task ([`iroh/src/runtime.rs:9`][iroh-runtime])
+  becomes native scope children — _"the entire `runtime.rs` file evaporates"_
+  ([concurrency][concurrency]).
+- **`Watchable`'s lost-wakeup guard cannot fire.** The epoch double-check against lost
+  wakeups is impossible with no concurrent poll, so `Watchable` reduces to
+  `struct { value; epoch; waiterList }` with no `RwLock` and no waker `Mutex`
+  ([concurrency][concurrency]).
+- **Determinism that _exceeds_ upstream.** The sans-io cores driven by `TestClock` +
+  `TestSched.advanceAndSettle` ([SPEC §10.3][eh-spec]) give run-to-quiescence tests
+  with virtual time, where iroh's own end-to-end tests fall back to `sleep(100–200ms)`
+  settling waits ([concurrency][concurrency]).
+
+### 2.3 What single-threading costs
+
+Three residues are neither pure protocol nor free to delete, and each needs explicit
+design.
+
+**(a) CPU-bound BLAKE3/bao on the loop thread — the one genuine throughput hazard.**
+[`bao-tree`][bao-tree] hashes every byte on the read path (≈`N/16384` group hashes plus
+≈`N/16384` parent merges for an `N`-byte blob) with _no yield points of its own_, and
+[`iroh-blobs`][blobs] re-hashes whole blobs on import (outboard computation) and on
+crash recovery (bitfield reconstruction). Rust hides this behind a **dedicated
+multi-thread runtime** — critically, `iroh-blobs` runs blocking `std::fs`, `redb`, and
+BLAKE3 all _inline_ on that runtime, with **zero `spawn_blocking`**
+([`store/fs.rs:1400`][blobs-fs]) — so the network runtime never stalls. A single loop
+has no such refuge: a multi-GiB verified decode monopolizes the loop and starves every
+connection, timer, and accept. Two mitigations, in increasing order of effort and both
+flagged for [bao-tree][bao-tree] and [blobs][blobs]:
+
+1. **Cooperative chunking.** Make the decoder's `next()` a `yieldNow`
+   cancellation/checkpoint every _N_ chunk groups (a 16 KiB group is tens of
+   microseconds of BLAKE3). This bounds latency and honours `withDeadline`/cancellation
+   without a second thread, at the cost of coupling hash throughput to network latency.
+   A SIMD BLAKE3 (AVX2/AVX-512/NEON) shrinks the per-group burst and widens the budget.
+2. **A bounded hashing worker.** Run the store on a second worker via
+   `Topology.threadPerCore` and `LoopGroup.postTo`, harvesting results with `MSG_RING`
+   completions ([SPEC §11][eh-spec]) — mirroring Rust's dedicated-runtime architecture
+   exactly. This keeps the network loop responsive during hashing at the price of
+   reintroducing cross-ring plumbing — the very complexity `single` avoids. The hashing
+   is pure (owned buffer in, hash out, no shared state), so it is cleanly isolable.
+
+The census shows Rust chose option 2 for exactly this reason; for the port it is a
+**measured trade-off**, not an obvious one, and the right first cut is option 1 with an
+instrumented yield budget.
+
+**(b) The missing cross-fiber channel (open-issue O20) — the load-bearing prerequisite.**
+event-horizon v1 has structured concurrency (`Scope`, `fork`, `JoinHandle`, `race`),
+cancellation (`CancelContext`, `withDeadline`), and one-shot park/wake (`isWaker`), but
+[no cross-fiber channel primitive][eh-spec]. **Every actor in the inventory is an inbox
+loop**, so the port cannot start subsystem work before landing a channel design. The
+needed shape is fully specified by the census — a bounded ring with sender-park-on-full
+for backpressure sites, `trySend` returning `Full` vs `Closed` for the _drop_ sites
+(relay datagram queues, the network-change fan-out), a `recvMany` batch drain for the
+relay's 20-datagram `recv_many`, and close semantics (recv returns none when all senders
+drop). The concrete D design is [§4.1](#41-the-cross-fiber-channel-chant--open-issue-o20).
+Request/reply `oneshot` traffic can bypass it entirely (a direct method call plus a
+parked-fiber rendezvous), but the _stream_ fan-ins — split-download progress, gossip
+topic events, docs replica events — genuinely need the queue.
+
+**(c) `spawn_blocking` with no thread pool.** event-horizon exposes no blocking-work
+executor, and three of the census's five offload sites dissolve: the lone
+`spawn_blocking` (relay TLS load) runs _synchronously at startup_ before the loop is
+hot; file I/O is native io_uring, so the file-I/O justification for the blobs and docs
+dedicated runtimes disappears. What genuinely remains is the **embedded blocking
+database**: `redb` is mmap + blocking syscalls with no io_uring path, so it needs a
+worker thread with completion injection or a redesign to an on-loop async store (or an
+LMDB C-binding with the same worker discipline). This is the residual reason the docs
+storage actor is a bare `std::thread` and the blobs store owns a whole runtime.
+
+### 2.4 The `select!` ≠ `race` trap
+
+The single most load-bearing translation error to avoid: a `tokio::select!` loop does
+**not** map to event-horizon's `race`. `select!` polls its arms _without cancelling
+them_ across loop iterations; `race` **cancels the losers** on the first terminal
+contender ([SPEC §10.4][eh-spec]). The faithful translation of every actor is one
+long-lived owner fiber blocking on a single inbox channel, fed by _one daemon forwarder
+fiber per event source_ — a `sleep` fiber for a timer, a watcher fiber for a
+`Watchable`, a `TaskSet` for child completions. A `biased` priority becomes inbox
+ordering; an `if`-guarded arm becomes "do not run that forwarder"; a `MaybeFuture` arm
+becomes "arm that `TIMEOUT` only when the state says so." A naive `race`-per-iteration
+translation that cancels and re-creates its arms every turn is both slower and a
+correctness bug (it drops the very completions `select!` would have kept alive). The
+paired transcription of the socket actor's 10-arm loop is worked in
+[concurrency § Mapping][concurrency]; the pattern recurs in [blobs][blobs]'s connection
+pool, [gossip][gossip]'s 9-arm event loop, and [docs-sync][docs-sync]'s `LiveActor`.
+
+---
+
+## Part 3 — The load-bearing seams
+
+Four seams carry the whole port. For each, the Rust shape (verbatim, cited) sits beside
+the proposed D equivalent — marked _proposed / sketch_, in Sparkles D idioms
+([`IoResult!`][eh-spec], `Buf`, `SmallBuffer`, capability structs, `Scope`).
+
+### 3.1 The `Runtime` / `AsyncUdpSocket` trait → an event-horizon capability row
+
+`noq` is application- and runtime-agnostic through four traits — `Runtime`,
+`AsyncUdpSocket`, `UdpSender`, `AsyncTimer` — and iroh's entire QUIC-stack coupling to
+its executor is the ~135-line adapter that implements them ([endpoint][endpoint]). This
+is the port's front door: the boxed, `Send + Sync`, `'static` trait object becomes a
+monomorphized capability row handed to the root fiber, with no vtable.
+
+```rust
+// noq/src/runtime/mod.rs:17-33 — authority as a boxed trait object shared across threads
+pub trait Runtime: Send + Sync + Debug + 'static {
+    fn new_timer(&self, i: Instant) -> Pin<Box<dyn AsyncTimer>>;
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>);
+    fn wrap_udp_socket(&self, t: std::net::UdpSocket) -> io::Result<Box<dyn AsyncUdpSocket>>;
+    fn now(&self) -> Instant { Instant::now() }
+}
+```
+
+```d
+// proposed / sketch — authority is a value row handed to the root fiber; dispatch
+// monomorphizes (no Send/Sync/'static, no vtable). `spawn` is not a field: driver
+// children are opened on the ambient Scope; `now` is the clock capability; the timer
+// is one in-ring TIMEOUT; wrap_udp_socket is DEAD CODE in iroh and is dropped entirely.
+struct QuicRuntime(Clock, Net)
+if (isClock!Clock && isNet!Net)
+{
+    Clock clock;        // clock.now() -> MonoTime; TestClock gives virtual-time determinism
+    Net   net;          // sendmsg / recvmsg — needs O19 msghdr for wire interop (below)
+    Scope* scope;       // structured-concurrency nursery; exit joins/cancels all drivers
+    EndpointId id;
+
+    void spawnDriver(scope void delegate() body) => scope.spawnDaemon(body);
+    Timer newTimer(MonoTime deadline)            => clock.timerAt(deadline);
+    MonoTime now()                                => clock.now();
+}
+```
+
+The `Runtime::now` clock is [`isClock`][eh-spec]; `new_timer`/`reset` collapse to a
+single in-ring `TIMEOUT` op keyed on the connection's one collapsed `poll_timeout()`
+deadline; `spawn` becomes `Scope.spawnDaemon`; and `wrap_udp_socket` is documented dead
+code in iroh (the endpoint uses `new_with_abstract_socket`) and is omitted. The
+`TaskTracker` + `CancellationToken` pair that iroh's `Runtime` carries _is_ a `Scope` —
+exit joins children, `abort` = cancel the subtree ([endpoint][endpoint]).
+
+### 3.2 A `noq` `Connection` → a fiber-owned D handle
+
+Below the seam, `noq-proto` exposes six purely synchronous pump methods
+(`handle_event`, `handle_timeout`, `poll_transmit`, `poll_timeout`, `poll`,
+`poll_endpoint_events`). `noq` welds them to `tokio` with two `Mutex<State>` cells, a
+spawned driver future per connection, and per-stream `FxHashMap<StreamId, Waker>` maps.
+Under `single` the driver becomes one fiber owning the `Connection` value outright, and
+every lock, waker map, `Notify`, and self-wake becomes zero code ([quic][quic]).
+
+```rust
+// noq/src/connection.rs:1403-1447 (trimmed) — connection state behind a lock,
+// pumped by a spawned Future; parked stream ops live in Waker maps.
+pub(crate) struct State {
+    pub(crate) inner: proto::Connection,          // the sans-io machine
+    driver: Option<Waker>,
+    timer: Option<Pin<Box<dyn AsyncTimer>>>,
+    blocked_writers: FxHashMap<StreamId, Waker>,
+    blocked_readers: FxHashMap<StreamId, Waker>,
+    sender: Pin<Box<dyn UdpSender>>,
+    buffered_transmit: Option<proto::Transmit>,   // stashed when the socket would block
+    // ... + oneshots, watches, broadcasts, Notifys
+}
+```
+
+```d
+// proposed / sketch — one fiber owns the Connection value; parked stream ops are fibers
+// in an intrusive wait-list; the six pump methods are plain calls. maxDatagrams:1 until
+// O19 lands (removes the GSO segment-size branch — noq supports this natively).
+Outcome!void driveConnection(ref QuicRuntime rt, ref Connection conn)
+{
+    for (;;)
+    {
+        while (auto ev = conn.nextInboundEvent())        // plain queue, same thread
+            conn.handleEvent(ev);
+
+        Buf dg = rt.pool.acquire();                       // pinned, io_uring-registered
+        while (auto t = conn.pollTransmit(rt.now(), maxDatagrams: 1, dg))
+            rt.net.sendTo(t.destination, move(dg));        // tier-B verb; parks THIS fiber
+
+        auto deadline = conn.pollTimeout();               // single collapsed Instant
+        auto ev = race(rt.net.recvReady(),                // whichever fires first
+                       rt.clock.sleepUntil(deadline));
+        if (ev.isTimeout) conn.handleTimeout(rt.now());
+    }
+}
+```
+
+The endpoint↔connection `mpsc`s that `noq` uses carry only _events_ (datagrams
+pre-decoded); on one thread `Endpoint::handle` delivers them by calling directly into
+the target connection's `VecDeque`, so no channel is needed _inside_ the proto layer.
+Drop-glue is protocol-visible and must be reproduced deliberately: `SendStream` drop ⇒
+finish-or-reset, `RecvStream` drop ⇒ `stop(0)`, last handle drop ⇒ `close(0)`. These map
+to `Scope.onExit` LIFO hooks attached at handle creation ([quic][quic]).
+
+### 3.3 The blobs get-side FSM → a straight-line fiber
+
+`iroh-blobs`'s low-level get path is an explicit _move-only typestate machine_
+(`AtInitial → AtConnected → AtStartRoot → AtBlobHeader → AtBlobContent →* AtEndBlob → …`)
+threaded with a `Box<Misc>` "so we don't have to memcpy it on every state transition."
+That machine exists only to drive a low-level API without async traits and lifetimes; a
+tier-B fiber with blocking-looking verbs needs none of it ([blobs][blobs]).
+
+```rust
+// iroh-blobs/src/get.rs (fsm) — the low-level typestate, abbreviated
+let start = fsm::start(connection, request, Default::default());
+let connected = start.next().await?;
+let ConnectedNext::StartRoot(at_start) = connected.next().await? else { … };
+let (mut content, size) = at_start.next().next().await?;   // AtBlobHeader → AtBlobContent
+loop {
+    match content.next().await {
+        BlobContentNext::More((next, item)) => { /* Parent|Leaf, verified */ content = next; }
+        BlobContentNext::Done(end_blob) => break end_blob,
+    }
+}
+```
+
+```d
+// proposed / sketch — Tier-B fiber over an `isByteStream` capability. The typestate
+// names survive as documentation checkpoints; the verified-decode stack machine
+// (bao-tree) runs on the loop fiber with a yield checkpoint per group (see §2.3a).
+IoResult!Stats fetchBlob(Stream)(ref Stream s, in GetRequest req, ref Env env)
+if (isByteStream!Stream)
+{
+    s.sendAll(encodeRequest(req));       // parks on submit; Buf ownership → kernel
+    s.finish();                           // graceful FIN == end-of-request marker
+    ubyte[8] hdr = s.recvExact!8();       // AtBlobHeader; EOF here ⇒ NotFound
+    immutable size = littleEndianU64(hdr);
+    auto dec = BaoDecoder(req.hash, size, req.ranges);  // bao-tree hash-stack machine
+    while (auto item = dec.next(s))       // Parent(64B) | Leaf(≤16 KiB); verified before return
+        env.store.writeBatch(item);       // io_uring write chain; no try_join! needed
+    return dec.stats;
+}
+```
+
+The whole `SendStream`/`RecvStream` generic seam the Rust get/provider stack is written
+over (`recv_bytes_exact`/`send_bytes`/`reset`/`stop`) is exactly an `isByteStream`
+capability, so the protocol is testable against `SimNet` with no QUIC ([blobs][blobs]).
+
+### 3.4 An actor + `mpsc` → a fiber owning state + the proposed channel
+
+The canonical iroh shape — a `select!` loop over an inbox `mpsc` plus event streams,
+timers, and a `JoinSet` of children — transcribes to one owner fiber blocking on a
+single inbox `Chan!T`, fed by daemon forwarders (per [§2.4](#24-the-select--race-trap)).
+The per-remote `RemoteStateActor`, the gossip `net::Actor`, the docs `LiveActor`, and
+the blobs `DownloaderActor`/`ConnectionPool` are all this pattern.
+
+```rust
+// iroh/src/socket.rs:1519 — the socket actor's select! loop (trimmed to 4 of 10 arms)
+loop {
+    tokio::select! {
+        biased;
+        _ = shutdown_token.cancelled() => break,
+        Some(msg) = inbox.recv() => self.handle_message(msg),
+        _ = re_stun_timer.tick() => self.trigger_net_report(),
+        Ok(()) = local_addrs_watcher.updated() => self.on_local_addrs_change(),
+        // … 6 more arms: net-report watch, direct-addr-done, portmap, netmon,
+        //   remote-map cleanup, MaybeFuture backoff
+    }
+}
+```
+
+```d
+// proposed / sketch — one owner fiber + forwarder daemons + one inbox (the Chan!T of §4.1).
+// The select! collapses into a single blocking recv; every other source is a daemon fiber
+// that forwards a tagged message into the shared inbox. State (RemoteMap, …) is a plain
+// owned field — no Arc, no Mutex under `single`.
+void runSocketActor(ref RootScope sc, ref Env env, ref Chan!ActorEvent inbox)
+{
+    sc.spawnDaemon({ repeat(sc, env.clock, spaced(restunInterval()),
+                            { inbox.send(ActorEvent.reStunTick); return ioOk(); }); });
+    sc.spawnDaemon({ foreach (v; localAddrsWatcher.updates)          // watcher fiber
+                         inbox.send(ActorEvent.localAddrs(v)); });
+    // … one daemon per net-report watch / portmap / netmon / remote-map cleanup
+
+    for (;;)
+    {
+        auto ev = inbox.recv();                 // parks; the ONLY multiplex point
+        if (ev.isNone) break;                   // all senders dropped ⇒ shutdown
+        final switch (ev.get.kind) with (ActorEvent.Kind)
+        {
+            case message:    handleMessage(ev.get.msg);          break;
+            case reStunTick: triggerNetReport();                 break;
+            case localAddrs: onLocalAddrsChange(ev.get.addrs);   break;
+            // …
+        }
+    }
+    // scope exit joins/cancels every forwarder daemon — no CancellationToken tree
+}
+```
+
+One hazard survives the translation and is _logical_, not a synchronization artifact:
+the docs `LiveActor` carries the warning that its self-send channel deadlocks if used
+from the actor's own methods ("Must not be used in methods called from `Self::run`
+directly to prevent deadlocks"). A fiber sending into its own full inbox deadlocks
+identically — inbox self-sends must be `trySend` or deferred. Likewise the relay's
+_arm-gating_ (stop reading input while the output is full, to preserve ordering and drop
+behaviour) is a policy the "park on send" default does not reproduce automatically
+([concurrency][concurrency]).
+
+---
+
+## Part 4 — The primitives event-horizon still owes the port
+
+The port cannot begin subsystem work before landing a short list of runtime types that
+v1 does not ship. Each is small, self-contained, and needed by _several_ subsystems, so
+they belong in a shared milestone ([§5, M1](#part-5--the-layered-build-order)), not
+inside any one protocol.
+
+| Primitive                                               | Needed by                                                                                | Proposed D shape                                                                                                                      |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cross-fiber channel** (`Chan!T`, [O20][eh-spec])      | every actor inbox; split-download / gossip / docs stream fan-ins; relay drop-queues      | bounded ring + two waiter lists; `send`/`trySend`/`recv`/`recvMany`/close ([§4.1](#41-the-cross-fiber-channel-chant--open-issue-o20)) |
+| **`Watchable!T`** (`n0-watcher` port)                   | `Endpoint.watch_addr`, `home_relay_status`, `net_report`, discovery, gossip addr updates | `struct { T value; ulong epoch; WaiterList }`; `set` dedups on `Eq`; `map`/`or`/`Join`; `Disconnected` on drop                        |
+| **Bounded broadcast + `Lagged`**                        | gossip topic events (cap 256/2048); per-connection path events (cap 8); docs subscribers | per-topic list of per-subscriber ring buffers; overflow drops + delivers `Lagged{missed}`                                             |
+| **Memoized completion cell** (`Shared<BoxFuture>` port) | 0-RTT "handshake accepted" future, awaited by many waiters                               | one-shot promise caching its `Outcome`; multi-waiter park; `JoinHandle` is single-consumer, so this is new                            |
+| **`buffered_unordered(n)` gate**                        | blobs split-download (32-in-flight); any bounded fan-out                                 | a `Scope` plus a counting semaphore admitting the next child fiber on each completion                                                 |
+| **msghdr I/O** ([O19][eh-spec])                         | `noq-udp` GSO/GRO/ECN/pktinfo; multipath source-IP selection                             | `sendMsg`/`recvMsg` verbs over `msghdr`/cmsg; until then `maxDatagrams:1`, no wire-interop GSO                                        |
+| **`WallClock` capability**                              | QUIC tokens (bind UNIX time, not `MonoTime`); docs µs timestamps                         | `isWallClock` beside `isClock`; `TestWallClock` double for deterministic token/timestamp tests                                        |
+| **`Rng` capability**                                    | ed25519 keygen; QUIC pn-skip filter, token nonces, CID grease; gossip                    | `isRng` DbI trait + `TestRng` deterministic double (matches `noq`'s seeded `StdRng` replay)                                           |
+
+### 4.1 The cross-fiber channel (`Chan!T`) — open-issue O20
+
+The channel is the keystone. Its full shape is dictated by the census, and
+single-threading makes it a plain ring with no atomics or locks — the parking is via the
+loop-free [`isWaker`][eh-spec] seam, and a parked `recv` is a non-I/O park, so
+cancellation latches the interrupt and wakes immediately ([SPEC §8.4][eh-spec]).
+
+```d
+// proposed / sketch — the cross-fiber channel event-horizon v1 lacks (open-issue O20).
+// One thread ⇒ no atomics/locks: a bounded ring plus two intrusive waiter lists.
+struct Chan(T, size_t N)                       // N = capacity; SmallBuffer-backed FIFO
+{
+    private SmallBuffer!(T, N) ring;
+    private WaiterList notFull;                 // senders parked on a full ring
+    private WaiterList notEmpty;                // owner parked on an empty ring
+    private uint senders = 1;                   // live producer count; 0 ⇒ closed
+
+    // Backpressure sender: parks the fiber when the ring is full (actor inboxes).
+    IoResult!void send(T v)
+    {
+        while (ring.length == N)
+        {
+            if (senders == 0) return chanClosed();
+            notFull.park(currentTask);          // resumes when the owner drains one
+        }
+        ring.pushBack(move(v));
+        notEmpty.wakeOne();
+        return ioOk();
+    }
+
+    // Drop sender: never parks — relay datagram queues, network-change fan-out.
+    enum SendResult : ubyte { ok, full, closed }
+    SendResult trySend(T v)
+    {
+        if (senders == 0)     return SendResult.closed;
+        if (ring.length == N) return SendResult.full;   // caller drops it (best-effort)
+        ring.pushBack(move(v)); notEmpty.wakeOne();
+        return SendResult.ok;
+    }
+
+    // The owner: parks on empty; returns none once all senders drop ⇒ graceful shutdown.
+    Option!T recv()
+    {
+        while (ring.empty)
+        {
+            if (senders == 0) return Option!T.init;
+            notEmpty.park(currentTask);
+        }
+        auto v = ring.popFront();
+        notFull.wakeOne();
+        return some(move(v));
+    }
+
+    // Batch drain — the relay's 20-datagram recv_many amortization.
+    uint recvMany(scope T[] out_);              // pop up to out_.length; wake notFull
+}
+```
+
+Because the callers and the owning fiber share one thread, request/reply traffic can
+bypass `Chan!T` entirely (a direct suspendable method call), so the channel is reserved
+for genuine many→one _stream_ fan-ins. This is the difference between the
+`irpc`-flavoured request enums (which monomorphize to direct calls locally) and the
+progress/observe streams (which need the queue) — see [blobs § irpc][blobs] and
+[concurrency § irpc][concurrency].
+
+---
+
+## Part 5 — The layered build order
+
+The milestones front-load pure value code and the missing primitives, cut the QUIC core
+only once its dependencies are green, and defer the cross-process control plane to the
+end. Each cross-links the deep-dive(s) it draws on.
+
+**M0 — Pure value code: identity, crypto, wire.** Ed25519 (keygen / deterministic sign
+/ `verify_strict`, interop-exact), SHA-512, BLAKE3 (`derive_key`, `keyed_hash`, and the
+`hazmat` chunk-counter CVs / ROOT-flag merges), a CSPRNG behind an `Rng` capability, and
+the `postcard` codec + `EndpointAddr`/ticket value types. All `@safe pure nothrow @nogc`,
+all testable against the three golden ticket vectors with no I/O — the strongest possible
+grounding for the riskiest interop surface (`verify_strict`'s edge rules, the `BTreeSet`
+canonical order). Draws on [identity-crypto][identity] and [wire-serialization][wire].
+
+**M1 — The missing runtime primitives (the gate).** `Chan!T` (O20),
+`Watchable!T`, the bounded broadcast + `Lagged`, the memoized completion cell, the
+`buffered_unordered` gate, and the `WallClock`/`Rng` capabilities — small library types
+the rest of the port consumes. Landing these first is what unblocks every actor
+translation. Draws on [concurrency][concurrency], with `Watchable` semantics from
+[endpoint][endpoint]/[gossip][gossip].
+
+**M2 — `bao-tree` verified streaming.** The pure geometry (`TreeNode` bit tricks, the
+shifted tree, outboard layout) and both codec state machines (verified decode / range
+encode) transliterate almost line-for-line; the only design work is the yield-checkpoint
+budget of [§2.3(a)](#23-what-single-threading-costs). Depends on M0's BLAKE3 hazmat.
+Draws on [bao-tree][bao-tree].
+
+**M3 — The sans-io QUIC core + TLS seam.** `noq-proto` driven by event-horizon's
+`isNet`-capability `AsyncUdpSocket`-equivalent ([§3.1](#31-the-runtime--asyncudpsocket-trait--an-event-horizon-capability-row)),
+one fiber per `Connection` ([§3.2](#32-a-noq-connection--a-fiber-owned-d-handle)), one
+collapsed in-ring `TIMEOUT`, `SumType!(Cubic, NewReno, Bbr3)` in place of
+`Box<dyn Controller>`, and the sans-io TLS 1.3 `Session` with the `PathId`-aware
+`PacketKey` nonce. The big rock. **Blocked on O19** for wire-interop GSO/multipath
+source-IP selection; ships with `maxDatagrams:1` until then. Draws on [quic][quic] and
+[identity-crypto][identity].
+
+**M4 — Endpoint & Router shell.** The identity model, the four interception layers, the
+guarded holepunching defaults, the DbI-typestate `Connection<State>`, and the router
+`race` loop over the QUIC core. Small and portable once M3 exists. Draws on
+[endpoint][endpoint].
+
+**M5 — Connectivity: socket, NAT traversal, relay, discovery, net-report.** The multipath
+socket (per-transport recv fibers, multishot `BufRing`, plain `MappedAddrs`), the QNT/QAD
+sans-io driver, the relay WebSocket client with a reconnect `Schedule`, pkarr/DNS
+discovery, and net-report/netwatch/portmapper. The relay _server_ and the DoH _server_
+are deferrable; the interface-enumeration and portmapper layers are C-binding candidates.
+Draws on [socket][socket], [nat-traversal][nat], [relay][relay], [discovery][discovery],
+[net-report][net-report].
+
+**M6 — Blobs + store.** The verified transfer protocol (`/iroh-bytes/4`) over
+`isByteStream` fibers ([§3.3](#33-the-blobs-get-side-fsm--a-straight-line-fiber)), the
+per-hash handle map (single-owner, load-on-demand, idle-evict), the io_uring write-batch
+chain, and the resumable downloader + `ConnectionPool`. **The CPU-hash decision of
+[§2.3(a)](#23-what-single-threading-costs) lands here**, as does the embedded-KV decision
+(LMDB C-binding vs on-loop store). Draws on [blobs][blobs] and [bao-tree][bao-tree].
+
+**M7 — Docs + gossip.** The gossip `proto/` core ports verbatim as a `GossipState` value
+type with a `TimerMap`; the docs `ranger` is a pure range reconciler; both `net/` layers
+become `Scope`-owned fibers consuming the M1 channel and broadcast primitives. The sans-io
+cores bring ready-made deterministic test rigs (`TestClock` + `TestSched`). Draws on
+[gossip][gossip] and [docs-sync][docs-sync].
+
+**M8 — The remote control plane and hardening.** The `irpc` remote framed-stream loops
+(the local path already monomorphized to direct calls in M6/M7), metrics, qlog, the relay
+server, and the DoH server. All deferrable without losing p2p interop. Draws on
+[concurrency][concurrency] and [blobs][blobs].
+
+---
+
+## Consensus: what the port keeps, deletes, and invents
+
+Cutting across the fifteen deep-dives, the port resolves into three piles.
+
+**Keep (verbatim design).** The four sans-io cores — `noq-proto`, gossip `proto/`, docs
+`ranger`, `bao-tree` — plus the wire schema (frozen `postcard` declaration order, the
+`ALPN` registry, the golden ticket vectors), the identity binding contract (44-byte SPKI
+equality + `ED25519` `CertificateVerify` + mandatory client auth), every timeout and
+capacity constant (they are protocol policy), and the `irpc` request-enum _design_. These
+transliterate; the risk is interop precision (`verify_strict`, the multipath AEAD nonce,
+the `BTreeSet` order), not architecture.
+
+**Delete (the `Send + Sync` tax).** Every `Arc<Mutex/RwLock>`, `AtomicU64`,
+`DashMap`/`papaya` map, `oneshot`, `TaskTracker`, `AbortOnDropHandle`, and the intricate
+actor-restart and immortal-actor mechanisms that exist only because tasks migrate across
+threads. Under `single` these are plain fields, direct calls, and structural scope
+teardown. Most of iroh's concurrency census is _deletable_, not _translatable_ —
+the reason the socket layer's own author calls the shared `Socket` handle a design
+confession worth tightening:
+
+> _"Shared state between an awful lot of iroh subsystems. In particular both the
+> `EndpointInner` as well as this actor itself have a copy. But also other subsystems
+> that consequently have access to way to much state."_ — [`iroh/src/socket.rs:1456-1459`][socket-src]
+
+**Invent (the primitives event-horizon owes).** The cross-fiber channel (O20), the
+`Watchable`, the bounded broadcast, the memoized completion cell, msghdr I/O (O19), and
+the `WallClock`/`Rng` capabilities. These are small and shared, and they gate the port —
+which is why M1 lands them before any subsystem, and why O19/O20 are the two
+event-horizon roadmap items the iroh port most directly pressures.
+
+The honest summary: the port is **one very large sans-io rock (`noq-proto` + TLS)** plus
+a ring of tractable native shells, sitting on **one runtime gap (the channel) and one
+throughput hazard (BLAKE3 on the loop)**. The QUIC core dominates the schedule; the
+channel dominates the ordering; the hash offload is the one place the `single` topology's
+purity is genuinely at stake, and the one place a second worker loop may be warranted.
+
+---
+
+## Key design decisions and trade-offs
+
+| Decision                                                                     | Rationale                                                                                          | Trade-off                                                                                           |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Drive the sans-io cores from fibers, keep their value-type design            | `noq-proto`/gossip/`ranger`/`bao-tree` are runtime-neutral; fibers replace wakers 1:1              | Interop precision (AEAD nonce, `verify_strict`) must be exact; ~38k LoC of QUIC still to write      |
+| Default `single` topology; delete `Arc/Mutex`/atomics/concurrent maps        | Single-thread ownership removes every data race; no lock or atomic on hot paths                    | A few "locks" are _logical_ (self-send deadlock, arm-gating) and survive the translation            |
+| Model each actor as one owner fiber + forwarder daemons on an inbox `Chan!T` | Faithful to `select!`'s poll-without-cancel semantics; `race` would wrongly cancel losers          | One extra daemon per event source; cross-source ordering re-established via inbox tagging           |
+| Land `Chan!T`/`Watchable`/broadcast (M1) before any subsystem                | Every actor is an inbox loop; the whole port waits on the channel primitive (O20)                  | A gating milestone with no user-visible protocol; pure runtime-library work up front                |
+| BLAKE3/bao on the loop with cooperative yields (option A first)              | No second thread, no cross-ring plumbing; matches the `single` default                             | Hash bursts couple to network latency; a large import stalls I/O unless the yield budget is tuned   |
+| …or a second hashing worker via `threadPerCore` + `MSG_RING` (option B)      | Mirrors Rust's dedicated runtime; keeps the network loop responsive during hashing                 | Reintroduces cross-ring channels and share-nothing message passing — the complexity `single` avoids |
+| No `spawn_blocking`; startup blocking synchronous, file I/O native io_uring  | The one real `spawn_blocking` (TLS load) runs before the loop is hot; io_uring covers files        | The embedded KV (`redb`/LMDB) has no io_uring home — needs a worker thread or a store redesign      |
+| Ship `maxDatagrams:1` until O19 (msghdr) lands                               | `noq-proto` natively supports segmentation-offload-off; unblocks the QUIC core early               | No GSO/GRO throughput and no multipath source-IP selection until msghdr I/O exists                  |
+| Keep the `irpc` request-enum design, drop the proc-macro                     | D introspection generates the message sum; local path monomorphizes to direct calls                | The remote framed-stream loop is hand-built; only the remote plane needs it (deferrable to M8)      |
+| TLS 1.3 + QUIC-AEAD: C-binding _or_ native sans-io `Session` (open decision) | Reimplementing a QUIC-correct TLS 1.3 is large; a binding is faster but constrains the crypto seam | A binding must expose the `PathId`-aware `PacketKey` nonce; a reimpl is a second large rock         |
+
+---
+
+## Sources
+
+This capstone synthesises the fifteen deep-dives; per-subsystem primary sources are
+cited in each. Load-bearing sources for the synthesis itself:
+
+- The concurrency census and the construct-by-construct translation table:
+  [Tokio Concurrency Inventory][concurrency].
+- The sans-io licence and the QUIC port budget: [QUIC Transport (`noq`)][quic],
+  [`noq-proto/src/lib.rs:3-8`][noq-lib], [`noq/src/runtime/mod.rs`][noq-runtime],
+  [`noq/src/connection.rs`][noq-conn].
+- The CPU-hash hazard and the dedicated-runtime fact: [bao-tree][bao-tree], [blobs][blobs],
+  [`iroh-blobs/src/store/fs.rs`][blobs-fs], [`iroh-blobs/DESIGN.md`][blobs-design],
+  [`iroh-blobs/src/get.rs`][blobs-get].
+- The runtime seam and the `Watchable`/completion-cell gaps: [endpoint][endpoint],
+  [`iroh/src/runtime.rs`][iroh-runtime]; the shared-state confession
+  [`iroh/src/socket.rs:1456-1459`][socket-src].
+- The sans-io-core wins and missing-primitive lists: [gossip][gossip],
+  [`iroh-gossip/src/proto/state.rs`][gossip-state], [docs-sync][docs-sync],
+  [socket][socket], [nat-traversal][nat].
+- The target platform: [event-horizon SPEC][eh-spec] (topologies §11, scopes §8,
+  buffers §6, capabilities §10, open-issues O19/O20).
+- Structural model and the runtime family it joins: async-io's [comparison][async-comparison],
+  [Tokio][tokio], [Glommio][glommio], [Monoio][monoio], and the
+  [algebraic-effects][alg-effects] survey.
+- Sibling iroh pages this plan integrates: [survey umbrella][index], [concepts][concepts],
+  [identity & cryptography][identity], [wire formats][wire], [QUIC transport][quic],
+  [endpoint & router][endpoint], [socket][socket], [NAT traversal][nat], [relay][relay],
+  [discovery][discovery], [net report][net-report], [blobs][blobs], [bao-tree][bao-tree],
+  [docs sync][docs-sync], [gossip][gossip], [concurrency][concurrency].
+
+<!-- References -->
+
+[index]: ./index.md
+[concepts]: ./concepts.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[quic]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[net-report]: ./net-report.md
+[blobs]: ./blobs.md
+[bao-tree]: ./bao-tree.md
+[docs-sync]: ./docs-sync.md
+[gossip]: ./gossip.md
+[concurrency]: ./concurrency.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[async-comparison]: ../async-io/comparison.md
+[tokio]: ../async-io/tokio.md
+[glommio]: ../async-io/glommio.md
+[monoio]: ../async-io/monoio.md
+[alg-effects]: ../algebraic-effects/index.md
+[noq-lib]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/lib.rs
+[noq-runtime]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq/src/runtime/mod.rs
+[noq-conn]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq/src/connection.rs
+[socket-src]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs
+[iroh-runtime]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/runtime.rs
+[blobs-fs]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/store/fs.rs
+[blobs-get]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/get.rs
+[blobs-design]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/DESIGN.md
+[gossip-state]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/proto/state.rs

--- a/docs/research/iroh/discovery.md
+++ b/docs/research/iroh/discovery.md
@@ -1,0 +1,726 @@
+# Address Lookup (Discovery)
+
+The subsystem that turns a bare [`EndpointId`][concepts] into dialable transport addresses — by publishing and resolving [BEP-44][bep44]-signed DNS packets over [pkarr] relays and the Domain Name System, so a peer can be reached knowing only its public key.
+
+| Field               | Value                                                                                                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)            | [`iroh`][repo] (`address_lookup` module), [`iroh-dns`][repo] (record + resolver), [`iroh-dns-server`][repo] (relay + authoritative DNS)                                         |
+| Version             | `iroh` `v1.0.1` (commit `22cac742`); `iroh-dns` `1.0.1`; `iroh-dns-server` `1.0.1`                                                                                              |
+| Repository          | [n0-computer/iroh][repo]                                                                                                                                                        |
+| Documentation       | [docs.rs/iroh · `address_lookup`][docs-iroh] · [docs.rs/iroh-dns][docs-dns] · [docs.rs/iroh-dns-server][docs-dns-server]                                                        |
+| ALPN(s)             | None — resolution rides DNS (UDP/TCP) and pkarr HTTP(S) `PUT`/`GET`, not an ALPN-negotiated QUIC protocol. Dialing the resolved address is [noq][quic]'s job, not this layer's. |
+| Approx. size (LoC)  | client (`iroh/src/address_lookup*` + `iroh-dns/src`) ≈ 5,050; server (`iroh-dns-server/src`) ≈ 4,006                                                                            |
+| Category            | Connectivity                                                                                                                                                                    |
+| Upstream spec/draft | [pkarr]; BitTorrent [BEP-44][bep44] (mutable items); [RFC 1035][rfc1035] (DNS wire); [RFC 1464][rfc1464] (`key=value` TXT); [RFC 8484][rfc8484] (DoH); [z-base-32][zb32]        |
+
+> [!NOTE]
+> **Naming.** What iroh 0.x called _discovery_ is, in 1.0, **address lookup**
+> (`iroh/src/address_lookup.rs`). `Discovery` → [`AddressLookup`][al-trait];
+> `DiscoveryItem` → [`Item`][al-item]; `NodeId`/`NodeInfo`/`NodeData` →
+> `EndpointId`/`EndpointInfo`/`EndpointData`. The DISCO UDP side-protocol and STUN of
+> 0.x are gone (see [NAT Traversal][nat]); address lookup is now purely a
+> _name → address_ directory, orthogonal to hole-punching.
+
+---
+
+## Overview
+
+### What it solves
+
+An iroh [`EndpointId`][concepts] is an ed25519 public key — a stable, self-certifying
+name that says nothing about _where_ the endpoint is. To open a QUIC connection you
+need transport addresses: a home [relay][relay] URL and/or direct `IP:port` candidates.
+Address lookup is the directory that maps the key to those addresses, in both
+directions:
+
+- **Publish** — an endpoint signs its own current addressing info under its key and
+  pushes it to a directory, so others can find it. Fire-and-forget, re-run whenever the
+  addresses change.
+- **Resolve** — given an `EndpointId`, fetch the latest signed record, verify it against
+  the key, and feed the addresses into the dialer.
+
+The design constraint is that the record must be **self-authenticating**: a resolver,
+relay, or DNS cache is untrusted infrastructure that can store and serve the bytes but
+must not be able to forge them. iroh solves this with [pkarr] — _Public-Key Addressable
+Resource Records_ — where the payload is an ordinary DNS reply packet wrapped in an
+ed25519 signature over a [BEP-44][bep44] mutable-item encoding. Any party can verify the
+signature; only the key-holder can produce a newer one.
+
+Two properties make it work as a directory rather than a broadcast: records are keyed
+by the public key (so lookups are `O(1)` point queries, not scans), and each publish
+carries a strictly-monotonic timestamp (so the newest record always wins and replays
+are rejected). Everything else — DNS as a transport, pkarr relays as a bridge, an
+in-tree authoritative server — is plumbing around that core.
+
+Address lookup is deliberately **not** the dialer. It only enriches a peer's candidate
+address set; which path actually connects is decided later by [noq][quic]'s multipath
+QUIC and [NAT traversal][nat]. A `connect` by bare `EndpointId` therefore blocks only
+until the _first_ usable address is known, not until every lookup service finishes
+(see [How lookups race with dialing](#how-lookups-race-with-dialing)).
+
+### Design philosophy
+
+The [`AddressLookup`][al-trait] trait is intentionally minimal and asymmetric: publish
+is a side-effecting best-effort call, resolve is a cancellable multi-result stream.
+From the trait's own doc comment ([`address_lookup.rs:334`][al-trait]):
+
+> _"Publishes the given [`EndpointData`] to the Address Lookup mechanism. This is fire
+> and forget, since the [`Endpoint`] can not wait for successful publishing. If
+> publishing is async, the implementation should start its own task."_
+
+The record format is pkarr, chosen because it decouples the directory from any single
+piece of infrastructure. The module documentation
+([`address_lookup/pkarr.rs:9`][pk-mod]) lays out the three bridges — DHT, DNS resolver,
+HTTP relay — and why iroh leans on the last two:
+
+> _"Pkarr normally stores these records on the [Mainline DHT], but also provides two
+> bridges that do not require clients to directly interact with the DHT: Resolvers are
+> servers which expose the pkarr Resource Record under a domain name … Relays are servers
+> which allow both publishing and looking up of the pkarr Resource Records using HTTP PUT
+> and GET requests."_
+
+Three consequences shape the API:
+
+1. **Compose publishers and resolvers separately.** [`PkarrPublisher`][pk-pub]
+   implements only `publish`; [`DnsAddressLookup`][al-dns] and [`PkarrResolver`][pk-res]
+   implement only `resolve`. The `N0` preset wires a pkarr publisher next to a DNS
+   resolver ([`endpoint/presets.rs:115`][presets]) — you publish over HTTP but resolve
+   over cheap, cacheable DNS.
+2. **Privacy by default.** The publisher's default [`AddrFilter`][al-filter] is
+   `relay_only()`, so raw IP addresses are _not_ leaked to a public pkarr server unless
+   the operator opts in ([`address_lookup/pkarr.rs:208`][pk-filter]): _"By default
+   [`AddrFilter::relay_only`] is used. This avoids leaking IP addresses to the public
+   pkarr server."_
+3. **Reuse DNS wire format for everything.** The signed payload _is_ a DNS packet, TXT
+   records use the [RFC 1464][rfc1464] `key=value` convention, and the same [`iroh-dns`][repo]
+   codec serves both the pkarr blob and third-party DNS caches. There is no bespoke record
+   schema.
+
+pkarr is **vendored, not depended on**: iroh 1.0 reimplements the signed-packet format
+in ~400 lines ([`iroh-dns/src/pkarr.rs`][dns-pkarr]) rather than pulling the upstream
+`pkarr` crate, and its client-side mDNS and Mainline-DHT lookups have moved out of the
+workspace into separate `iroh-mdns-address-lookup` / `iroh-mainline-address-lookup`
+crates ([`address_lookup.rs:46`][al-trait]). What ships in-tree is the pkarr-over-HTTP
+and DNS path, plus a server that is both.
+
+---
+
+## How it works
+
+### The record: a pkarr signed packet
+
+An endpoint's discoverable identity is packed into a **signed packet**: an ed25519
+signature over a [BEP-44][bep44] mutable-item encoding of an RFC 1035 DNS reply packet.
+The layout ([`iroh-dns/src/pkarr.rs:26`][dns-pkarr]) is fixed-prefix + variable DNS body:
+
+```text
+offset  size    field
+0       32      ed25519 public key (raw bytes) = the EndpointId
+32      64      ed25519 signature over the BEP-44 signable
+96      8       timestamp, u64 big-endian, microseconds since UNIX epoch
+104     ≤1000   DNS reply packet (RFC 1035 wire format, name-compressed)
+```
+
+The size constants are `MAX_DNS_PACKET_SIZE = 1000`, `HEADER_SIZE = 104`, and
+`MAX_SIGNED_PACKET_SIZE = 1104` ([`pkarr.rs:17`][dns-pkarr]); a buffer shorter than
+`HEADER_SIZE` is rejected `TooShort`, one over 1104 is `TooLarge`. The DNS packet is a
+_reply_ with id `0` (`Packet::new_reply(0)`), answers only.
+
+The **signable bytes** are the BEP-44 mutable-item bencode: the ASCII string
+`"3:seqi{timestamp}e1:v{len}:"` followed by the raw DNS packet bytes
+([`pkarr.rs:290`][dns-pkarr]). Crucially the BEP-44 `seq` field **is** the microsecond
+timestamp — iroh carries no separate sequence number:
+
+```rust
+// iroh-dns/src/pkarr.rs:290 — signable()
+fn signable(timestamp: u64, v: &[u8]) -> Vec<u8> {
+    let mut signable = format!("3:seqi{}e1:v{}:", timestamp, v.len()).into_bytes();
+    signable.extend(v);
+    signable
+}
+```
+
+### TXT records: the `_iroh` zone
+
+Inside the DNS packet, addressing info lives in TXT records under the name
+`_iroh.<z32-endpoint-id>` ([`iroh-dns/src/attrs.rs:19`][dns-attrs]); the serving DNS
+server appends its origin so the fully-qualified name a resolver queries is
+`_iroh.<z32-endpoint-id>.<origin-domain>`. `z32` is [z-base-32][zb32] with the alphabet
+`ybndrfg8ejkmcpqxot1uwisza345h769` ([`iroh-base/src/key.rs:20`][base-key]); a 32-byte
+key becomes a 52-char label.
+
+Each TXT value is an [RFC 1464][rfc1464] `key=value` string; the keys are the
+kebab-cased [`IrohAttr`][dns-attrs] variants `relay`, `addr`, and `user-data`:
+
+```text
+_iroh.<z32-endpoint-id>.<origin>.  IN TXT "relay=https://relay.example./"
+_iroh.<z32-endpoint-id>.<origin>.  IN TXT "addr=213.208.157.87:60165"
+_iroh.<z32-endpoint-id>.<origin>.  IN TXT "user-data=foobar"
+```
+
+Encoding an [`EndpointInfo`][dns-info] walks its ordered `Vec<TransportAddr>` and emits
+one TXT record per address — `relay=<url>` for [`TransportAddr::Relay`][dns-info],
+`addr=<socketaddr-or-custom>` for `Ip`/`Custom` — plus at most one `user-data`
+([`endpoint_info.rs:486`][dns-info]). The address order is significant: it encodes
+publish priority so higher-preference addresses land first when a record must be
+truncated to fit the packet. Decoding is deliberately lenient — unparseable values are
+silently dropped via `filter_map(... .ok())` — and the `endpoint_id` label is validated
+to be label 2 of the queried name, so records for other names or record types in a
+response are ignored.
+
+`user-data` is capped at **245 bytes** ([`UserData::MAX_LENGTH`][dns-info]) — the DNS
+character-string limit of 255 minus the `user-data=` prefix — and the first `user-data`
+attribute wins.
+
+### The `AddressLookup` trait and registry
+
+The client contract is two optional methods ([`address_lookup.rs:333`][al-trait]):
+
+```rust
+// iroh/src/address_lookup.rs:333
+pub trait AddressLookup: std::fmt::Debug + Send + Sync + 'static {
+    fn publish(&self, _data: &EndpointData) {}
+    fn resolve(&self, _endpoint_id: EndpointId) -> Option<BoxStream<Result<Item, Error>>> {
+        None
+    }
+}
+```
+
+`publish` is fire-and-forget; `resolve` returns a **stream** (not a future) so a service
+can emit multiple/updated results, and returning `None` means "this service does not
+resolve." Dropping the stream must cancel pending work. A companion
+`AddressLookupBuilder::into_address_lookup(self, &Endpoint)` lets a service grab the
+endpoint's secret key, DNS resolver, and TLS config at bind time; every plain
+`AddressLookup` gets a blanket no-op builder.
+
+Services are held in an [`AddressLookupServices`][al-services] registry —
+`Arc<RwLock<Vec<Box<dyn AddressLookup>>>>` plus the last-published `EndpointData` (so a
+service added later is immediately primed with the current addresses) and an optional
+global [`AddrFilter`][al-filter]. Its `resolve()` fans out to every service and merges
+the per-service streams with `MergeBounded` (from `n0-future`). The merge policy is the
+whole point of the subsystem's robustness ([`address_lookup.rs:540`][al-trait]):
+
+> _"Errors from individual services are yielded inline as `Ok(Err(error))` and do not
+> terminate the stream: a single failing service must not hide results from others still
+> in flight."_
+
+Concretely: an [`Item`][al-item] is yielded `Ok(Ok(item))` the moment any service
+produces one; a per-service error is yielded inline as `Ok(Err(e))` _and_ buffered; only
+if the merged stream ends having emitted zero items does it emit a terminal
+`Err(AddressLookupFailed::NoResults { errors })`. With no services configured it emits a
+single `Err(NoServiceConfigured)`. This is the fix for iroh issue #4125, where one
+failing resolver used to truncate the merge (regression test at
+[`address_lookup.rs:913`][al-trait]).
+
+### How lookups race with dialing
+
+`Endpoint::connect` does not block on lookups. It calls
+`Socket::resolve_remote(EndpointAddr)`, which sends `ActorMessage::ResolveRemote` to the
+[socket][socket] actor and **does not await the reply** — a hanging lookup for one peer
+cannot serialize connects to others ([`socket.rs:1320`][socket-src], regression test
+[`address_lookup.rs:960`][al-trait]). The socket forwards to the per-remote
+`RemoteStateActor`, which:
+
+1. Inserts any caller-supplied addresses (from the `EndpointAddr`) into its path map
+   with provenance `Source::App`.
+2. Registers the caller's reply-`oneshot` and calls `trigger_address_lookup` — a no-op
+   if a path is already selected or a lookup is already running
+   ([`remote_state.rs:866`][remote-src]).
+3. Replies `Ok(())` **immediately** if any path is already known (caller-supplied
+   addresses suffice) — the lookup continues in the background, adding more candidate
+   paths ([`path_state.rs:161`][path-src]).
+
+Each stream item's addresses are inserted with provenance
+`Source::AddressLookup { name }`; inserting the _first_ path drains any parked
+`connect` callers with `Ok(())`. Stream end or failure drains them with the error only
+if the path map is still empty. `connect` then dials the resulting
+`EndpointIdMappedAddr` via [noq][quic] multipath QUIC. The "race" between lookup results
+and dialing is thus mediated entirely by the path map: **lookup results merely add
+candidate paths; QUIC-native hole-punching and path selection ([NAT traversal][nat])
+pick the winner.** Connecting by bare `EndpointId` blocks only until the first usable
+address is known.
+
+The per-remote actor has a 60 s idle timeout (`ACTOR_MAX_IDLE_TIMEOUT`,
+[`remote_state.rs:73`][remote-src]), but pending resolve requests keep it alive.
+
+### Publishing: `PkarrPublisher`
+
+The socket calls `publish_my_addr()` whenever direct addresses change, the home relay
+changes (or on initial bind), or user data changes ([`socket.rs:511`][socket-src]). It
+assembles `EndpointData` from the current direct sockaddrs, home relay URL, and user
+data, and skips the publish entirely when all three are empty. The only in-tree
+publisher is [`PkarrPublisher`][pk-pub]: `publish` stores the filtered `EndpointInfo`
+in an `n0_watcher::Watchable`, and a background `PublisherService::run` task watches it,
+signs a fresh packet, and HTTP-`PUT`s it to the pkarr relay:
+
+- republishes every `DEFAULT_REPUBLISH_INTERVAL` = **5 min** even when unchanged
+  ([`pkarr.rs:146`][pk-const]);
+- on error, retries after `Duration::from_secs(failed_attempts)` — linear 1 s, 2 s,
+  3 s… backoff ([`pkarr.rs:387`][pk-pub]);
+- default packet TTL is **30 s** (`DEFAULT_PKARR_TTL`), _explicitly documented as
+  ignored_ by n0's own server ([`pkarr.rs:135`][pk-const]);
+- each fresh packet takes a new strictly-monotonic timestamp, so a republish always
+  supersedes the prior record.
+
+The default `AddrFilter` is `relay_only()`, keeping IPs off the public relay.
+
+### Resolving: two transports
+
+1. **`DnsAddressLookup`** queries `_iroh.<z32>.<origin>` TXT via the endpoint's
+   `DnsResolver`, using **staggered** lookups. Extra attempts fire at
+   +200/300/600/1000/2000/3000 ms (`DNS_STAGGERING_MS`,
+   [`address_lookup/dns.rs:22`][al-dns]), each with a 3 s `DNS_TIMEOUT`
+   ([`iroh-dns/src/dns.rs:42`][dns-resolver]) so _"a lookup will finally abort after 6
+   seconds."_ Each delay gets ±20% jitter (`MAX_JITTER_PERCENT`); first success wins,
+   otherwise a `StaggeredError` summarizes every failure.
+2. **`PkarrResolver`** HTTP-`GET`s `<relay>/<z32-key>` and verifies the returned signed
+   packet against the queried key ([`address_lookup/pkarr.rs:619`][pk-res]).
+
+Both produce a one-shot stream (`once_future`). The `N0` preset installs
+`PkarrPublisher::n0_dns()` + `DnsAddressLookup::n0_dns()` (or `PkarrResolver` in wasm
+browsers, where UDP DNS is unavailable) plus the default relay map
+([`endpoint/presets.rs:115`][presets]).
+
+### The client DNS resolver stack
+
+`DnsResolver` wraps a swappable `Box<dyn Resolver>` in an `ArcSwap` guarded by a
+`tokio::sync::Notify` ([`iroh-dns/src/dns.rs:251`][dns-resolver]). The default
+implementation is **hickory-resolver 0.26**, configured from the host
+(`/etc/resolv.conf`; JNI on Android; Google `8.8.8.8` fallback on failure), forcing
+`LookupIpStrategy::Ipv4thenIpv6` and `negative_max_ttl = 0`, and stripping Windows'
+dead site-local `fec0:0:0:ffff::1..3` nameservers. Every operation runs through
+`Inner::op`, a biased `select!` racing the lookup future against a reset-notification
+and a per-attempt timeout; on a network change, `reset()` compare-and-swaps in a
+freshly built resolver and wakes in-flight ops to retry against it. Caching is delegated
+entirely to hickory's record cache — **iroh adds no client-side cache for endpoint
+records** — and the same `DnsResolver` is plumbed into `reqwest` for pkarr relay HTTP
+requests ([`iroh/src/util.rs:10`][iroh-util]), so all name resolution in iroh flows
+through one component.
+
+### The server: `iroh-dns-server`
+
+One process is both a **pkarr relay** and an **authoritative DNS server**
+([`iroh-dns-server/src/lib.rs`][repo]). Its HTTP(S) frontend (axum) exposes:
+
+- `PUT /pkarr/{z32-key}` — verify the packet signature against the key in the URL path,
+  then upsert into the `ZoneStore`. Only `PUT` is rate-limited (tower-governor:
+  `per_second(4)`, `burst_size(2)`, keyed by peer IP / `X-Forwarded-For`,
+  [`http/rate_limiting.rs:61`][srv-rate]).
+- `GET /pkarr/{z32-key}` — return the relay payload (`204` on PUT, `404` if unknown),
+  `Content-Type: application/x-pkarr-signed-packet`.
+- `GET|POST /dns-query` — DoH, both `application/dns-message` ([RFC 8484][rfc8484]) and
+  Google-style `application/dns-json`.
+
+The **relay payload** — the HTTP body for `PUT`/`GET` — is everything after the pubkey,
+i.e. `<64 sig><8 ts><dns packet>`; the 32-byte key rides in the URL path, so it is not
+re-sent in the body.
+
+The store is a two-tier stack: an in-memory `ZoneCache` (LRU of **1,048,576** zones)
+in front of a **redb** table `signed-packets-1` mapping the 32-byte pubkey to
+`<8-byte last_seen><packet bytes>`, with a `update-time-1` multimap (timestamp → key)
+as the eviction index ([`store/signed_packets.rs:20`][srv-store]). Writes go through a
+dedicated actor on its own OS thread (redb IO is blocking), batching up to **65,536**
+messages or **1 s** per write transaction; a second thread evicts packets older than
+**7 days**, scanned every **10 s**. An upsert compares recency by `(timestamp, packet
+bytes)` and rejects stale updates. Optionally the store falls back to the BitTorrent
+[Mainline DHT] for unknown keys (5-minute cache), but mainline is **disabled** in the
+shipped prod config.
+
+The DNS frontend (hickory-server, UDP+TCP) serves a static SOA/NS authority per origin
+and parses any other query as `<subdomain>.<z32-pubkey>.<origin>`, fetching that key's
+zone and re-rooting the stored records by appending the origin
+([`dns/node_zone_handler.rs:108`][srv-zone]). Because the pkarr packet stores names
+relative to the bare z32 zone, the _same_ stored packet is served under every origin the
+server is configured with — and an origin of `"."` makes it answer for any domain.
+
+### What n0 runs
+
+Production origin **`dns.iroh.link.`** and pkarr relay
+**`https://dns.iroh.link/pkarr`** ([`iroh-dns/src/dns.rs:45`][dns-resolver],
+[`address_lookup/pkarr.rs:127`][pk-const]); staging equivalents under
+`staging-dns.iroh.link`, selected by the `IROH_FORCE_STAGING_RELAYS` env var. The n0
+server _"does not interact with the Mainline DHT, so is a more central service."_
+Default relays are `use1-1.relay.n0.iroh.link.` and its `usw1`/`euc1`/`aps1` siblings
+([`iroh/src/defaults.rs:27`][iroh-defaults]).
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+Three distinct wire representations, all grounded in DNS:
+
+| Artifact           | Bytes / framing                                                               | Cite                              |
+| ------------------ | ----------------------------------------------------------------------------- | --------------------------------- |
+| Signed packet      | `<32 pubkey><64 sig><8 BE timestamp-µs><≤1000 B DNS reply>`, total ≤ 1104 B   | [`pkarr.rs:26`][dns-pkarr]        |
+| BEP-44 signable    | ASCII `"3:seqi{ts}e1:v{len}:"` ++ raw DNS packet bytes; `seq` == timestamp    | [`pkarr.rs:290`][dns-pkarr]       |
+| Relay HTTP payload | signed packet minus pubkey: `<64 sig><8 ts><dns packet>`; key in URL path     | [`http/pkarr.rs`][srv-http-pkarr] |
+| TXT record         | RFC 1464 `key=value`, one record per address; `relay=`, `addr=`, `user-data=` | [`attrs.rs`][dns-attrs]           |
+| DNS name           | `_iroh.<z32-endpoint-id>.<origin>`, z32 = 52-char label from a 32-byte key    | [`key.rs:20`][base-key]           |
+| Server storage row | `<8 B BE last_seen-µs><≤1104 B signed packet>` in redb                        | [`signed_packets.rs`][srv-store]  |
+
+The DNS packet uses [RFC 1035][rfc1035] name compression (via `simple-dns`), which the
+1000-byte budget depends on. Multi-string TXT records are concatenated without separator
+before parsing. Recency is total-ordered by `(timestamp, lexicographic packet bytes)`.
+The [wire-serialization][wire] page covers the shared DNS/TXT codec and how tickets pack
+the same `EndpointAddr` addresses.
+
+| Constant                     | Value                       | Cite                               |
+| ---------------------------- | --------------------------- | ---------------------------------- |
+| `MAX_DNS_PACKET_SIZE`        | 1000 B                      | [`pkarr.rs:17`][dns-pkarr]         |
+| `MAX_SIGNED_PACKET_SIZE`     | 1104 B                      | [`pkarr.rs:23`][dns-pkarr]         |
+| `UserData::MAX_LENGTH`       | 245 B                       | [`endpoint_info.rs`][dns-info]     |
+| `DNS_TIMEOUT` (per query)    | 3 s                         | [`dns.rs:42`][dns-resolver]        |
+| `DNS_STAGGERING_MS`          | 200,300,600,1000,2000,3000  | [`dns.rs:22`][al-dns]              |
+| jitter                       | ±20%                        | [`dns.rs`][dns-resolver]           |
+| `DEFAULT_PKARR_TTL`          | 30 s (ignored by n0 server) | [`pkarr.rs:135`][pk-const]         |
+| `DEFAULT_REPUBLISH_INTERVAL` | 5 min                       | [`pkarr.rs:146`][pk-const]         |
+| server zone LRU              | 1,048,576 zones             | [`store.rs`][srv-store-idx]        |
+| store eviction               | 7 days, scanned every 10 s  | [`signed_packets.rs`][srv-store]   |
+| write batch                  | 65,536 msgs / 1 s           | [`signed_packets.rs`][srv-store]   |
+| `PUT` rate limit             | 4/s, burst 2, per-IP        | [`rate_limiting.rs:61`][srv-rate]  |
+| remote actor idle timeout    | 60 s                        | [`remote_state.rs:73`][remote-src] |
+
+### Cryptography & identity
+
+The only cryptographic operation is ed25519 sign/verify over the BEP-44 signable
+(`ed25519-dalek`, via [`iroh-base`][base-key]). The signing key _is_ the
+[`EndpointId`][identity], so the record is self-certifying: the 32-byte pubkey prefix
+_is_ the name a resolver queried for, and verification is "does this signature match this
+key over these bytes." A pkarr relay or DNS cache is untrusted storage — it can withhold
+or replay but not forge. See [Identity & Cryptography][identity] for the key type, z32
+encoding, and the shared ed25519 primitives.
+
+Replay protection is the strictly-monotonic timestamp, which doubles as the BEP-44 `seq`.
+Its documentation ([`pkarr.rs:325`][dns-pkarr]) states the guarantee:
+
+> _"[`Timestamp::now`] is guaranteed to be strictly monotonic: it will never return the
+> same value twice and will never go backward, even if the system clock is corrected by
+> NTP."_
+
+This is enforced process-globally via an `AtomicU64` CAS loop returning at least
+`last + 1`, protecting against both NTP steps and two publishes within the same
+microsecond (which BEP-44's strictly-increasing-`seq` rule would otherwise reject). TLS
+enters only at the transport edges — pkarr `PUT`/`GET` over HTTPS (`rustls`) and DoH — and
+is orthogonal to record authenticity, which the signature already guarantees end to end.
+
+### State machines & lifecycle
+
+Five distinct state machines, three client-side and two server-side:
+
+1. **`PublisherService`** (pkarr publish loop, [`pkarr.rs:376`][pk-pub]). States
+   _Idle-no-data_ → _Published_ (republish timer at +5 min) → _Backoff_ (timer at +`failed_attempts` s). A `Watchable` update triggers an immediate re-publish; `Ok`
+   resets `failed_attempts` and arms the 5-min timer; `Err` increments it and arms the
+   linear-backoff timer; a `Disconnected` watcher (all publisher clones dropped) exits
+   the loop, and the whole task is abort-on-drop.
+2. **Per-remote lookup** (inside `RemoteStateActor`, [`remote_state.rs:850`][remote-src]).
+   States _NoLookup_ ⇄ _LookupRunning_. `ResolveRemote` with no selected path and no
+   running stream starts the merged stream; each `Ok(item)` inserts addresses (possibly
+   draining parked `connect` callers); terminal `Err`/end drains the rest and returns to
+   _NoLookup_. A selected path makes future triggers no-ops; 60 s idle with no pending
+   resolvers terminates the actor.
+3. **`AddressLookupStream` merge** ([`address_lookup.rs:582`][al-trait]). States _Open_ →
+   _Closed_. Emits `Ok(Ok)` (sets `did_emit`), `Ok(Err)` (buffers), and on inner
+   exhaustion emits `Err(NoResults{errors})` iff `!did_emit`.
+4. **`DnsResolver::op` retry loop** ([`dns.rs:311`][dns-resolver]). Per attempt races
+   (biased) lookup-completes / `notify_reset` / timeout; a reset reloads the resolver and
+   restarts with a fresh timeout. A swap-before-notify ordering means a missed wake still
+   observes the new resolver.
+5. **Server store actor batching** ([`signed_packets.rs`][srv-store]). _Waiting_ →
+   _Batching_ (write txn open), leaving when 65,536 messages, 1 s, or cancellation fires.
+   A companion eviction task snapshots the update-time index, then re-verifies each
+   candidate against the live table before deleting (it may have been refreshed since the
+   snapshot).
+
+The **staggered DNS lookup** is not a persistent state machine but a fan-out: n+1
+futures each prefixed by a jittered sleep, first `Ok` wins.
+
+### Dependencies & coupling
+
+| Crate                   | Depth (D-port cost)          | Role                                                                                                                                                                          |
+| ----------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `simple-dns` 0.11       | load-bearing (client+shared) | builds/parses the DNS packet inside signed packets, incl. name compression. Needs a minimal RFC 1035 writer/parser: header, QNAME compression, TXT char-string RDATA, A/AAAA. |
+| `hickory-resolver` 0.26 | load-bearing (client)        | full stub resolver: system config, UDP/TCP/DoT/DoH, caching, `Ipv4thenIpv6`. **Biggest reimplementation item.**                                                               |
+| `ed25519-dalek`         | load-bearing                 | sign/verify the BEP-44 signable (via [`iroh-base`][base-key]).                                                                                                                |
+| `data-encoding`         | small                        | z-base-32 with a custom alphabet (~30 lines to reimplement).                                                                                                                  |
+| `n0-future`             | API-surface                  | `MergeBounded`, `FuturesUnorderedBounded`, `once_future`, `BoxStream`, time shims.                                                                                            |
+| `n0-watcher`            | structural                   | `Watchable`/`Direct` watch-channel (last-value + async `updated()`) — **no event-horizon equivalent**.                                                                        |
+| `arc-swap`              | structural                   | lock-free resolver swap — collapses to a plain field single-threaded.                                                                                                         |
+| `reqwest` + `rustls`    | API-surface                  | pkarr relay HTTPS `PUT`/`GET` with the iroh `DnsResolver` plumbed in.                                                                                                         |
+| `tokio` (sync, timers)  | structural                   | mpsc/oneshot/broadcast/Notify/Mutex, sleep/interval — see [Concurrency Inventory][concurrency].                                                                               |
+| server-only             | server-only                  | `redb`, `lru`, `ttl_cache`, `mainline`, `axum`/`tower-governor`, `hickory-server` — only if porting the relay/DNS server.                                                     |
+| `strum`                 | trivial                      | kebab-case enum ↔ string for `IrohAttr`.                                                                                                                                      |
+
+The subsystem couples _upward_ to the [socket][socket] (which drives publish and consumes
+resolve into the path map) and the [endpoint][endpoint] (which owns the registry and hands
+services the secret key at bind time), and _sideways_ to [identity-crypto][identity]
+(signing) and [wire-serialization][wire] (the DNS/TXT codec). It couples _downward_ only
+to raw UDP/TCP (DNS) and HTTPS (pkarr) — it never dials QUIC itself.
+
+### Concurrency & I/O model
+
+Client-side, the moving parts are: one background `PublisherService` task per publisher
+(fed by a `Watchable`, driven by a `select!` of watcher-updated vs a resettable republish
+timer); the `RwLock`-guarded registry; the `MergeBounded` fan-in of resolve streams; and
+the `ArcSwap` + `Notify` resolver hot-swap. Lookups are I/O-bound: DNS is small
+UDP round-trips (staggered, jittered, timed out); pkarr is two-verb HTTPS with ≤1104-byte
+bodies. There is no CPU-heavy work — ed25519 verify on a ≤1104-byte packet is negligible.
+
+Server-side adds the redb write actor and eviction thread (both on dedicated OS threads
+because redb IO is blocking), an mpsc mailbox per store request, an axum `JoinSet` of
+HTTP/HTTPS listeners, a per-DoH-request broadcast(1) channel adapting hickory's push
+`ResponseHandler` into a pull, and the mainline DHT's own internal threads. The full
+tally lives in the [Tokio Concurrency Inventory][concurrency]; the load-bearing shapes
+for a port are the **watch channel**, the **mpsc actor inboxes**, and the **oneshot**
+reply for `connect`.
+
+### Mapping to event-horizon
+
+Address lookup is a good fit for [event-horizon][eh-spec]'s single-threaded fibers +
+capabilities model, with three genuine gaps that need new design (all flagged in the
+[event-horizon spec][eh-spec] as open issues).
+
+**The trait → a DbI capability.** [`AddressLookup`][al-trait] is a textbook
+Design-by-Introspection concept: a struct with optional `publish`/`resolve` members
+detected by presence. Static compositions need no vtable; the _dynamic_ registry
+(`Box<dyn AddressLookup>`) needs a small hand-rolled interface, but since iroh apps
+rarely add services at runtime, a `Vec`-of-interface with two methods is the honest
+mapping. The Rust trait alongside a proposed D capability trait:
+
+```rust
+// iroh/src/address_lookup.rs:333 (verbatim)
+pub trait AddressLookup: std::fmt::Debug + Send + Sync + 'static {
+    fn publish(&self, _data: &EndpointData) {}
+    fn resolve(&self, _endpoint_id: EndpointId) -> Option<BoxStream<Result<Item, Error>>> {
+        None
+    }
+}
+```
+
+```d
+// proposed / sketch — an event-horizon DbI capability.
+// Static services are detected by member presence (isAddressLookup!T);
+// the runtime registry is a small interface with the same two verbs.
+enum isAddressLookup(T) =
+    is(typeof(T.init.publish(EndpointData.init))) ||
+    is(typeof(T.init.resolve(EndpointId.init)));
+
+interface AddressLookup                       // used only for the dynamic Vec-of-services
+{
+    void publish(in EndpointData data);       // fire-and-forget; may spawn a fiber
+    // returns null if this service does not resolve; the caller owns the stream's Scope
+    ResolveStream* resolve(EndpointId id) @safe;
+}
+```
+
+**Resolve streams and the merge.** `resolve()` returns a cancellable multi-item stream
+merged across services with inline error buffering. Under event-horizon tier B the
+natural shape is a fiber per service pushing items into a per-lookup collector — but
+event-horizon **lacks cross-fiber channels (open issue O20)**, and `race`/first-completion
+is _not_ enough here: losing services must keep running and keep contributing addresses.
+The honest interim is a fiber-owned result buffer plus a wakeable condition, with the
+per-remote fiber as the single consumer; under the default `single` topology there is no
+lock around it. The inline-error-buffering policy (emit `NoResults{errors}` only if zero
+items were produced) is a small state machine over that buffer.
+
+**Cancellation is free.** _"Once the returned `BoxStream` is dropped, the service should
+stop any pending work"_ ([`address_lookup.rs:345`][al-trait]) maps directly to a child
+`Scope`: spawn each service's lookup in a scope owned by the lookup; exiting the scope
+cancels all children. A parked DNS/HTTP fiber is cancelled via `ASYNC_CANCEL` and resumes
+only at its terminal completion.
+
+**Staggered lookups map cleanly.** One `Scope`, spawn n+1 fibers each doing
+`sleep(jittered delay); attempt()`, first success cancels siblings — i.e. a `race` where
+each contestant has a sleep prefix. Jitter needs an RNG capability; the delays and the
+3 s timeout are `withDeadline` cancel scopes. Republish (5-min resettable), retry
+backoff, and the 60 s actor idle are all in-ring `TIMEOUT` ops; the resettable republish
+`sleep` becomes re-arming a timer op.
+
+**The watch channel has no equivalent.** `n0_watcher::Watchable` (socket → publisher) is
+last-value-wins + level-triggered wakeup, and event-horizon has nothing for it. A tiny
+cell suffices single-threaded, and it recurs across iroh subsystems (direct addrs, home
+relay), so design it once:
+
+```rust
+// n0_watcher::Watchable<Option<EndpointInfo>> (conceptual)
+//   .set(value)         // last-value-wins
+//   .watch().updated()  // async: wakes on the next change
+```
+
+```d
+// proposed / sketch — single-threaded watch cell (no locking under `single` topology).
+struct Watched(T)
+{
+    private T value;
+    private ulong version_;
+    private Waker waker;                       // event-horizon cross-fiber wake
+
+    void set(T v) @safe { value = v; version_++; waker.wake(); }
+
+    // parks the caller until version_ advances past `seen`
+    T await(ref ulong seen) @safe;            // returns value, updates seen := version_
+}
+```
+
+**Actors collapse to state-owning fibers.** The `RemoteStateActor` and the server store
+actor are mpsc actor loops → a single fiber owning its state; their inboxes again hit
+O20. The `connect` `oneshot` reply maps to `fork` → `JoinHandle.join`, or a one-slot cell
+
+- wake. The `ArcSwap` + `Notify` resolver reset dance collapses to a plain field swap plus
+  waking parked lookup fibers at their next checkpoint; interrupt-and-retry maps to a
+  `Cause.interrupt` requeue under a per-attempt `CancelContext`.
+
+**No thread pool needed.** The server's redb IO threads and eviction thread exist only
+because redb is blocking; on io_uring, file I/O is native, so a from-scratch D store (even
+a flat append-log + eviction index) runs on the ring directly — no `spawn_blocking`
+equivalent to fake.
+
+**The crypto/IO split is clean and `@nogc`-friendly.** `SignedPacket` build/verify is pure
+and allocation-light: the packet caps at 1104 bytes, ideal for a `SmallBuffer!(ubyte,
+1104)`; verification is one ed25519 check over a `SmallBuffer`-built BEP-44 signable. The
+monotonic `Timestamp` needs only a module-level `ulong` under `single` topology — no CAS:
+
+```d
+// proposed / sketch — strictly-monotonic pkarr timestamp, single-threaded.
+private ulong lastTimestamp;                   // module-level; no atomics under `single`
+
+ulong nowMicrosMonotonic(scope Clock clock) @safe nothrow @nogc
+{
+    const wall = clock.unixMicros();
+    const next = wall > lastTimestamp ? wall : lastTimestamp + 1;
+    lastTimestamp = next;
+    return next;                               // never repeats, never goes backward
+}
+```
+
+**The one large item with no shortcut is the DNS resolver.** hickory has no cheap
+replacement, but the [`Resolver`][dns-resolver] trait boundary is explicitly designed for
+a custom implementation. A D port starts with UDP TXT/A/AAAA queries to the configured
+nameservers via event-horizon `OpSend`/`OpRecv` with a 3 s deadline, a minimal RFC 1035
+codec (shared with the pkarr packet codec), and `/etc/resolv.conf` parsing. The pkarr
+`PUT`/`GET` client is plain HTTPS/1.1 with two verbs and tiny bodies — a `sparkles:http`
+client over [event-horizon][eh-spec] plus a TLS layer, reusing the same DNS capability for
+host resolution.
+
+---
+
+## Strengths
+
+- **Self-certifying records.** ed25519 over BEP-44 means every hop of infrastructure
+  (relay, DNS cache) is untrusted; forgery requires the secret key, and the pubkey _is_
+  the name.
+- **Transport-agnostic directory.** The same signed packet resolves over DNS (cheap,
+  cacheable, browser-friendly via DoH) or a pkarr HTTP relay, with no per-transport record
+  schema.
+- **Robust fan-out.** The `MergeBounded` merge with inline-error buffering guarantees one
+  failing resolver cannot hide another's results — a regression-tested invariant.
+- **Non-blocking dial path.** `connect` proceeds on the first known address; lookups
+  enrich candidates in the background and never serialize other peers' connects.
+- **Privacy-preserving default.** `relay_only()` keeps raw IPs off the public relay unless
+  the operator opts in.
+- **Small, self-contained record.** ≤1104 bytes total — trivially fits a stack buffer,
+  ideal for a `@nogc` D port.
+- **A single reference server** that is simultaneously pkarr relay and authoritative DNS,
+  serving the same stored packet under any configured origin.
+
+## Weaknesses
+
+- **hickory is a heavy dependency.** The client DNS stack (system config, UDP/TCP/DoT/DoH,
+  caching) is the single largest reimplementation item and has no small equivalent.
+- **pkarr is vendored, not shared.** iroh reimplements the signed-packet format rather
+  than depending on the upstream `pkarr` crate, so it can drift from the ecosystem
+  (compatibility with third-party `pkarr.org` relays is inferred, not verified).
+- **No client-side record cache.** Endpoint records rely entirely on hickory's cache, and
+  negative caching is disabled (`negative_max_ttl = 0`) — every miss re-queries.
+- **TTL is a lie on n0 infra.** `DEFAULT_PKARR_TTL = 30 s` is documented as ignored by the
+  n0 server (records live until superseded or 7-day eviction), so the field only affects
+  third-party DNS caches.
+- **Multiple `relay=` records are unresolved.** There is no defined policy for choosing a
+  home relay when several are published (an open upstream TODO on
+  [`Item::last_updated`][al-item]).
+- **Server complexity for a small job.** The reference server carries redb, an LRU, a TTL
+  cache, an optional DHT, rate limiting, and two OS threads — a lot of machinery around a
+  key→bytes map.
+
+## Key design decisions and trade-offs
+
+| Decision                                                 | Rationale                                                                                 | Trade-off                                                                                      |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| pkarr signed packet (ed25519 over BEP-44 DNS)            | Self-certifying records; infra is untrusted storage; reuses DNS wire format everywhere    | ≤1104-byte cap constrains how many addresses fit; name compression must stay within budget     |
+| BEP-44 `seq` == microsecond timestamp                    | One field for recency and replay protection; NTP-safe via strict monotonicity             | Two publishes in one µs need a process-global CAS/counter; no independent revision number      |
+| `resolve` returns a stream, `publish` is fire-and-forget | Services can emit multiple/updated results; endpoint can't wait on best-effort publish    | Asymmetric API; drop-to-cancel discipline; needs a channel-like fan-in (event-horizon O20)     |
+| Merge with inline error buffering                        | One failing service must not truncate results; report all errors only on total failure    | Callers must distinguish `Ok(Err)` (inline) from the terminal `Err`; extra buffering state     |
+| Non-blocking `connect` (first-address-wins)              | A slow/hanging lookup can't serialize other connects; dial starts ASAP                    | Lookup keeps running after `connect` returns; path selection deferred to QUIC/NAT traversal    |
+| `relay_only()` publish filter by default                 | Avoids leaking IPs to a public relay                                                      | Direct-IP dialing needs an explicit opt-in; default path always involves a relay hop           |
+| Vendor pkarr, drop in-tree mDNS/DHT lookups              | ~400-line focused impl; keeps the workspace lean; DHT/mDNS live in optional crates        | Ecosystem drift risk; loses zero-infrastructure DHT resolution unless the extra crate is added |
+| Reference server is relay + DNS in one process           | Same stored packet served over DoH and pkarr HTTP; one origin config answers many domains | Heavy dependency surface (redb, DHT, axum, two OS threads) for a conceptually simple store     |
+| No client-side record cache (`negative_max_ttl = 0`)     | Freshness over hit-rate; lookups feed a live path map, not a cache                        | Every miss re-queries; relies wholly on hickory's record cache                                 |
+
+---
+
+## Sources
+
+- [`iroh/src/address_lookup.rs`][al-trait] — `AddressLookup` trait, `AddressLookupServices` registry, `MergeBounded` merge, `Item`, `AddressLookupFailed`
+- [`iroh/src/address_lookup/pkarr.rs`][pk-pub] — `PkarrPublisher`, `PkarrResolver`, `PkarrRelayClient`, `PublisherService` loop, n0 relay constants
+- [`iroh/src/address_lookup/dns.rs`][al-dns] — `DnsAddressLookup`, staggered lookups
+- [`iroh-dns/src/pkarr.rs`][dns-pkarr] — `SignedPacket` wire format, BEP-44 signable, monotonic `Timestamp`
+- [`iroh-dns/src/attrs.rs`][dns-attrs] — `_iroh` TXT name, `IrohAttr`, `TxtAttrs`
+- [`iroh-dns/src/endpoint_info.rs`][dns-info] — `EndpointData`/`EndpointInfo`/`UserData`/`AddrFilter`, TXT codecs
+- [`iroh-dns/src/dns.rs`][dns-resolver] — `DnsResolver`, `Resolver` trait, hickory backend, staggering/jitter/reset
+- [`iroh-base/src/key.rs`][base-key] — z-base-32 alphabet, `EndpointId`
+- [`iroh-dns-server/src/store/signed_packets.rs`][srv-store] — redb store actor, batching, eviction
+- [`iroh-dns-server/src/http/pkarr.rs`][srv-http-pkarr] · [`http/rate_limiting.rs`][srv-rate] · [`dns/node_zone_handler.rs`][srv-zone] — relay/DNS frontends
+- [`iroh/src/socket/remote_map/remote_state.rs`][remote-src] · [`path_state.rs`][path-src] — how lookups race with dialing
+- [pkarr] · BitTorrent [BEP-44][bep44] · [RFC 1035][rfc1035] · [RFC 1464][rfc1464] · [RFC 8484][rfc8484] · [z-base-32][zb32]
+- Related pages: [Identity & Cryptography][identity] · [Wire Formats & Serialization][wire] · [The Relay Protocol][relay] · [Endpoint & Protocol Router][endpoint] · [The Multipath Socket][socket] · [NAT Traversal][nat] · [Tokio Concurrency Inventory][concurrency]
+
+<!-- References -->
+
+[repo]: https://github.com/n0-computer/iroh/tree/22cac742ca
+[docs-iroh]: https://docs.rs/iroh/1.0.1/iroh/address_lookup/index.html
+[docs-dns]: https://docs.rs/iroh-dns/1.0.1/iroh_dns/
+[docs-dns-server]: https://docs.rs/iroh-dns-server/1.0.1/iroh_dns_server/
+[al-trait]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup.rs#L333
+[al-item]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup.rs#L370
+[al-services]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup.rs#L461
+[al-filter]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns/src/endpoint_info.rs#L229
+[al-dns]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup/dns.rs#L22
+[pk-mod]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup/pkarr.rs#L9
+[pk-pub]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup/pkarr.rs#L270
+[pk-res]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup/pkarr.rs#L619
+[pk-const]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup/pkarr.rs#L127
+[pk-filter]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/address_lookup/pkarr.rs#L208
+[presets]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/presets.rs#L115
+[dns-pkarr]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns/src/pkarr.rs#L26
+[dns-attrs]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns/src/attrs.rs#L19
+[dns-info]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns/src/endpoint_info.rs#L70
+[dns-resolver]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns/src/dns.rs#L251
+[base-key]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-base/src/key.rs#L20
+[srv-store]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns-server/src/store/signed_packets.rs#L20
+[srv-store-idx]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns-server/src/store.rs#L28
+[srv-http-pkarr]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns-server/src/http/pkarr.rs
+[srv-rate]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns-server/src/http/rate_limiting.rs#L61
+[srv-zone]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns-server/src/dns/node_zone_handler.rs#L108
+[socket-src]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1320
+[remote-src]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L73
+[path-src]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state/path_state.rs#L161
+[iroh-util]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/util.rs#L10
+[iroh-defaults]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/defaults.rs#L27
+[bep44]: https://www.bittorrent.org/beps/bep_0044.html
+[pkarr]: https://pkarr.org
+[Mainline DHT]: https://www.bittorrent.org/beps/bep_0005.html
+[rfc1035]: https://www.rfc-editor.org/rfc/rfc1035
+[rfc1464]: https://www.rfc-editor.org/rfc/rfc1464
+[rfc8484]: https://www.rfc-editor.org/rfc/rfc8484
+[zb32]: https://philzimmermann.com/docs/human-oriented-base-32-encoding.txt
+[concepts]: ./concepts.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[quic]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[concurrency]: ./concurrency.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md

--- a/docs/research/iroh/docs-sync.md
+++ b/docs/research/iroh/docs-sync.md
@@ -1,0 +1,398 @@
+# Document Sync (`iroh-docs`)
+
+iroh's multi-writer, eventually-consistent key–value store: ed25519-signed `(namespace, author, key)` entries reconciled between peers by recursive range fingerprinting, with content bytes delegated to [blobs][blobs] and change notification to [gossip][gossip].
+
+| Field               | Value                                                                                                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)            | [`iroh-docs`][docs-repo] (sync engine + range reconciler + redb store + irpc client)                                                                                                                  |
+| Version             | `iroh-docs` 0.101.0 (git tag `v0.101.0`, commit `091e8cac47`) · against `iroh` 1.0.1 (`22cac742`), `iroh-blobs` 0.103.0, `iroh-gossip` 0.101.0, `irpc` 0.17.0, `redb` 4.1, `postcard` 1, `blake3` 1.8 |
+| Repository          | [`n0-computer/iroh-docs`][docs-repo]                                                                                                                                                                  |
+| Documentation       | [docs.rs/iroh-docs][docs-docs]                                                                                                                                                                        |
+| ALPN(s)             | `/iroh-sync/1` ([`net.rs`][docs-net], line 18)                                                                                                                                                        |
+| Approx. size (LoC)  | ~14,500 across `src/` (~9,000 non-test); the two load-bearing modules are `sync.rs` (2,688) and `ranger.rs` (1,652)                                                                                   |
+| Category            | Protocols                                                                                                                                                                                             |
+| Upstream spec/draft | Aljoscha Meyer, [_Range-Based Set Reconciliation_][meyer] (arXiv:2212.13567); data model informally after [Willow][willow] ("This is going to change!", [`sync.rs`][docs-sync-rs] lines 3–7)          |
+
+---
+
+## Overview
+
+### What it solves
+
+A _document_ in `iroh-docs` is a **multi-writer, eventually-consistent key–value map**. Internally it is a _replica_: a set of _entries_, each keyed by the triple `(NamespaceId, AuthorId, key-bytes)` ([`sync.rs`][docs-sync-rs], `RecordIdentifier`). The map's value is deliberately _not_ the payload — it is a `Record { len, hash, timestamp }` metadata pointer, and the content bytes it names live in [iroh-blobs][blobs], fetched separately by hash. Any number of authors may write the same key; conflicts resolve by a last-writer-wins rule (timestamp, then content hash). Deletion is modelled as writing an _empty_ entry, so a delete is itself a signed, replicated fact.
+
+The hard problem is convergence: two peers each hold a large set of signed entries, and they must compute the _union_ of those sets over a network without shipping the whole set every time. `iroh-docs` solves it with **range-based set reconciliation** — a recursive protocol that fingerprints ranges of the ordered key space and only descends into ranges whose fingerprints disagree, so the traffic is proportional to the _difference_ between the two sets rather than their size. On top of that pairwise protocol, an [epidemic broadcast][gossip] layer fans out change notifications so a whole swarm converges from pairwise syncs. This page is the byte-level and state-machine contract for that stack; the serialization details it references live on the [wire-serialization][wire] page.
+
+### Design philosophy
+
+The reconciliation core is a direct implementation of Aljoscha Meyer's [range-based set reconciliation][meyer]; the crate documents the thesis verbatim ([`lib.rs`][docs-lib], lines 21–23):
+
+> "Range-based set reconciliation is a simple approach to efficiently compute the union of two sets over a network, based on recursively partitioning the sets and comparing fingerprints of the partitions to probabilistically detect whether a partition requires further work."
+
+The data model borrows its shape — namespaces, authors, prefix-pruning deletion, timestamp-then-hash ordering — from the [Willow][willow] protocol, with an explicit disclaimer that it is provisional ([`sync.rs`][docs-sync-rs], lines 3–7):
+
+> "Names and concepts are roughly based on Willows design at the moment: https://hackmd.io/DTtck8QOQm6tZaQBBtTf7w … This is going to change!"
+
+The prefix-pruning conflict rule is quoted from Willow directly in the `put` implementation ([`ranger.rs`][docs-ranger], lines 567–570): "Remove all entries whose timestamp is strictly less than the timestamp of any other entry … whose path is a prefix of `p`" and then "remove all but those whose record has the greatest hash component". This is the entire CRDT semantics, and it is encoded as the `Ord` impl on the entry value. The engineering philosophy is equally explicit and pragmatic: a single actor thread serialises _all_ store and reconciliation work so the store never needs to be `Sync`, and every wire artifact is [`postcard`][postcard] over a QUIC bidirectional stream. Both of those choices dissolve under a single-threaded runtime — see [Mapping to event-horizon](#mapping-to-event-horizon).
+
+---
+
+## How it works
+
+### The data model
+
+Identity is raw bytes. `NamespaceId` and `AuthorId` are `[u8; 32]` newtypes over ed25519 public keys ([`keys.rs`][docs-keys], lines 349, 367); the matching secrets are `NamespaceSecret` (the **write capability** for a whole document) and `Author` (an authorship proof), each wrapping an `iroh` `SecretKey`. A `RecordIdentifier` is one contiguous buffer — `namespace(32) || author(32) || key(var)` — ordered bytewise via a derived `Ord` on the underlying `Bytes` ([`sync.rs`][docs-sync-rs], lines 1006–1008). That single ordering drives _both_ the [redb][redb] key layout and the reconciliation range order, so the store and the reconciler never disagree about "what comes next".
+
+The value is a metadata record, and its conflict order is fixed at the type level ([`sync.rs`][docs-sync-rs], lines 1126–1147):
+
+```rust
+// iroh-docs/src/sync.rs:1126-1147 (verbatim)
+pub struct Record {
+    len: u64,          // length of the data referenced by `hash`
+    hash: Hash,        // blake3 of the content; Hash::EMPTY + len==0 => tombstone
+    timestamp: u64,    // micros since the Unix epoch
+}
+// "Compares first the timestamp, then the content hash."
+impl Ord for Record {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.timestamp.cmp(&other.timestamp)
+            .then_with(|| self.hash.cmp(&other.hash))
+    }
+}
+```
+
+An `Entry { id: RecordIdentifier, record: Record }` is the unsigned fact; a `SignedEntry { signature: EntrySignature, entry: Entry }` carries two ed25519 signatures — one by the author, one by the namespace — over the _same_ canonical payload ([`sync.rs`][docs-sync-rs], lines 838–842, 913–917).
+
+### The canonical signing payload
+
+The bytes both signatures cover are **hand-rolled, not `postcard`** ([`sync.rs`][docs-sync-rs], lines 984–994, 1220–1224). They are `id.encode() || record.encode()`:
+
+```text
+signing payload (both author + namespace ed25519 signatures cover these bytes):
+  namespace   32 bytes
+  author      32 bytes
+  key         var bytes        ── id.encode()  (RecordIdentifier)
+  len         8 bytes  big-endian
+  hash        32 bytes
+  timestamp   8 bytes  big-endian   ── record.encode()
+```
+
+Two subtleties a byte-exact port must reproduce. First, this fixed-width big-endian layout is _not_ how a `SignedEntry` serialises on the wire: the `postcard` form encodes `len` and `timestamp` as LEB128 varints and `id` as a length-prefixed `Bytes`, so the signed bytes and the transmitted bytes differ — the verifier must reconstruct the canonical payload from the decoded fields, it cannot re-hash the received frame. Second, there is a standing `// TODO` that the payload "should probably include a namespace prefix" for domain separation ([`sync.rs`][docs-sync-rs], lines 861–863); today the namespace bytes lead the payload but there is no explicit domain-separation tag.
+
+### Conflict resolution and prefix pruning
+
+Insertion is a CRDT operation defined once as the default `Store::put` in the reconciler ([`ranger.rs`][docs-ranger], lines 551–584). A new entry is stored iff its value compares **strictly greater** than the value of every existing entry whose key _is a prefix of, or equal to,_ the new key (the `prefixes_of` walk). Then every existing entry whose key is _prefixed by_ the new key with a value ≤ the new value is physically deleted (`remove_prefix_filtered`), and finally the new entry is written. So the semantics are last-writer-wins per `(author, key)`, with the content `hash` as tiebreaker, and an exact duplicate is a no-op (`InsertOutcome::NotInserted`). Because the comparison is on `Record`, an author can always win a conflict by choosing a larger timestamp.
+
+### Tombstones and deletion
+
+Deletion is not a separate operation — it is an _empty_ entry. `Record::empty(ts) = Record::new(Hash::EMPTY, 0, ts)` ([`sync.rs`][docs-sync-rs], lines 1169–1177), and `Replica::delete_prefix` signs an empty entry whose key is the prefix to erase; the `put` prefix-pruning rule above then removes everything under it ([`sync.rs`][docs-sync-rs], lines 401–417). A normal `insert` refuses an empty payload (`InsertError::EntryIsEmpty`), and remote entries must satisfy the invariant `hash == EMPTY ⟺ len == 0` (`validate_empty`, error `InvalidEmptyEntry`). Tombstones persist as ordinary rows and replicate like any entry, but queries filter them out unless `include_empty` is set ([`store/fs/query.rs`][docs-repo]). A prefix delete physically drops the pruned rows with no per-row event, so the deleted set is unrecoverable except by re-syncing from a peer that still holds newer, non-pruned data.
+
+Validation on every insert (`validate_entry`, [`sync.rs`][docs-sync-rs], lines 615–644): the namespace must match the replica, both signatures are verified for non-local origins, and the timestamp must be ≤ now + `MAX_TIMESTAMP_FUTURE_SHIFT` = 600,000,000 µs = 10 minutes ([`sync.rs`][docs-sync-rs], lines 46–48). Entries arbitrarily far in the _past_ are accepted; only the future is bounded.
+
+### Range-based set reconciliation (`ranger.rs`)
+
+Ranges are wrap-around pairs `Range { x, y }` over `RecordIdentifier`s ([`ranger.rs`][docs-ranger], lines 64–68): `x == y` means "everything", `x < y` is the half-open `[x, y)`, and `x > y` is the complement wrap. A range's `Fingerprint` is a 32-byte value combined by **byte-wise XOR** of per-entry fingerprints ([`ranger.rs`][docs-ranger], lines 106–128):
+
+```rust
+// iroh-docs/src/ranger.rs:106-128 (verbatim)
+pub struct Fingerprint(pub [u8; 32]);
+impl Fingerprint {
+    pub(crate) fn empty() -> Self { Fingerprint(*blake3::hash(&[]).as_bytes()) }
+}
+impl std::ops::BitXorAssign for Fingerprint {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        for (a, b) in self.0.iter_mut().zip(rhs.0.iter()) { *a ^= b; }
+    }
+}
+```
+
+A per-entry fingerprint is `BLAKE3(namespace(32) || author(32) || key || timestamp_be(8) || content_hash(32))` ([`sync.rs`][docs-sync-rs], lines 826–834). Note that this fingerprint order differs from the signing payload: it _omits_ `len` and puts `timestamp` **before** `hash`. The empty-set fingerprint is `BLAKE3("")` — the hash of the empty string, deliberately _not_ all-zeros, so XOR-combination stays well-defined ([`ranger.rs`][docs-ranger], lines 115–120).
+
+`Store::process_message` ([`ranger.rs`][docs-ranger], lines 324–549) consumes a `Message { parts: Vec<MessagePart> }` where each part is a `RangeFingerprint` or a `RangeItem`. The algorithm:
+
+- **Incoming `RangeItem`** — store each value that passes `validate_cb` via `put` (firing `on_insert_cb` for real inserts). If the item's `have_local` flag is `false`, compute the _diff_ — local entries in the range absent from the peer's set, or present with a strictly smaller peer value — and reply `RangeItem { values: diff, have_local: true }`. `have_local: true` ends that branch.
+- **Incoming `RangeFingerprint`** — three cases:
+  1. equal fingerprints → the range is already in sync, no output;
+  2. _recursion anchor_: if the local count ≤ 1, or the remote fingerprint equals the empty fingerprint, reply with all local values as a `RangeItem { have_local: false }`;
+  3. otherwise **split** the range into `split_factor` subranges at pivots drawn from evenly spaced local elements, and for each non-empty subrange reply with a fresh `RangeFingerprint` if its chunk exceeds `max_set_size`, else a `RangeItem` carrying the values.
+
+If no parts are produced, the reply is `None`, which terminates the session. The initial message is a single `RangeFingerprint` over the whole set (`Range(first_key, first_key)`, [`ranger.rs`][docs-ranger], lines 200–207). The configuration is effectively hardcoded: `process_message` is always called with `&SyncConfig::default()`, i.e. **`max_set_size: 1`, `split_factor: 2`** ([`ranger.rs`][docs-ranger], lines 673–688; call site [`sync.rs`][docs-sync-rs] line 547) — so a mismatched range is bisected until each subrange holds at most one element. The tunables are dead config in production. Termination is guaranteed because every recursion strictly reduces range cardinality, and equal fingerprints or a completed item exchange produce no output.
+
+Every outgoing entry is annotated with a `ContentStatus` (`Complete`/`Incomplete`/`Missing`) obtained by awaiting a `content_status_cb` — a blobs-availability probe carried inline in the `RangeItem` values ([`ranger.rs`][docs-ranger], lines 384–388, 427–432). When no blob store is wired in, the default is `Missing` ([`sync.rs`][docs-sync-rs], lines 575–581). This callback is the _only_ asynchronous point inside `process_message`; all store work is synchronous.
+
+### The network protocol (`net.rs`, `net/codec.rs`)
+
+One sync session is one bidirectional QUIC stream under ALPN `/iroh-sync/1`. The dialer (`connect_and_sync`) opens `open_bi`, runs the initiator ("Alice") loop, then performs a clean close — `finish()` → `stopped()` → `read_to_end(0)` ([`net.rs`][docs-net], lines 23–92). The acceptor (`handle_connection`) mirrors with `accept_bi` and the responder ("Bob") loop.
+
+Framing is a 4-byte **big-endian `u32`** length prefix followed by a `postcard`-encoded `Message`, with a maximum frame of `MAX_MESSAGE_SIZE = 1024 * 1024 * 1024` = 1 GiB and the self-deprecating comment "This is likely too large, but lets have some restrictions" ([`net/codec.rs`][docs-codec], lines 22–68). The session envelope is a three-variant enum ([`net/codec.rs`][docs-codec], lines 76–89):
+
+```rust
+// iroh-docs/src/net/codec.rs:76-89 (verbatim) — postcard varint discriminants 0/1/2
+enum Message {
+    Init { namespace: NamespaceId, message: ProtocolMessage },  // only the dialer, exactly once
+    Sync(ProtocolMessage),                                       // both directions
+    Abort { reason: AbortReason },                              // only the acceptor
+}
+// iroh-docs/src/net.rs:280-288
+pub enum AbortReason { NotFound, AlreadySyncing, InternalServerError }  // 0/1/2
+```
+
+`ProtocolMessage` is `ranger::Message<SignedEntry>`. Progress is threaded through every call as a `SyncOutcome { heads_received, num_recv, num_sent }`.
+
+### The store actor and redb schema
+
+All store and replica access is funnelled through a **dedicated OS thread** named `"sync-actor"` that runs a current-thread tokio runtime inside a `LocalSet` (on wasm it degrades to a spawned task) ([`actor.rs`][docs-actor], lines 266–306). The rationale is documented on the handle ([`actor.rs`][docs-actor], lines 220–224):
+
+> "The [`SyncHandle`] exposes async methods which all send messages into the actor thread, usually returning something via a return channel. The actor thread itself is a regular [`std::thread`] which processes incoming messages sequentially."
+
+Callers send `Action`s over a bounded `async_channel` (`ACTION_CAP = 1024`) and receive replies via `tokio::sync::oneshot` (or an irpc `mpsc` for streaming). The actor owns the [redb][redb] `Store`, the `HashMap<NamespaceId, OpenReplica>` of open replicas with handle refcounts, and a `JoinSet` of streaming tasks. Its loop `select!`s over a **500 ms flush timer** (`MAX_COMMIT_DELAY`) that commits the pending redb write transaction, `join_next()` reaping, and the action channel. Writes reuse an open write transaction until it is 500 ms old, then commit and reopen (`CurrentTransaction`, [`store/fs.rs`][docs-store-fs], lines 229–294) — a coarse batching that trades durability latency for throughput.
+
+The persistent schema is seven redb tables ([`store/fs/tables.rs`][docs-tables], lines 13–73):
+
+| Table                     | Key                                             | Value                                                                         |
+| ------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------- |
+| `authors-1`               | `[u8;32]` `AuthorId`                            | `[u8;32]` author secret                                                       |
+| `namespaces-2`            | `[u8;32]` `NamespaceId`                         | `(u8, [u8;32])` = `(CapabilityKind, secret-or-id)`                            |
+| `records-1`               | `([u8;32], [u8;32], &[u8])` = (ns, author, key) | `(u64, [u8;64], [u8;64], u64, [u8;32])` = (ts, ns-sig, author-sig, len, hash) |
+| `records-by-key-1`        | `([u8;32], &[u8], [u8;32])` = (ns, key, author) | `()` — pure secondary index                                                   |
+| `latest-by-author-1`      | `([u8;32], [u8;32])` = (ns, author)             | `(u64, &[u8])` = (timestamp, key)                                             |
+| `sync-peers-1` (multimap) | `[u8;32]` ns                                    | `(u64 nanos, [u8;32] peer)` — LRU of 5 useful peers                           |
+| `download-policy-1`       | `[u8;32]` ns                                    | `postcard` `DownloadPolicy`                                                   |
+
+`entry_put` writes the `records`, `records-by-key`, and `latest-by-author` tables atomically ([`store/fs.rs`][docs-store-fs], lines 760–793); signatures are stored inline (64 + 64 bytes per row). Queries choose an index via `IndexKind::from(&Query)`: author-then-key scans hit `records-1` directly, while key-then-author and "single latest per key" scans walk `records-by-key-1` and join back per hit. Range scans for the reconciler split a wrap-around range into up to two chained redb bounds-scans, and `prefixes_of` (the CRDT parent walk) is `O(key_len)` point lookups.
+
+### Engine, live sync, gossip and blobs handoff
+
+`Engine::spawn` wires the store actor, a `ContentStatusCallback` mapping `blobs.status(hash)` to `Complete`/`Incomplete`/`Missing`, a GC-protect task that streams doc-referenced hashes to the blobs garbage collector, and the **LiveActor** ([`engine.rs`][docs-engine]). The LiveActor is a single-owner event loop whose biased `select!` multiplexes its command inbox (`mpsc`, `ACTOR_CHANNEL_CAP = 64`), a replica-events channel (`async_channel`, cap 1024, subscribed into every open-for-sync replica), three `JoinSet`s (connect-syncs, accept-syncs, downloads), and per-namespace gossip progress ([`engine/live.rs`][docs-live], lines 239–294).
+
+Live flow: `start_sync(namespace, peers)` opens the replica with `sync: true`, registers peer addresses in a `MemoryLookup` address book, joins the per-namespace [gossip][gossip] topic (topic id = the raw 32-byte `NamespaceId`), and kicks an initial sync for each bootstrap peer. Thereafter each replica insert raises a `LocalInsert` or `RemoteInsert` event; the LiveActor turns a `LocalInsert` into a gossip broadcast of `Op::Put(SignedEntry)` and a `RemoteInsert` into a content-download decision ([`engine/live.rs`][docs-live], lines 708–742). The gossip payloads are three ([`engine/live.rs`][docs-live], lines 40–56):
+
+```rust
+// iroh-docs/src/engine/live.rs:40-56 (verbatim) — postcard Op, discriminants 0/1/2
+pub enum Op {
+    Put(SignedEntry),
+    ContentReady(Hash),
+    SyncReport(SyncReport),   // { namespace: NamespaceId, heads: Vec<u8> /* encoded AuthorHeads */ }
+}
+```
+
+An incoming `Op::Put` becomes an `insert_remote`, with `ContentStatus::Complete` assumed iff the message arrived direct from a neighbor (`msg.scope.is_direct()`), else `Missing`. `Op::ContentReady(hash)` triggers a download from that neighbor only if the hash is still missing. `Op::SyncReport` carries a size-capped `AuthorHeads` (the newest timestamp per author, [`heads.rs`][docs-heads]); the receiver compares heads via `has_news_for_us` and, if the reporter is ahead, starts a sync with it. Critically, **after every successful sync that received > 0 entries, the node broadcasts its own `SyncReport`** to gossip neighbors — this anti-entropy fan-out is what lets a swarm converge from pairwise syncs ([`engine/live.rs`][docs-live], lines 566–584). Downloads go through the iroh-blobs `Downloader` with a `ProviderNodes` map (hash → known provider endpoint ids) and `SplitStrategy::None`; completion emits `Event::ContentReady` plus a gossip `Op::ContentReady`, and failure re-queues the hash.
+
+Concurrent syncs are deduplicated by a `PeerState` per `(namespace, peer)`: starting a connect while `Running` is refused, and a simultaneous dial+accept is resolved deterministically — the node with the _larger_ id bytes accepts, the other's dial wins (`expected_sync_direction`, [`engine/state.rs`][docs-state], lines 215–256).
+
+### The irpc API seam
+
+The client API (`DocsApi`, `Doc`) is a thin layer over [irpc][irpc] 0.17 ([`api.rs`][docs-api]). `DocsApi` wraps an `irpc::Client<DocsProtocol>` — a 26-variant request enum, each variant a `oneshot` or server-streaming `mpsc` reply, none carrying client-update channels ([`api/protocol.rs`][docs-api-proto], lines 307–366). irpc's essential design is _one serde request enum_ + a per-variant `(Tx, Rx)` channel-type mapping + a message type that is the request combined with its live channels; in-process this is a channel send into an actor, and remotely it is one QUIC bidi stream carrying `varint-len ++ postcard` frames, with no request IDs or headers — multiplexing is entirely QUIC's ([`irpc lib.rs`][irpc-lib], lines 50–52). Notably, the docs remote handler is hand-rolled as a 26-arm match rather than the derive-generated `remote_handler`, and the entire RPC plane dials the loopback (`"localhost"`, self-signed certs) over vanilla `noq` — it is a **cross-process CLI/daemon** feature, never the p2p endpoint. irpc's own goal is to be so lightweight it replaces "a mpsc channel with a giant message enum where each enum case contains mpsc or oneshot backchannels" ([`irpc lib.rs`][irpc-lib], lines 5–9) — which is exactly what a single-threaded D port makes unnecessary in-process (direct method calls).
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+Everything is [`postcard`][postcard] over a QUIC bidi stream, except the two hand-rolled cryptographic payloads (the signing payload and the fingerprint pre-image). The complete surface, all cross-referenced from [wire-serialization][wire]:
+
+- **ALPN**: `b"/iroh-sync/1"` ([`net.rs`][docs-net], line 18).
+- **Frame**: 4-byte big-endian `u32` length (body only) + `postcard` body; max body 1 GiB (`MAX_MESSAGE_SIZE`, [`net/codec.rs`][docs-codec], line 22). Note this is a _third_ varint dialect coexisting with `postcard` LEB128 and QUIC varints: docs uses a plain fixed 4-byte big-endian prefix, matching [gossip's][gossip] framing but unlike blobs.
+- **Session envelope** (`postcard` enum, varint discriminant): `0 = Init { namespace: [u8;32], message }`, `1 = Sync(message)`, `2 = Abort { reason }`. `AbortReason`: `0 = NotFound`, `1 = AlreadySyncing`, `2 = InternalServerError`.
+- **Reconciliation message**: `Message { parts: Vec<MessagePart> }`; `MessagePart`: `0 = RangeFingerprint { range: {x, y}, fingerprint: [u8;32] }`, `1 = RangeItem { range, values: Vec<(SignedEntry, ContentStatus)>, have_local: bool }`. `Range<RecordIdentifier>` serialises as two `Bytes` (varint length + bytes each). `ContentStatus`: `0 = Complete`, `1 = Incomplete`, `2 = Missing`.
+- **`SignedEntry`** (`postcard` field order): `signature { author_signature(64), namespace_signature(64) }`, then `entry { id: Bytes, record { len: varint, hash: [u8;32], timestamp: varint } }`. `iroh::Signature` wraps `ed25519_dalek::Signature` behind a wire-stable `serialize_tuple` impl so the on-wire format is independent of upstream `serde` changes ([`sync.rs`][docs-sync-rs], lines 17–22).
+- **Canonical signing payload** (hand-rolled, big-endian, _not_ `postcard`): `namespace(32) || author(32) || key || len_be(8) || hash(32) || timestamp_be(8)`.
+- **Per-entry fingerprint**: `BLAKE3(namespace(32) || author(32) || key || timestamp_be(8) || content_hash(32))`; range fingerprint = XOR of entry fingerprints; empty-set fingerprint = `BLAKE3("")`.
+- **`AuthorHeads`** (inside `SyncReport.heads`): `postcard` `Vec<(u64 timestamp, [u8;32] author)>`, newest-first, tail-truncated until it fits the gossip max message size.
+- **Gossip `Op`**: `0 = Put(SignedEntry)`, `1 = ContentReady([u8;32])`, `2 = SyncReport { namespace(32), heads: Vec<u8> }`; gossip topic id = the raw `NamespaceId` bytes.
+- **`DocTicket`**: `postcard` of a single-variant `TicketWireFormat` (leading `0x00`) → `Capability` (`Write(secret 32)` = 0 / `Read(id 32)` = 1) + 32-byte key + `Vec<EndpointAddr>`; string form is `"doc"` + lowercase base32-nopad, decode rejects empty `nodes` ([`ticket.rs`][docs-ticket]). See [wire-serialization][wire] for the byte-exact golden vector.
+
+Constants a decoder must enforce: `MAX_MESSAGE_SIZE` = 1 GiB, `MAX_TIMESTAMP_FUTURE_SHIFT` = 600,000,000 µs, `PEERS_PER_DOC_CACHE_SIZE` = 5. The 1 GiB frame is a genuine hazard: a `RangeItem` can legitimately carry a huge value set, so a port should stream item parts or cap far lower.
+
+### Cryptography & identity
+
+Every entry carries **two** ed25519 signatures over the same canonical payload — the author's (proof of authorship) and the namespace's (write authority) ([`sync.rs`][docs-sync-rs], `EntrySignature`). Verification recovers both public keys directly from the id bytes (they _are_ the 32-byte keys) and checks both signatures; a `MemPublicKeyStore` caches the decompressed ed25519 points to avoid repeated curve decompression during a sync ([`store/pubkeys.rs`][docs-repo]). Ids are stored and transmitted as raw bytes that may not be valid curve points until decompressed, so verification is where malformed keys are rejected.
+
+The capability model is coarse. Holding the `NamespaceSecret` is the write capability; the read capability is simply **knowledge of the 32-byte `NamespaceId`**. A sync session performs _no_ authentication of the reader: Bob's accept callback only checks that the namespace is in the local sync set (else `NotFound`), so anyone who holds the id can fetch the entire document from any syncing node. A `DocTicket` with a `Write` capability embeds the raw namespace secret in the copy-pasteable string — tickets are bearer credentials. The full algorithm inventory (ed25519, blake3) belongs to [identity-crypto][identity-crypto]; the one docs-specific note is the missing domain-separation tag flagged in the signing-payload `TODO`.
+
+### State machines & lifecycle
+
+Eight interacting machines govern a session; all are synchronous except where noted:
+
+1. **Initiator ("Alice")** (`run_alice`, [`net/codec.rs`][docs-codec]): _SendInit_ → _Loop_. Send `Init { namespace, whole-set fingerprint }`; on each `Sync(msg)` call `sync_process_message`, send the reply if `Some`, break if `None`. An unexpected `Init` or an `Abort` is a hard error; the clean close is `finish` → `stopped` → `read_to_end(0)`. No timers at this layer — QUIC handles liveness.
+2. **Responder ("Bob")** (`BobState::run`, [`net/codec.rs`][docs-codec]): state variable `namespace: Option<NamespaceId>`. `(Init, None)` runs the accept callback (an async round-trip into the LiveActor); `Reject` → send `Abort` and error; `Allow` → process and set the namespace. `(Sync, Some)` → process. A double `Init`, a `Sync` before `Init`, or an `Abort` received by Bob are all protocol violations.
+3. **Per-range recursion** (implicit, distributed): whole-set fingerprint → split into 2 → each subrange is either a fingerprint (chunk > 1 element) or an item exchange (≤ 1 element, or remote-empty). Terminates because cardinality strictly decreases.
+4. **`PeerState` per `(namespace, peer)`** ([`engine/state.rs`][docs-state]): `Idle → Running{origin} → Idle`; a `SyncReport` while `Running` sets `resync_requested` so a fresh sync fires on completion; simultaneous dial+accept resolved by the id-bytes tie-break.
+5. **`PendingContentReady` gate**: after a sync finishes, `PendingContentReady` is emitted exactly once — immediately if nothing was queued, else when the namespace's queued-hash set drains.
+6. **Store transaction state** (`CurrentTransaction`): `None ↔ Read ↔ Write`; writes reuse the open write tx until it is 500 ms old, then commit; any snapshot request commits first.
+7. **Content download tracking**: a hash is in exactly one of `missing_hashes`, `queued_hashes`, or done; a neighbor `ContentReady` moves missing → queued; a failed download moves it back.
+8. **Replica open/close refcount** (`OpenReplicas`): open increments `handles` and merges the `sync` flag and subscribers; close decrements and evicts at 0.
+
+### Dependencies & coupling
+
+| Crate                         | Depth               | Notes for a D port                                                                                                                                                                                                                                                  |
+| ----------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`redb`][redb] 4.1            | load-bearing        | Embedded ordered KV with multi-table ACID writes, forward/reverse range scans, multimap tables, `extract_from_if`/`retain_in`. A port needs an ordered persistent map with prefix/range scans and batched transactions. In-memory mode is redb's `InMemoryBackend`. |
+| [`postcard`][postcard] 1      | load-bearing (wire) | Every wire artifact is `postcard`; reproduce bit-exactly (see [wire-serialization][wire]).                                                                                                                                                                          |
+| `blake3` 1.8                  | load-bearing        | Entry and empty-set fingerprints — same library as [blobs][blobs]/[bao-tree][bao-tree].                                                                                                                                                                             |
+| ed25519 (via `iroh`)          | load-bearing        | Two signatures per entry; ids are the public keys.                                                                                                                                                                                                                  |
+| [`iroh`][iroh-repo] 1.0.1     | integration         | `Endpoint`/`Connection` (QUIC bidi streams over [noq][quic-transport]), `EndpointAddr`, `MemoryLookup` address book.                                                                                                                                                |
+| [`iroh-gossip`][gossip] 0.101 | integration         | topic subscribe/broadcast, neighbor up/down events, `scope.is_direct()`.                                                                                                                                                                                            |
+| [`iroh-blobs`][blobs] 0.103   | integration         | `blobs.status(hash)`, `Downloader::download_with_opts` + `ContentDiscovery`, `add_bytes`, GC protect.                                                                                                                                                               |
+| [`irpc`][irpc] 0.17           | API surface         | Client API plumbing; in-proc = channels, remote = `noq`. Any RPC veneer substitutes.                                                                                                                                                                                |
+
+`tokio-util` codec, `async-channel`, `tokio::sync`, `n0-future`, `self_cell`, and the derive-convenience crates are all shallow plumbing a port replaces with event-horizon constructs.
+
+### Concurrency & I/O model
+
+`iroh-docs` is one of the most concurrency-dense subsystems in the workspace — the [concurrency][concurrency] inventory catalogues ~26 distinct primitives. The shape is a **hierarchy of single-owner actors**: the `"sync-actor"` OS thread serialises all store and CRDT work behind an `async_channel` mailbox with per-request `oneshot` replies; the `LiveActor` task orchestrates live sync behind an `mpsc` inbox and three `JoinSet`s (connect/accept/download); the `RpcActor` task dispatches the irpc client protocol; and per-namespace gossip receive loops feed the LiveActor. Fan-out to subscribers is a `join_all` over per-replica `async_channel` senders that **back-pressures inserts** if a subscriber stops reading ([`sync.rs`][docs-sync-rs], lines 296–299). Shared state that survives the actor boundary — `ProviderNodes`, `MemPublicKeyStore`, `DefaultAuthor` — is wrapped in `Arc<Mutex<…>>`/`Arc<RwLock<…>>`. The two load-bearing rationales are Rust ownership (the store must not be `Sync`) and moving blocking redb I/O off the multi-threaded tokio runtime — both of which vanish under a single loop thread.
+
+### Mapping to event-horizon
+
+Under [`sparkles:event-horizon`][eh-spec]'s default `single` topology — one loop, one thread, completion-first io_uring — the entire actor-and-mailbox scaffolding collapses, and the subsystem becomes markedly simpler. Four moves matter.
+
+**1. The store actor collapses into a plain fiber-owned struct.** The `"sync-actor"` thread exists only for Rust ownership and to keep blocking redb I/O off the runtime; io_uring covers file I/O natively (no `spawn_blocking` substitute needed, per the [eh brief][eh-spec]). The `Action`/`oneshot` message set becomes an ordinary method interface on a non-`shared` struct one fiber owns:
+
+```rust
+// iroh-docs/src/actor.rs:232-241 (verbatim) — the handle to the actor thread
+pub struct SyncHandle {
+    tx: async_channel::Sender<Action>,
+    join_handle: Arc<Option<std::thread::JoinHandle<()>>>,
+    metrics: Arc<Metrics>,
+}
+```
+
+```d
+// proposed / sketch — no thread, no mailbox, no oneshot; "Action"s are methods.
+struct SyncStore
+{
+    Db db;                         // redb-equivalent ordered KV (own module)
+    OpenReplicas open;            // NamespaceId -> OpenReplica { handles, sync, subs }
+    MemPubKeyCache keys;          // decompressed ed25519 points
+
+    // was Action::InsertLocal { .. } + oneshot reply
+    IoResult!InsertOutcome insertLocal(NamespaceId ns, in Author a,
+                                       scope const(ubyte)[] key, Hash h, ulong len);
+
+    // was Action::SyncProcessMessage — see the invariant below.
+    IoResult!(Message*) processMessage(NamespaceId ns, Message* msg,
+                                       scope ContentStatusFn contentStatus);
+}
+```
+
+The one invariant to preserve is **sequential store access**: `process_message` mutates the store mid-message (validate → put → diff), and the async point inside it is _only_ the `content_status_cb`. In Rust the actor thread serialises interleaving; in D, either run `processMessage`'s store work to completion without yielding, or gate a store with a logical "busy" token so two sessions cannot interleave at the `contentStatus` await. Model `content_status_cb` as a DbI capability (`isContentStatus`) so docs-sync is testable with no blob store (default `Missing`).
+
+**2. The LiveActor becomes a `Scope` with a `race` loop.** The biased `tokio::select!` over inbox / replica-events / three `JoinSet`s / gossip progress maps to a `race` over an inbound command source plus child-fiber completions; the `JoinSet`s become child fibers `fork`ed in a `Scope`, and the scope's exit-join replaces `JoinSet` reaping — strictly stronger than Rust's abort-on-drop, whose swallowed panics are a known flaw. The obstacle is that **event-horizon has no cross-fiber channel primitive yet** (open issue O20), and this subsystem leans on channels heavily (the mailbox, the cap-1024 replica-events channel, subscriber fan-outs). Two viable paths: (a) resolve the channel design first (bounded SPSC suffices), or (b) restructure LiveActor callbacks as direct method calls on the single-threaded object — feasible precisely because the Rust `sync_actor_tx` self-send exists _only_ to avoid a same-thread deadlock ([`engine/live.rs`][docs-live], lines 157–159), which does not arise when one fiber owns the loop.
+
+**3. Sync sessions map cleanly to Tier-B fibers.** `run_alice` / `BobState::run` are sequential recv → process → send loops over one QUIC bidi stream — ideal direct-style code with blocking-looking `recv`/`send` verbs, no function coloring:
+
+```d
+// proposed / sketch — one bidi noq stream; parks the fiber on recv, no channel/task.
+Outcome!SyncOutcome runAlice(ref BiStream s, NamespaceId ns,
+                             ref SyncStore store, in Env env)
+{
+    s.send(encode(Message.init(ns, store.initialMessage(ns))));  // Init{ns, whole-set fp}
+    for (;;)
+    {
+        auto frame = s.recvFramed();          // u32-BE length + postcard body
+        auto reply = store.processMessage(ns, decode!Message(frame), env.contentStatus);
+        if (reply.isNone) break;              // None => reconciliation converged
+        s.send(encode(reply.get));
+    }
+    s.finish(); s.stopped(); s.readToEnd(0);  // clean-close handshake ([noq] stream verbs)
+    return ok(store.outcome);
+}
+```
+
+The clean-close handshake needs the [noq][quic-transport] stream API equivalents of `finish`/`stopped`/`read_to_end(0)`; whether `read_to_end(0)` keeps quinn's "error if the peer sent unread data" semantics on the new noq API is an open interop question. Cancellation maps _better_ than Rust: a sync fiber cancelled by scope teardown resumes only at its terminal CQE, and the `Cause.interrupt` arm is the natural carrier for the `AlreadySyncing`/shutdown path.
+
+**4. Locks and clocks become plain fields and capabilities.** Every `Arc<Mutex<…>>`/`RwLock` (`ProviderNodes`, `MemPublicKeyStore`, `DefaultAuthor`) is single-threaded refcount noise and collapses to a plain field. The tie-break logic (`expected_sync_direction`) and the `PeerState` machine are already pure and port as-is. The 500 ms flush timer is an in-ring `TIMEOUT` op re-armed per loop iteration; transaction age uses `MonoTime`. The determinism win is real: wall-clock `SystemTime::now` → µs timestamps should route through the `RingClock`/`isClock` capability so `TestClock` drives the timestamp-conflict tests deterministically, and `SimNet` can replace the QUIC stream entirely (the Rust tests already use `tokio::io::duplex`). The wasm single-thread mode `iroh-docs` already ships validates that the whole subsystem runs single-threaded. The irpc remote plane (`DocsApi::connect`/`listen`) is a localhost cross-process feature over vanilla QUIC, independent of the p2p wire, and can be deferred to a later milestone — but the request-enum schema should be fixed early because the in-process API shape derives from it (see [concurrency § irpc][concurrency]).
+
+---
+
+## Strengths
+
+- **Sub-linear convergence.** Range-based set reconciliation exchanges traffic proportional to the _difference_ between two sets, not their size — a swarm of near-synchronised peers reconciles cheaply.
+- **Clean three-layer separation.** Metadata (docs) / content ([blobs][blobs]) / propagation ([gossip][gossip]) are decoupled; a document row is a signed pointer, and content transfer is a separate, hash-verified fetch.
+- **Genuine multi-writer semantics.** Authorship (`Author`) is separated from write authority (`NamespaceSecret`), and every entry is doubly signed, so a document can accept writes from many authors while any node can verify provenance offline.
+- **Deletion is first-class and replicable.** Tombstones are signed empty entries and prefix deletes prune subtrees, so deletion converges like any other CRDT fact rather than being a local-only operation.
+- **One ordering drives everything.** The bytewise `RecordIdentifier` order is simultaneously the redb key layout and the reconciliation range order, eliminating a whole class of store/reconciler mismatch bugs.
+- **Anti-entropy fan-out.** Broadcasting a `SyncReport` after each successful sync lets pairwise reconciliation converge an entire gossip swarm without a coordinator.
+- **Already single-threaded-capable.** The wasm task-fallback mode proves the design runs without the actor thread — direct validation of the event-horizon `single`-topology port shape.
+
+## Weaknesses
+
+- **No incremental fingerprints.** `get_fingerprint` is a full `O(n)` range walk with a standing `// TODO: optimize` ([`store/fs.rs`][docs-store-fs], lines 747–748) — there is no cached fingerprint tree, so even reconciling two _equal_ sets costs a full scan for the initial fingerprint, and blake3 over the whole range runs on the serialising actor thread.
+- **A 1 GiB max frame.** `MAX_MESSAGE_SIZE` is 1 GiB with a self-deprecating comment; a `RangeItem` can carry an unbounded value set, so a hostile or unlucky peer can force a huge allocation. A port needs streaming item parts or a far smaller cap.
+- **Sender-chosen wall-clock timestamps.** With only a +10-minute future bound and no lower bound, an author can win any conflict by post-dating within 10 minutes, and arbitrarily-past entries are accepted — the conflict rule is trust-based, not causal.
+- **Prefix deletes are irreversible and silent.** Pruned rows are physically dropped with no per-row event; the deleted set is unrecoverable except by re-syncing from a peer that still holds newer, non-pruned data.
+- **The read capability is just the id.** Knowledge of the 32-byte `NamespaceId` grants a full read; a syncing node authenticates no reader, so id leakage leaks the whole document.
+- **Dead configuration.** `SyncConfig`'s `max_set_size`/`split_factor` are always `Default` (1, 2) in production; the tunables cannot be exercised without code changes.
+- **A provisional, Willow-derived model.** The crate states outright that names and concepts "are going to change", and the signing payload lacks an explicit domain-separation tag ([`sync.rs`][docs-sync-rs], `TODO` at 861–863).
+- **Heavy channel/actor coupling.** ~26 concurrency primitives and a subscriber `join_all` that back-pressures inserts make the Rust structure the densest translation target in the workspace; a `same_channel` identity check even resorts to `mem::transmute_copy` on channel senders.
+
+## Key design decisions and trade-offs
+
+| Decision                                                                | Rationale                                                                                        | Trade-off                                                                                            |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| Range-based set reconciliation (Meyer) as the transfer protocol         | Traffic scales with the set _difference_; probabilistic fingerprint comparison avoids full dumps | Every fingerprint is an `O(n)` scan (no incremental tree); reconciling equal sets still costs a scan |
+| Value = `Record` metadata pointer, content in [blobs][blobs]            | Documents stay small and fast to reconcile; content transfer is separate and hash-verified       | Two subsystems and a `ContentStatus` handoff to coordinate; a synced row may name content you lack   |
+| Last-writer-wins by `(timestamp, hash)` with prefix pruning (Willow)    | A total order on values makes CRDT merge trivial and deterministic; deletes are ordinary entries | Sender-chosen wall-clock; post-dating wins conflicts; pruned rows are physically, silently dropped   |
+| Dual ed25519 signatures (author + namespace) over a hand-rolled payload | Separates authorship from write authority; wire-stable signature encoding independent of `serde` | Two verifications per remote entry; the signed bytes differ from the wire bytes; no domain-sep tag   |
+| Read capability = knowing the 32-byte `NamespaceId`                     | Simple bearer-token sharing via tickets; no key exchange to read                                 | Any id holder can fetch the whole doc from a syncing node; no per-reader authentication              |
+| A single `"sync-actor"` thread serialises all store + CRDT work         | The store never needs to be `Sync`; blocking redb I/O stays off the async runtime                | A mailbox/`oneshot`/`JoinSet` scaffold to maintain; the blake3 fingerprint scan runs on one thread   |
+| 500 ms write-transaction batching (`MAX_COMMIT_DELAY`)                  | Amortises redb commit cost across bursts of inserts                                              | Up to 500 ms of durability latency; a crash loses the open transaction's uncommitted writes          |
+| `postcard` + `u32`-BE length frames on a QUIC bidi stream per session   | Compact, `serde`-native, one stream = one session; QUIC handles liveness and multiplexing        | 1 GiB frame cap admits huge `RangeItem`s; no streaming of large value sets                           |
+| Anti-entropy `SyncReport` over gossip after each sync                   | Swarm convergence from pairwise reconciliation without a coordinator                             | Extra gossip traffic; content-location `Complete` is a scope heuristic, not a sender claim           |
+
+---
+
+## Sources
+
+- [`iroh-docs/src/lib.rs`][docs-lib] — crate docs, Meyer/Willow framing, redb backing
+- [`iroh-docs/src/sync.rs`][docs-sync-rs] — `Record`/`Entry`/`SignedEntry`, signing payload, conflict + tombstone rules, per-entry fingerprint
+- [`iroh-docs/src/ranger.rs`][docs-ranger] — range reconciliation, `Fingerprint` XOR, `process_message`, `SyncConfig` defaults
+- [`iroh-docs/src/net.rs`][docs-net] · [`iroh-docs/src/net/codec.rs`][docs-codec] — ALPN, framing, `Init`/`Sync`/`Abort`, Alice/Bob loops
+- [`iroh-docs/src/actor.rs`][docs-actor] — the `"sync-actor"` thread, `SyncHandle`, `Action`/`ReplicaAction` set
+- [`iroh-docs/src/store/fs.rs`][docs-store-fs] · [`iroh-docs/src/store/fs/tables.rs`][docs-tables] — redb store, transaction batching, schema
+- [`iroh-docs/src/engine.rs`][docs-engine] · [`engine/live.rs`][docs-live] · [`engine/state.rs`][docs-state] — Engine, LiveActor, gossip/blobs handoff, `PeerState`
+- [`iroh-docs/src/heads.rs`][docs-heads] · [`iroh-docs/src/keys.rs`][docs-keys] · [`iroh-docs/src/ticket.rs`][docs-ticket] — `AuthorHeads`, id/secret types, `DocTicket`
+- [`iroh-docs/src/api.rs`][docs-api] · [`api/protocol.rs`][docs-api-proto] · [`irpc/src/lib.rs`][irpc-lib] — the irpc client seam
+- [Meyer, _Range-Based Set Reconciliation_][meyer] (arXiv:2212.13567) · [Willow protocol][willow] · [redb][redb] · [postcard][postcard]
+- Related pages: [Blobs][blobs] · [bao-tree][bao-tree] · [Gossip][gossip] · [Wire Formats & Serialization][wire] · [Identity & Cryptography][identity-crypto] · [QUIC Transport (noq)][quic-transport] · [Endpoint & Protocol Router][endpoint] · [Tokio Concurrency Inventory][concurrency] · [D Architecture Migration][d-migration] · [Concepts][concepts] · [survey umbrella][index]
+
+<!-- References -->
+
+[index]: ./index.md
+[concepts]: ./concepts.md
+[identity-crypto]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[quic-transport]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[blobs]: ./blobs.md
+[bao-tree]: ./bao-tree.md
+[gossip]: ./gossip.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[irpc]: https://docs.rs/irpc/0.17.0/irpc/
+[docs-repo]: https://github.com/n0-computer/iroh-docs
+[docs-docs]: https://docs.rs/iroh-docs/0.101.0/iroh_docs/
+[docs-lib]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/lib.rs
+[docs-sync-rs]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/sync.rs
+[docs-ranger]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/ranger.rs
+[docs-net]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/net.rs
+[docs-codec]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/net/codec.rs
+[docs-actor]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/actor.rs
+[docs-engine]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/engine.rs
+[docs-live]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/engine/live.rs
+[docs-state]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/engine/state.rs
+[docs-store-fs]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/store/fs.rs
+[docs-tables]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/store/fs/tables.rs
+[docs-heads]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/heads.rs
+[docs-keys]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/keys.rs
+[docs-ticket]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/ticket.rs
+[docs-api]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/api.rs
+[docs-api-proto]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/api/protocol.rs
+[irpc-lib]: https://github.com/n0-computer/irpc/blob/v0.17.0/src/lib.rs
+[iroh-repo]: https://github.com/n0-computer/iroh/tree/22cac742ca
+[meyer]: https://arxiv.org/abs/2212.13567
+[willow]: https://willowprotocol.org/
+[redb]: https://docs.rs/redb/latest/redb/
+[postcard]: https://docs.rs/postcard/latest/postcard/

--- a/docs/research/iroh/endpoint.md
+++ b/docs/research/iroh/endpoint.md
@@ -1,0 +1,549 @@
+# Endpoint & Protocol Router
+
+iroh's public front door: a cheaply-clonable `Endpoint` handle — an `Arc<EndpointInner>` shell over the [`noq`][quic] QUIC stack — paired with a `Router` that multiplexes inbound connections onto per-`ALPN` `ProtocolHandler`s. This is the API surface a D port must mirror one-for-one.
+
+| Field               | Value                                                                                                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)            | `iroh` — modules `endpoint`, `endpoint::connection`, `protocol`, `runtime`, `tls` — over `noq` / `noq-proto`                                                                                              |
+| Version             | iroh **v1.0.1** (git `v1.0.1-6-g22cac742ca`, commit `22cac742ca`); `noq` tag `noq-v1.0.1`                                                                                                                 |
+| Repository          | [`n0-computer/iroh`][repo] (crate under `iroh/`)                                                                                                                                                          |
+| Documentation       | [docs.rs/iroh][docs]                                                                                                                                                                                      |
+| ALPN(s)             | None owned by this layer — `ALPN`s are application-chosen byte strings (`b"iroh-example/echo/0"`, `b"n0/iroh/transfer/example/1"`); the accept side picks the winner                                      |
+| Approx. size (LoC)  | ~8.3k across `endpoint.rs` (4121), `connection.rs` (1642), `protocol.rs` (1059), `quic.rs` (716), plus `bind.rs`/`hooks.rs`/`presets.rs`/`runtime.rs` (~740); ≈6.1k non-test                              |
+| Category            | Connectivity                                                                                                                                                                                              |
+| Upstream spec/draft | None of its own; rides QUIC [RFC 9000][rfc9000], TLS 1.3 [RFC 8446][rfc8446], `ALPN` [RFC 7301][rfc7301]. Multipath / NAT drafts live under [`quic-transport`][quic-transport] and [`nat-traversal`][nat] |
+
+> [!NOTE]
+> iroh 1.0 is a major restructure of the 0.x API. In this subsystem: **`magicsock` → the [socket][socket] layer**, **"discovery" → `address_lookup`** (see [`discovery`][discovery]), **`NodeId` → `EndpointId`**, `NodeAddr` → `EndpointAddr` (vocabulary in [Concepts][concepts]). The `DISCO` UDP side-protocol and STUN are gone — NAT traversal and address discovery are now QUIC-native inside `noq-proto` (see [`nat-traversal`][nat]). `NodeAddr`-era folklore does not compile. This page is part of the [iroh survey][index].
+
+---
+
+## Overview
+
+### What it solves
+
+An application that wants to speak an iroh peer-to-peer protocol needs three things wired together: a bound QUIC endpoint with a stable cryptographic identity, an outbound `connect(addr, alpn)` that resolves a peer's `EndpointId` to a live network path and negotiates a protocol, and an inbound accept path that maps each incoming connection to the right handler. The `endpoint` and `protocol` modules are exactly this glue. They own **no wire bytes of their own** — QUIC/TLS framing, streams, datagrams, multipath, NAT-traversal, address discovery, retry tokens and 0-RTT all live in `noq`/`noq-proto` (see [`quic-transport`][quic-transport]) — and are best understood as a **thin state-tracking + policy shell** that adds iroh's identity model, its four interception layers, its holepunching-tuned QUIC defaults, and a protocol-router run loop on top of that stack.
+
+`Endpoint` is the primary object; the crate documentation recommends a single instance per process ([`endpoint.rs:861`][ep-single]). `Router` is the optional multiplexer for servers that speak more than one `ALPN`. Everything else in the module — the builder's ~20 knobs, the `Incoming` verbs, the type-state `Connection<State>`, the hooks, the `Runtime` seam — exists to make those two objects safe, configurable, and (critically for the D port) driven by a **host-injectable concurrency substrate** rather than a hard-wired runtime.
+
+### Design philosophy
+
+The endpoint is meant to be shared, long-lived, and singular. From the `Endpoint` doc comment ([`endpoint.rs:861`][ep-single]):
+
+> _"It is recommended to only create a single instance per application. This ensures all the connections made share the same peer-to-peer connections to other iroh endpoints, while still remaining independent connections. This will result in more optimal network behaviour."_
+
+Three consequences shape the API:
+
+1. **Cloning is cheap and shares state.** `Endpoint` is `#[derive(Clone)]` over `Arc<EndpointInner>` ([`endpoint.rs:897`][ep-struct]); every clone shares one QUIC endpoint, one socket actor, one `Runtime`, and one TLS-ticket cache. UDP sockets close only when the last clone drops.
+2. **Closing is an explicit async drain, not a `Drop`.** Because QUIC acknowledgements are implemented in user-land, a graceful close must wait for `CONNECTION_CLOSE` frames to be delivered and acked ([`endpoint.rs:1695`][ep-close-comment]). Dropping an `EndpointInner` without `close()` is an error-level event that aborts ungracefully ([`socket.rs:220`][socket-drop]).
+3. **The concurrency substrate is a trait, not a hard dependency.** `noq` never spawns tokio tasks directly — it drives every driver task and timer through the `noq::Runtime` trait, which iroh implements in ~135 lines ([`runtime.rs:9`][runtime]). This single seam is the entire QUIC stack's coupling to its host executor, and is the port's front door (see [Mapping to event-horizon](#mapping-to-event-horizon)).
+
+The design is deliberately **layered as a veneer**: ~50 `noq`/`noq-proto` types — streams, datagrams, `VarInt`, connection stats, `ConnectionError` — are re-exported verbatim ([`quic.rs:15`][quic-reexport]), a handful newtyped (`QuicTransportConfig`, `ServerConfig`) so iroh can pin holepunching-critical defaults the raw `noq` builder would leave open.
+
+---
+
+## How it works
+
+### Layering: what an `Endpoint` actually holds
+
+`Endpoint` is a newtype over `Arc<EndpointInner>` ([`endpoint.rs:897`][ep-struct]); `EndpointInner` ([`socket.rs:204`][ep-inner]) derefs (via `#[deref(forward)]`) to the [`Socket`][socket] multipath transport and owns the QUIC endpoint plus the concurrency machinery:
+
+```rust
+// iroh/src/socket.rs:204-218 — what Endpoint actually holds
+pub(crate) struct EndpointInner {
+    #[deref(forward)]
+    sock: Arc<Socket>,
+    actor_task: Mutex<Option<AbortOnDropHandle<()>>>, // empty when shutdown
+    actor_sender: mpsc::Sender<ActorMessage>,
+    endpoint: noq::Endpoint,
+    runtime: Arc<Runtime>,
+    pub(crate) static_config: StaticConfig,
+}
+```
+
+`StaticConfig` ([`socket.rs:232`][ep-inner]) is the immutable per-endpoint bundle: the TLS config, base server/client QUIC configs, the retry-token key, the TLS-ticket `TokenStore` (a `noq::TokenMemoryCache`), and the transport config. The socket `Actor` (fed by `actor_sender`) owns per-remote state; `resolve_remote` and `register_connection` are request/response round-trips into it ([`socket.rs:1320`][socket-resolve], [`socket.rs:1379`][socket-actormsg]).
+
+### Builder → bind: mandatory `Preset`, mandatory crypto provider
+
+`Endpoint::builder(preset)` takes a **mandatory** `Preset` argument ([`presets.rs:21`][presets]). `Builder::empty()` starts with two implicit IP transports (`0.0.0.0` and `[::]`, the latter allowed to fail) and _no_ relay, _no_ address-lookup, and _no_ crypto provider ([`endpoint.rs:191`][ep-empty]). `Builder::bind()` ([`endpoint.rs:225`][ep-bind]) then: (1) generates a `SecretKey` if unset; (2) **fails** with `BindError::InvalidCryptoProvider` if no rustls `CryptoProvider` was configured — the crypto provider is a required knob, normally supplied by the `Minimal`/`N0` presets ([`endpoint.rs:747`][ep-crypto]); (3) builds the retry-token key and `TlsConfig`; (4) constructs `socket::Options` and awaits `EndpointInner::bind` ([`socket.rs:874`][socket-bind]), which binds the transports and creates the `noq::Endpoint` via `new_with_abstract_socket(...)` ([`socket.rs:1027`][socket-abstract]) — the QUIC stack talks to an **abstract socket**, not a raw UDP fd; (5) instantiates each queued address-lookup service against the live endpoint.
+
+The presets are the supported way to reach a bindable state ([`presets.rs`][presets]):
+
+| Preset           | Applies                                                                                                            | Cite                           |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| `Empty`          | Nothing — `bind()` fails unless a crypto provider is set manually                                                  | [`presets.rs:21`][presets]     |
+| `Minimal`        | Sets only `crypto_provider` (prefers `ring` over `aws-lc-rs` when both features are on)                            | [`presets.rs:57`][presets-min] |
+| `N0`             | `Minimal` + a `PkarrPublisher::n0_dns()` publisher + `DnsAddressLookup::n0_dns()` resolver + `relay_mode(default)` | [`presets.rs:110`][presets-n0] |
+| `N0DisableRelay` | `N0`, then `RelayMode::Disabled`                                                                                   | [`presets.rs:110`][presets-n0] |
+
+The builder exposes roughly twenty knobs. The complete inventory, defaults, and citations ([`endpoint.rs`][ep-bind]):
+
+| Knob                                                          | Default                                                                   |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `bind_addr(A)` / `bind_addr_with_opts(A, BindOpts)`           | `0.0.0.0` + `[::]` implicit; `BindOpts{prefix_len:0, is_required:true}`   |
+| `clear_ip_transports()` / `clear_relay_transports()`          | —                                                                         |
+| `secret_key(SecretKey)`                                       | random                                                                    |
+| `alpns(Vec<Vec<u8>>)`                                         | empty (accept needs ≥1)                                                   |
+| `relay_mode(RelayMode)`                                       | `Disabled` in `empty()`; `N0` sets Default/Staging                        |
+| `address_lookup(...)` (repeatable) / `clear_address_lookup()` | none (see [`discovery`][discovery])                                       |
+| `addr_filter(AddrFilter)` / `clear_addr_filter()`             | none                                                                      |
+| `user_data_for_address_lookup(UserData)`                      | none                                                                      |
+| `external_addr(SocketAddr)` (repeatable)                      | none                                                                      |
+| `transport_config(QuicTransportConfig)`                       | iroh-tuned default                                                        |
+| `dns_resolver(DnsResolver)`                                   | system config                                                             |
+| `proxy_url(Url)` / `proxy_from_env()`                         | none (`HTTP_PROXY`/`http_proxy`/`HTTPS_PROXY`/`https_proxy`, CGI-guarded) |
+| `ca_tls_config(CaTlsConfig)`                                  | webpki defaults                                                           |
+| `keylog(bool)`                                                | `false` (`SSLKEYLOGFILE`)                                                 |
+| `max_tls_tickets(usize)`                                      | 256 (`8 * 32`, ≈150 KiB)                                                  |
+| `crypto_provider(Arc<CryptoProvider>)`                        | **mandatory** (via preset)                                                |
+| `hooks(impl EndpointHooks)` (repeatable, ordered)             | none                                                                      |
+| `portmapper_config(...)`                                      | Enabled — UPnP/PCP/NAT-PMP (see [`net-report`][net-report])               |
+| `net_report_config(...)`                                      | default (see [`net-report`][net-report])                                  |
+| `add_custom_transport(...)`                                   | unstable                                                                  |
+| `path_selector(...)`                                          | `BiasedRttPathSelector` (IPv6>IPv4, relay=backup, sticky); unstable       |
+
+A subtle bind-time trick: `endpoint_config.grease_quic_bit(false)` is set so that non-QUIC UDP packets — whose first byte iroh's transport zeroes — are silently dropped by `noq` rather than needing a buffer rewrite ([`socket.rs:1013`][socket-grease]).
+
+### Timing constants and limits
+
+The holepunching-critical values (`QuicTransportConfigBuilder::new()` overriding `noq` defaults, [`quic.rs:151`][quic-defaults]) and the socket constants ([`socket.rs:109`][socket-const]):
+
+| Constant                                                   | Value            | Source                          |
+| ---------------------------------------------------------- | ---------------- | ------------------------------- |
+| `keep_alive_interval`                                      | 5 s              | [`quic.rs:151`][quic-defaults]  |
+| `default_path_keep_alive_interval` (`HEARTBEAT_INTERVAL`)  | 5 s              | [`socket.rs:109`][socket-const] |
+| `default_path_max_idle_timeout` (`PATH_MAX_IDLE_TIMEOUT`)  | 15 s             | [`socket.rs:109`][socket-const] |
+| relay-path idle timeout                                    | 30 s             | [`socket.rs:109`][socket-const] |
+| connection `max_idle_timeout`                              | 30 s             | [`quic.rs:151`][quic-defaults]  |
+| `max_concurrent_multipath_paths` (`MAX_MULTIPATH_PATHS`)   | 8                | [`socket.rs:109`][socket-const] |
+| `max_remote_nat_traversal_addresses` (`MAX_QNT_ADDRESSES`) | 32               | [`socket.rs:109`][socket-const] |
+| retry-token lifetime                                       | 15 s             | [`quic.rs:613`][quic-server]    |
+| TLS tickets (`8 * 32`)                                     | 256 (≈150 KiB)   | [`tls.rs:35`][tls-tickets]      |
+| `max_incoming`                                             | 65536            | [`quic.rs:613`][quic-server]    |
+| per-`Incoming` buffer / total                              | 10 MiB / 100 MiB | [`quic.rs:613`][quic-server]    |
+| `initial_rtt`                                              | 333 ms           | [`quic.rs:151`][quic-defaults]  |
+| `initial_mtu` / `min_mtu`                                  | 1200             | [`quic.rs:151`][quic-defaults]  |
+
+Public setters _guard_ the holepunching values: multipath paths `< 9` are ignored with a warning (code enforces `MAX_MULTIPATH_PATHS + 1`, though the doc says "recommended 13" — a doc/code mismatch, [`quic.rs:462`][quic-guards]); path idle `> 15 s` is clamped; path keep-alive `> 5 s` is ignored; NAT addresses `< 8` are ignored.
+
+### Connect flow
+
+`Endpoint::connect(addr, alpn)` is `connect_with_opts(...).await?` then awaiting the `Connecting` future ([`endpoint.rs:1050`][ep-connect]). `connect_with_opts` ([`endpoint.rs:1090`][ep-connect-opts]) runs a fixed pipeline:
+
+```text
+Endpoint::connect(addr, alpn)
+  └─ connect_with_opts(addr, alpn, opts)
+       1. closed check                       → EndpointClosed
+       2. hooks.before_connect(&addr, alpn)  → LocallyRejected on Reject
+       3. self-connect check                 → SelfConnect
+       4. inner.resolve_remote(addr)  ──────▶ socket Actor (RemoteStateActor):
+             starts/updates remote state, seeds relay + IP paths,
+             kicks off address_lookup if no path known,
+             returns EndpointIdMappedAddr (a synthetic per-remote IP)
+       5. build ClientConfig { [alpn] ++ additional_alpns, transport_config }
+       6. noq.connect_with(cfg, mapped.private_socket_addr(),
+                           "<base32(endpoint_id)>.iroh.invalid")
+  └─ .await  ⇒  Connecting
+       poll noq::Connecting → handshake done → conn_from_noq_conn:
+         extract EndpointId from the single ed25519 cert,
+         extract negotiated ALPN from rustls HandshakeData,
+         register_connection with the RemoteStateActor,
+         hooks.after_handshake(&conn) → LocallyRejected on Reject
+  ⇒  Connection<HandshakeCompleted>
+```
+
+The key indirection is that `noq` never sees a real peer address: `resolve_remote` returns an `EndpointIdMappedAddr` — a synthetic per-remote IP the QUIC stack dials while the real path selection happens underneath in the [socket][socket] layer ([`socket.rs:1320`][socket-resolve]). The TLS `server_name` (`SNI`) is `base32(endpoint_id) + ".iroh.invalid"` ([`tls/name.rs:17`][tls-name-enc]). A code comment notes the `noq` connect "will time out after 10 seconds if no reachable address is available" ([`endpoint.rs:1090`][ep-connect-opts]); the exact origin of that 10 s bound is a handshake-phase/PTO limit inside `noq` (see [`quic-transport`][quic-transport]), not a constant in this layer. On handshake completion, `conn_from_noq_conn` extracts the remote `EndpointId` from the single ed25519 certificate ([`connection.rs:377`][conn-identity]).
+
+### Accept flow and the `Incoming` verbs
+
+`Endpoint::accept()` returns `Accept<'_>` wrapping `noq::Accept` ([`endpoint.rs:1162`][ep-accept]); it yields `None` once the endpoint is closed. Each yield is an `Incoming` — the server has _not yet_ begun its handshake, so the application can screen it cheaply before spending crypto:
+
+```text
+Endpoint::accept()  ⇒  Accept<'_>  (yields None once closed)
+  each yield: Incoming             (server has not begun its handshake)
+    inspectors: local_addr(), remote_addr() -> IncomingAddr,
+                remote_addr_validated(),
+                decrypt() -> Option<DecryptedInitial>   (peek ALPNs pre-handshake)
+    verbs:
+      accept()            → Accepting                  (begin handshake)
+      accept_with(cfg)    → Accepting                  (per-connection ServerConfig)
+      refuse()            → CONNECTION_REFUSED
+      retry()             → QUIC RETRY packet          (Err(RetryError) if already validated)
+      ignore()            → no response (peer times out)
+      drop                → same as ignore
+  Accepting  ── await ──▶ handshake done
+    → register_with_socket → hooks.after_handshake → Connection<HandshakeCompleted>
+    or Accepting::into_0rtt() (infallible) → Connection<IncomingZeroRtt>
+```
+
+`decrypt()` clones and decrypts the ~1200-byte Initial to reassemble `CRYPTO` frames and parse `ALPN`s out of the `ClientHello` _before_ handshaking ([`connection.rs:217`][conn-decrypt]; parser in [`noq-proto/src/endpoint.rs:1310`][noq-initial]). `retry()` is dual-purpose — for direct connections it is address validation; for [relay][relay] connections it is a cost-imposition mechanism ([`protocol.rs:197`][proto-retry]):
+
+> _"In short: for direct connections, `Retry` is address validation; for relay connections, it is a cost-imposition mechanism."_
+
+`Accepting` mirrors `Connecting` (`alpn().await`, `handshake_data().await`, `remote_addr()`, `into_0rtt()`) and resolves to `Connection` through the same two-phase poll: poll the inner `noq` handshake, then build and drive a `'static` register-with-socket + `after_handshake` future ([`connection.rs:660`][conn-accepting]).
+
+### Type-state `Connection<State>` and 0-RTT
+
+`Connection` is generic over a sealed state ([`connection.rs:736`][conn-typestate]):
+
+```rust
+// iroh/src/endpoint/connection.rs:736-803 — type-state connection
+pub struct Connection<State: ConnectionState = HandshakeCompleted> {
+    inner: noq::Connection,
+    data: State::Data,
+}
+pub trait ConnectionState: sealed::Sealed { type Data: std::fmt::Debug + Clone; }
+pub struct HandshakeCompleted;   // Data = { info: StaticInfo, paths: PathStateReceiver }
+pub struct IncomingZeroRtt;      // Data = { accepted: Shared<BoxFuture<...>> }
+pub struct OutgoingZeroRtt;      // Data = { accepted: Shared<BoxFuture<...>> }
+```
+
+The shared `impl<State: ConnectionState>` exposes every stream/datagram op in every state; only `alpn()` and `remote_id()` differ — infallible in `HandshakeCompleted`, `Option`/`Result` in the 0-RTT states. 0-RTT is asymmetric: the client's `Connecting::into_0rtt() -> Result<OutgoingZeroRttConnection, Connecting>` **fails** (handing the `Connecting` back) when no session ticket is cached ([`connection.rs:528`][conn-0rtt-client]), while the server's `Accepting::into_0rtt() -> IncomingZeroRttConnection` is **infallible** — _"incoming connections can always be converted to 0-RTT"_ ([`connection.rs:620`][conn-0rtt-server]). Both wrap the `noq` connection plus a `Shared<BoxFuture>` "accepted" future that, once the real handshake completes, runs `conn_from_noq_conn` and yields either a `Connection` (server) or `ZeroRttStatus::{Accepted, Rejected}(Connection)` (client) via `handshake_completed()`. Streams opened pre-handshake survive `Accepted` and error with `ZeroRttRejected` on `Rejected`, so the client resends on fresh streams ([`0rtt.rs:92`][ex-0rtt]).
+
+### The `Router` and `ProtocolHandler`
+
+`Router::builder(endpoint).accept(alpn, handler)…spawn()` registers a `ProtocolMap: BTreeMap<Vec<u8>, Box<dyn DynProtocolHandler>>` ([`protocol.rs:377`][proto-map]), calls `endpoint.set_alpns(...)`, and spawns one run-loop task ([`protocol.rs:501`][proto-runloop]). `ProtocolHandler` is an async trait with default methods ([`protocol.rs:228`][proto-handler]):
+
+```rust
+// iroh/src/protocol.rs:228-287 (trimmed)
+pub trait ProtocolHandler: Send + Sync + std::fmt::Debug + 'static {
+    fn on_accepting(&self, accepting: Accepting)
+        -> impl Future<Output = Result<Connection, AcceptError>> + Send
+    { async move { Ok(accepting.await?) } }
+    fn accept(&self, connection: Connection)
+        -> impl Future<Output = Result<(), AcceptError>> + Send;      // required
+    fn shutdown(&self) -> impl Future<Output = ()> + Send
+    { async move {} }
+}
+```
+
+The run loop is a `tokio::select! { biased; }` over three arms, in priority order ([`protocol.rs:501`][proto-runloop]): (a) the router's `CancellationToken`; (b) `join_set.join_next()` — a task panic breaks the loop, failures break, cancellations are ignored; (c) `endpoint.accept()`. For each `Incoming`, an optional **`IncomingFilter`** — a _synchronous_ `Arc<dyn Fn(&Incoming) -> IncomingFilterOutcome>` with outcomes `Accept`/`Retry`/`Reject`/`Ignore` — runs inline _before_ any task spawn ([`protocol.rs:168`][proto-filter]). Accepted connections spawn a `handle_connection` task into a `JoinSet<Option<()>>`, wrapped in a per-handler `child_token().run_until_cancelled(...)`. `handle_connection` does `incoming.accept()` → `accepting.alpn().await` → `protocols.get(&alpn)` (unknown `ALPN`: log + drop) → `handler.on_accepting(accepting).await` → `handler.accept(connection).await` ([`protocol.rs:625`][proto-handle]).
+
+`Router::shutdown` is a **two-phase graceful teardown** ([`protocol.rs:429`][proto-shutdown]): cancel the router token, then (1) await `protocols.shutdown()` (all handlers' `shutdown()` concurrently via `join_all`), (2) cancel `handler_cancel_token` (aborts in-flight `accept` futures), (3) `endpoint.close().await`, (4) `join_set.abort_all()` + drain. The `Router` handle is `Clone`; its run-loop task is stored as `Arc<Mutex<Option<AbortOnDropHandle<()>>>>`, so dropping the last `Router` aborts the loop.
+
+### The `Runtime` seam
+
+`noq` drives every driver task and timer through the `noq::Runtime` trait; iroh's implementation is the whole QUIC stack's coupling to its host executor ([`runtime.rs:9`][runtime]):
+
+```rust
+// iroh/src/runtime.rs:9-18 — the runtime seam noq drives everything through
+pub(crate) struct Runtime {
+    id: EndpointId,
+    tasks: TaskTracker,
+    cancel: CancellationToken,
+    task_counter: AtomicU64,
+}
+impl noq::Runtime for Runtime {
+    fn new_timer(&self, i: std::time::Instant) -> Pin<Box<dyn noq::AsyncTimer>>;
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>);
+    fn wrap_udp_socket(&self, t: std::net::UdpSocket)
+        -> io::Result<Box<dyn noq::AsyncUdpSocket>>; // "not actually using this"
+}
+```
+
+`spawn` refuses when closed, wraps each future in `cancel.run_until_cancelled(...)`, and tracks it; `new_timer` delegates to `noq::TokioRuntime`; `wrap_udp_socket` is documented dead code — the endpoint uses `new_with_abstract_socket`, so the QUIC stack never touches a raw UDP socket through this trait ([`runtime.rs:103`][runtime-wrap]). `shutdown()` = cancel + close the tracker + `tasks.wait().await`; `abort()` = cancel + close with no wait.
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+This subsystem defines almost no wire bytes — QUIC/TLS framing lives in `noq` (see [`wire-serialization`][wire]). What it _does_ pin:
+
+- **`ALPN` identifiers** are free-form byte strings chosen by applications: `b"iroh-example/echo/0"` ([`echo.rs:20`][ex-echo]), `b"n0/iroh/transfer/example/1"` ([`transfer.rs:68`][ex-transfer]). Router dispatch is exact-match on `ALPN` bytes; the **accept side determines the negotiated protocol**, connect-side order is irrelevant ([`endpoint.rs:1799`][ep-accept-decides]).
+- **TLS `SNI` / server name**: `BASE32_DNSSEC(endpoint_id_32_bytes) + ".iroh.invalid"` — 52 base32 chars plus suffix (hex would exceed the 63-char DNS-label limit) ([`tls/name.rs:17`][tls-name-enc]). The `.invalid` TLD is chosen per [RFC 2606][rfc2606] precisely so per-remote names bucket 0-RTT session tickets correctly ([`tls/name.rs:1`][tls-name]):
+
+  > _"We used to use a constant "localhost" for the TLS server name - however, that affects 0-RTT and would put all of the TLS session tickets we receive into the same bucket in the TLS session ticket cache. So we choose something that'd dependent on the EndpointId. … We use the `.invalid` TLD, as that's specified (in RFC 2606) to never actually resolve "for real"."_
+
+- **Peer identity**: exactly one `CertificateDer` in the TLS handshake; `EndpointId` = the ed25519 verifying key parsed with `VerifyingKey::from_public_key_der` (SPKI DER). A count `≠ 1` or a parse failure yields `RemoteEndpointIdError` ([`connection.rs:377`][conn-identity]). See [`identity-crypto`][identity].
+- **Close frames**: `close(error_code: VarInt, reason: &[u8])` — code and reason are application-opaque, reason truncated to one packet ([`connection.rs:935`][conn-close]). `Endpoint::close` and connection-drop use code `0` + empty reason.
+- **Initial-packet `ALPN` peek**: `DecryptedInitial::alpns()` reassembles `CRYPTO` frames and parses the `ClientHello` (handshake type `0x01`, u24 length, `ALPN` extension `0x0010`, u8-length-prefixed names) — best-effort, `None` if the hello spans packets it cannot reassemble ([`noq-proto/src/endpoint.rs:1310`][noq-initial]).
+
+### Cryptography & identity
+
+The endpoint's identity is an ed25519 `SecretKey` (random if unset); the corresponding `EndpointId` is the public key, transported as the single self-signed TLS certificate and re-derived on the peer from `HandshakeData` ([`connection.rs:377`][conn-identity]). The crypto provider is a **mandatory** rustls `CryptoProvider` ([`endpoint.rs:747`][ep-crypto]), shared with relay/pkarr/DoH HTTPS TLS. Post-quantum is not a dedicated API: an `X25519MLKEM768`-only provider is injected via `crypto_provider` (requires the `aws-lc-rs` backend), though PQ-only endpoints cannot yet reach n0 relay/lookup infrastructure ([`pq-only-key-exchange.rs:90`][ex-pq]). TLS 1.3 session resumption backs 0-RTT; the ticket cache defaults to `8 * 32 = 256` entries (≈150 KiB) keyed per-remote via the `SNI` scheme above ([`tls.rs:35`][tls-tickets]). `export_keying_material` ([RFC 5705][rfc5705]) is exposed on `HandshakeCompleted` connections. Full treatment in [`identity-crypto`][identity].
+
+### State machines & lifecycle
+
+Six state machines govern this subsystem:
+
+1. **`Incoming` (accept side)** — `Incoming` → `accept()`/`accept_with(cfg)` → `Accepting` → register-with-socket → `after_handshake` → `Connection`. Alternative exits: `refuse()`, `retry()` (with `RetryError` recovery via `into_incoming()`), `ignore()`, drop ([`connection.rs:137`][conn-incoming]).
+2. **`Connecting` (dial side)** — the connect pipeline above; `into_0rtt()` succeeds only with a cached ticket ([`connection.rs:528`][conn-0rtt-client]).
+3. **`Connection<State>` type-state** — `IncomingZeroRtt`/`OutgoingZeroRtt` → `HandshakeCompleted`, _witnessed_ by `handshake_completed()` (not mutated in place); the 0-RTT handles stay usable for streams throughout ([`connection.rs:736`][conn-typestate]).
+4. **`Router` lifecycle** — `spawn()` → biased-select run loop → `shutdown()` (or drop-guard) → the four-step teardown. A handler panic breaks the loop and resurfaces from `Router::shutdown` as a `JoinError` ([`protocol.rs:429`][proto-shutdown]).
+5. **Endpoint shutdown** — `ShutdownState { at_close_start, at_endpoint_closed, closed }` ([`socket.rs:281`][socket-shutdown]). `close()`: cancel `at_close_start` (stops net-reports) → clear address-lookup services → `noq.close(0, b"")` → `wait_all_draining().await` (close-frame delivery + ack, worst case ≈3 s PTO) → cancel `at_endpoint_closed` → 100 ms grace for the actor task → `runtime.shutdown().await`. Idempotent; `abort()` (the Drop path) skips all waiting ([`socket.rs:1148`][socket-drain]).
+6. **`online()` wait loop** — watches `home_relay_status()` and returns once any relay `is_connected()`; **pends forever** if no relay is configured or reachable — deliberately timeout-free ([`endpoint.rs:1355`][ep-online]).
+
+The QUIC-vs-TCP asymmetry motivates the drain ([`endpoint.rs:1695`][ep-close-comment]):
+
+> _"Someone used to closing TCP sockets might wonder why it is necessary to wait for timeouts when closing QUIC endpoints … This is due to QUIC and its acknowledgments being implemented in user-land, while TCP sockets usually get closed and drained by the operating system in the kernel during the 'Time-Wait' period."_
+
+### Dependencies & coupling
+
+| Crate                            | Depth                                                                                                    | Note for the D port                                                                |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `noq` / `noq-proto` (quinn fork) | **Load-bearing** — the entire QUIC stack, ~50 types re-exported verbatim ([`quic.rs:15`][quic-reexport]) | Reimplement separately ([`quic-transport`][quic-transport]); this layer is a shell |
+| `rustls` + `ring`/`aws-lc-rs`    | Load-bearing: TLS 1.3, `ALPN`, session tickets, kx groups, keying-material export                        | Needs a TLS 1.3 stack with resumption + raw ed25519-cert verification              |
+| `ed25519-dalek` (+pkcs8)         | `VerifyingKey::from_public_key_der` for identity ([`connection.rs:377`][conn-identity])                  | ed25519 + SPKI DER parse (see [`identity-crypto`][identity])                       |
+| `n0-error`                       | API surface: `stack_error` derive, `e!`, `ensure!`, `AnyError`                                           | Only the error _shapes_ matter → `Expected`/`Cause` taxonomy                       |
+| `n0-future`                      | `task::{spawn, JoinSet, AbortOnDropHandle, JoinError}`, `BoxFuture`                                      | event-horizon natives                                                              |
+| `n0-watcher`                     | `Watcher` — watch-like observable (`get`/`updated`/`stream`/`or`/`map`)                                  | **No event-horizon equivalent — needs design** (a `Watchable!T`)                   |
+| `tokio` / `tokio-util`           | runtime; `CancellationToken`, `TaskTracker`, `run_until_cancelled`                                       | `CancelContext` tree covers all uses                                               |
+| `futures-util`                   | `Shared` (multi-waiter future), `FutureExt`                                                              | Needs a memoized multi-waiter completion cell                                      |
+| `data-encoding`                  | `BASE32_DNSSEC` for `SNI` ([`tls/name.rs:17`][tls-name-enc])                                             | Trivial base32                                                                     |
+
+The coupling to `noq` is total but _narrow_: it flows through the re-export list plus the `Runtime` trait. The port's job is to reimplement `noq`, then re-shell it — this module's logic (identity extraction, the four interception layers, the guarded config knobs, the router loop) is small and portable.
+
+### Concurrency & I/O model
+
+The subsystem's concurrency inventory — a small, [tokio][tokio]-shaped surface (see the [async-io survey][async-io] for the runtime it is built on) ([`protocol.rs`][proto-runloop], [`runtime.rs`][runtime], [`socket.rs`][socket-actormsg]):
+
+| Primitive                                                       | Purpose                                                                  |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `task::spawn` + `AbortOnDropHandle` (run loop)                  | Router accept loop                                                       |
+| `JoinSet<Option<()>>`                                           | one `handle_connection` task per accepted connection                     |
+| `CancellationToken` ×2 (`cancel_token`, `handler_cancel_token`) | shutdown signal; per-handler `run_until_cancelled`                       |
+| `tokio::select! { biased; }`                                    | cancel > task-reap > accept priority                                     |
+| `Runtime`: `TaskTracker` + `CancellationToken` + `AtomicU64`    | ALL noq-spawned tasks (EndpointDriver, ConnectionDrivers)                |
+| `mpsc::channel(256)` `ActorMessage`                             | socket Actor inbox: `ResolveRemote`, `AddConnection`, `NetworkChange`, … |
+| `oneshot` replies                                               | `resolve_remote` / `register_connection` request-response                |
+| `Shared<BoxFuture>` (futures-util)                              | multi-waiter 0-RTT "handshake completed" future                          |
+| `n0_watcher::Watcher`                                           | `watch_addr`, `home_relay_status`, `net_report`, `online()`              |
+
+There is **no `spawn_blocking`**, no `broadcast`, and no `RwLock` beyond `configured_addrs`. The `Mutex`es on `Router.task` and `actor_task` exist only to make the handles `Clone + Send` while permitting a `take()`-then-await at shutdown — vestigial under single-threaded ownership. This is a full inventory-level treatment in [`concurrency`][concurrency].
+
+### Mapping to event-horizon
+
+The `noq::Runtime` seam is the port's front door: it is exactly the shape [`event-horizon`][eh-spec] — the completion-first fiber + [algebraic-effect][algebraic-effects] runtime — replaces. The `TaskTracker` + `CancellationToken` pair _is_ a `Scope` — exit joins children, `abort` = cancel the subtree — so the boxed trait object becomes a monomorphized capability row handed to the QUIC core:
+
+```rust
+// iroh/src/runtime.rs:9-18 (see full definition above)
+pub(crate) struct Runtime {
+    id: EndpointId, tasks: TaskTracker,
+    cancel: CancellationToken, task_counter: AtomicU64,
+}
+// spawn → run_until_cancelled + track; new_timer → tokio; wrap_udp_socket → dead code
+```
+
+```d
+// proposed / sketch — the concurrency seam becomes an event-horizon capability row,
+// not a boxed trait object; noq's driver fibers live on the Endpoint's Scope.
+struct QuicRuntime(Env)
+{
+    Env       env;      // CtxOf!(RingClock, RingNet, ...) — authority, monomorphized
+    Scope*    scope;    // structured-concurrency nursery; exit joins all drivers
+    EndpointId id;
+
+    // was noq::Runtime::spawn(BoxFuture<()>): a daemon driver fiber on the scope
+    void spawnDriver(scope void delegate() @safe body) => scope.spawnDaemon(body);
+
+    // was noq::Runtime::new_timer(Instant): an in-ring TIMEOUT op / deadline scope
+    Timer newTimer(MonoTime deadline) => env.clock.timerAt(deadline);
+
+    // was wrap_udp_socket: DEAD CODE in iroh (new_with_abstract_socket) — omit entirely
+}
+```
+
+**Router run loop** → one fiber owning the `ProtocolMap`, using `race` (cancel vs accept — the `biased` priority is the natural first-completion semantics of `race`); per-connection handlers → `Scope.spawn` into a child scope; `handler_cancel_token` → a child `CancelContext`; `abort_all` → scope cancel. `accept() -> Option` (None when closed) maps to an `Outcome` interrupt or a sentinel; the `select!`-in-a-loop consumers translate to `repeat`/`race` drivers.
+
+The **type-state `Connection<State>`** maps beautifully to a D template with `static if`-gated members — DbI-native, zero-cost; the sealed-trait trick is unnecessary because module-private template constraints seal it:
+
+```rust
+// iroh/src/endpoint/connection.rs:736-803 (see full definition above)
+pub struct Connection<State: ConnectionState = HandshakeCompleted> {
+    inner: noq::Connection,
+    data: State::Data,
+}
+```
+
+```d
+// proposed / sketch — DbI typestate: one template, `static if`-gated members.
+struct Connection(State = HandshakeCompleted)
+    if (isConnectionState!State)
+{
+    NoqConnection inner;          // the re-exported noq connection handle
+    State.Data    data;
+
+    // shared surface, present in every state:
+    IoResult!Stream openBi() { /* ... */ }
+    IoResult!void   sendDatagram(scope const(ubyte)[] d) { /* ... */ }
+
+    static if (is(State == HandshakeCompleted))
+    {
+        // infallible in the completed state:
+        const(ubyte)[] alpn()     @safe pure nothrow @nogc { return data.info.alpn; }
+        EndpointId     remoteId() @safe pure nothrow @nogc { return data.info.endpointId; }
+    }
+    else  // IncomingZeroRtt / OutgoingZeroRtt — optional until the handshake completes
+    {
+        Nullable!(const(ubyte)[]) alpn() { /* ... */ }
+    }
+}
+```
+
+**`ProtocolHandler`** — an async trait with default methods, dyn-erased via `DynProtocolHandler` — becomes a struct-of-delegates row keyed by exact `ALPN` bytes (the `BTreeMap` ordering is irrelevant; only exact-match lookup happens):
+
+```rust
+// iroh/src/protocol.rs:228-287 (see full definition above)
+pub trait ProtocolHandler: Send + Sync + std::fmt::Debug + 'static {
+    fn on_accepting(&self, accepting: Accepting) -> impl Future<...> + Send { /* default */ }
+    fn accept(&self, connection: Connection)     -> impl Future<...> + Send;      // required
+    fn shutdown(&self)                            -> impl Future<...> + Send { /* no-op */ }
+}
+```
+
+```d
+// proposed / sketch — a row of fiber-blocking delegates keyed by exact ALPN bytes.
+// No async-trait, no dyn-erasure, no boxed futures; dispatch is exact-match lookup.
+struct ProtocolHandler
+{
+    Outcome!Connection delegate(Accepting) onAccepting;  // default: just await accepting
+    Outcome!void       delegate(Connection) accept;      // required
+    void               delegate()           shutdown;    // default: no-op
+}
+
+alias ProtocolMap = ProtocolHandler[immutable(ubyte)[]]; // exact-match AA, order irrelevant
+```
+
+Three constructs have **no event-horizon equivalent and need new design**:
+
+- **`Shared<BoxFuture>` 0-RTT accepted future** — cloned and awaited by many waiters ([`connection.rs:736`][conn-typestate]). `JoinHandle.join` is single-consumer; the port needs a **memoized one-shot completion cell** (a promise/event caching its `Outcome`). Flag as a new primitive.
+- **`n0_watcher::Watcher`** — `watch_addr`, `home_relay_status`, `online()`, `net_report` all sit on it. The brief notes `tokio::sync::watch` has no counterpart, so a **`Watchable!T`** (version-counter + waiter list on one loop) is a prerequisite for `Endpoint.addr()`/`online()`.
+- **The socket `Actor` + `oneshot`** (`resolve_remote`, `register_connection`) — under the `single` topology there is no data race, so these can be **direct capability-method calls** on the socket state object, eliminating the `mpsc(256)` + `oneshot` pair. But `resolve_remote` _awaits_ address lookup, so it must remain a **suspendable** (fiber-blocking) method, not a plain getter. Keeping actor isolation for clarity instead would hit open-issue **O20** (no cross-fiber channels).
+
+**Single-threaded implications** are favourable: `noq`'s tasks are host-spawned and the endpoint uses an abstract socket, so a fiber port never needs `wrap_udp_socket`; the `Arc<Mutex<…>>` handle-guards collapse to plain ownership; CPU work here is trivial (no blake3 on this loop — that concern belongs to [`blobs`][blobs]). The `IncomingFilter` is deliberately synchronous — a plain `@nogc` delegate that must stay non-suspending by construction ([`protocol.rs:168`][proto-filter]). Hooks, by contrast, are _awaitable_ (the auth example runs a full side-connection inside `before_connect`), so they must run on the calling fiber and take the `Connection` by non-owning reference to preserve the "don't keep it alive" contract — implying the port needs weak-connection semantics (a `WeakConnectionHandle`, or an id + registry lookup) ([`hooks.rs:93`][hooks-weak]). Close/drop maps to an `onExit` LIFO hook on the endpoint's `Scope` running `close()` as structured teardown; the "drop without close" case becomes a debug assert in the destructor, since single-threaded lifetimes are deterministic. See [`d-architecture-migration`][d-migration] for the whole-stack synthesis.
+
+---
+
+## Strengths
+
+- **Small, portable policy shell.** The identity model, the four interception layers, the guarded holepunching defaults, and the router loop are a few thousand lines over `noq` — the reimplementation surface for _this_ module is tractable once the QUIC core exists.
+- **Host-injectable concurrency.** The `noq::Runtime` trait is a clean seam: the entire QUIC stack's task/timer coupling is one ~135-line adapter, ideal for swapping in an event-horizon `Scope`/`Env` capability.
+- **Type-state `Connection<State>`** encodes 0-RTT correctness in the type system and translates to zero-cost DbI templates in D.
+- **Four distinct, well-placed interception layers** — synchronous `IncomingFilter`, async `before_connect`, `on_accepting`, async `after_handshake` — cover screening from cheapest (pre-decrypt) to richest (post-identity).
+- **Cheap-clone, share-everything endpoint** with a principled graceful-close drain that respects QUIC's user-land ack semantics.
+- **Abstract-socket design** means the QUIC stack never touches a raw UDP fd through the runtime seam — a natural fit for a completion-first port.
+
+## Weaknesses
+
+- **Total `noq` dependency.** The module is a veneer; nothing works until the QUIC/TLS core (multipath, NAT-traversal ext., address discovery, retry tokens, 0-RTT) is reimplemented — by far the larger effort (see [`quic-transport`][quic-transport]).
+- **Three primitives with no event-horizon analogue** (`Watcher`, `Shared` multi-waiter future, actor + `oneshot`) force new designs before `Endpoint.addr()`/`online()`/0-RTT can be ported.
+- **`online()` can pend forever** by design — a foot-gun without an application-level deadline.
+- **Mandatory-`Preset` + mandatory-crypto-provider** ergonomics: `bind()` fails at runtime (`InvalidCryptoProvider`) rather than at compile time if the provider is missing.
+- **Doc/code mismatches** in the guarded knobs (`max_concurrent_multipath_paths` doc says "13", code enforces `9`) are latent porting traps.
+- **`Drop`-without-`close()`** is only an error-level log, not a hard failure — a hazard the D port should tighten into a destructor assert.
+
+## Key design decisions and trade-offs
+
+| Decision                                                             | Rationale                                                                                     | Trade-off                                                                                          |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `Endpoint` = `Arc<EndpointInner>`, single instance per app           | Share peer-to-peer connections + ticket cache across all clones for optimal network behaviour | All clones share fate; close must be coordinated; hidden global-ish state                          |
+| Concurrency behind the `noq::Runtime` trait                          | Decouples the QUIC stack from any specific executor; one adapter is the whole coupling        | An indirection layer + boxed futures in Rust; the port must supply the substrate                   |
+| Abstract socket (`new_with_abstract_socket`)                         | QUIC talks to iroh's multipath transport, not a UDP fd; enables synthetic mapped addresses    | `wrap_udp_socket` is dead code; extra address-space translation (`EndpointIdMappedAddr`)           |
+| Mandatory `Preset` + mandatory crypto provider                       | Forces an explicit, correct crypto configuration; presets bundle the common setups            | Runtime `bind()` failure instead of a compile-time guarantee; more ceremony for `Empty`            |
+| Type-state `Connection<State>` (sealed) for 0-RTT                    | Encodes handshake-completion invariants in types; shared op surface stays ergonomic           | Sealed-trait + `Shared` boilerplate; client `into_0rtt` is fallible, server infallible (asymmetry) |
+| Four interception layers (sync filter + 3 async hooks)               | Screen from cheapest (pre-decrypt) to richest (post-identity) at the right cost               | More API surface; hooks are awaitable and can block the accept path                                |
+| Router run loop = `select! { biased }` + `JoinSet` + 2 cancel tokens | Prioritise cancel > reap > accept; graceful two-phase shutdown with per-handler abort         | Bespoke lifecycle; handler panics break the loop; `Arc<Mutex<…>>` handle-guards for `Clone`        |
+| `SNI` = `base32(EndpointId).iroh.invalid`                            | Per-remote ticket bucketing for correct 0-RTT; `.invalid` never resolves (RFC 2606)           | Non-standard server name; base32 chosen only to fit the 63-char DNS-label limit                    |
+| Graceful close waits `wait_all_draining` (≈3 s PTO)                  | QUIC acks are user-land; frames must be flushed + acked, unlike kernel TCP `TIME-WAIT`        | `close()` is async and slow-ish; `Drop` fallback aborts and only logs an error                     |
+
+---
+
+## Sources
+
+- [`iroh/src/endpoint.rs`][ep-struct] — `Endpoint`, `Builder`, connect/accept/close, knob inventory
+- [`iroh/src/endpoint/connection.rs`][conn-typestate] — `Incoming`/`Accepting`/`Connecting`, type-state `Connection`, 0-RTT, identity
+- [`iroh/src/endpoint/hooks.rs`][hooks-weak] — `EndpointHooks`, `before_connect`/`after_handshake`
+- [`iroh/src/endpoint/presets.rs`][presets] — `Preset`, `Empty`/`Minimal`/`N0`/`N0DisableRelay`
+- [`iroh/src/endpoint/quic.rs`][quic-reexport] — noq re-exports, `QuicTransportConfig`/`ServerConfig` guards
+- [`iroh/src/protocol.rs`][proto-runloop] — `Router`, `ProtocolHandler`, `IncomingFilter`, run loop, shutdown
+- [`iroh/src/runtime.rs`][runtime] — the `noq::Runtime` seam
+- [`iroh/src/socket.rs`][ep-inner] — `EndpointInner`, `bind`, `resolve_remote`, `ShutdownState`, drain
+- [`iroh/src/tls.rs`][tls-tickets] / [`iroh/src/tls/name.rs`][tls-name] — ticket constant, `SNI` encoding
+- [`noq-proto/src/endpoint.rs`][noq-initial] — `DecryptedInitial` `ALPN` peek parser
+- Examples: [`echo.rs`][ex-echo], [`transfer.rs`][ex-transfer], [`0rtt.rs`][ex-0rtt], [`auth-hook.rs`][ex-auth], [`pq-only-key-exchange.rs`][ex-pq]
+- Related iroh pages: [`socket`][socket] · [`quic-transport`][quic-transport] · [`discovery`][discovery] · [`nat-traversal`][nat] · [`identity-crypto`][identity] · [`concurrency`][concurrency] · [`d-architecture-migration`][d-migration]
+
+<!-- References -->
+
+[repo]: https://github.com/n0-computer/iroh/tree/22cac742ca
+[docs]: https://docs.rs/iroh/1.0.1/iroh/
+[ep-struct]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L897
+[ep-single]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L861
+[ep-empty]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L191
+[ep-bind]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L225
+[ep-crypto]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L747
+[ep-connect]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L1050
+[ep-connect-opts]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L1090
+[ep-accept]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L1162
+[ep-accept-decides]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L1799
+[ep-close-comment]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L1695
+[ep-online]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs#L1355
+[conn-typestate]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs#L736
+[conn-identity]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs#L377
+[conn-incoming]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs#L137
+[conn-decrypt]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs#L217
+[conn-accepting]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs#L660
+[conn-0rtt-client]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs#L528
+[conn-0rtt-server]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs#L620
+[conn-close]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs#L935
+[hooks-weak]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/hooks.rs#L93
+[presets]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/presets.rs#L21
+[presets-min]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/presets.rs#L57
+[presets-n0]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/presets.rs#L110
+[quic-reexport]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/quic.rs#L15
+[quic-defaults]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/quic.rs#L151
+[quic-guards]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/quic.rs#L462
+[quic-server]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/quic.rs#L613
+[proto-runloop]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/protocol.rs#L501
+[proto-handler]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/protocol.rs#L228
+[proto-map]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/protocol.rs#L377
+[proto-handle]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/protocol.rs#L625
+[proto-shutdown]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/protocol.rs#L429
+[proto-filter]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/protocol.rs#L168
+[proto-retry]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/protocol.rs#L197
+[runtime]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/runtime.rs#L9
+[runtime-wrap]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/runtime.rs#L103
+[ep-inner]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L204
+[socket-bind]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L874
+[socket-abstract]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1027
+[socket-grease]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1013
+[socket-resolve]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1320
+[socket-actormsg]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1379
+[socket-shutdown]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L281
+[socket-drain]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1148
+[socket-drop]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L220
+[socket-const]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L109
+[tls-tickets]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/tls.rs#L35
+[tls-name]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/tls/name.rs#L1
+[tls-name-enc]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/tls/name.rs#L17
+[ex-echo]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/examples/echo.rs#L20
+[ex-transfer]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/examples/transfer.rs#L68
+[ex-0rtt]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/examples/0rtt.rs#L92
+[ex-auth]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/examples/auth-hook.rs#L175
+[ex-pq]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/examples/pq-only-key-exchange.rs#L90
+[noq-initial]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/endpoint.rs#L1310
+[quic]: ./quic-transport.md
+[quic-transport]: ./quic-transport.md
+[socket]: ./socket.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[net-report]: ./net-report.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[blobs]: ./blobs.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[concepts]: ./concepts.md
+[index]: ./index.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[tokio]: ../async-io/tokio.md
+[async-io]: ../async-io/index.md
+[algebraic-effects]: ../algebraic-effects/index.md
+[rfc9000]: https://www.rfc-editor.org/rfc/rfc9000
+[rfc8446]: https://www.rfc-editor.org/rfc/rfc8446
+[rfc7301]: https://www.rfc-editor.org/rfc/rfc7301
+[rfc2606]: https://www.rfc-editor.org/rfc/rfc2606
+[rfc5705]: https://www.rfc-editor.org/rfc/rfc5705

--- a/docs/research/iroh/gossip.md
+++ b/docs/research/iroh/gossip.md
@@ -1,0 +1,452 @@
+# Epidemic Broadcast (`iroh-gossip`)
+
+Topic-scoped epidemic broadcast: a [HyParView][hyparview] partial-view membership protocol keeps a small set of live bidirectional neighbors per 32-byte topic, and a [Plumtree][plumtree] eager/lazy-push layer self-optimizes those neighbors into a low-redundancy broadcast spanning tree — the whole protocol expressed as a pure, IO-less state machine driven over per-peer [noq][quic-transport] QUIC connections.
+
+| Field               | Value                                                                                                                                                                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)            | [`iroh-gossip`][gossip-repo] (`proto/` pure state machine + `net/` tokio actor + irpc-based `api`)                                                                                                                                                |
+| Version             | `iroh-gossip` 0.101.0 (git tag `v0.101.0`, commit `2ce78af`) · against `iroh` 1.0.1 (`22cac742`), `irpc` 0.17.0, `postcard` 1, `blake3` 1.8, `rand` 0.10.1, `indexmap` 2, `n0-future` 0.3                                                         |
+| Repository          | [`n0-computer/iroh-gossip`][gossip-repo]                                                                                                                                                                                                          |
+| Documentation       | [docs.rs/iroh-gossip][gossip-docs]                                                                                                                                                                                                                |
+| ALPN(s)             | `b"/iroh-gossip/1"` ([`net.rs`][g-net], line 45) — overridable per instance via `Builder::alpn` ([`net.rs`][g-net], lines 172–181)                                                                                                                |
+| Approx. size (LoC)  | ~8,000 across `src/` (~6,900 excluding the 1,140-line discrete-event simulator); the pure `proto/` state machine is ~3,300 lines, the `net/` actor ~2,600; the two densest modules are `net.rs` (1,977) and `proto/plumtree.rs` (910)             |
+| Category            | Protocols                                                                                                                                                                                                                                         |
+| Upstream spec/draft | HyParView — Leitão, Pereira, Rodrigues, [_HyParView: a membership protocol for reliable gossip-based broadcast_][hyparview] (DSN 2007); Plumtree — Leitão, Pereira, Rodrigues, [_Epidemic Broadcast Trees_][plumtree] (SRDS 2007). No IETF draft. |
+
+---
+
+## Overview
+
+### What it solves
+
+`iroh-gossip` provides **reliable one-to-many broadcast inside a swarm** without a central coordinator, in the presence of churn (nodes joining and failing) and without every node maintaining a connection to every other node. Two classic problems are solved separately and composed:
+
+- **Membership** — how does a node learn about, and stay connected to, a useful subset of the swarm as peers come and go? Solved by [HyParView][hyparview]: each node keeps a small `active_view` (size 5) of peers it holds live bidirectional connections to, plus a larger `passive_view` (size 30) address book it draws from to heal the active view after a failure. Random walks (`ForwardJoin`, `Shuffle`) diffuse membership across the swarm.
+- **Broadcast** — how does a message reach every member cheaply, i.e. without the O(n²) flooding of pushing every payload to every neighbor? Solved by [Plumtree][plumtree]: each active neighbor is either _eager_ (receives full payloads) or _lazy_ (receives only a `blake3` message-id announcement, `IHave`). The eager set forms a spanning tree that carries payloads once per edge; the lazy set is a redundant backstop that repairs gaps and continually re-optimizes the tree toward lowest latency.
+
+Everything is scoped by a `TopicId` — a 32-byte identifier that names an independent swarm and broadcast domain. Joining N topics means N parallel membership + broadcast state machines and up to N unidirectional streams per peer connection. The default per-message ceiling is **4096 bytes** (`DEFAULT_MAX_MESSAGE_SIZE`, [`proto.rs`][g-proto], line 68), so gossip is a _control-plane_ / small-payload transport: [`iroh-docs`][docs-sync] rides on it to fan out `SyncReport`/`Op::Put` change notifications, and bulk content moves through [`iroh-blobs`][index] instead.
+
+The crate is strictly layered ([`README.md`][g-readme]): `proto/` is a **pure state machine with no I/O**, and `net/` is a tokio actor that runs that state machine over iroh QUIC connections. This separation is the single most important fact for a D port — see [Mapping to event-horizon](#mapping-to-event-horizon).
+
+### Design philosophy
+
+The crate root states the architecture in its first line ([`proto.rs`][g-proto], line 1):
+
+> "Implementation of the iroh-gossip protocol, as an IO-less state machine"
+
+The membership and broadcast layers are documented as faithful implementations of the two Leitão et al. papers, and the self-optimizing property of the broadcast tree is called out explicitly ([`proto.rs`][g-proto], lines 39–43):
+
+> "When requesting a message from a currently-lazy peer, this peer is also upgraded to be an eager peer from that moment on. This strategy self-optimizes the messaging graph by latency. Note however that this optimization will work best if the messaging paths are stable, i.e. if it's always the same peer that broadcasts. If not, the relative message redundancy will grow and the ideal messaging graph might change frequently."
+
+The design consequence that matters most: **all protocol logic is a deterministic function of injected events, an injected clock, and an injected RNG** — no wall-clock reads, no sockets, no allocation of I/O. Time enters only as a `now: Instant` argument; timers are emitted as _data_ (`OutEvent::ScheduleTimer`) and fired back as _data_ (`InEvent::TimerExpired`); randomness is a generic `Rng` parameter ([`state.rs`][g-state], lines 78–86, 154–162). This is precisely the [sans-io][async-io] discipline the [event-horizon][eh-spec] runtime is built to drive, and it is documented as an intentional goal on the `State` type ([`state.rs`][g-state], lines 147–148):
+
+> "The implementation works as an IO-less state machine. The implementer injects events through [`Self::handle`], which returns an iterator of [`OutEvent`]s to be processed."
+
+---
+
+## How it works
+
+### The two-layer stack, per topic
+
+For each joined `TopicId` there is one `topic::State<PI, R>` composed of two sub-machines ([`topic.rs`][g-topic], lines 206–213):
+
+- `swarm: hyparview::State<PI, RG>` — the membership layer, holding `active_view` and `passive_view` as `IndexSet<PI>` (an insertion-ordered set that supports O(1) random pick-by-index and swap-remove) plus `pending_neighbor_requests`, `peer_data`, and `alive_disconnect_peers` ([`hyparview.rs`][g-hyparview], lines 229–253).
+- `gossip: plumtree::State<PI>` — the broadcast layer, holding `eager_push_peers` and `lazy_push_peers` as `BTreeSet<PI>`, a `lazy_push_queue`, a `missing_messages` map, and two time-bounded caches ([`plumtree.rs`][g-plumtree], lines 349–383).
+
+The protocol is generic over the peer identity via a trait ([`proto.rs`][g-proto], lines 85–89):
+
+```rust
+// iroh-gossip/src/proto.rs:85-89 (verbatim)
+pub trait PeerIdentity: Hash + Eq + Ord + Copy + fmt::Debug + Serialize + DeserializeOwned {}
+```
+
+In the iroh instantiation `PI = PublicKey` (the ed25519 verifying key that _is_ the `EndpointId`, [`iroh-base` `key.rs`][iroh-key], line 70). Addresses never enter `proto/`: a peer's transport coordinates travel as an opaque `PeerData(Bytes)` ([`proto.rs`][g-proto], lines 95–97) carried on membership messages, which the net layer decodes into an `AddrInfo`.
+
+### The sans-io interface
+
+The entire protocol is one function. `proto::State::handle` takes an input event, the current instant, and an optional metrics sink, and returns a _lazy iterator of output events_ the caller must execute ([`state.rs`][g-state], lines 233–238):
+
+```rust
+// iroh-gossip/src/proto/state.rs:233-238 (verbatim)
+pub fn handle(
+    &mut self,
+    event: InEvent<PI>,
+    now: Instant,
+    metrics: Option<&Metrics>,
+) -> impl Iterator<Item = OutEvent<PI>> + '_ + use<'_, PI, R> {
+```
+
+The input and output alphabets are small and closed ([`topic.rs`][g-topic], lines 21–47):
+
+```rust
+// iroh-gossip/src/proto/topic.rs:21-47 (verbatim, doc comments trimmed)
+pub enum InEvent<PI> {
+    RecvMessage(PI, Message<PI>),   // a frame arrived from the network
+    Command(Command<PI>),           // Join(Vec<PI>) | Broadcast(Bytes, Scope) | Quit
+    TimerExpired(Timer<PI>),        // a previously-scheduled timer fired
+    PeerDisconnected(PI),           // transport-level connection dropped
+    UpdatePeerData(PeerData),       // our own address info changed
+}
+pub enum OutEvent<PI> {
+    SendMessage(PI, Message<PI>),   // transmit a frame to a peer
+    EmitEvent(Event<PI>),           // deliver an app event (NeighborUp/Down, Received)
+    ScheduleTimer(Duration, Timer<PI>), // runtime must fire TimerExpired after Duration
+    DisconnectPeer(PI),             // close the transport connection to a peer
+    PeerData(PI, PeerData),         // learned new address info for a peer
+}
+```
+
+`Timer<PI>` is likewise pure data — a `TopicId` plus a `topic::Timer` that is one of the swarm timers (`DoShuffle`, `PendingNeighborRequest(PI)`) or the gossip timers (`SendGraft(MessageId)`, `DispatchLazyPush`, `EvictCache`) ([`state.rs`][g-state], lines 76–86; [`hyparview.rs`][g-hyparview], lines 62–65; [`plumtree.rs`][g-plumtree], lines 68–80). The runtime owns nothing but a timer queue and a set of connections; the protocol owns all the logic.
+
+### HyParView membership state machine
+
+A node keeps every peer in an implicit lifecycle relative to itself: _unknown_ → _passive_ (address-book only) → _pending-neighbor_ (a `Neighbor` request is outstanding) → _active_ (a live bidirectional connection). The `Join`/`ForwardJoin` random walk seeds membership; `Shuffle` walks keep the passive view fresh; failures trigger refill from the passive view. The full transition table ([`hyparview.rs`][g-hyparview]):
+
+| #   | Trigger                                           | Transition / actions                                                                                                                                                                                                                               | Cite             |
+| --- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 1   | `Command::Join(peer)`                             | send `Join(me_data)` to the bootstrap peer                                                                                                                                                                                                         | lines 322–327    |
+| 2   | recv `Join(data)`                                 | force-add the joiner to the active view at `High` priority (evicting a random active peer if full — the evictee first gets a `ShuffleReply` then `Disconnect{alive:true}`); fan out `ForwardJoin{ttl: ARWL=6}` to every _other_ active peer        | 380–401, 694–726 |
+| 3   | recv `ForwardJoin`                                | already active → renew via `Neighbor(High)`; `ttl==0` or `active_view.len() ≤ 1` → send `Neighbor(High)` to the joiner (paper deviation, below); `ttl == PRWL=3` → insert into passive view; else forward `ttl−1` to a random active peer ≠ sender | 403–448          |
+| 4   | recv `Neighbor{priority}`                         | clear the pending flag; `High` always accepted (random eviction if full); `Low` accepted only if a slot is free, else reply `ShuffleReply` + `Disconnect{alive:true}`                                                                              | 450–460, 694–726 |
+| 5   | recv `Shuffle`                                    | ttl expired or `active_view.len() ≤ 1` → absorb the sampled nodes into the passive view and reply `ShuffleReply` (same node count) directly to `origin`; else forward `ttl−1` to a random active peer ∉ {`origin`, sender}                         | 486–504          |
+| 6   | recv `ShuffleReply`                               | absorb nodes into passive view; `refill_active_from_passive`                                                                                                                                                                                       | 523–528          |
+| 7   | recv `Disconnect{alive}`                          | if active: remove (emit `NeighborDown`, keep in passive iff `alive`, mark `alive_disconnect_peers`) then refill; if passive and `alive`: mark `alive_disconnect`                                                                                   | 330–343, 639–680 |
+| 8   | `PeerDisconnected` (transport)                    | if active: remove with reason `ConnectionClosed` (keep passive iff previously marked alive); else drop from passive + `peer_data` unless marked alive                                                                                              | 346–354          |
+| 9   | timer `DoShuffle` (**every 60 s**)                | send `Shuffle{origin: me, nodes: 3 active + 4 passive + me, ttl: 6}` to one random active peer; re-arm                                                                                                                                             | 530–562          |
+| 10  | timer `PendingNeighborRequest(peer)` (**500 ms**) | if still pending: **delete the candidate from the passive view** and try the next one                                                                                                                                                              | 632–637          |
+| 11  | `Command::Quit`                                   | for each active peer: send a `ShuffleReply` (up to 7 nodes) then `Disconnect{alive:false}` + `DisconnectPeer`                                                                                                                                      | 356–378          |
+| 12  | any message from a _non-active_ peer              | after handling, immediately `DisconnectPeer(from)` — walk-relay connections are ephemeral (the author flags doubt in a `TODO`)                                                                                                                     | 315–319          |
+
+The configuration is entirely defaulted from the paper, with two "wild guess" timers ([`hyparview.rs`][g-hyparview], lines 197–221):
+
+| Parameter                                                  | Default  | Source       |
+| ---------------------------------------------------------- | -------- | ------------ |
+| `active_view_capacity`                                     | 5        | paper p9     |
+| `passive_view_capacity`                                    | 30       | paper p9     |
+| `active_random_walk_length` (ARWL)                         | `Ttl(6)` | paper p9     |
+| `passive_random_walk_length` (PRWL)                        | `Ttl(3)` | paper p9     |
+| `shuffle_random_walk_length`                               | `Ttl(6)` | paper p9     |
+| `shuffle_active_view_count` / `shuffle_passive_view_count` | 3 / 4    | paper p9     |
+| `shuffle_interval`                                         | 60 s     | "Wild guess" |
+| `neighbor_request_timeout`                                 | 500 ms   | "Wild guess" |
+
+One deliberate divergence from the paper is called out in the code ([`hyparview.rs`][g-hyparview], lines 414–417):
+
+> "Modification from paper: Instead of adding the peer directly to our active view, we only send the Neighbor message. We will add the peer to our active view once we receive a reply from our neighbor. This prevents us adding unreachable peers to our active view."
+
+Another is a courtesy that is _not_ in the paper: every voluntary disconnect (eviction, low-priority denial, `Quit`) is preceded by a free `ShuffleReply` so the other side does not starve for peers ([`hyparview.rs`][g-hyparview], lines 363–366):
+
+> "Before disconnecting, send a `ShuffleReply` with some of our nodes to prevent the other node from running out of connections. This is especially relevant if the other node just joined the swarm."
+
+### Plumtree broadcast state machine
+
+Plumtree operates on two independent axes. On the **peer axis**, every active neighbor is either eager or lazy (`add_eager`/`add_lazy` are mutually-exclusive moves, [`plumtree.rs`][g-plumtree], lines 691–700). On the **message axis**, a message id moves _unknown_ → _missing_ (an `IHave` was seen but the payload is not here yet) → _received_ (the id is cached for `message_id_retention`, the payload for `message_cache_retention`). A `MessageId` is `blake3(content)` — the content-address _is_ the id ([`plumtree.rs`][g-plumtree], lines 27–38). The full transition table:
+
+| #   | Trigger                                                | Transition / actions                                                                                                                                                                                                                                                                                   | Cite             |
+| --- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| 1   | `Broadcast(data, Swarm)`                               | `id = blake3(data)`; record id (90 s) + cache payload (30 s); eager-push `Gossip{id, content, round 0}`; queue `IHave{id, round}` for lazy peers                                                                                                                                                       | lines 467–487    |
+| 2   | recv `Gossip`, valid id, **duplicate**                 | demote sender to lazy; send `Prune`                                                                                                                                                                                                                                                                    | 504–506          |
+| 3   | recv `Gossip`, valid id, **new** (Swarm)               | record id; `round+1`; cache payload; eager-push + lazy-push to _other_ peers; **tree optimization**: if a prior `IHave` for this id arrived with a round ≥ `optimization_threshold`(7) hops lower, `Graft` the IHave sender (→eager) and `Prune` the Gossip sender (→lazy); emit `Received` to the app | 509–544, 552–582 |
+| 4   | recv `Gossip`, **invalid id** (`id ≠ blake3(content)`) | drop and `warn!` — a spoofed message id                                                                                                                                                                                                                                                                | 491–500          |
+| 5   | recv `Prune`                                           | demote sender to lazy                                                                                                                                                                                                                                                                                  | 584–586          |
+| 6   | recv `IHave(vec)`                                      | for each unseen id: push `(sender, round)` onto `missing_messages`; if no timer is armed for it, arm `SendGraft(id)` at **graft_timeout_1 = 80 ms**                                                                                                                                                    | 597–614          |
+| 7   | timer `SendGraft(id)`                                  | if still missing: pop the first announcer, promote it to eager, send `Graft{id: Some(id), round}`; re-arm at **graft_timeout_2 = 40 ms** to fall through to the next announcer                                                                                                                         | 617–646          |
+| 8   | recv `Graft{id?}`                                      | promote sender to eager; if `id` is set and the payload is still cached (≤30 s) reply with the `Gossip`, else debug-log a silent miss                                                                                                                                                                  | 649–661          |
+| 9   | `NeighborUp` (from HyParView)                          | add to eager                                                                                                                                                                                                                                                                                           | 664–666          |
+| 10  | `NeighborDown`                                         | drop from both eager and lazy; scrub the peer from `missing_messages`                                                                                                                                                                                                                                  | 672–679          |
+| 11  | timer `DispatchLazyPush` (**5 ms**, armed on demand)   | drain `lazy_push_queue`, send chunked `IHave` batches                                                                                                                                                                                                                                                  | 447–461, 728–734 |
+| 12  | timer `EvictCache` (**1 s**, self-re-arming)           | expire the payload cache (30 s) and id cache (90 s)                                                                                                                                                                                                                                                    | 681–688          |
+
+The gossip parameters ([`plumtree.rs`][g-plumtree], lines 306–327):
+
+| Parameter                                              | Default    |
+| ------------------------------------------------------ | ---------- |
+| `graft_timeout_1` (arm on `IHave`)                     | 80 ms      |
+| `graft_timeout_2` (re-arm after `Graft`)               | 40 ms      |
+| `dispatch_timeout` (lazy-push flush)                   | 5 ms       |
+| `optimization_threshold`                               | `Round(7)` |
+| `message_cache_retention` (payloads for Graft replies) | 30 s       |
+| `message_id_retention` (dedup ids)                     | 90 s       |
+| `cache_evict_interval`                                 | 1 s        |
+
+A `Scope::Neighbors` broadcast (`DeliveryScope::Neighbors`) bypasses caching, rounds, `IHave`, and forwarding entirely — it is a direct eager-push that is delivered once but never relayed ([`plumtree.rs`][g-plumtree], lines 469–487, 509–544). It is the "tell my current neighbors, don't flood the swarm" primitive.
+
+### Composition and multi-topic multiplexing
+
+`topic::State::handle` demultiplexes a per-topic `InEvent` into the two sub-machines and — crucially — **forwards HyParView's `NeighborUp`/`NeighborDown` outputs straight into Plumtree's inputs within the same call**, so a new active neighbor becomes an eager peer immediately ([`topic.rs`][g-topic], lines 258–328). A `PeerDisconnected` is delivered to _both_ layers.
+
+Above the topics, `proto::State` is a thin router ([`state.rs`][g-state], lines 154–162, 233–301): it holds `states: HashMap<TopicId, topic::State>` and `peer_topics: HashMap<PI, HashSet<TopicId>>`, routes topic-tagged events to the matching topic state, creates a topic state lazily on `Command::Join` (seeding a fresh child RNG from the parent), drops it after `Command::Quit`, and fans `PeerDisconnected`/`UpdatePeerData` to every topic. The one subtlety is that a `topic::OutEvent::DisconnectPeer` is filtered through `peer_topics` so that a single shared QUIC connection is only closed at the transport level when no other topic still needs the peer — although the filter's `list.remove(&topic) || list.is_empty()` logic looks incorrect (it tears the connection down whenever the topic _was_ present, regardless of other topics), and `peer_topics` is only populated on _received_ messages, never on sends ([`state.rs`][g-state], lines 319–328; treat as an upstream bug to verify — see [Weaknesses](#weaknesses)).
+
+### The net layer: one actor, per-peer connections, per-topic streams
+
+`net.rs` runs a single `Actor` task that owns `proto::State<PublicKey, StdRng>` outright — no locks, sole mutator ([`net.rs`][g-net], lines 206–213). The actor's `run` loop is a biased 9-arm `tokio::select!` ([`net.rs`][g-net], lines 383–479) over: the local control channel (shutdown / new inbound connection), the irpc request channel, the app command streams, our-own-address updates, dial completions, inbound protocol events, the timer queue, and the two `JoinSet`s reaping connection and subscriber tasks.
+
+Transport shape: **one QUIC connection per remote peer**, shared across all topics. Within a connection, each `(topic, direction)` gets its own **unidirectional** stream. A send stream begins with exactly one `StreamHeader { topic_id }` frame ([`net/util.rs`][g-netutil], lines 58–89), after which frames carry only `topic::Message` — the topic id is not repeated per frame. A topic's stream is `finish()`ed after its `Disconnect` message ([`net/util.rs`][g-netutil], lines 295–307). Each connection runs `connection_loop = tokio::join!(send_loop, recv_loop)` as a task in a `JoinSet` ([`net.rs`][g-net], lines 545–561):
+
+- The **send loop** lazily opens one uni stream per topic on first use, writes the header, then writes length-prefixed postcard frames pulled from a per-connection `mpsc` ([`net/util.rs`][g-netutil], lines 198–311).
+- The **recv loop** accepts uni streams, reads each header, then reads frames from all streams concurrently via a `FuturesUnordered`, forwarding `InEvent::RecvMessage(peer, msg)` into the actor's `in_event` channel ([`net/util.rs`][g-netutil], lines 91–158).
+
+Per-peer connection state is a two-state machine ([`net.rs`][g-net], lines 759–769):
+
+```rust
+// iroh-gossip/src/net.rs:759-769 (verbatim, doc comments trimmed)
+enum PeerState {
+    Pending {
+        queue: Vec<ProtoMessage>,     // buffered until a dial completes
+    },
+    Active {
+        active_send_tx: mpsc::Sender<ProtoMessage>,  // into this conn's send loop
+        active_conn_id: ConnId,
+        other_conns: Vec<ConnId>,     // superseded but still draining
+    },
+}
+```
+
+Duplicate connections are _kept, not rejected_: a second connection to the same peer becomes the new sender while the old one drains ([`net.rs`][g-net], lines 790–796):
+
+> "We already have an active connection. We keep the old connection intact, but only use the new connection for sending from now on."
+
+Dial-side, a `Dialer` spawns `endpoint.connect(endpoint_id, alpn)` per peer under a `CancellationToken`; a dial failure for a non-active peer injects `PeerDisconnected` so the membership machine can try another candidate ([`net.rs`][g-net], lines 435–444, 993–1070). Learned `PeerData` is decoded into `AddrInfo { relay_url, direct_addresses }` and fed into a `GossipAddressLookup` registered with the iroh endpoint, so a peer known only through gossip resolves through iroh's normal [address-lookup][discovery] machinery — entries expire after 5 minutes, evicted every 30 s ([`net.rs`][g-net], lines 188–195; [`net/address_lookup.rs`][g-addrlookup], lines 25–40).
+
+The app surface (`api.rs`, built on [irpc][irpc] so the same API works in-process or over an RPC connection): `subscribe(topic, bootstrap)` yields a `GossipTopic = GossipSender + GossipReceiver`. The sender exposes `Broadcast`, `BroadcastNeighbors`, and `JoinPeers`; the receiver is a stream of `Event::{NeighborUp, NeighborDown, Received(Message), Lagged}`, tracks a client-side neighbor set, and `joined()` awaits the first `NeighborUp` ([`api.rs`][g-api], lines 170–330).
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+Every byte on the wire is [`postcard`][postcard] inside a QUIC unidirectional stream; the topic id is factored out into the one-shot stream header rather than repeated per frame. The complete surface, cross-referenced from [wire-serialization][wire]:
+
+- **ALPN**: `b"/iroh-gossip/1"` ([`net.rs`][g-net], line 45), overridable per instance so private swarms can namespace themselves; all peers of a network must agree.
+- **Stream header**: one `StreamHeader { topic_id: [u8;32] }` per `(connection, topic, direction)` ([`net/util.rs`][g-netutil], lines 58–89), then a sequence of `topic::Message<PI>` frames.
+- **Frame**: a 4-byte **big-endian `u32`** length prefix (`read_u32`/`write_u32`, [`net/util.rs`][g-netutil], lines 359, 390) followed by the postcard body. This matches [`iroh-docs`][docs-sync] framing but differs from QUIC varints and from blobs' framing — a third length dialect in the stack ([wire-serialization][wire]).
+- **Size limits**: `DEFAULT_MAX_MESSAGE_SIZE = 4096`, hard floor `MIN_MAX_MESSAGE_SIZE = 512` ([`proto.rs`][g-proto], lines 68–71). The checks are asymmetric: read rejects `size > max` ([`net/util.rs`][g-netutil], lines 364–366) but write rejects `len >= max` ([`net/util.rs`][g-netutil], lines 383–385) — a one-byte discrepancy worth reproducing consciously or fixing.
+- **Message enums** (postcard uses a `varint(u32)` discriminant in declaration order):
+  - outer `topic::Message`: `Swarm = 0`, `Gossip = 1` ([`topic.rs`][g-topic], lines 92–97).
+  - `hyparview::Message`: `Join = 0`, `ForwardJoin = 1`, `Shuffle = 2`, `ShuffleReply = 3`, `Neighbor = 4`, `Disconnect = 5` ([`hyparview.rs`][g-hyparview], lines 69–88). `Priority::High = 0`, `Low = 1`. `Disconnect` still carries an obsolete `_respond: bool` "kept in the struct to maintain wire compatibility".
+  - `plumtree::Message`: `Gossip = 0`, `Prune = 1`, `Graft = 2`, `IHave = 3` ([`plumtree.rs`][g-plumtree], lines 137–149). `DeliveryScope::Swarm(Round) = 0`, `Neighbors = 1`.
+  - Field encodings: `[u8;32]` is 32 raw bytes with no prefix; `Bytes`/`Vec` is a varint length + elements; `u16` (`Ttl`, `Round`) is a varint (≤ 3 bytes); `Option` is `0x00`/`0x01` + value; `bool` is one byte. So a `Prune` frame is `01 01` (`Gossip` outer tag, `Prune` inner tag) inside a 4-byte length prefix.
+- **Max broadcast payload**: `max_message_size − postcard_header_size()`. `postcard_header_size()` is computed as the serialized size of `{topic: [u8;32], Gossip(Prune)}` minus one, i.e. `32 + 1 + 1 − 1 = 33` bytes ([`state.rs`][g-state], lines 48–58) — so the usable payload is `4096 − 33 = 4063` bytes at the default. This still reserves the 32-byte topic even though frames no longer carry it (a conservative holdover from the pre-stream-header framing).
+- **`IHave` batching**: on the dispatch timer, queued `IHave`s are chunked at `chunk_len = (max_message_size − 1 − 2) / IHave::POSTCARD_MAX_SIZE` per `Message::IHave` frame, where `IHave::POSTCARD_MAX_SIZE = 32 (id) + 3 (round varint) = 35` — i.e. **116 `IHave`s per frame** at the 4096 default ([`plumtree.rs`][g-plumtree], lines 447–457).
+- **`PeerData`** (iroh instantiation): postcard of `AddrInfo { relay_url: Option<RelayUrl>, direct_addresses: BTreeSet<SocketAddr> }`; empty bytes decode to default ([`net.rs`][g-net], lines 903–930).
+
+### Cryptography & identity
+
+**There is no cryptography inside the gossip protocol.** Gossip payloads are _unsigned_ and carry no author identity — the only integrity check is that a received `Gossip`'s claimed id equals `blake3(content)`, which detects a corrupted/spoofed _id_ but not a forged _message_ ([`plumtree.rs`][g-plumtree], lines 491–500). Peer authenticity is _per-hop only_: it comes entirely from the QUIC/TLS connection, whose peer identity is the ed25519 `EndpointId` (see [identity-crypto][identity-crypto] and [quic-transport][quic-transport]). The receiver knows only the previous hop, never the origin — the `Received` event's `delivered_from` field is documented as "not the peer that originally broadcasted the message, but the peer before us in the gossiping path" ([`plumtree.rs`][g-plumtree], lines 93–95).
+
+The absence is itself the finding: any swarm member can inject a message that every other member will relay and deliver, attributed to no one. The only content-addressing property is the `MessageId = blake3(content)` used for dedup and `Graft` lookups. Applications that need authenticated broadcast must sign payloads themselves and treat gossip as an untrusted transport — which is exactly what [`iroh-docs`][docs-sync] does (its `Op::Put` carries a doubly-ed25519-signed `SignedEntry`, verified above the gossip layer).
+
+### State machines & lifecycle
+
+Three tiers of lifecycle, and — the key property — the innermost two are **fully sans-io** ([`proto.rs`][g-proto], line 1). The single entry point `proto::State::handle(InEvent, now, metrics) -> Iterator<OutEvent>` samples no clock (`now` is injected), performs no I/O, and draws randomness from an injected `Rng`; timers are `OutEvent::ScheduleTimer(Duration, Timer)` data that the runtime must return as `InEvent::TimerExpired(Timer)` ([`state.rs`][g-state], lines 76–86). Both the shuffle timer and the plumtree `EvictCache` timer _self-bootstrap_ on the first `handle()` call of any kind — the machines assume at least one input event before any timer exists ([`hyparview.rs`][g-hyparview], lines 291–298; [`plumtree.rs`][g-plumtree], lines 406–410).
+
+- **Per-topic** (membership × broadcast): the HyParView and Plumtree tables above. A single `handle` call can walk a peer from unknown to eager and schedule several timers.
+- **Multi-topic** (`state.rs`): topic state created on `Command::Join`, destroyed after `Command::Quit`; shared connections survive per-topic disconnects via the `peer_topics` filter (modulo the suspected bug).
+- **Net-layer `PeerState`** (`net.rs`): `Pending{queue}` → `Active{send_tx, conn_id, other_conns}` on the first completed dial or accepted inbound connection ([`net.rs`][g-net], lines 525–561, 771–810). A second connection replaces the sender and parks the old id in `other_conns`; when the _active_ connection task finishes, the actor injects `PeerDisconnected` and closes the connection with code 0, reason `b"close from disconnect"` ([`net.rs`][g-net], lines 564–593). An `OutEvent::DisconnectPeer` drops the whole peer entry, whose dropped send channel triggers a graceful stream finish ([`net.rs`][g-net], lines 732–736).
+
+Because the protocol layer is a deterministic function, the crate ships a discrete-event simulator (`proto/sim.rs`, 1,140 lines) that runs thousands of nodes on a virtual clock and asserts convergence — symmetric active views (`check_synchronicity`) and round statistics (single-sender at 100 peers: last-delivery-hop `ldh < 15`, relative-message-redundancy `rmr < 0.2`, [`tests/sim.rs`][g-testsim]). That simulator is directly reusable as a conformance oracle for a port (see below).
+
+### Dependencies & coupling
+
+| Crate                                                                                   | Depth                                                                                                                                            | Port implication                                                                                         |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| [`postcard`][postcard]                                                                  | load-bearing (all frames, `PeerData`, `serialized_size`, `MaxSize` derive for `IHave` chunking)                                                  | reimplement postcard varint/enum/struct/`Option`/`Vec`/`[u8;N]` encoding in D — small and self-contained |
+| [`blake3`][blake3]                                                                      | load-bearing (`MessageId = blake3(content)`, spoof check)                                                                                        | need blake3 in D (ImportC C binding or native) — same dependency as [blobs][index]/[bao-tree][index]     |
+| [`indexmap`][indexmap] (`IndexSet<PI>`)                                                 | load-bearing semantics: O(1) random pick-by-index and swap-remove; iteration order affects `ForwardJoin` fan-out                                 | any array-backed set works; swap-remove order-perturbation is acceptable (selection is already random)   |
+| `rand` (`StdRng`)                                                                       | uniform index pick + Fisher–Yates shuffle; seeded `ChaCha` in tests/sim                                                                          | any uniform RNG, kept injectable for deterministic simulation                                            |
+| [`iroh`][iroh-key]                                                                      | API surface: `Endpoint`/`Connection`, `open_uni`/`accept_uni`, `finish`/`stopped`/`closed`, `close_reason`, the `AddressLookup` trait, `Watcher` | maps to the D port's [endpoint][endpoint] subsystem                                                      |
+| [`irpc`][irpc]                                                                          | API plumbing only (a bidi-streaming `Join` RPC; in-process path + optional `noq` remote path)                                                    | replace with native API calls; the RPC veneer is optional                                                |
+| `futures-concurrency` (`StreamGroup`)                                                   | mux of per-subscription command streams with stable keys                                                                                         | replace with per-subscription fiber or a polled list                                                     |
+| `tokio` (`sync`, `io-util` only)                                                        | channels + `read_u32`/`write_u32` framing                                                                                                        | event-horizon channels/streams; note the BE-`u32` frame prefix                                           |
+| `tokio-util` (`CancellationToken`)                                                      | dial cancellation                                                                                                                                | maps to `CancelContext`                                                                                  |
+| `bytes`                                                                                 | zero-copy payload sharing (`Bytes` cloned into caches, events, and N send queues)                                                                | a ref-counted immutable buffer is essential — naive copies multiply a payload by its fan-out             |
+| `n0-future`, `iroh-metrics`, `n0-error`, `derive_more`, `serde`, `hex`, `data-encoding` | shallow plumbing                                                                                                                                 | trivial                                                                                                  |
+
+The protocol core depends on _nothing from iroh_ — `proto/` is generic over `PeerIdentity` and knows only opaque `PeerData`. All the iroh coupling (`EndpointId`, address lookup, QUIC streams) lives in `net/`. That clean cut is what makes `proto/` portable in isolation.
+
+### Concurrency & I/O model
+
+The whole crate's concurrency budget is: **1 actor task + 1 task per QUIC connection + 1 task per subscriber + 1 task per in-flight dial + 1 address-eviction task.** There is no `spawn_blocking` and no thread pool (blake3 over ≤4 KiB payloads runs inline). The primitives ([concurrency][concurrency] carries the workspace-wide inventory):
+
+| Primitive                                                          | Cap                           | Purpose                                                                                                         |
+| ------------------------------------------------------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| main actor task (`AbortOnDropHandle`)                              | —                             | sole owner of `proto::State`, `peers`, `topics`, timers, dialer — no locks ([`net.rs`][g-net], lines 206–213)   |
+| actor `tokio::select!` (biased, 9 arms)                            | —                             | the single park point multiplexing every channel/timer/JoinSet ([`net.rs`][g-net], lines 383–479)               |
+| `mpsc` rpc / local / in_event                                      | 64 / 16 / **1024**            | irpc `Join`s / control / inbound `InEvent`s from all recv loops ([`net.rs`][g-net], lines 49–52)                |
+| `mpsc` send (per connection)                                       | 64                            | outbound `ProtoMessage`s for one peer ([`net.rs`][g-net], line 526)                                             |
+| `broadcast::Sender<ProtoEvent>` (per topic)                        | 256                           | fan-out of topic events to N subscribers; overflow → `Lagged` ([`net.rs`][g-net], lines 53–54, 822–831)         |
+| irpc per-subscription channels                                     | commands 64 / events **2048** | app-facing publish/subscribe streams ([`api.rs`][g-api], lines 21–23)                                           |
+| `JoinSet connection_tasks` / `topic_event_forwarders`              | —                             | one task per connection (`join!(send, recv)`) / per subscriber ([`net.rs`][g-net], lines 301–303, 545–561)      |
+| `Dialer` (`JoinSet` + `CancellationToken` map)                     | —                             | one cancellable task per outbound dial ([`net.rs`][g-net], lines 993–1070)                                      |
+| `Timers = TimerMap` (binary heap keyed by `Instant`, seq tiebreak) | —                             | all protocol timers; the actor drains everything `≤ now` per wakeup ([`net/util.rs`][g-netutil], lines 395–435) |
+| `GossipAddressLookup`: `Arc<RwLock<BTreeMap>>` + evictor           | evict 30 s / retain 300 s     | learned peer addresses — **the only lock in the crate** ([`net/address_lookup.rs`][g-addrlookup], lines 25–89)  |
+
+The `in_event` channel (cap 1024) is the backpressure valve: when it fills, all connection recv loops block awaiting the actor, so a slow actor exerts head-of-line blocking across peers — undocumented but structural. Subscriber fan-out uses a lag policy instead of blocking, so a slow _subscriber_ is dropped rather than stalling the loop ([`api.rs`][g-api], lines 393–396):
+
+> "This is to prevent a single slow subscriber from blocking the dispatch loop. If a subscriber is lagging, it should be closed and re-opened."
+
+### Mapping to event-horizon
+
+Under [`sparkles:event-horizon`][eh-spec]'s default `single` topology — one loop, one thread, completion-first io*uring — this subsystem maps \_unusually* well, because its designers already did the hard separation for us. Six moves.
+
+**1. `proto/` is a gift — port it verbatim as a pure D struct.** It is a genuine sans-io state machine (`handle(InEvent, now) -> OutEvent[]`, injected clock, injected RNG, timers-as-data). It needs no fibers, no I/O, no capabilities — just a value type and a caller-supplied output sink mirroring the Rust `IO<PI>` push trait. `PI` becomes a template parameter constrained like `PeerIdentity`:
+
+```rust
+// iroh-gossip/src/proto/state.rs:233-238 (verbatim) — the sans-io seam
+pub fn handle(
+    &mut self,
+    event: InEvent<PI>,
+    now: Instant,
+    metrics: Option<&Metrics>,
+) -> impl Iterator<Item = OutEvent<PI>> + '_ + use<'_, PI, R> {
+```
+
+```d
+// proposed / sketch — a plain @safe value type; the caller owns the OutEvent sink
+// (mirrors Rust's `IO<PI>` push trait) so `handle` never allocates a result vector.
+// `now` is injected (MonoTime), `Rng` is injected, timers are data. No I/O here.
+struct GossipState(PI, Rng)
+if (isPeerIdentity!PI)
+{
+    HashMap!(TopicId, TopicState!(PI, Rng)) states;
+    ConnsMap!PI peerTopics;
+    Rng rng;
+
+    // Attributes inferred: @safe, and @nogc/nothrow wherever the maps allow.
+    void handle(Sink)(in InEvent!PI event, MonoTime now, ref Sink outbox)
+        if (isOutEventSink!(Sink, PI));   // outbox.push(OutEvent!PI)
+}
+```
+
+The determinism this buys is the same the Rust simulator exploits: drive `GossipState` from a `TestSched` + `TestClock` ([event-horizon][eh-spec] test doubles) and port `proto/sim.rs`'s `Network`/`TimedEventQueue` to get thousand-node convergence tests with zero real I/O. The timer heap (`TimerMap`, binary heap + insertion-order tiebreak) ports directly and is driven by a single in-ring `TIMEOUT` op re-armed to the earliest deadline — the actor only ever sleeps to `first()` and drains all expired timers on wake.
+
+**2. The actor collapses into one fiber owning `proto::State`.** Under `single` topology there is nothing to lock: `Arc<Metrics>`, `Arc<Inner>`, and the `RwLock` in `GossipAddressLookup` all become plain fields. The biased 8-arm `select!` becomes the fiber's park point via [`race`][eh-spec]. But most of those arms are _channel receives_, and that collides head-on with event-horizon's recognized **O20 gap (no cross-fiber channel primitive)**. The cleanest D shape sidesteps the biggest channel entirely: the `in_event` `mpsc` (cap 1024) exists in Rust only to hand `&mut proto::State` exclusivity across recv loops — which single-threaded D ownership grants for free. A connection recv fiber can call a method on the gossip-state object _directly_ instead of sending an `InEvent` through a queue:
+
+```rust
+// iroh-gossip/src/net.rs:759-769 (verbatim) — per-peer connection state
+enum PeerState {
+    Pending { queue: Vec<ProtoMessage> },
+    Active {
+        active_send_tx: mpsc::Sender<ProtoMessage>,
+        active_conn_id: ConnId,
+        other_conns: Vec<ConnId>,
+    },
+}
+```
+
+```d
+// proposed / sketch — no mpsc into a send loop; the peer entry holds the outbound
+// stream handles directly and is mutated by the one owning fiber. `Buf` is the
+// event-horizon move-only buffer handle; payloads are ref-counted, never copied
+// per fan-out.
+struct PeerState
+{
+    enum Kind { pending, active }
+    Kind kind;
+    SmallBuffer!(ProtoMessage, 8) queue;   // Pending: buffered until dial completes
+    ConnId activeConnId;                    // Active: the current send stream owner
+    SmallBuffer!(ConnId, 2) otherConns;     // superseded conns, still draining
+    UniStreamMap streams;                   // one send stream per topic, lazily opened
+}
+```
+
+Trade-off to preserve consciously: the 1024-deep `mpsc` _smooths bursts_. Direct calls remove that buffer, so a burst of inbound frames now runs `GossipState.handle` synchronously on the recv fiber. That is fine (handle is cheap and non-blocking), but there is no longer a place for the head-of-line backpressure the Rust design accepts — the port should decide backpressure explicitly (e.g. a bounded provided-buffer ring on the recv path).
+
+**3. Per-connection tasks become a `Scope` with two child fibers.** `connection_loop = join!(send_loop, recv_loop)` maps to a [`Scope`][eh-spec] with two `fork`ed children joined at scope exit; the send loop's `finishing` `JoinSet` (awaiting `stream.stopped()` per topic, drained with a 5 s timeout) becomes `spawnDaemon`ed stopped-waiters plus a `withDeadline` drain on exit. The recv loop's `FuturesUnordered` over per-topic streams simplifies to one fiber per accepted uni stream, each calling back into the owning state. Scope exit-join is strictly stronger than tokio's `AbortOnDrop`, whose swallowed panics are a known hazard.
+
+**4. `broadcast::Sender` per topic has no event-horizon equivalent (also O20).** Reimplement it as a per-topic list of bounded per-subscriber ring buffers with the documented lag policy: on overflow, drop the message and deliver a `Lagged` marker (Rust caps: actor-side broadcast 256, api-side events 2048). This is a small, self-contained primitive worth building once and reusing for [docs-sync][docs-sync]'s subscriber fan-out too.
+
+**5. Address updates and dialing map to capability callbacks and forks.** The `endpoint.watch_addr().stream()` watcher (our own address changing → `UpdatePeerData`) has no watch primitive in event-horizon; model it as a coalescing 1-slot mailbox fed by the [socket][socket] subsystem, or a capability callback. The `Dialer` becomes a `fork` per dial inside the actor's scope with `CancellationToken` → `CancelContext`; the `next_conn()` "pending-forever-when-idle" trick disappears because a dial completion calls back into the owning state directly rather than being polled out of a `JoinSet`.
+
+**6. No thread pool needed; drop-driven cleanup becomes explicit.** The crate never uses `spawn_blocking` — blake3 over ≤4 KiB payloads is fine inline on the loop thread, so the single-threaded model pays no CPU-offload penalty here (unlike [blobs][index], where blake3 over large content is a real concern). The one behavioral gap: tokio's topic GC is driven by _handle drops_ (`still_needed`, [`net.rs`][g-net], lines 833–839); D has no drop-on-await, so a subscriber closing must be an explicit event — model it via `onExit` RAII hooks on the subscriber's scope.
+
+The net result: the pure `proto/` layer ports almost mechanically and gains a deterministic test harness for free; the `net/` layer shrinks (no `Arc`, no `Mutex`, one fewer channel) but forces the port to build two small missing primitives — a bounded SPSC/broadcast channel (O20) and a coalescing watch mailbox — that several other iroh subsystems also need. Those belong in the shared [D architecture migration][d-migration] plan, not in gossip alone.
+
+---
+
+## Strengths
+
+- **A textbook sans-io core.** The entire protocol is `handle(InEvent, now) -> OutEvent[]` with injected time and randomness — no sockets, no clock reads, no allocation of I/O. This is the cleanest possible target for [event-horizon][eh-spec] and comes with a reusable discrete-event simulator as a conformance oracle.
+- **Clean layer cut.** `proto/` depends on nothing from iroh (generic over `PeerIdentity`, opaque `PeerData`); all transport coupling is quarantined in `net/`. The core is portable in isolation.
+- **Self-optimizing broadcast tree.** Plumtree's eager/lazy split converges to a low-redundancy spanning tree, and `Graft`-on-`IHave` continuously re-optimizes it toward lowest latency (`rmr < 0.2` at 100 peers in the crate's own tests).
+- **Robust membership under churn.** HyParView's active/passive split with random-walk diffusion and passive-view refill gives auto-healing connectivity; the "wait for `Neighbor` reply before adding" deviation avoids poisoning the active view with unreachable peers.
+- **Small, predictable footprint.** A 4096-byte default frame, one connection per peer shared across topics, a bounded timer heap, and a fixed handful of tasks — no unbounded growth, no thread pool.
+- **Address-lookup integration, not addr-book stuffing.** Gossip registers its own `GossipAddressLookup` provider into the endpoint's [address-lookup][discovery] stack (5-minute retention), matching the iroh-1.0 discovery→address-lookup model rather than mutating a shared address book.
+
+## Weaknesses
+
+- **Unsigned messages.** No per-message signature or origin identity anywhere; only `blake3(content) == id` validation ([`plumtree.rs`][g-plumtree], lines 491–500). Any swarm member can inject a message the whole swarm relays and delivers, attributed to no one — authentication is the application's job.
+- **Suspected cross-topic disconnect bug.** The shared-connection filter `list.remove(&topic) || list.is_empty()` ([`state.rs`][g-state], lines 319–328) tears down a peer's connection whenever _this_ topic used it, ignoring other topics; and `peer_topics` is populated only on received messages, never on sends. A port should implement the obvious intent (remove, then check empty) and verify upstream. Tests never exercise two topics sharing one connection.
+- **Aggressive passive-view eviction.** A low-priority `Neighbor` candidate that misses the 500 ms `PendingNeighborRequest` timeout is _deleted from the passive view_ ([`hyparview.rs`][g-hyparview], lines 632–637) — the paper's "consider failed and remove" applied even to a merely-slow peer.
+- **Bounded dedup window.** `message_id_retention` is 90 s; a message re-broadcast after 90 s is re-delivered. Exactly-once delivery is the application's responsibility, which the code implies but never documents.
+- **Head-of-line backpressure across peers.** When the actor's `in_event` channel (cap 1024) fills, _all_ connection recv loops block — an undocumented structural coupling between unrelated peers.
+- **Silent `Graft` misses and untested overflow.** A `Graft` whose payload has already been evicted (>30 s) fails silently with only a debug log ([`plumtree.rs`][g-plumtree], lines 649–661); `Round::next` is an unchecked `self.0 + 1` ([`plumtree.rs`][g-plumtree], lines 129–133), so behavior at 65535 hops is untested (unlike `Ttl`, which saturates). The simulator models latency and connection kills but _no packet loss_, so loss behavior at the proto layer is unexercised.
+- **`Bytes` cloning fan-out.** A broadcast payload is cloned into the payload cache and into every eager-push send ([`plumtree.rs`][g-plumtree], lines 703–714); without a ref-counted buffer, a 4 KiB payload at fan-out 5 is memcpy'd six times.
+
+## Key design decisions and trade-offs
+
+| Decision                                                        | Rationale                                                                                                   | Trade-off                                                                                                                   |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Sans-io state machine (`proto/`) + thin actor (`net/`)          | Protocol logic is deterministic, testable in a virtual-time simulator, and portable with no I/O coupling    | Two layers and an event-translation seam; the runtime must own the timer queue and re-inject `TimerExpired`                 |
+| HyParView active(5)/passive(30) partial views + random walks    | Bounded connection count with auto-healing membership under churn; bidirectional-only active links          | Membership is eventually-consistent and probabilistic; parameters are paper defaults with "wild guess" timers               |
+| Plumtree eager/lazy push with `Graft`-on-`IHave` optimization   | Payloads travel once per tree edge; the tree self-optimizes toward lowest latency; lazy set repairs gaps    | Redundancy grows when the broadcaster changes often; `Graft` recovery adds 80/40 ms latency tails                           |
+| `MessageId = blake3(content)`, messages unsigned                | Content-addressed dedup and `Graft` lookup with no key management; integrity of the id is free              | No message authentication or origin identity; per-hop trust only, from QUIC/TLS                                             |
+| One QUIC connection per peer, one uni stream per `(topic, dir)` | Connection reuse across topics; per-topic streams isolate flow control and let a topic finish independently | Topic id factored into a one-shot header — `postcard_header_size` still conservatively reserves 32 bytes it no longer sends |
+| Keep duplicate connections (new sends, old drains)              | Deterministic simultaneous-connect handling without id-based tie-breaking                                   | Transient double connections and superseded-conn bookkeeping (`other_conns`)                                                |
+| Single actor owns all state, no locks                           | `&mut` exclusivity via one task; a `1024`-deep `mpsc` smooths inbound bursts                                | Head-of-line blocking across peers when the inbox fills; a channel-per-everything structure to translate                    |
+| Subscriber lag policy (drop + `Lagged`) instead of blocking     | A slow subscriber cannot stall the dispatch loop                                                            | Lossy delivery to lagging subscribers; the app must re-subscribe to catch up                                                |
+| 4096-byte default frame (control-plane sizing)                  | Gossip is for small notifications; bulk data goes to [blobs][index]                                         | Unusable for large payloads; a broadcaster must chunk or delegate                                                           |
+
+---
+
+## Sources
+
+- [`iroh-gossip/src/proto.rs`][g-proto] — crate docs (IO-less framing, HyParView/Plumtree overview), `PeerIdentity`, `PeerData`, size constants
+- [`iroh-gossip/src/proto/state.rs`][g-state] — multi-topic router, the sans-io `handle` seam, `Timer`, `postcard_header_size`
+- [`iroh-gossip/src/proto/topic.rs`][g-topic] — per-topic composition, `InEvent`/`OutEvent`/`Command`/`Timer`/`IO` interface
+- [`iroh-gossip/src/proto/hyparview.rs`][g-hyparview] — membership state machine, `State`/`Message`/`Config`, paper deviations
+- [`iroh-gossip/src/proto/plumtree.rs`][g-plumtree] — broadcast state machine, `Message`/`MessageId`/`Round`/caches, timers, tree optimization
+- [`iroh-gossip/src/net.rs`][g-net] · [`net/util.rs`][g-netutil] · [`net/address_lookup.rs`][g-addrlookup] — ALPN, actor, `PeerState`, framing, address-lookup integration
+- [`iroh-gossip/src/api.rs`][g-api] — irpc `subscribe`/`Broadcast` API, `GossipTopic`, subscriber lag policy
+- [`iroh-base/src/key.rs`][iroh-key] — `PublicKey`/`EndpointId` (the concrete `PeerIdentity`)
+- Leitão, Pereira, Rodrigues — [_HyParView_][hyparview] (DSN 2007) · [_Epidemic Broadcast Trees_][plumtree] (SRDS 2007)
+- [postcard][postcard] · [blake3][blake3] · [indexmap][indexmap] · [irpc][irpc]
+- Related pages: [Document Sync (iroh-docs)][docs-sync] · [QUIC Transport (noq)][quic-transport] · [Endpoint & Protocol Router][endpoint] · [Address Lookup (Discovery)][discovery] · [The Multipath Socket][socket] · [Identity & Cryptography][identity-crypto] · [Wire Formats & Serialization][wire] · [Tokio Concurrency Inventory][concurrency] · [D Architecture Migration][d-migration] · [Concepts][concepts] · [survey umbrella][index] · [async-io survey][async-io] · [Tokio (Rust)][tokio]
+
+<!-- References -->
+
+[index]: ./index.md
+[concepts]: ./concepts.md
+[identity-crypto]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[quic-transport]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[discovery]: ./discovery.md
+[docs-sync]: ./docs-sync.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[async-io]: ../async-io/index.md
+[tokio]: ../async-io/tokio.md
+[gossip-repo]: https://github.com/n0-computer/iroh-gossip
+[gossip-docs]: https://docs.rs/iroh-gossip/0.101.0/iroh_gossip/
+[g-proto]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/proto.rs
+[g-state]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/proto/state.rs
+[g-topic]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/proto/topic.rs
+[g-hyparview]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/proto/hyparview.rs
+[g-plumtree]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/proto/plumtree.rs
+[g-net]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/net.rs
+[g-netutil]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/net/util.rs
+[g-addrlookup]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/net/address_lookup.rs
+[g-api]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/api.rs
+[g-readme]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/README.md
+[g-testsim]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/tests/sim.rs
+[iroh-key]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-base/src/key.rs#L70
+[hyparview]: https://asc.di.fct.unl.pt/~jleitao/pdf/dsn07-leitao.pdf
+[plumtree]: https://asc.di.fct.unl.pt/~jleitao/pdf/srds07-leitao.pdf
+[postcard]: https://docs.rs/postcard/latest/postcard/
+[blake3]: https://docs.rs/blake3/latest/blake3/
+[indexmap]: https://docs.rs/indexmap/latest/indexmap/
+[irpc]: https://docs.rs/irpc/0.17.0/irpc/

--- a/docs/research/iroh/identity-crypto.md
+++ b/docs/research/iroh/identity-crypto.md
@@ -1,0 +1,610 @@
+# Identity & Cryptography
+
+An iroh endpoint's entire identity is a single Ed25519 keypair — the public key _is_ the [`EndpointId`][key] — and the whole security model is that keypair proving itself in an [RFC 7250][rfc7250] raw-public-key [TLS 1.3][rfc8446] handshake carried in QUIC `CRYPTO` frames, with no PKI, no X.509, and (unlike iroh 0.x) no separate Diffie-Hellman key derived from the identity.
+
+| Field                 | Value                                                                                                                                                                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Crate(s)              | [`iroh-base`][docs-iroh-base] (`key.rs`), [`iroh`][docs-iroh] (`iroh/src/tls/*`), plus signing surfaces in `iroh-relay`, `iroh-dns`, `iroh-docs`                                                                                           |
+| Version               | iroh workspace **v1.0.1** (commit `22cac742ca`); `iroh-docs` 0.101.0                                                                                                                                                                       |
+| Repository            | [`n0-computer/iroh`][repo]                                                                                                                                                                                                                 |
+| Documentation         | [docs.rs/iroh-base][docs-iroh-base] · [docs.rs/iroh][docs-iroh]                                                                                                                                                                            |
+| ALPN(s)               | None owned here — ALPN is per-protocol (see [`endpoint.md`][endpoint]); the TLS layer only _requires_ that a negotiated ALPN exist post-handshake (`AuthenticationError::NoAlpn`, [`connection.rs`][connection])                           |
+| Approx. size (LoC)    | ≈1,200 — `iroh-base/src/key.rs` (564) + `iroh/src/tls/*` (`tls.rs` 142, `verifier.rs` 211, `resolver.rs` 100, `name.rs` 63, `misc.rs` 125). **Excludes** the [TLS 1.3 engine itself][quic] (`rustls`, via [`noq`][quic])                   |
+| Category              | Foundations                                                                                                                                                                                                                                |
+| Upstream spec / draft | [RFC 8032][rfc8032] (Ed25519), [RFC 7250][rfc7250] (raw public keys), [RFC 8446][rfc8446] (TLS 1.3), [RFC 9001][rfc9001] (QUIC-TLS), [RFC 4648][rfc4648]/[RFC 5155][rfc5155] (base32), [RFC 2606][rfc2606] (`.invalid`), [BEP 0044][bep44] |
+
+> [!NOTE]
+> This page owns **cryptography and identity**. The postcard byte layouts of tickets and
+> `EndpointAddr` live in [Wire Formats & Serialization][wire]; the QUIC/TLS key schedule,
+> Retry-token wire format, 0-RTT gating, and multipath AEAD nonce live in
+> [QUIC Transport (`noq`)][quic]; pkarr address publishing lives in [Address Lookup][discovery].
+> Those are cross-linked, not duplicated here.
+
+---
+
+## Overview
+
+### What it solves
+
+Every iroh endpoint needs a globally-unique, self-certifying name that doubles as the root of
+trust for all its connections. iroh 1.0 collapses **four** concerns onto a single Ed25519
+keypair:
+
+1. **Identity** — the 32-byte public key is the [`EndpointId`][key] (`pub type EndpointId = PublicKey`), a globally-unique name that requires no registry or CA.
+2. **Addressing** — an `EndpointAddr { id, addrs }` is the id plus a set of hints about where to reach it (see [Wire Formats & Serialization][wire]); dialing by bare id is legal.
+3. **Authentication** — during the QUIC handshake each side proves possession of its secret key by signing the TLS 1.3 `CertificateVerify` transcript; the connection is thereby bound to the dialed id.
+4. **Transport security** — the authenticated handshake keys a TLS 1.3 session, so every byte after the handshake is confidential and integrity-protected to that specific peer.
+
+The crypto surface a port must reproduce is deliberately tiny and **fixed**: Ed25519
+(keygen/sign/`verify_strict`) with its internal SHA-512 and Edwards-point decompression,
+[BLAKE3][blake3] (`derive_key` and `keyed_hash`) for two auxiliary MACs, and a CSPRNG. There is
+**no X25519, no ECDH, no HKDF, and no Ed25519→Curve25519 conversion** anywhere in the workspace
+(a grep for `to_montgomery`, `crypto_box`, `x25519`, `shared_secret`, `diffie` returns only an
+unrelated test shim). This is the single largest change from the 0.x era: the old **DISCO**
+sealed-box side-protocol (which converted node keys to Curve25519 for NaCl `crypto_box`) is
+gone, replaced by QUIC-native NAT traversal that rides the same authenticated TLS session (see
+[NAT Traversal & Address Discovery][nat]).
+
+The identity model also drives a total rename cascade versus 0.x: `NodeId`→`EndpointId`,
+`NodeAddr`→`EndpointAddr`, `NodeTicket`→`EndpointTicket`. Old `node…` ticket strings are
+unparseable by 1.0; there is no migration shim in the pinned tree.
+
+### Design philosophy
+
+The crate root states the identity thesis directly ([`iroh-base/src/key.rs`][key]):
+
+> _"Each endpoint in iroh has a unique identifier created as a cryptographic key. This can be
+> used to globally identify an endpoint. Since it is also a cryptographic key it is also the
+> mechanism by which all traffic is always encrypted for a specific endpoint only."_
+
+Two naming conventions follow from that dual role, also fixed in the doc comment: use the name
+`PublicKey` "when performing cryptographic operations, but use `EndpointId` when referencing an
+endpoint" — they are the identical type ([`key.rs`][key]).
+
+The security layer is equally minimal and equally explicit. The TLS module opens with a
+one-mechanism statement ([`iroh/src/tls.rs`][tls]):
+
+> _"Currently there is one mechanism available: - Raw Public Keys, using the TLS extension
+> described in [RFC 7250]"_
+
+There is **no X.509 certificate at all** on the peer-to-peer plane. iroh 0.x carried a
+self-signed X.509 cert with a libp2p extension binding the host key; 1.0 sends a bare 44-byte
+Ed25519 `SubjectPublicKeyInfo` (SPKI) in place of a certificate, and the verifiers never build a
+chain, check an expiry, or consult revocation — raw public keys do not expire. The design
+consequence is that the entire trust decision reduces to a single byte-equality: _does the raw
+key the peer presented equal the key I dialed?_
+
+> [!NOTE]
+> The doc-comment claim that the key "is the mechanism by which all traffic is always
+> encrypted" is true at the level of _authentication_, not key agreement. In 1.0 the session
+> secret comes from the TLS 1.3 ephemeral key exchange (X25519 by default, optionally the
+> `X25519MLKEM768` hybrid). The Ed25519 identity key **signs** the handshake transcript; it
+> never performs Diffie-Hellman. Confidentiality "to a specific endpoint only" is the product
+> of that signature plus the SNI/SPKI binding described below.
+
+---
+
+## How it works
+
+### The one keypair: `PublicKey`, `EndpointId`, `SecretKey`, `Signature`
+
+[`PublicKey`][key] is a `#[repr(transparent)]` newtype over
+`curve25519_dalek::edwards::CompressedEdwardsY` — exactly the 32-byte compressed Edwards
+y-coordinate. Construction is the only place a curve check happens: `from_bytes` calls
+`VerifyingKey::from_bytes`, which decompresses the point and rejects invalid encodings, then
+stores the canonicalised compressed bytes. After that the type is a plain 32-byte value —
+`Eq`, `Ord`, `Hash`, `Borrow<[u8; 32]>`, `Deref<Target = [u8; 32]>` all operate on the raw
+bytes — and it re-derives a `VerifyingKey` on demand with an `expect("already verified")`
+because the point-validity invariant holds from construction onward.
+
+```rust
+// iroh-base/src/key.rs — the whole identity surface
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct PublicKey(CompressedEdwardsY);       // 32-byte compressed y-coordinate
+
+pub type EndpointId = PublicKey;                 // same type, addressing-context name
+pub const LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH; // 32
+
+#[derive(Clone, zeroize::ZeroizeOnDrop)]
+pub struct SecretKey(SigningKey);                // 32-byte seed, scrubbed on drop
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Signature(ed25519_dalek::Signature);  // 64 bytes
+```
+
+Verification funnels through `PublicKey::verify`, and it is `verify_strict`, not the permissive
+`verify` ([`key.rs`][key]):
+
+```rust
+// iroh-base/src/key.rs
+pub fn verify(&self, message: &[u8], signature: &Signature) -> Result<(), SignatureError> {
+    self.as_verifying_key()
+        .verify_strict(message, &signature.0)
+        .map_err(|_| SignatureError::new())
+}
+```
+
+`verify_strict` is load-bearing for interop: it rejects the malleable and small-order /
+mixed-order edge cases that plain `verify` accepts. Because the TLS `CertificateVerify` check
+routes through exactly this function (via the [`Ed25519Dalek`][verifier] adapter below), a D port
+must replicate dalek's `verify_strict` semantics — a canonical-`S` bound plus the cofactorless
+group-equation check — or handshakes with iroh peers will disagree on borderline signatures.
+
+[`SecretKey`][key] wraps `ed25519_dalek::SigningKey` and derives `zeroize::ZeroizeOnDrop`. Its
+API is small: `public()` derives the `PublicKey` from the verifying key; `generate()` is
+`Self::from_bytes(&rand::random())` — 32 random seed bytes from the default `rand` CSPRNG;
+`sign(msg)` produces a deterministic Ed25519 `Signature`; `to_bytes()`/`from_bytes()` round-trip
+the 32-byte **seed** ("The public part can always be recovered"). There is no key-derivation, no
+DH, no Curve25519 conversion.
+
+### String encodings
+
+The identity type is rendered five different ways depending on context; getting each alphabet
+exactly right is a hard interop requirement. (The raw postcard byte forms belong to
+[Wire Formats & Serialization][wire].)
+
+| Encoding                                        | Alphabet                           | Where used                                                                              | Cite                        |
+| ----------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------- | --------------------------- |
+| lowercase hex (`HEXLOWER`)                      | `0-9a-f`, 64 chars                 | `Display` / `Debug` of `PublicKey`; JSON serde; the `IROH_SECRET` env var               | [`key.rs`][key]             |
+| `BASE32_NOPAD` ([RFC 4648][rfc4648])            | `A-Z2-7`, no pad, 52 chars         | `FromStr` alternative input (case-insensitive); ticket string bodies (see [wire][wire]) | [`key.rs`][key]             |
+| z-base-32                                       | `ybndrfg8ejkmcpqxot1uwisza345h769` | `to_z32`/`from_z32` — pkarr / DNS domain labels only                                    | [`key.rs`][key]             |
+| `BASE32_DNSSEC` ([RFC 5155][rfc5155] base32hex) | `0-9a-v` lowercase, 52 chars       | the TLS server name (SNI), see below                                                    | [`name.rs`][name]           |
+| `BASE64URL_NOPAD`                               | url-safe base64, no pad            | relay `ClientAuth` HTTP header (see [relay][relay])                                     | [`handshake.rs`][handshake] |
+
+`Display` is **lowercase hex** (not the 0.x base32), so human-readable serde emits 64 hex
+characters. `FromStr` accepts **either** hex (when the input length is 64) or `BASE32_NOPAD`
+(uppercased first, `decode_len == 32`) through the shared `decode_base32_hex` helper —
+`SecretKey::from_str` uses the same helper on the seed. `fmt_short()` renders the first 5 bytes
+as 10 hex chars for logs and is used at ~70 call sites in `iroh/src`.
+
+### The RFC 7250 raw-public-key handshake
+
+The "certificate" iroh sends is a bare DER `SubjectPublicKeyInfo`: a constant 12-byte prefix
+plus the 32 raw key bytes, 44 bytes total. It is built once per endpoint by
+`ResolveRawPublicKeyCert::new` via `rustls::sign::public_key_to_spki(&alg_id::ED25519, pk_bytes)`
+([`resolver.rs`][resolver]) and served unconditionally by both the `ResolvesClientCert` and
+`ResolvesServerCert` implementations, each declaring `only_raw_public_keys() == true` (which makes
+`rustls` advertise `client_certificate_type`/`server_certificate_type = RawPublicKey(0x02)`).
+
+```text
+SPKI "certificate" — 44 bytes, DER SubjectPublicKeyInfo
+30 2a                     SEQUENCE, 42 bytes
+   30 05                  SEQUENCE (AlgorithmIdentifier), 5 bytes
+      06 03 2b 65 70      OID 1.3.101.112  (id-Ed25519)
+   03 21 00               BIT STRING, 33 bytes = 1 unused-bits byte (00) + 32 key bytes
+   <32 raw public-key bytes>
+--------------------------------------------------------------
+constant 12-byte prefix:  30 2a 30 05 06 03 2b 65 70 03 21 00
+```
+
+Signing is narrowly scoped: [`IrohSecretKey`][resolver] implements `rustls::sign::SigningKey` +
+`Signer`, `choose_scheme` returns `Some` only if the peer offered `SignatureScheme::ED25519`, and
+`Signer::sign` returns the raw 64-byte Ed25519 signature over the TLS transcript. The signature
+scheme on the wire is therefore always `ED25519` (`0x0807`); TLS 1.2 is disabled outright
+(`PROTOCOL_VERSIONS = [&rustls::version::TLS13]`).
+
+**The client's identity check** ([`ServerCertificateVerifier`][verifier]) is the crux of the whole
+model, and it is a byte comparison, not a chain build:
+
+```rust
+// iroh/src/tls/verifier.rs — verify_server_cert (abridged)
+let ServerName::DnsName(dns_name) = server_name else { return Err(UnsupportedNameType) };
+let Some(remote_peer_id) = super::name::decode(dns_name.as_ref())   // SNI -> expected EndpointId
+    else { return Err(InvalidCertificate(NotValidForName)) };
+if !intermediates.is_empty() { return Err(InvalidCertificate(UnknownIssuer)) }
+
+let end_entity_as_spki = SubjectPublicKeyInfoDer::from(end_entity.as_ref());
+let remote_public_spki  = public_key_to_spki(&alg_id::ED25519, remote_peer_id.as_bytes());
+if remote_public_spki != end_entity_as_spki {                        // whole-buffer equality
+    return Err(InvalidCertificate(UnknownIssuer));
+}
+Ok(ServerCertVerified::assertion())
+```
+
+`_ocsp_response` and `_now` are ignored. The `ServerName` compared against is the name the
+**client itself** passed to `connect_with` — so the binding is local intent, not attacker-supplied
+data. A man-in-the-middle presenting a different raw key fails the equality; a peer presenting the
+right key but not proving possession fails the separate `CertificateVerify` signature check
+(delegated to `verify_tls13_signature_with_raw_key` over the `ED25519_DALEK`-only algorithm set,
+which parses the SPKI as a `webpki` raw-public-key entity and runs `PublicKey::verify`).
+
+**The SNI carries the dialed id.** `tls::name::encode` produces `"{BASE32_DNSSEC(id)}.iroh.invalid"`
+([`name.rs`][name]) — 52 base32hex characters plus the suffix. The reasons are documented on the
+module and are worth quoting because they explain an otherwise surprising choice:
+
+> _"We used to use a constant "localhost" for the TLS server name - however, that affects 0-RTT
+> and would put all of the TLS session tickets we receive into the same bucket in the TLS session
+> ticket cache. So we choose something that'd dependent on the EndpointId. We cannot use hex to
+> encode the EndpointId, as that'd encode to 64 characters, but we only have 63 maximum per DNS
+> subdomain. Base32 is the next best alternative."_ — [`iroh/src/tls/name.rs`][name]
+
+Hex would exceed the 63-char DNS label limit; the `.invalid` TLD ([RFC 2606][rfc2606]) never
+resolves; the `iroh` middle label is noted as possibly-removable in future. The SNI thus does
+double duty: it is the authorization datum the client checks the SPKI against, **and** the cache
+key that buckets 0-RTT session tickets and NEW_TOKEN entries per peer. Snapshot for the all-zero
+secret key: `7dl2ff6emqi2qol3l382krodedij45bn3nh479hqo14a32qpr8kg.iroh.invalid`.
+
+**Mutual auth is mandatory but asymmetric in what it checks.** The server's
+[`ClientCertificateVerifier`][verifier] returns `offer_client_auth() == true`, so client
+authentication is required, yet `verify_client_cert` checks essentially nothing:
+
+> _"Beyond checking for no intermediates, we don't check the client certificate. The actual
+> signatures are already verified - this ensures authentication."_ — [`iroh/src/tls/verifier.rs`][verifier]
+
+The server does not know _who_ connected until after the handshake, when
+`remote_id_from_noq_conn` downcasts `Connection::peer_identity()` to a one-element
+`Vec<CertificateDer>` and parses it with `ed25519_dalek::pkcs8::DecodePublicKey::from_public_key_der`
+([`connection.rs`][connection], covered from the connection side in [`endpoint.md`][endpoint]).
+
+### Relay challenge signing
+
+The identity key is exercised a second way, outside TLS, when authenticating to a relay
+([`iroh-relay/src/protos/handshake.rs`][handshake]). The server sends 16 random challenge bytes;
+the client does **not** sign them directly — it signs a BLAKE3-derived key:
+
+```rust
+// iroh-relay/src/protos/handshake.rs
+const DOMAIN_SEP_CHALLENGE: &str = "iroh-relay handshake v1 challenge signature";
+
+fn message_to_sign(&self) -> [u8; 32] {
+    blake3::derive_key(DOMAIN_SEP_CHALLENGE, &self.challenge)   // then SecretKey::sign(..)
+}
+```
+
+The rationale is domain separation against a signing oracle:
+
+> _"We're signing a key instead of the direct challenge. This gives us domain separation
+> protecting from multiple possible attacks… Assume a malicious relay. If the protocol required
+> the client to sign the challenge directly, this would allow the relay to obtain an arbitrary
+> 16-byte signature, if it maliciously choses the challenge."_ — [`handshake.rs`][handshake]
+
+The response is a `ClientAuth { public_key, signature }` postcard struct. A TLS-fast-path variant
+`KeyMaterialClientAuth` instead signs the first 16 bytes of TLS-exported keying material
+(exporter context = the client's own public key), sent as a `BASE64URL_NOPAD` HTTP header. Full
+relay-protocol framing is in [The Relay Protocol][relay].
+
+### Auxiliary keyed hashing: reset tokens
+
+BLAKE3 appears once more in the identity-adjacent auth surface. QUIC stateless-reset tokens use
+[`Blake3HmacKey`][misc] — `blake3::keyed_hash` with a per-process random 32-byte key, verified in
+constant time via `ctutils::CtEq`:
+
+```rust
+// iroh/src/tls/misc.rs — the reset-token MAC
+fn sign(&self, data: &[u8], out: &mut [u8]) { out.copy_from_slice(blake3::keyed_hash(&self.0, data).as_slice()) }
+fn verify(&self, data: &[u8], sig: &[u8]) -> Result<(), CryptoError> {
+    if blake3::keyed_hash(&self.0, data).as_slice().ct_eq(sig).to_bool() { Ok(()) } else { Err(CryptoError) }
+}
+```
+
+`noq` truncates the 32-byte MAC of a connection id to the 16-byte reset token. The choice of
+keyed BLAKE3 over HMAC-SHA256 means a port needs BLAKE3's keyed mode anyway (it is already
+load-bearing in [blobs][blobs] / [`bao-tree`][bao]). The separate address-validation Retry /
+NEW_TOKEN tokens are AEAD-sealed with the TLS provider's cipher rather than BLAKE3; their wire
+format and validation state machine belong to [QUIC Transport][quic].
+
+### Post-quantum key exchange
+
+Post-quantum protection is **pure provider configuration**, not iroh code: replace the `kx_groups`
+on an `aws-lc-rs` provider with `[X25519MLKEM768]` for PQ-only, or prepend it before
+`X25519`/`SECP256R1`/`SECP384R1` for PQ-preferred ([`iroh/examples/pq-only-key-exchange.rs`][pq]).
+Two constraints: `ring` has no ML-KEM (its group list is `X25519, SECP256R1, SECP384R1`), so
+`tls-aws-lc-rs` is required; and n0's public relay/discovery infrastructure "does not support PQ
+key exchange yet", so a PQ-only endpoint cannot reach them. Because this only touches the
+`CryptoProvider`, it changes nothing about the Ed25519 **identity** — the id, the SPKI, the
+`CertificateVerify` signature scheme are all unchanged.
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+This subsystem defines only a few byte layouts of its own; the bulk of iroh's wire formats —
+`EndpointAddr`, the three ticket kinds, postcard framing rules — are owned by
+[Wire Formats & Serialization][wire] and are not repeated here. What crypto contributes:
+
+- **The 44-byte SPKI "certificate"** (byte layout above): a constant 12-byte DER prefix
+  (`30 2a 30 05 06 03 2b 65 70 03 21 00`) + 32 key bytes, compared whole-buffer. A D port builds
+  it by constant concatenation and never parses ASN.1 for the peer id beyond stripping the prefix.
+- **The SNI string**: `BASE32_DNSSEC(id) ++ ".iroh.invalid"`, 65 characters, a DNS name.
+- **The `Signature`** on the wire is 64 raw bytes (`serialize_tuple(64)` for serde, a raw
+  64-byte flight in TLS); **`PublicKey`** is 32 raw bytes (fixed array, no length prefix).
+- **Relay `ClientAuth` / `KeyMaterialClientAuth`** are postcard structs
+  `{ public_key: PublicKey, signature: [u8; 64], (+ key_material_suffix: [u8; 16]) }`,
+  `BASE64URL_NOPAD`-encoded in an HTTP header (detailed in [relay][relay]).
+
+The one framing subtlety intrinsic to identity is that `CertificateVerify` signs the TLS 1.3
+handshake **transcript**, not a naked message — so the sign/verify callbacks receive the exact
+bytes the TLS engine computes, and a D implementation must feed `verify_strict` the identical
+context string + transcript hash the engine constructs (a [QUIC Transport][quic] concern that the
+identity layer only supplies the primitive for).
+
+### Cryptography & identity
+
+The exact primitive set a D port needs for iroh 1.0 identity, and nothing more:
+
+| Primitive                                         | Used for                                                                                | Cite                               |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------- |
+| Ed25519 keygen (seed → scalar/prefix via SHA-512) | `SecretKey::generate` / `from_bytes`, `public()`                                        | [`key.rs`][key]                    |
+| Ed25519 deterministic sign                        | TLS `CertificateVerify`, relay challenge, pkarr `SignedPacket`, docs entries            | [`key.rs`][key]                    |
+| Ed25519 `verify_strict`                           | every signature check (`PublicKey::verify`) — **strict** semantics required for interop | [`key.rs`][key]                    |
+| Edwards point decompression + validity            | `PublicKey::from_bytes` / deserialize — the type invariant                              | [`key.rs`][key]                    |
+| SHA-512                                           | internal to Ed25519 (nonce + challenge hashing per [RFC 8032][rfc8032])                 | [`key.rs`][key]                    |
+| BLAKE3 `derive_key`                               | relay challenge domain separation (`DOMAIN_SEP_CHALLENGE`)                              | [`handshake.rs`][handshake]        |
+| BLAKE3 `keyed_hash`                               | QUIC stateless-reset token MAC (`Blake3HmacKey`)                                        | [`misc.rs`][misc]                  |
+| CSPRNG                                            | `SecretKey::generate`, reset-token key, relay challenge, token nonces                   | [`key.rs`][key], [`misc.rs`][misc] |
+
+Conspicuously **absent**: X25519 / ECDH, HKDF, and any Ed25519→Curve25519 conversion. HKDF and
+X25519 do appear in iroh's dependency closure, but only inside the TLS 1.3 key schedule that lives
+in the `rustls` `CryptoProvider` (`ring` or `aws-lc-rs`) — not in iroh's own identity code. If a D
+port pairs its own TLS engine with hand-rolled AEAD/HKDF (see [QUIC Transport][quic]), the
+**identity** module still needs only the eight rows above.
+
+Crypto backend pins are exact release candidates, a notable operational fact: `ed25519-dalek`
+is `=3.0.0-rc.0` and `curve25519-dalek` is `=5.0.0-rc.0` ([`iroh-base/Cargo.toml`][base-cargo]).
+`iroh-base` enables the dalek features `serde, rand_core, zeroize`; `iroh` additionally enables
+`pkcs8, pem` (only DER `from_public_key_der` was found in use — the PEM feature may be spillover).
+
+### State machines & lifecycle
+
+The identity subsystem is deliberately **state-free** — pure value types and codecs. There are
+only three state-machine-shaped elements, and two of them belong to sibling pages:
+
+1. **The `PublicKey` validity invariant.** Every constructor (`from_bytes`, `TryFrom<&[u8]>`,
+   deserialize) must pass point decompression, after which "always a valid curve point" holds and
+   `as_verifying_key` relies on it with an `expect`. This is an invariant, not a transition.
+2. **Key lifecycle in an endpoint.** `Endpoint::builder().secret_key(..)` is optional; `bind()`
+   falls back to `SecretKey::generate` ([`endpoint.rs`][endpoint-src]). Apps such as `dumbpipe` /
+   `sendme` read a hex secret from `IROH_SECRET` or generate and print one. Once bound, the key is
+   an immutable field of the endpoint for its lifetime.
+3. **The TLS handshake pump** _uses_ this subsystem's sign/verify as callbacks but is itself a
+   `rustls`/`noq` state machine (handshake keys → 1-RTT keys → key update; 0-RTT accept/reject).
+   That machine is documented in [QUIC Transport][quic] and [Endpoint & Protocol Router][endpoint].
+
+No timers, no I/O-driven transitions originate in identity/crypto. (The pkarr publisher's
+monotonic-timestamp CAS loop is a [discovery][discovery] concern.)
+
+### Dependencies & coupling
+
+| Crate                     | Pin                   | Role                                                                                                                   |
+| ------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `ed25519-dalek`           | `=3.0.0-rc.0` (exact) | **The identity algorithm.** keygen, `Signer::sign`, `verify_strict`, `VerifyingKey::from_bytes`, `from_public_key_der` |
+| `curve25519-dalek`        | `=5.0.0-rc.0` (exact) | Storage type only: `CompressedEdwardsY`; no point arithmetic called directly                                           |
+| `blake3`                  | 1.x                   | `derive_key` (relay challenge) + `keyed_hash` (reset tokens)                                                           |
+| `zeroize`                 | 1.9                   | `SecretKey: ZeroizeOnDrop`                                                                                             |
+| `rand` / `getrandom`      | 0.10 / 0.4            | CSPRNG for keygen and nonces (`wasm_js` backend for browsers)                                                          |
+| `data-encoding` (+ macro) | 2.6 / 0.1.19          | HEXLOWER, BASE32_NOPAD, BASE32_DNSSEC, BASE64URL_NOPAD, the z-base-32 alphabet                                         |
+| `rustls` + `webpki_types` | 0.23-line             | The TLS engine; identity provides the RPK resolver/verifier plug-ins and the `alg_id::ED25519` SPKI helper             |
+| `ctutils` (`CtEq`)        | —                     | constant-time MAC compare                                                                                              |
+
+Coupling runs outward from a small core. The **identity binding contract** (SPKI equality +
+`ED25519` `CertificateVerify` + mandatory client auth) is defined in `iroh/src/tls`, but the TLS
+1.3 machinery it plugs into is `rustls`, reached through [`noq`][quic]. The **same** `SecretKey`
+is reused verbatim by three other subsystems with zero extra crypto: relay auth ([relay][relay]),
+pkarr publishing ([discovery][discovery]), and iroh-docs, whose `Author` and `NamespaceSecret`
+are thin wrappers around `iroh::SecretKey` that sign/verify with the identical primitives
+([`iroh-docs/src/keys.rs`][docs-keys]; see [Document Sync][docs-sync]). A D crypto layer that
+implements the eight primitives above supports **all four** signing surfaces.
+
+### Concurrency & I/O model
+
+The identity/crypto layer spawns nothing, awaits nothing, and owns no timers or channels. Its only
+shared state is immutable-and-`Arc`'d, present purely to satisfy `rustls`'s ownership model:
+
+| Primitive                                                           | Where                                      | Why it exists                                                                                     |
+| ------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `Arc<ResolveRawPublicKeyCert>` / `Arc<CertifiedKey>`                | [`tls.rs`][tls], [`resolver.rs`][resolver] | one signed identity shared across all sessions; **Arc pointer identity** matters for rustls 0-RTT |
+| `Arc<ServerCertificateVerifier>` / `Arc<ClientCertificateVerifier>` | [`tls.rs`][tls]                            | immutable unit structs; also pointer-compared by rustls across 0-RTT sessions                     |
+| `Arc<dyn ClientSessionStore>` = `ClientSessionMemoryCache(256)`     | [`tls.rs`][tls]                            | interior-`Mutex` LRU of TLS tickets keyed by the per-peer SNI                                     |
+| `Arc<Mutex<LruCache<PublicKey, ()>>>` (`KeyCache`)                  | `iroh-relay/src/key_cache.rs`              | dedupe expensive point decompression when a relay parses millions of repeated keys                |
+
+The rationale for the `Arc` pointer-identity constraint is documented on `TlsConfig`
+([`tls.rs`][tls]): _"the `server_verifier` and `client_verifier` Arc pointers are checked to be
+the same between different TLS session calls with 0-RTT data in rustls."_ This is an artifact of
+rustls's config-identity checks, not an inherent concurrency requirement.
+
+### Mapping to event-horizon
+
+Everything in this subsystem is `@safe pure nothrow @nogc`-friendly value code — no fibers,
+scopes, `Scope.spawn`, `race`, or `JoinHandle` are needed anywhere (contrast the [tokio
+inventory][tokio-async]). The two places a **capability** should be threaded in are the CSPRNG and
+(for token/ticket freshness) the clock — matching the event-horizon capability model of DbI traits
+with deterministic test doubles ([SPEC][eh-spec]).
+
+`PublicKey`/`EndpointId` map to a struct over `ubyte[32]` with a validated-invariant constructor
+returning [`Expected!`][eh-spec]:
+
+```rust
+// iroh-base/src/key.rs (Rust, verbatim)
+#[repr(transparent)]
+pub struct PublicKey(CompressedEdwardsY);
+pub type EndpointId = PublicKey;
+
+pub fn from_bytes(bytes: &[u8; 32]) -> Result<Self, KeyParsingError> {
+    let key = VerifyingKey::from_bytes(bytes).map_err(|_| e!(KeyParsingError::InvalidKeyData))?;
+    Ok(Self(CompressedEdwardsY(key.to_bytes())))
+}
+```
+
+```d
+// proposed / sketch — validated 32-byte ed25519 point; the invariant holds post-construction
+struct PublicKey
+{
+    private ubyte[32] _compressed;   // CompressedEdwardsY y-coordinate
+
+    // Point-decompression check is the only fallible path; `verify_strict` domain.
+    static Expected!(PublicKey, KeyParsingError) fromBytes(const ubyte[32] bytes)
+        @safe pure nothrow @nogc;
+
+    bool verify(scope const(ubyte)[] message, in Signature sig) const
+        @safe nothrow @nogc;         // MUST match dalek verify_strict
+
+    // lowercase hex, staged through sparkles.base.text.writers (no GC)
+    void toString(Writer)(ref Writer w) const;
+}
+alias EndpointId = PublicKey;
+```
+
+`SecretKey` has no direct D idiom for `ZeroizeOnDrop`; the port holds the seed in a non-GC array,
+scrubs it in the destructor, and never routes the seed through a GC-allocated hex string (the
+`IROH_SECRET` decode must land in a scratch static array). The RNG becomes a capability so a
+`TestRng` double gives deterministic keygen:
+
+```rust
+// iroh-base/src/key.rs (Rust, verbatim)
+#[derive(Clone, zeroize::ZeroizeOnDrop)]
+pub struct SecretKey(SigningKey);
+pub fn generate() -> Self { Self::from_bytes(&rand::random()) }   // global CSPRNG
+```
+
+```d
+// proposed / sketch — seed off the GC heap; entropy is a capability, not a global
+struct SecretKey
+{
+    private ubyte[32] _seed;         // ed25519 seed; never touches the GC
+
+    // Rng is a DbI capability (isRng); attributes inferred on the template.
+    static SecretKey generate(Rng)(ref Rng rng) if (isRng!Rng);
+
+    PublicKey public_() const @safe nothrow @nogc;                 // SHA-512 expand + basepoint mul
+    Signature sign(scope const(ubyte)[] msg) const @safe nothrow @nogc;
+
+    ~this() @trusted nothrow @nogc { volatileScrub(_seed[]); }     // no ZeroizeOnDrop in D
+}
+```
+
+Further mapping notes:
+
+- **All five `Arc`s in `TlsConfig` collapse** under the `single` topology to plain fields of the
+  endpoint struct; `ClientSessionMemoryCache`, `TokenMemoryCache`, and the relay `KeyCache` become
+  plain `SmallBuffer`-backed LRUs with no `Mutex`. The rustls "same Arc pointer across 0-RTT
+  sessions" constraint simply disappears — it never applied to a single-threaded owner.
+- **Encoders** (hex, two base32 alphabets, z-base-32, base64url) are all table-driven codecs with
+  a computable max output size; implement once with the alphabet as a template/DbI parameter and
+  stage into a `SmallBuffer` (`⌈8n/5⌉` for base32), keeping `toString` allocation-free.
+- **No `spawn_blocking` substitute is needed.** Ed25519 sign/verify and BLAKE3 are microsecond
+  scale; running them inline on the loop fiber is fine, which matters because event-horizon has
+  **no** thread pool (flagged in [`d-architecture-migration.md`][migration]).
+- **`verify_strict` is the one irreducible interop risk.** The exact rejection rules live in
+  `ed25519-dalek 3.0.0-rc.0` and are not vendored in the pinned tree; a D port must extract them
+  from dalek to stay handshake-compatible.
+- **The TLS 1.3 engine is the big missing piece**, not part of identity per se: a sans-I/O state
+  machine that the D port implements as a plain struct owned by the connection fiber, fed byte
+  slices from the QUIC driver. It plugs into this subsystem only via the sign/verify callbacks and
+  the SPKI helper. Its full feature list and D shape are in [QUIC Transport][quic] and
+  [D Architecture Migration][migration].
+
+---
+
+## Strengths
+
+- **Radically small trust model.** One keypair; no CA, no chain, no expiry, no revocation. The
+  entire server-auth decision is a 44-byte buffer equality plus one Ed25519 `verify_strict`.
+- **Minimal, fixed crypto surface.** Ed25519 + SHA-512 + BLAKE3 + a CSPRNG covers all four signing
+  surfaces (TLS, relay, pkarr, docs). No X25519/ECDH/HKDF in iroh's own code.
+- **Self-certifying names.** `EndpointId` = `PublicKey` means the address _is_ the verification
+  key; there is no separate binding step to spoof.
+- **0-RTT-aware by construction.** Encoding the dialed id into the SNI keys the ticket cache and
+  NEW_TOKEN store per peer, avoiding cross-peer ticket pollution — a subtle but deliberate win.
+- **PQ-ready without touching identity.** `X25519MLKEM768` is a one-line provider swap; the id and
+  its signatures are unchanged.
+- **Domain-separated auxiliary signatures.** Signing `derive_key(DOMAIN_SEP, challenge)` rather
+  than the raw challenge closes a signing-oracle attack from a malicious relay.
+
+## Weaknesses
+
+- **Release-candidate crypto pins.** `ed25519-dalek =3.0.0-rc.0` and `curve25519-dalek =5.0.0-rc.0`
+  are exact-pinned RCs; a shipping 1.0 depends on pre-release cryptography.
+- **Interop hinges on `verify_strict`'s edge-case rules**, which are defined only in dalek's
+  sources — a re-implementer must replicate them precisely or silently diverge on malleable /
+  small-order signatures.
+- **`SecretKey` inside a `DocTicket::Write` is a bearer credential.** A write ticket embeds a raw
+  32-byte namespace secret in a copy-pasteable string (see [Document Sync][docs-sync]); tickets are
+  secrets, not just addresses.
+- **No forward secrecy _from the identity key_ is even conceptually available**; all confidentiality
+  rests on the TLS ephemeral exchange, so a broken TLS provider is total — the identity layer
+  offers no defence in depth beyond authentication.
+- **Server-side SNI is unchecked against the server's own id.** The server serves its single key to
+  any SNI and never validates `HandshakeData::server_name`; correctness relies entirely on the
+  client's local comparison.
+- **`.invalid` SNI is opaque to standard tooling.** Packet captures and TLS debuggers see a
+  synthetic name that no resolver understands; operators must know the base32hex→id decoding.
+
+## Key design decisions and trade-offs
+
+| Decision                                                          | Rationale                                                                                   | Trade-off                                                                                         |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| One Ed25519 keypair is identity + addressing + auth               | Self-certifying names; no registry/CA; smallest possible trust root                         | The id can never rotate without becoming a different endpoint; key compromise is total            |
+| RFC 7250 raw public keys, no X.509 on the p2p plane               | No parsing, expiry, chain-building, or revocation; a 44-byte SPKI + one signature           | Loses X.509 tooling/interop; server auth is a bespoke byte-equality, not a standard PKI path      |
+| SNI encodes the dialed id (`{b32}.iroh.invalid`)                  | Keys 0-RTT tickets and NEW_TOKENs per peer; carries authorization without a wire round-trip | Synthetic, tooling-opaque name; 52-char base32hex chosen only to fit the 63-char DNS label limit  |
+| `verify_strict`, not `verify`                                     | Rejects malleable / small-order signatures; safer and unambiguous                           | Re-implementers must replicate dalek's exact strict rules for handshake interop                   |
+| BLAKE3 `derive_key` / `keyed_hash` for aux MACs (not HMAC-SHA256) | Domain separation for free; reuses BLAKE3 already needed by blobs                           | A second hash family in the stack; reset tokens truncate a 32-byte MAC to 16 bytes                |
+| Drop DISCO / x25519; NAT-traversal auth rides QUIC-TLS            | One authenticated channel; no separate sealed-box key or conversion                         | Loses the pre-handshake authenticated side-channel 0.x had; everything depends on the TLS session |
+| Mandatory but check-nothing client auth                           | Cheap mutual possession proof; id learned post-handshake from `peer_identity()`             | The server cannot gate on identity _during_ the handshake — only afterward                        |
+| Exact-pinned RC dalek crates                                      | Track the latest Ed25519 API/perf before dalek 3.0/5.0 final                                | A production release depends on pre-release cryptography; upgrades may churn                      |
+
+---
+
+## Sources
+
+- [`iroh-base/src/key.rs`][key] — `PublicKey`/`EndpointId`/`SecretKey`/`Signature`, `verify_strict`, all encodings
+- [`iroh-base/Cargo.toml`][base-cargo] — exact dalek pins + features
+- [`iroh/src/tls.rs`][tls] — `TlsConfig`, RFC 7250 statement, `DEFAULT_MAX_TLS_TICKETS`
+- [`iroh/src/tls/verifier.rs`][verifier] — server/client verifiers, `Ed25519Dalek` adapter
+- [`iroh/src/tls/resolver.rs`][resolver] — `ResolveRawPublicKeyCert`, `IrohSecretKey`, SPKI construction
+- [`iroh/src/tls/name.rs`][name] — `EndpointId` ↔ SNI codec, the `.iroh.invalid` rationale
+- [`iroh/src/tls/misc.rs`][misc] — `Blake3HmacKey` reset-token MAC
+- [`iroh-relay/src/protos/handshake.rs`][handshake] — relay challenge `derive_key` signing
+- [`iroh/src/endpoint/connection.rs`][connection] — post-handshake peer-id extraction
+- [`iroh/src/endpoint.rs`][endpoint-src] — `SecretKey` entry point, `bind()` fallback
+- [`iroh/examples/pq-only-key-exchange.rs`][pq] — `X25519MLKEM768` provider configuration
+- [`iroh-docs/src/keys.rs`][docs-keys] — `Author`/`NamespaceSecret` reuse of `SecretKey`
+- [`noq-proto/src/crypto.rs`][noq-crypto] — the `Session` trait a D TLS engine must implement
+- Specs: [RFC 8032][rfc8032], [RFC 7250][rfc7250], [RFC 8446][rfc8446], [RFC 9001][rfc9001], [RFC 4648][rfc4648], [RFC 5155][rfc5155], [RFC 2606][rfc2606], [BEP 0044][bep44]
+- Related iroh pages: [Concepts & Vocabulary][concepts] · [Wire Formats & Serialization][wire] · [QUIC Transport][quic] · [Endpoint & Protocol Router][endpoint] · [The Multipath Socket][socket] · [NAT Traversal][nat] · [The Relay Protocol][relay] · [Address Lookup][discovery] · [Blobs][blobs] · [`bao-tree`][bao] · [Document Sync][docs-sync] · [D Architecture Migration][migration]
+- Cross-tree: [event-horizon SPEC][eh-spec] · [Tokio (async-io)][tokio-async] · [Algebraic effects][alg-eff]
+
+<!-- References -->
+
+[repo]: https://github.com/n0-computer/iroh/tree/22cac742ca
+[key]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-base/src/key.rs
+[base-cargo]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-base/Cargo.toml
+[tls]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/tls.rs
+[verifier]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/tls/verifier.rs
+[resolver]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/tls/resolver.rs
+[name]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/tls/name.rs
+[misc]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/tls/misc.rs
+[handshake]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/protos/handshake.rs
+[connection]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/connection.rs
+[endpoint-src]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint.rs
+[pq]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/examples/pq-only-key-exchange.rs
+[docs-keys]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/keys.rs
+[noq-crypto]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/crypto.rs
+[docs-iroh-base]: https://docs.rs/iroh-base/1.0.1/iroh_base/
+[docs-iroh]: https://docs.rs/iroh/1.0.1/iroh/
+[blake3]: https://docs.rs/blake3/latest/blake3/
+[rfc8032]: https://www.rfc-editor.org/rfc/rfc8032
+[rfc7250]: https://www.rfc-editor.org/rfc/rfc7250
+[rfc8446]: https://www.rfc-editor.org/rfc/rfc8446
+[rfc9001]: https://www.rfc-editor.org/rfc/rfc9001
+[rfc4648]: https://www.rfc-editor.org/rfc/rfc4648
+[rfc5155]: https://www.rfc-editor.org/rfc/rfc5155
+[rfc2606]: https://www.rfc-editor.org/rfc/rfc2606
+[bep44]: https://www.bittorrent.org/beps/bep_0044.html
+[concepts]: ./concepts.md
+[wire]: ./wire-serialization.md
+[quic]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[blobs]: ./blobs.md
+[bao]: ./bao-tree.md
+[docs-sync]: ./docs-sync.md
+[migration]: ./d-architecture-migration.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[tokio-async]: ../async-io/tokio.md
+[alg-eff]: ../algebraic-effects/index.md

--- a/docs/research/iroh/index.md
+++ b/docs/research/iroh/index.md
@@ -1,0 +1,313 @@
+# Iroh: Peer-to-Peer QUIC Networking & Content-Addressed Data
+
+A source-grounded survey of [iroh][repo-iroh]'s Rust implementation — n0's stack for
+authenticated peer-to-peer QUIC connectivity and content-addressed data transfer — read at
+workspace **v1.0.1** (commit [`22cac742ca`][repo-iroh]) to inform a clean-room native **D**
+reimplementation running on [`sparkles:event-horizon`][eh-spec] (single-threaded,
+completion-first `io_uring`/kqueue/IOCP, fibers + algebraic effects). Each subsystem was read
+against its pinned tree, cited to real `path:line`s, and written up as an independent deep-dive;
+this page is the map that ties them together.
+
+This survey answers eight questions:
+
+1. **What is a peer, and how does it prove who it is?** — every endpoint is a single Ed25519
+   keypair whose 32-byte public key _is_ its [`EndpointId`][identity], authenticated in an
+   [RFC 7250][rfc7250] raw-public-key [TLS 1.3][rfc8446] handshake carried in QUIC `CRYPTO`
+   frames — no PKI, no X.509. See [Identity & Cryptography][identity] (shared vocabulary in
+   [Concepts][concepts]).
+2. **How does every iroh value become bytes?** — exactly one application codec ([`postcard`][postcard]),
+   base32-wrapped tickets, and an [ALPN][rfc7301] registry. See [Wire Formats & Serialization][wire].
+3. **What carries the connection, and what must a port rebuild?** — [`noq`][repo-noq], n0's
+   sans-io fork of [`quinn`][quinn] extended with QUIC Multipath, QUIC Address Discovery, and an
+   in-QUIC NAT-traversal protocol. See [QUIC Transport (`noq`)][quic]; the app-facing
+   `connect`/`accept` + protocol-router shell is [Endpoint & Protocol Router][endpoint].
+4. **How does one logical connection ride many changing network paths?** — the multipath
+   [Socket][socket] (the module formerly called `magicsock`) that fans QUIC datagrams across
+   direct, IPv6, and relay carriers under one `noq::AsyncUdpSocket`.
+5. **How do two NATed peers get a direct path, and what happens when they cannot?** —
+   QUIC-native simultaneous-open [NAT Traversal & Address Discovery][nat] (the `DISCO` UDP
+   side-protocol and STUN are **gone**); the always-reachable [Relay][relay] is rendezvous and
+   fallback; [Net Report][net-report] measures the local vantage point via `netwatch` /
+   `portmapper`.
+6. **How do you reach a peer knowing only its key?** — [Address Lookup][discovery]: [BEP-44][bep44]-signed
+   records published and resolved over [pkarr][pkarr] relays and the DNS.
+7. **How is application data moved, verified, synced, and broadcast?** — content-addressed
+   [Blobs][blobs] over [BLAKE3 verified streaming][bao-tree], multi-writer [Document Sync][docs-sync],
+   and epidemic [Gossip][gossip].
+8. **What concurrency runs all of this, and how does it collapse onto a single-threaded loop?**
+   — a complete [Tokio Concurrency Inventory][concurrency] feeding the [D Architecture
+   Migration][d-arch] onto [`sparkles:event-horizon`][eh-spec].
+
+> [!NOTE]
+> **Scope.** This is the master index for the iroh research tree. Each row below links to a
+> deep-dive that was written and fact-checked independently against its pinned source tree;
+> where this index summarizes a subsystem, the **deep-dive is the source of truth**. The
+> workspace is pinned at iroh **v1.0.1** (`22cac742ca`); companion crates at [`iroh-blobs`][repo-blobs]
+> 0.103.0, [`iroh-docs`][repo-docs] 0.101.0, [`iroh-gossip`][repo-gossip] 0.101.0, [`noq`][repo-noq]
+> 1.0.1 (`noq-v1.0.1`), [`bao-tree`][repo-bao] 0.16.0, [`iroh-util`][repo-util] 0.6.0, and
+> [`irpc`][repo-irpc] 0.17.0. **iroh 1.0 is a major restructure of the 0.x API** — `magicsock` →
+> the [socket][socket] layer, "discovery" → `address_lookup`, `NodeId` → `EndpointId`, and the
+> `DISCO` UDP side-protocol + STUN replaced by QUIC-native NAT traversal + QUIC Address Discovery
+> inside [`noq-proto`][quic]. `NodeAddr`-era folklore does not compile; treat pre-1.0 material with
+> suspicion.
+
+**Last reviewed:** July 6, 2026
+
+---
+
+## Master Catalog
+
+One row per subsystem, grouped by [layer](#by-layer). **ALPN / role** gives the wire-bearing
+[ALPN][rfc7301] string where the subsystem owns one, otherwise its function. Versions are the
+pinned tags read; per-`path:line` provenance lives in each deep-dive's `Sources` block.
+
+### Foundations
+
+| Subsystem                                | Crate(s)                                | Version                                  | ALPN / role                            | What it does                                                                                     | Link                    |
+| ---------------------------------------- | --------------------------------------- | ---------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------- |
+| **[Identity & Cryptography][identity]**  | `iroh-base`, `iroh` (`tls/*`)           | iroh 1.0.1 (`22cac742ca`)                | none — raw-public-key TLS 1.3 identity | Ed25519 keypair = `EndpointId`; RFC 7250 handshake; BLAKE3 auxiliary MACs; no PKI, no ECDH       | [Deep-dive →][identity] |
+| **[Wire Formats & Serialization][wire]** | `iroh-tickets`, `iroh-base`, `postcard` | `iroh-tickets` 1.0.0 / `iroh-base` 1.0.1 | owns the ALPN registry                 | one non-self-describing `postcard` codec, base32 tickets, five base codecs, per-protocol framing | [Deep-dive →][wire]     |
+| **[QUIC Transport (`noq`)][quic]**       | `noq`, `noq-proto`, `noq-udp`           | `noq-v1.0.1` (`340e9c7`)                 | none — transport is ALPN-agnostic      | sans-io QUIC v1 state machine + Multipath + Address Discovery + in-QUIC NAT traversal (≈48k LoC) | [Deep-dive →][quic]     |
+
+### Connectivity
+
+| Subsystem                                             | Crate(s)                                        | Version                                              | ALPN / role                                              | What it does                                                                                             | Link                      |
+| ----------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------- |
+| **[Endpoint & Protocol Router][endpoint]**            | `iroh` (`endpoint`, `protocol`, `runtime`)      | iroh 1.0.1 (`22cac742ca`)                            | app-chosen (e.g. `b"iroh-example/echo/0"`)               | cheaply-clonable `Endpoint` over `noq`; `Router` multiplexes inbound connections onto `ProtocolHandler`s | [Deep-dive →][endpoint]   |
+| **[The Multipath Socket][socket]**                    | `iroh` (`socket`, ex-`magicsock`)               | iroh 1.0.1 (`22cac742ca`)                            | none — sits below QUIC/TLS                               | one `AsyncUdpSocket` over IP + relay + custom carriers; synthetic-IPv6 mapped addrs; path selection      | [Deep-dive →][socket]     |
+| **[NAT Traversal & Address Discovery][nat]**          | `noq-proto`, `noq`, `iroh`, `iroh-relay`        | `noq-v1.0.1` / iroh 1.0.1                            | `/iroh-qad/0` (QAD server); QNT rides the app connection | simultaneous-open `ADD_ADDRESS`/`REACH_OUT`/`REMOVE_ADDRESS` over the encrypted 1-RTT dataplane          | [Deep-dive →][nat]        |
+| **[The Relay Protocol][relay]**                       | `iroh-relay`, `iroh` (relay transport)          | iroh-relay 1.0.1                                     | WS subprotocol `iroh-relay-v2`; QAD ALPN `/iroh-qad/0`   | authenticated WebSocket packet-forwarder keyed on `EndpointId` + a bare QAD QUIC endpoint (port 7842)    | [Deep-dive →][relay]      |
+| **[Address Lookup (Discovery)][discovery]**           | `iroh`, `iroh-dns`, `iroh-dns-server`           | iroh 1.0.1 / `iroh-dns` 1.0.1                        | none — DNS + pkarr HTTP(S)                               | `EndpointId` → dialable addresses via BEP-44-signed DNS packets over pkarr relays and the DNS            | [Deep-dive →][discovery]  |
+| **[Net Report, Watching & Port Mapping][net-report]** | `iroh` (`net_report`), `netwatch`, `portmapper` | iroh 1.0.1 / `netwatch` 0.19.1 / `portmapper` 0.19.1 | `/iroh-qad/0` probe; HTTPS fallback                      | measures UDP reachability, public address, NAT type, home relay; interface watching + UPnP/PCP/NAT-PMP   | [Deep-dive →][net-report] |
+
+### Protocols
+
+| Subsystem                                              | Crate(s)                                      | Version               | ALPN / role                                 | What it does                                                                                                  | Link                     |
+| ------------------------------------------------------ | --------------------------------------------- | --------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| **[Blobs: Content-Addressed Transfer][blobs]**         | `iroh-blobs`, `iroh-util`, `irpc`, `bao-tree` | `iroh-blobs` 0.103.0  | `/iroh-bytes/4`                             | request/response BLAKE3 verified-stream transfer; crash-consistent store; resumable multi-provider downloader | [Deep-dive →][blobs]     |
+| **[BLAKE3 Verified Streaming (`bao-tree`)][bao-tree]** | `bao-tree`                                    | `bao-tree` 0.16.0     | n/a — a codec, not a wire protocol          | exposes BLAKE3's internal Merkle tree as an incrementally-verifiable stream (16 KiB chunk groups)             | [Deep-dive →][bao-tree]  |
+| **[Document Sync (`iroh-docs`)][docs-sync]**           | `iroh-docs`                                   | `iroh-docs` 0.101.0   | `/iroh-sync/1`                              | multi-writer eventually-consistent KV store; recursive range-fingerprint set reconciliation                   | [Deep-dive →][docs-sync] |
+| **[Epidemic Broadcast (`iroh-gossip`)][gossip]**       | `iroh-gossip`                                 | `iroh-gossip` 0.101.0 | `/iroh-gossip/1` (per-instance overridable) | HyParView partial-view membership + Plumtree eager/lazy-push broadcast tree, as an IO-less state machine      | [Deep-dive →][gossip]    |
+
+### D migration
+
+| Subsystem                                      | Crate(s)                               | Version                         | ALPN / role                      | What it does                                                                                                              | Link                       |
+| ---------------------------------------------- | -------------------------------------- | ------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| **[Tokio Concurrency Inventory][concurrency]** | `n0-future`, `n0-watcher`, `irpc`, all | workspace 1.0.1 (`irpc` 0.17.0) | none — process-internal plumbing | census of every task, channel, lock, `select!` loop, `spawn_blocking`, timer; protocol-inherent vs `Send + Sync` artifact | [Deep-dive →][concurrency] |
+
+> [!NOTE]
+> Two catalog entries are cross-cutting rather than subsystems: [Concepts & Vocabulary][concepts]
+> (the shared glossary every page references) and [D Architecture Migration][d-arch] (the capstone
+> that maps the whole stack onto [event-horizon][eh-spec]). Both are in [Quick Navigation](#quick-navigation),
+> not the Master Catalog.
+
+---
+
+## Taxonomy
+
+Three re-cuts of the same fourteen subsystems, one axis each. Every row links back to a deep-dive.
+
+### By layer
+
+The catalog's grouping: where a subsystem sits from the identity root up to the runtime that
+drives it. Higher layers depend on lower ones.
+
+| Layer            | Concern                                                              | Subsystems                                                                                                                          |
+| ---------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Foundations**  | Identity, bytes, and the transport state machine everything rides    | [Identity & Cryptography][identity], [Wire Formats][wire], [QUIC Transport][quic]                                                   |
+| **Connectivity** | Getting an authenticated QUIC path to a peer, wherever it is         | [Endpoint][endpoint], [Socket][socket], [NAT Traversal][nat], [Relay][relay], [Address Lookup][discovery], [Net Report][net-report] |
+| **Protocols**    | Application services built on top of a connection                    | [Blobs][blobs], [`bao-tree`][bao-tree], [Document Sync][docs-sync], [Gossip][gossip]                                                |
+| **D migration**  | Porting artifacts — the concurrency census and the architecture plan | [Concurrency Inventory][concurrency], [D Architecture Migration][d-arch]                                                            |
+
+### By network role
+
+The same set cut by _what job it does on the wire_ rather than where it sits in the stack.
+
+| Role                    | Question it answers                                            | Subsystems                                                                                                    |
+| ----------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Identity & encoding** | Who is this peer, and how do its values serialize?             | [Identity & Cryptography][identity], [Wire Formats][wire]                                                     |
+| **Transport**           | How is an authenticated, multiplexed byte pipe established?    | [QUIC Transport][quic], [Endpoint][endpoint]                                                                  |
+| **Connectivity / NAT**  | How do we _reach_ a peer, and stay reached as the net changes? | [Socket][socket], [NAT Traversal][nat], [Relay][relay], [Address Lookup][discovery], [Net Report][net-report] |
+| **Data protocols**      | What application semantics ride the connection?                | [Blobs][blobs], [`bao-tree`][bao-tree], [Document Sync][docs-sync], [Gossip][gossip]                          |
+| **Runtime**             | What schedules all of the above?                               | [Concurrency Inventory][concurrency]                                                                          |
+
+### By port difficulty
+
+The axis that matters most for the D reimplementation: how a subsystem should be _acquired_. A
+subsystem can appear in more than one class — [Socket][socket], for instance, is both policy to
+re-implement and raw OS surface to bind.
+
+| Class                         | What the port does                                                                                                                                   | Subsystems                                                                                                                                                                                                                   |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Reuse a sans-io core**      | The logic is already a pure `(state, event) → effects` machine with no OS or runtime coupling; re-derive the state machine and drive it from a fiber | [QUIC Transport][quic] (`noq-proto`), [Gossip][gossip] (`proto/`), [Document Sync][docs-sync] (range reconciler), [`bao-tree`][bao-tree], [Wire Formats][wire] (`postcard`)                                                  |
+| **Reimplement policy / glue** | Moderate protocol and policy logic over a sans-io core; no exotic OS or crypto surface                                                               | [Endpoint][endpoint], [Socket][socket] (routing fabric), [NAT Traversal][nat] (orchestration), [Relay][relay], [Address Lookup][discovery], [Blobs][blobs] (protocol/store/downloader), [Concurrency substrate][concurrency] |
+| **Needs an OS binding**       | Must bind raw per-OS surfaces the language runtime does not provide                                                                                  | [Net Report][net-report] (`netwatch` netlink/`AF_ROUTE`/`/proc/net/route`/IP Helper/`getifaddrs`; `portmapper` UPnP/PCP/NAT-PMP), [Socket][socket] (UDP send/recv, GSO/GRO, rebind)                                          |
+| **Needs a crypto primitive**  | Depends on cryptographic primitives that must be spec-exact and constant-time                                                                        | [Identity & Cryptography][identity] (Ed25519, TLS 1.3 raw-public-key, BLAKE3 `keyed_hash`/`derive_key`), [`bao-tree`][bao-tree] & [Blobs][blobs] (BLAKE3), [Relay][relay] (TLS keying-material export, [RFC 5705][rfc5705])  |
+
+> [!NOTE]
+> The single largest _reuse-a-sans-io-core_ item, [`noq-proto`][quic], is ≈48k lines of protocol
+> logic — deterministic and portable, but the dominant effort of the whole port. Its own crate root flags
+> it as of interest to anyone who wants "a different event loop than the one tokio provides" —
+> precisely event-horizon's brief. See [QUIC Transport § Mapping to event-horizon][quic].
+
+---
+
+## Milestones: the 0.x → 1.0 restructure
+
+iroh 1.0 is not an increment; it deletes whole subsystems and QUIC-natively absorbs their jobs. The
+table below is the evolution the survey documents, subsystem by subsystem.
+
+> [!NOTE]
+> The pinned trees carry no dated changelog of the 0.x release line, and this survey trusts only the
+> pinned sources — so only the **1.0-era tag dates are absolute**: [`noq`][repo-noq] `noq-v1.0.1`
+> released **2026-06-29** (`340e9c7`); iroh [`v1.0.1`][repo-iroh] committed **2026-07-03**
+> (`22cac742ca`). The "iroh 0.x" column describes the _prior architecture_ each deep-dive contrasts
+> against, not a dated release; treat the ordering as logical, not chronological.
+
+| Capability                  | iroh 0.x                                                                                          | iroh 1.0                                                                                                                             | Surveyed in                                |
+| --------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| NAT-traversal signalling    | **DISCO** — a bespoke UDP ping/pong side-protocol using NaCl `crypto_box` (node key → Curve25519) | **QUIC-native (QNT)** — `ADD_ADDRESS`/`REACH_OUT`/`REMOVE_ADDRESS` frames on the encrypted 1-RTT dataplane                           | [NAT Traversal][nat], [Identity][identity] |
+| Reflexive-address discovery | **STUN** against relay servers                                                                    | **QUIC Address Discovery** (`/iroh-qad/0`) on the main endpoint — no STUN code remains                                               | [Net Report][net-report], [Relay][relay]   |
+| Connectivity module         | `magicsock` (`MagicSock`)                                                                         | `socket` (`Socket`, `pub(crate)`)                                                                                                    | [Socket][socket]                           |
+| Path model                  | Duplicate each datagram onto UDP **and** relay; DISCO ping/pong picks a winner                    | Relay and every direct address are **concurrent QUIC multipath paths** on one connection; switching = flipping a path's `PathStatus` | [Socket][socket], [QUIC][quic]             |
+| QUIC library                | [`quinn`][quinn]                                                                                  | [`noq`][repo-noq] fork — adds Multipath, Address Discovery, in-QUIC NAT traversal                                                    | [QUIC Transport][quic]                     |
+| Identity vocabulary         | `NodeId` / `NodeAddr` / `NodeTicket`                                                              | `EndpointId` / `EndpointAddr` / `EndpointTicket` — old `node…` tickets are unparseable                                               | [Identity][identity], [Wire][wire]         |
+| Address directory           | `discovery` (`Discovery` / `DiscoveryItem`)                                                       | `address_lookup` (`AddressLookup` / `Item`); pkarr/DNS-centric                                                                       | [Address Lookup][discovery]                |
+| Relay wire format           | DERP-era bespoke framing / magic strings                                                          | Binary WebSocket subprotocol `iroh-relay-v2` (v1 legacy); the `Health` frame is removed in v2                                        | [Relay][relay]                             |
+| Blobs store contract        | A `Store` / `Map` trait hierarchy                                                                 | "Whatever handles the `Command` enum" over [`irpc`][repo-irpc]                                                                       | [Blobs][blobs]                             |
+| Blobs downloader            | Dial queues, retry backoff, request dedup baked in                                                | ~550-line re-planning orchestrator + a generic `ConnectionPool`; those concerns pushed to consumers                                  | [Blobs][blobs]                             |
+| Blobs transfer ALPN         | `/iroh-bytes/4`                                                                                   | `/iroh-bytes/4` — **unchanged** across the rename (a deliberate interop-stability point)                                             | [Blobs][blobs]                             |
+| Gossip ALPN                 | `/iroh-gossip/0`                                                                                  | `/iroh-gossip/1`, now per-instance overridable via `Builder::alpn`                                                                   | [Gossip][gossip]                           |
+
+---
+
+## Quick Navigation
+
+### Suggested reading paths
+
+- **"I want the connectivity story."** [QUIC Transport][quic] → [Endpoint][endpoint] → [Socket][socket]
+  → [NAT Traversal][nat] → [Relay][relay] → [Address Lookup][discovery] → [Net Report][net-report].
+- **"I want the identity & byte layer."** [Concepts][concepts] → [Identity & Cryptography][identity]
+  → [Wire Formats][wire].
+- **"I want the data protocols."** [Blobs][blobs] → [`bao-tree`][bao-tree] → [Document Sync][docs-sync]
+  → [Gossip][gossip].
+- **"I want a minimal interop MVP."** The smallest byte-compatible target is an echo/`dumbpipe`
+  peer — one ALPN, no store, no docs/gossip: [Identity][identity] → [Wire Formats][wire] →
+  [Endpoint][endpoint] → [QUIC Transport][quic] → [Socket][socket] → [Relay][relay] →
+  [NAT Traversal][nat].
+- **"I'm designing the D port."** [Concurrency Inventory][concurrency] (what actually runs) →
+  [D Architecture Migration][d-arch] (the plan) → the four sans-io cores you can port directly
+  ([QUIC][quic], [Gossip][gossip], [Document Sync][docs-sync], [`bao-tree`][bao-tree]) → the
+  [event-horizon spec][eh-spec] and the [async-io tree][async-io] — especially [Tokio][tokio] (the
+  model being replaced) and [Glommio][glommio] / [monoio][monoio] (the thread-per-core,
+  share-nothing stance event-horizon adopts).
+
+### Overview & synthesis
+
+- **[Concepts & Vocabulary][concepts]** — the shared glossary: `EndpointId`, `EndpointAddr`,
+  tickets, ALPN, path, relay, the 0.x → 1.0 rename map every page relies on.
+- **[Tokio Concurrency Inventory][concurrency]** — the exhaustive census of tasks, channels, locks,
+  `select!` loops, and blocking work, classified protocol-inherent vs `Send + Sync` artifact.
+- **[D Architecture Migration][d-arch]** — the capstone: Rust constructs beside proposed D
+  equivalents on [event-horizon][eh-spec], the bottlenecks (CPU-bound BLAKE3 on the loop thread, the
+  missing cross-fiber channel primitive), and the sans-io reuse strategy.
+
+### Cross-tree
+
+- **[event-horizon spec][eh-spec]** — the D runtime the port targets: completion-first loop, fibers,
+  `Scope`/`race`/`JoinHandle` structured concurrency, capability effects, `IoResult!`/`Outcome!`.
+- **[async-io survey][async-io]** — the prior-art runtime survey; [Tokio][tokio], [Glommio][glommio],
+  and [monoio][monoio] are the directly-relevant deep-dives.
+- **[algebraic-effects corpus][ae-index]** — the effect-handler background behind event-horizon's
+  capability layer.
+
+---
+
+## Sources
+
+Each deep-dive carries its own primary-source citations to exact `path:line`s in the pinned trees;
+this index's classifications derive from them. The pinned upstream artifacts are:
+
+- **iroh workspace** (`iroh`, `iroh-base`, `iroh-tickets`, `iroh-relay`, `iroh-dns`,
+  `iroh-dns-server`) — [`n0-computer/iroh`][repo-iroh] at `22cac742ca` · [docs.rs/iroh][docs-iroh].
+- **Transport** — [`n0-computer/noq`][repo-noq] at `noq-v1.0.1` (`noq`, `noq-proto`, `noq-udp`) ·
+  [docs.rs/noq][docs-noq]; a fork of [`quinn`][quinn].
+- **Data protocols** — [`iroh-blobs`][repo-blobs] 0.103.0 · [docs.rs/iroh-blobs][docs-blobs];
+  [`bao-tree`][repo-bao] 0.16.0 · [docs.rs/bao-tree][docs-bao]; [`iroh-docs`][repo-docs] 0.101.0 ·
+  [docs.rs/iroh-docs][docs-docs]; [`iroh-gossip`][repo-gossip] 0.101.0 · [docs.rs/iroh-gossip][docs-gossip].
+- **Runtime & RPC** — [`irpc`][repo-irpc] 0.17.0 · [docs.rs/irpc][docs-irpc]; [`iroh-util`][repo-util]
+  0.6.0 (`connection_pool`); `n0-future` / `n0-watcher`.
+- **Connectivity sensing** — [`n0-computer/net-tools`][repo-nettools] (`netwatch` 0.19.1,
+  `portmapper` 0.19.1).
+- **Protocol drafts** — QUIC Multipath ([`draft-ietf-quic-multipath`][draft-multipath]), QUIC
+  NAT-traversal ([`draft-seemann-quic-nat-traversal`][draft-qnt]), QUIC Address Discovery
+  ([`draft-seemann-quic-address-discovery`][draft-qad]); [QUIC v1 (RFC 9000)][rfc9000],
+  [TLS 1.3 (RFC 8446)][rfc8446]; [BLAKE3][blake3].
+
+<!-- References -->
+
+<!-- Deep-dives & synthesis (siblings) -->
+
+[concepts]: ./concepts.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[quic]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[net-report]: ./net-report.md
+[blobs]: ./blobs.md
+[bao-tree]: ./bao-tree.md
+[docs-sync]: ./docs-sync.md
+[gossip]: ./gossip.md
+[concurrency]: ./concurrency.md
+[d-arch]: ./d-architecture-migration.md
+
+<!-- Cross-tree -->
+
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[async-io]: ../async-io/index.md
+[tokio]: ../async-io/tokio.md
+[glommio]: ../async-io/glommio.md
+[monoio]: ../async-io/monoio.md
+[ae-index]: ../algebraic-effects/index.md
+
+<!-- Upstream repositories -->
+
+[repo-iroh]: https://github.com/n0-computer/iroh/tree/22cac742ca
+[repo-noq]: https://github.com/n0-computer/noq/tree/noq-v1.0.1
+[repo-blobs]: https://github.com/n0-computer/iroh-blobs/tree/v0.103.0
+[repo-docs]: https://github.com/n0-computer/iroh-docs/tree/v0.101.0
+[repo-gossip]: https://github.com/n0-computer/iroh-gossip/tree/v0.101.0
+[repo-bao]: https://github.com/n0-computer/bao-tree/tree/v0.16.0
+[repo-util]: https://github.com/n0-computer/iroh-util/tree/v0.6.0
+[repo-irpc]: https://github.com/n0-computer/irpc/tree/v0.17.0
+[repo-nettools]: https://github.com/n0-computer/net-tools
+
+<!-- docs.rs -->
+
+[docs-iroh]: https://docs.rs/iroh/1.0.1
+[docs-noq]: https://docs.rs/noq/1.0.1
+[docs-blobs]: https://docs.rs/iroh-blobs/0.103.0
+[docs-docs]: https://docs.rs/iroh-docs/0.101.0
+[docs-gossip]: https://docs.rs/iroh-gossip/0.101.0
+[docs-bao]: https://docs.rs/bao-tree/0.16.0
+[docs-irpc]: https://docs.rs/irpc/0.17.0
+
+<!-- External specs & prior art -->
+
+[quinn]: https://github.com/quinn-rs/quinn
+[postcard]: https://docs.rs/postcard/latest/postcard/
+[pkarr]: https://github.com/pubky/pkarr
+[bep44]: https://www.bittorrent.org/beps/bep_0044.html
+[blake3]: https://github.com/BLAKE3-team/BLAKE3
+[draft-multipath]: https://datatracker.ietf.org/doc/draft-ietf-quic-multipath/
+[draft-qnt]: https://datatracker.ietf.org/doc/draft-seemann-quic-nat-traversal/
+[draft-qad]: https://datatracker.ietf.org/doc/draft-seemann-quic-address-discovery/
+[rfc9000]: https://www.rfc-editor.org/rfc/rfc9000
+[rfc8446]: https://www.rfc-editor.org/rfc/rfc8446
+[rfc7250]: https://www.rfc-editor.org/rfc/rfc7250
+[rfc7301]: https://www.rfc-editor.org/rfc/rfc7301
+[rfc5705]: https://www.rfc-editor.org/rfc/rfc5705

--- a/docs/research/iroh/nat-traversal.md
+++ b/docs/research/iroh/nat-traversal.md
@@ -1,0 +1,735 @@
+# NAT Traversal & Address Discovery
+
+iroh 1.0 punches through NATs entirely inside QUIC: three cooperating draft extensions — QUIC Address Discovery (the STUN replacement), QUIC Multipath, and n0's own NAT-traversal protocol (QNT) — coordinate a simultaneous-open `PATH_CHALLENGE`/`PATH_RESPONSE` exchange over the encrypted connection, with no DISCO side-protocol and no STUN packets on the wire.
+
+| Field               | Value                                                                                                                                                                                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Crate(s)            | `noq-proto` (sans-io QNT/QAD/MP core), `noq` (async façade), `iroh` (the `RemoteStateActor` driver), `iroh-relay` (QAD server)                                                                                                                         |
+| Version             | `noq-v1.0.1` (HEAD `340e9c7`, 2026-06-29); iroh `v1.0.1` (commit `22cac742ca`, 2026-07-03)                                                                                                                                                             |
+| Repository          | [`n0-computer/noq`][noq-readme] · [`n0-computer/iroh`][iroh-repo]                                                                                                                                                                                      |
+| Documentation       | [docs.rs/noq-proto][docs-noq-proto] · [docs.rs/iroh][docs-iroh]                                                                                                                                                                                        |
+| ALPN(s)             | `/iroh-qad/0` (relay QAD server, [`ALPN_QUIC_ADDR_DISC`][relay-quic]); QNT itself has **no** distinct ALPN — it rides the normal iroh application connection                                                                                           |
+| Approx. size (LoC)  | noq-proto QNT/QAD core ≈ 1,150 (`n0_nat_traversal.rs` 1,075 + `address_discovery.rs` 73), plus multipath additions in `frame.rs`/`paths.rs`/`connection/mod.rs`; iroh driver ≈ 1,530 (`remote_state.rs`)                                               |
+| Category            | Connectivity                                                                                                                                                                                                                                           |
+| Upstream spec/draft | [`draft-seemann-quic-nat-traversal-02`][draft-qnt] (QNT inspiration), [`draft-ietf-quic-multipath`][draft-multipath] (MP), [`draft-seemann-quic-address-discovery`][draft-qad] (QAD); [RFC 9000][rfc9000] §8.1 (amplification), §8.2 (path validation) |
+
+> [!NOTE]
+> This page covers the **NAT-traversal semantics**: the extensions, the frames, the round/probe/backoff
+> state machine, and iroh's hole-punch orchestration. The QUIC dataplane those frames ride on — packet
+> building, per-path CID machinery, congestion control, path scheduling — is [QUIC Transport (`noq`)][quic-transport].
+> How punched paths are _chosen and consumed_ is [The Multipath Socket][socket]; where _candidate addresses_
+> come from is [Address Lookup][discovery] and [Net Report][net-report]; the relay fallback is [The Relay Protocol][relay].
+
+---
+
+## Overview
+
+### What it solves
+
+Two iroh endpoints, each behind a NAT, want a direct UDP path between them. Neither can simply
+`connect` to the other's advertised address: the NAT has no mapping for an unsolicited inbound packet,
+and neither peer reliably knows its own _reflexive_ (post-NAT) address. The classic fix is
+**simultaneous open** — both peers send to each other's reflexive address at the same time, so each
+NAT sees the outbound packet as "the reply I was expecting" and installs a mapping. Coordinating that
+requires (1) each peer learning its own reflexive address, (2) the peers exchanging those addresses,
+and (3) both firing probes at the right moment.
+
+iroh 0.x solved this with **DISCO**, a bespoke UDP side-protocol of magic ping/pong packets alongside
+the QUIC traffic, plus **STUN** against relay servers to learn reflexive addresses. iroh 1.0 deletes
+both. Everything now happens _inside_ the QUIC connection, expressed as QUIC frames on the encrypted
+1-RTT dataplane:
+
+- **Reflexive-address discovery** is [QUIC Address Discovery (QAD)][sec-qad]: the peer at the other end
+  of a connection tells you the source address it observes for you, in an `OBSERVED_ADDRESS` frame.
+  Against dedicated relay QAD servers (ALPN `/iroh-qad/0`) this fully replaces STUN.
+- **Path punching** is n0's **NAT-traversal (QNT)** extension: `ADD_ADDRESS`/`REMOVE_ADDRESS`/`REACH_OUT`
+  frames advertise candidate addresses, and off-path `PATH_CHALLENGE`/`PATH_RESPONSE` frames are the
+  actual probes both peers fire simultaneously.
+- **The punched hole becomes a path** via **QUIC Multipath (MP)**: a successful probe opens a new
+  multipath _path_ on the validated 4-tuple, independently validated, congestion-controlled, and
+  abandonable, that the connection can migrate onto or use in parallel with the relayed path.
+
+The decisive architectural property is that **QNT lives inside the QUIC state machine**, not beside it.
+A native D port cannot bolt hole-punching onto an off-the-shelf QUIC library: it must own a QUIC stack
+that supports multipath, custom frames, and custom transport parameters. This is the single largest
+reimplementation cost in the whole iroh port.
+
+### Design philosophy
+
+QNT is deliberately _n0's own_ protocol, not a faithful implementation of any IETF draft. From the
+transport-parameter definition ([`transport_parameters.rs:731-732`][tparams]):
+
+> _"inspired by https://www.ietf.org/archive/id/draft-seemann-quic-nat-traversal-02.html,
+> simplified to n0's own protocol."_
+
+The simplification shows up everywhere: fixed client/server roles instead of role negotiation, a
+whimsical private transport-parameter id (`0x3d7f91120401`) and frame-id block (`0x3d7f90…0x3d7f94`)
+rather than IETF-assigned codepoints, and a hand-tuned retry schedule. The design's second pillar is
+that the protocol _engine_ is **sans-io**: `ClientState`/`ServerState` are plain value-mutating structs
+whose methods return "frames to send" and "next timer deadline". No tasks, channels, locks, or timers
+live inside `noq-proto`; the only "timer" is a `ConnTimer::NatTraversalProbeRetry` entry the driver is
+told to arm ([`timer.rs`][timer]). That shape maps cleanly onto a single fiber owning a connection.
+
+The third pillar is a candid amplification trade-off. The comment on the probe budget spells out the
+tension between reliability, NAT behaviour, and abusing innocent third parties
+([`n0_nat_traversal.rs:19-30`][nat]):
+
+> _"Maximum number of times we send a NAT probe to the same remote address in a round. This is a
+> trade-off between several factors: - Probe packets could be lost. This allows recovery. - We may
+> need two probes to reach the NAT firewall to get through. - We may be sending probes to innocent
+> bystanders on the internet. - A round never "finishes": probing of remotes only stops when: 1. A new
+> round is started. 2. A probe was successful. 3. This number of attempts is exhausted. … With this we
+> send probes for up to 4s by default."_
+
+---
+
+## How it works
+
+### The three cooperating extensions
+
+All three extensions are negotiated in the TLS handshake via QUIC transport parameters, and they
+compose with a strict dependency: **QNT requires MP**. Setting the QNT limit auto-enables multipath
+if it is not already on ([`config/transport.rs:452-457`][cfg-transport]):
+
+```rust
+// noq-proto/src/config/transport.rs:452-457
+pub fn max_remote_nat_traversal_addresses(&mut self, max_addresses: u8) -> &mut Self {
+    self.max_remote_nat_traversal_addresses = NonZeroU8::new(max_addresses);
+    if max_addresses != 0 && self.max_concurrent_multipath_paths.is_none() {
+        self.max_concurrent_multipath_paths(8);   // MP auto-enabled, capped at 8 paths
+    }
+    self
+}
+```
+
+The negotiation is wired in `handle_peer_params` ([`connection/mod.rs:6693-6713`][conn-proto]): QNT
+state is created **only if both peers sent the `N0NatTraversal` parameter AND multipath negotiated**.
+The two limit values cross over — `max_local_addresses` (how many _we_ may advertise) is the value the
+_remote_ sent, and `max_remote_addresses` (how many the remote may advertise to us) is the value _we_
+sent. If QNT is requested but MP is missing, it logs and stays disabled.
+
+### Negotiation: transport parameters
+
+Each transport parameter is `varint(id) | varint(len) | value` in the handshake
+([`transport_parameters.rs`][tparams]):
+
+| Parameter             | Id (varint)      | Value                                                                 | Cite                                                                          |
+| --------------------- | ---------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| QAD `ObservedAddr`    | `0x9f81a176`     | `varint(role)`, role ∈ {`0`=send-only, `1`=receive-only, `2`=both}    | [`transport_parameters.rs:726`][tparams], [`address_discovery.rs:64-73`][qad] |
+| MP `InitialMaxPathId` | `0x3e`           | `varint(path_id)` = max `PathId` this endpoint allows                 | [`transport_parameters.rs:729`][tparams]                                      |
+| QNT `N0NatTraversal`  | `0x3d7f91120401` | fixed length `1`, one raw `u8` = `max_remote_nat_traversal_addresses` | [`transport_parameters.rs:733`][tparams]                                      |
+
+The QNT parameter is encoded specially — `varint(id) | 0x01 | u8(max)` — a literal length byte `1`
+followed by a raw `u8` rather than a varint. Decoding rejects `0` (the value is a `NonZeroU8`) and any
+length other than `1` as `Malformed`. MP is "on" only if _both_ sides send `InitialMaxPathId`; the
+effective ceiling is `min(local, remote)` ([`connection/mod.rs:6680-6691`][conn-proto]).
+`max_concurrent_multipath_paths(n)` maps to `initial_max_path_id = n - 1` — a _count_ of paths, so N
+paths means max id N−1. Changing a QAD role or the QNT max between a 0-RTT resumption and the live
+connection is a `PROTOCOL_VIOLATION` ([`transport_parameters.rs:217-218`][tparams]).
+
+iroh configures **8** concurrent multipath paths ([`MAX_MULTIPATH_PATHS`][iroh-socket]) and **32**
+QNT addresses ([`MAX_QNT_ADDRESSES`][iroh-socket]), applied through the
+[`QuicTransportConfigBuilder`][iroh-quic].
+
+### QUIC Address Discovery: learning your reflexive address {#sec-qad}
+
+QAD replaces STUN. A peer with QAD `send` whose peer has `receive`
+([`Role::should_report`][qad], `address_discovery.rs:59-63`) attaches an `OBSERVED_ADDRESS` frame
+reporting the source `SocketAddr` it sees for the peer. Emission is scheduled on
+`PathData.pending.observed_address`, set whenever a path is created, migrated, or a
+`PATH_CHALLENGE`/`PATH_RESPONSE` is sent ([`connection/mod.rs:6204-6231`][conn-proto]), and each report
+carries a monotonic per-connection `next_observed_addr_seq_no`. On receipt, the report is validated
+(must be negotiated, must be in the Data space), `PathData::update_observed_addr_report` keeps only the
+highest-seq report per path, and a changed address emits `PathEvent::ObservedAddr{id, addr}`
+([`paths.rs:613-638`][paths]).
+
+iroh consumes QAD two ways:
+
+1. **Dedicated relay QAD probes.** iroh opens connections to relay QAD servers with ALPN
+   `/iroh-qad/0` ([`iroh-relay/src/quic.rs:10`][relay-quic]), tuned with a low `initial_rtt` of
+   111 ms, purely to learn direct addresses for [net_report][net-report]. The QAD close code is
+   `QUIC_ADDR_DISC_CLOSE_CODE = 1`.
+2. **In-band on every connection.** Every regular iroh connection feeds
+   `observed_external_addr` ([`noq/src/connection.rs:1643-1649`][conn-async]).
+
+These reflexive addresses become the local candidate set that QNT advertises.
+
+### QNT candidate exchange
+
+Roles are **fixed by the QUIC client/server side, not by who is behind NAT**
+([`n0_nat_traversal.rs:144-165`][nat]). The QUIC **client** runs `ClientState`; the QUIC **server**
+runs `ServerState`. The role never flips.
+
+- **The server advertises** its candidates to the client via `ADD_ADDRESS` frames (each with a
+  monotonic `seq_no`) and withdraws them via `REMOVE_ADDRESS`. The client stores them keyed by `seq_no`
+  in `ClientState::remote_addresses`, surfacing `Event::AddressAdded`/`AddressRemoved` to the
+  application.
+- **The client advertises** its own candidates to the server, but **only when it starts a round**, via
+  `REACH_OUT` frames carrying the round number. The server does not persist client addresses outside a
+  round.
+
+Both sides feed local addresses with `add_nat_traversal_address`/`remove_nat_traversal_address`
+([`connection/mod.rs:7101-7125`][conn-proto]); for the client these populate `local_addresses` (used
+later in `REACH_OUT`), while for the server each returns an `ADD_ADDRESS` frame to queue.
+
+### A NAT-traversal round: the hole-punch itself
+
+A **round** is one coordinated burst of probing, always **started by the client** via
+`initiate_nat_traversal_round` ([`n0_nat_traversal.rs:456-506`][nat],
+[`connection/mod.rs:7155-7181`][conn-proto]):
+
+1. Increment `round`, reset `attempt = 0`, clear `sent_challenges` and `pending_probes`.
+2. For every known remote (server) candidate, enqueue a probe (`pending_probes`) and set its
+   `ProbeState::Active(MAX_NAT_PROBE_ATTEMPTS - 1)`. IPv6 candidates on an IPv4-only socket are skipped
+   (`Active(0)`).
+3. Build `REACH_OUT` frames from the client's `local_addresses` (all carrying the new `round`) and
+   queue them.
+4. Arm the `NatTraversalProbeRetry` conn-timer at `now + retry_delay`.
+
+When the server receives a `REACH_OUT` with a **higher** round
+([`n0_nat_traversal.rs:789-822`][nat]), it adopts the new round, clears its per-round state, records
+the client's address in `remotes`, enqueues a probe back to it, and arms **its own**
+`NatTraversalProbeRetry` timer. **Both peers now probe each other simultaneously** — the
+simultaneous-open that punches both NATs.
+
+Each probe is an **off-path** `PATH_CHALLENGE` sent to the candidate address
+([`send_nat_traversal_path_challenge`][conn-proto], `connection/mod.rs:2076-2130`):
+
+- pull `next_probe_addr()` from `pending_probes`;
+- require an existing **validated** path to hang the probe on, plus an active remote CID for that path;
+- write `PATH_CHALLENGE(random u64 token)` into a fresh datagram destined to the _probe_ address (not
+  the path's normal remote), and record `mark_probe_sent(remote, token)` so `sent_challenges[token] = remote`.
+
+Two details are load-bearing. First, the probe is **not padded to 1200 bytes**, so a successful
+response validates only the _address_, not the full path MTU ([`n0_nat_traversal.rs:288-291`][nat]):
+
+> _"Returns true if it was a response to one of the NAT traversal probes and a path needs to be opened.
+> Note that the NAT probes are not padded to 1200 bytes so only the address is validated, but not the
+> entire path."_
+
+Second, the off-path challenge is sent from `src_ip: None` and is **not congestion-controlled**
+(off-path packets bypass the path's congestion window). These unpadded, uncontrolled datagrams _are_
+the holes being punched.
+
+When a probe reaches the peer, the peer sees a `PATH_CHALLENGE` on an unknown 4-tuple and queues an
+off-path `PATH_RESPONSE` ([`paths.rs:846-884`][paths]), sent back **padded to `MIN_INITIAL_SIZE` (1200)**
+via `send_off_path_path_response`. If the responder is _also_ a QNT client, it piggybacks its own
+fresh `PATH_CHALLENGE` on that response to accelerate mutual validation
+([`connection/mod.rs:2036-2039`][conn-proto]):
+
+> _"If we are a client doing NAT traversal, always include a PATH_CHALLENGE with any off-path
+> PATH_RESPONSE. No need to schedule any retries for this, if NAT traversal is taking place then this
+> remote already is being probed with retries, this only speeds up a successful traversal."_
+
+When _our_ probe's `PATH_RESPONSE` returns, `State::handle_path_response`
+([`n0_nat_traversal.rs:610-659`][nat]) matches the token in `sent_challenges` against the source. On a
+match it removes the challenge, marks the remote `ProbeState::Succeeded`, and — **on the client only** —
+pushes the validated `FourTuple` onto `paths_to_be_opened`. The server just records success; multipath
+rules forbid servers from opening paths ([`connection/mod.rs:570-572`][conn-proto]). The client then
+drains `paths_to_be_opened` in `open_nat_traversed_paths` ([`connection/mod.rs:5676-5719`][conn-proto]),
+calling `open_path_ensure(path, PathStatus::Backup)`. Path opening can be blocked on
+`RemoteCidsExhausted` or `MaxPathIdReached`; those entries are re-queued and retried whenever new CIDs
+or a higher `MAX_PATH_ID` arrive.
+
+### Retry and backoff
+
+A round never terminates on its own; probing a remote stops only when (1) a new round starts, (2) that
+probe succeeds, or (3) `MAX_NAT_PROBE_ATTEMPTS = 9` is exhausted ([`n0_nat_traversal.rs:32`][nat]).
+Each `NatTraversalProbeRetry` firing calls `queue_retries` (decrement remaining, re-enqueue probes),
+then re-arms via `retry_delay` ([`connection/mod.rs:2471-2485`][conn-proto]).
+
+`retry_delay` ([`n0_nat_traversal.rs:306-343`][nat]) is a capped exponential backoff scaled to
+`TransportConfig::initial_rtt` (default **333 ms**, [`config/transport.rs:564`][cfg-transport]):
+
+- `base = initial_rtt / 10` → 33.3 ms for the default;
+- the interval before attempt `a` is the _increment_ of the exponential, `base · 2^(a-1)`, capped at
+  `MAX_INTERVAL = 2 s` (`MAX_BACKOFF_EXPONENT = 8`);
+- the observed sequence from the tests is `33.3, 66.6, 133.2, 266.4, 532.8, 1065.6, 2000 (cap)` ms
+  ([`n0_nat_traversal.rs:1005-1008`][nat]) — "up to 4s by default";
+- it returns `None` (arm no timer) once no remote has retries remaining.
+
+### The punched path's multipath lifecycle
+
+Once opened, the punched 4-tuple is an ordinary multipath path ([`paths.rs`][paths]). Even though the
+QNT probe already validated the _address_, the new `PathId` still undergoes a **full on-path RFC 9000
+§8.2 validation** before iroh sees it as usable: `ensure_path` marks it `pending_challenge`, the first
+on-path `PATH_CHALLENGE` flips its `OpenStatus` from `Pending` to `Sent` and arms
+`AbandonFromValidation` at `now + 3 × (pto_base + max_ack_delay)`, and a matching on-path
+`PATH_RESPONSE` sets `validated = true`, emits `PathEvent::Established`, and seeds the initial RTT
+([`connection/mod.rs:5604-5655`][conn-proto]). Path status is `Available` or `Backup`; the iroh driver
+promotes the selected path to `Available` and leaves the rest `Backup`. A path is abandoned
+(`PATH_ABANDON` frame) on idle timeout, validation failure, network change, remote abandon, or
+application close; abandoning the last path arms a `NoAvailablePath` grace timer (3×PTO) and, if no
+replacement opens, closes the connection with `NO_VIABLE_PATH`
+([`connection/mod.rs:652-667`][conn-proto]). Full path lifecycle, scheduling and CID plumbing:
+[QUIC Transport][quic-transport].
+
+### The iroh driver: `RemoteStateActor`
+
+`iroh/src/socket/remote_map/remote_state.rs` is the tokio actor that turns raw QNT/path primitives
+into iroh's "one endpoint, possibly several connections and paths, pick the best" model. Per remote
+`EndpointId` there is one `RemoteStateActor` driving a biased `tokio::select!` loop
+([`remote_state.rs:272-332`][remote-state]) over: its inbox, per-connection `path_events` and
+`nat_traversal_updates` streams, connection-close notifications, local direct-address changes,
+scheduled hole-punch/path-open timers, address-lookup results, and a periodic `UPGRADE_INTERVAL`
+(60 s) check.
+
+Hole-punch orchestration is deliberately economical about _which_ connection punches
+([`remote_state.rs:508-511`][remote-state]):
+
+> _"Holepunching happens on the Connection with the lowest ConnId which is a client. - Both endpoints
+> may initiate holepunching if both have a client connection. - Any opened paths are opened on all
+> other connections without holepunching."_
+
+- `update_qnt_candidates` diffs the current direct-address set against the connection's advertised QNT
+  addresses and calls `add`/`remove_nat_traversal_address`, keeping noq's advertised set in sync.
+- `trigger_holepunching` picks the lowest-`ConnId` client connection; if candidates are unchanged since
+  the last attempt and it was recent, it defers via a `scheduled_holepunch` timer
+  (`HOLEPUNCH_ATTEMPTS_INTERVAL = 5 s`); otherwise it calls `do_holepunching`.
+- `do_holepunching` calls `conn.initiate_nat_traversal_round()`, records a `HolepunchAttempt`, and on
+  `Multipath`/`NotEnoughAddresses` errors reschedules in 100 ms.
+- Successful paths surface as `PathEvent::Established`; the actor registers the path, replays it onto
+  all other connections (`open_path_on_all_conns`), and re-runs its biased-RTT `select_path`.
+
+Re-hole-punch triggers: remote-candidate updates, local-address updates, a major network change, and
+the periodic `check_connections` when no IP path is "good enough" (`GOOD_ENOUGH_LATENCY = 10 ms`).
+
+The relevant iroh constants ([`iroh/src/socket.rs`][iroh-socket], [`remote_state.rs`][remote-state]):
+
+| Constant                      | Value   | Role                                                       |
+| ----------------------------- | ------- | ---------------------------------------------------------- |
+| `MAX_MULTIPATH_PATHS`         | `8`     | concurrent multipath paths                                 |
+| `MAX_QNT_ADDRESSES`           | `32`    | advertised QNT candidate addresses                         |
+| `HEARTBEAT_INTERVAL`          | `5 s`   | multipath keep-alive ping                                  |
+| `PATH_MAX_IDLE_TIMEOUT`       | `15 s`  | direct-path idle timeout (3× heartbeat)                    |
+| `RELAY_PATH_MAX_IDLE_TIMEOUT` | `30 s`  | relayed-path idle timeout                                  |
+| `HOLEPUNCH_ATTEMPTS_INTERVAL` | `5 s`   | min gap between hole-punch attempts (unchanged candidates) |
+| `GOOD_ENOUGH_LATENCY`         | `10 ms` | below which a path is not upgraded                         |
+| `UPGRADE_INTERVAL`            | `60 s`  | periodic path-upgrade check                                |
+| `ACTOR_MAX_IDLE_TIMEOUT`      | `60 s`  | per-remote actor idle shutdown                             |
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+All integers are QUIC varints unless a fixed width is stated; IPs are raw network-order bytes (4 or
+16), ports are `u16` big-endian. There is no `postcard`/serde here — frames are hand-encoded via the
+`Encodable`/`Decodable` traits ([`frame.rs`][frame]). See [Wire Formats & Serialization][wire] for how
+this differs from iroh's `postcard` types.
+
+A distinctive choice: **the address family is encoded in the frame type id**, not a discriminator byte.
+`OBSERVED_ADDRESS`, `ADD_ADDRESS`, and `REACH_OUT` each have separate v4/v6 ids, and the decoder is told
+`is_ipv6` from the id itself ([`frame.rs:1665-1692`][frame]).
+
+| Frame                   | Type id (varint)                  | Body                                        | Cite                        |
+| ----------------------- | --------------------------------- | ------------------------------------------- | --------------------------- |
+| `PATH_CHALLENGE`        | `0x1a`                            | `u64` token (fixed 8 bytes)                 | [`frame.rs:81`][frame]      |
+| `PATH_RESPONSE`         | `0x1b`                            | `u64` token                                 | [`frame.rs:83`][frame]      |
+| `OBSERVED_ADDRESS`      | `0x9f81a6` (v4) / `0x9f81a7` (v6) | `varint(seq_no)` ‖ `ip(4/16)` ‖ `u16(port)` | [`frame.rs:100-103`][frame] |
+| `ADD_ADDRESS`           | `0x3d7f90` (v4) / `0x3d7f91` (v6) | `varint(seq_no)` ‖ `ip` ‖ `u16(port)`       | [`frame.rs:126-129`][frame] |
+| `REACH_OUT`             | `0x3d7f92` (v4) / `0x3d7f93` (v6) | `varint(round)` ‖ `ip` ‖ `u16(port)`        | [`frame.rs:130-133`][frame] |
+| `REMOVE_ADDRESS`        | `0x3d7f94`                        | `varint(seq_no)`                            | [`frame.rs:134-135`][frame] |
+| `PATH_ABANDON`          | `0x3e75`                          | `varint(path_id)` ‖ `error_code`            | [`frame.rs:109-110`][frame] |
+| `PATH_STATUS_BACKUP`    | `0x3e76`                          | `varint(path_id)` ‖ `varint(status_seq_no)` | [`frame.rs:111-112`][frame] |
+| `PATH_STATUS_AVAILABLE` | `0x3e77`                          | `varint(path_id)` ‖ `varint(status_seq_no)` | [`frame.rs:113-114`][frame] |
+| `MAX_PATH_ID`           | `0x3e7a`                          | `varint(path_id)`                           | [`frame.rs:119-120`][frame] |
+| `PATHS_BLOCKED`         | `0x3e7b`                          | `varint(path_id)`                           | [`frame.rs:121-122`][frame] |
+| `PATH_CIDS_BLOCKED`     | `0x3e7c`                          | `varint(path_id)` ‖ `varint(count)`         | [`frame.rs:123`][frame]     |
+
+QNT and QAD frames ride the normal packet dataplane, ordered inside `populate_packet` after the ACK and
+`PATH_CHALLENGE`/`PATH_RESPONSE` frames but before `CRYPTO`/stream data
+([`connection/mod.rs:6061-6540`][conn-proto]); the exact frame order and coalescing rules are in
+[QUIC Transport][quic-transport]. The off-path probe datagram carries just the `PATH_CHALLENGE`
+(unpadded); the off-path response carries the `PATH_RESPONSE` padded to 1200.
+
+### Cryptography & identity
+
+QNT introduces **no cryptography of its own** — this is a finding, and a sharp contrast to iroh 0.x's
+DISCO, which had its own key exchange and authenticated magic packets. Every QNT and QAD frame is a
+frame in the QUIC **Data (1-RTT) space**, protected by the connection's AEAD keys: they are encrypted
+and authenticated by the same TLS 1.3 session that authenticates the peer's [EndpointId][identity-crypto].
+An off-path `PATH_CHALLENGE` is a full QUIC short-header packet, sealed with the connection keys and
+sent to a new candidate 4-tuple; there is no unauthenticated side-channel to spoof. Because noq is
+multipath, the **`PathId` is mixed into the AEAD nonce** (via mainline rustls 0.23's
+`encrypt_in_place_for_path`), so a packet on one path cannot be replayed as another path's — see
+[QUIC Transport § crypto][quic-transport]. The `PATH_CHALLENGE` token itself is a random `u64` drawn
+from the connection's RNG, and validation is by token match plus source-4-tuple.
+
+Address validation and amplification is the security envelope hole-punching operates inside. QUIC's
+§8.1 rule — until a peer's address is validated, a server may send it at most **3× the bytes it has
+received** — is enforced _per path_ (`total_recvd · 3 < total_sent`, [`paths.rs:407-408`][paths]),
+which matters precisely because hole-punching creates many unvalidated paths at once. The
+unpadded-probe / padded-response asymmetry is the deliberate amplification trade-off in miniature: the
+prober spends a small packet, and the responder's 1200-byte reply is bounded by that path's 3× budget.
+
+The connection-establishment token machinery (Retry tokens, `NEW_TOKEN` validation tokens) is adjacent
+but largely **dormant in stock iroh 1.0.1**. iroh depends on noq with `default-features = false` and
+without the `bloom` feature, so `BloomTokenLog` is not even compiled and `ValidationTokenConfig::default()`
+degrades to `NoneTokenLog` with `sent: 0` ([`config/mod.rs:519-531`][cfg-mod]): default iroh servers
+send **zero** `NEW_TOKEN` frames and treat any received validation token as absent. The **Retry** half
+is always live (a noq server may answer an Initial with a Retry packet under load; iroh's router exposes
+it via `IncomingFilterOutcome::Retry`), binding the client's exact `ip:port` and valid for 15 s. iroh
+freshly randomizes its token AEAD key (`RustlsTokenKey`) at every `Endpoint::bind`, so tokens never
+survive a process restart. The reuse rule that matters for a port is anti-replay: a `TokenLog` "MUST
+ensure that replay of tokens is prevented or limited" ([`token.rs:21-23`][token], quoting RFC 9000
+§8.1.4), and `take` on the client store "must never be returned twice, as doing so can be used to
+de-anonymize a client's traffic" ([`token.rs:87-89`][token]). Full token lifecycle:
+[QUIC Transport][quic-transport].
+
+### State machines & lifecycle
+
+Seven state machines interlock. Three are the QNT core; the rest are the multipath and iroh-driver
+lifecycles that a punched path flows through.
+
+**SM-1 — QNT `State` (per connection).** `NotNegotiated` → `ClientSide(ClientState)` or
+`ServerSide(ServerState)` on `handle_peer_params` if both transport parameters and MP are present; the
+side is terminal and never flips ([`n0_nat_traversal.rs:144-165`][nat]).
+
+**SM-2 — `ProbeState` per remote candidate.** `Active(n)` counts down remaining retries;
+`queue_retries` decrements and re-enqueues; a matching `PATH_RESPONSE` moves it to `Succeeded`;
+`Active(0)` stops probing that remote. `retry_delay` returns `None` once no remote has retries left.
+
+**SM-3 — round progression (client).** `round` is monotonic (`saturating_add`); a new round cancels the
+previous by clearing `sent_challenges`/`pending_probes`, so late `PATH_RESPONSE`s no-op. The server
+tracks the client's `round`, ignores `REACH_OUT` for older rounds, and `PendingReachOutFrames` auto-drops
+frames from stale rounds ([`spaces.rs:802-830`][spaces]).
+
+**SM-4 — `OpenStatus` per path.** `Pending` → `Sent` (first on-path `PATH_CHALLENGE`; arms
+`AbandonFromValidation` 3×PTO) → `Informed` (first matching on-path `PATH_RESPONSE`; emits
+`Established`) ([`spaces.rs:498`][spaces], [`connection/mod.rs:5604-5655`][conn-proto]).
+
+**SM-5/6 — path validation and lifecycle.** RFC 9000 §8.2 validation with `PathValidationFailed`,
+`PathChallengeLost`, and `AbandonFromValidation` timers; then `Established → … → Abandoned{reason} →
+(3×PTO drain) → Discarded`. Abandon reasons: `ApplicationClosed`, `ValidationFailed`, `TimedOut`,
+`UnusableAfterNetworkChange`, `RemoteAbandoned` ([`paths.rs:1093-1112`][paths]). Detailed in
+[QUIC Transport][quic-transport].
+
+**SM-7 — iroh hole-punch scheduling.** Triggers (remote-candidate update, local-addr update, major
+network change, `check_connections`) feed `trigger_holepunching`; a guard defers via
+`scheduled_holepunch` (5 s) if candidates are unchanged and an attempt was recent; `do_holepunching`
+reschedules on `Multipath`/`NotEnoughAddresses` in 100 ms; path-open blocked on CIDs re-queues via
+`scheduled_open_path` (333 ms).
+
+**Timing budget of one hole punch.** A default round fires the first probe immediately, then retries at
+`33.3, 66.6, 133.2, 266.4, 532.8, 1065.6, 2000, 2000 ms` (9 attempts), spanning ≈4 s. If it fails, the
+iroh driver waits `HOLEPUNCH_ATTEMPTS_INTERVAL = 5 s` before another round (unless candidates changed),
+and rechecks path quality every `UPGRADE_INTERVAL = 60 s`. A successful probe then costs one more
+on-path validation RTT (bounded by 3×PTO) before `Established`.
+
+### Dependencies & coupling
+
+| Dependency                                                                       | Depth                          | Notes for a D port                                                                                                                                                                                            |
+| -------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `noq-proto` (the QUIC engine)                                                    | load-bearing                   | QNT/QAD/MP are _inside_ the QUIC state machine. Cannot bolt onto an off-the-shelf QUIC — must own a multipath QUIC stack with custom frames + transport parameters. The single biggest reimplementation cost. |
+| `rustc_hash` (`FxHashMap`/`FxHashSet`)                                           | API-surface                    | Fast hash maps keyed on `VarInt`/`IpPort`/`u64`; any D map works.                                                                                                                                             |
+| `bytes` (`Buf`/`BufMut`)                                                         | API-surface                    | Frame encode/decode; a bounded D writer over [`SmallBuffer`][eh-spec] suffices.                                                                                                                               |
+| `tokio::sync::{broadcast, watch, mpsc, oneshot}`                                 | load-bearing (noq/iroh layers) | _These are_ the concurrency model; a port must redesign them (see below).                                                                                                                                     |
+| `n0_future`/`tokio_stream` (`MergeUnbounded`, `FuturesUnordered`, `MaybeFuture`) | load-bearing                   | The actor's select-over-many-streams pattern; needs a fiber redesign.                                                                                                                                         |
+| `iroh_base` (`EndpointId`, `TransportAddr`, `RelayUrl`)                          | load-bearing                   | Addressing types the driver keys on — see [Identity & Cryptography][identity-crypto].                                                                                                                         |
+| [Address Lookup][discovery] / [net_report][net-report]                           | load-bearing (adjacent)        | Feed candidate + reflexive addresses; co-driven with QNT.                                                                                                                                                     |
+
+Algorithms a D port must reimplement with no library shortcut: QUIC multipath path management,
+per-path validation, the QNT round/attempt/backoff machine, off-path challenge/response plumbing, and
+the transport-parameter/frame codecs. All the 0.x folklore — STUN, DISCO, ping/pong side-channels — is
+**gone**; do not port it.
+
+### Concurrency & I/O model
+
+QNT itself is **fully sans-io**: `State`/`ClientState`/`ServerState` are plain structs mutated
+synchronously inside `Connection`'s poll methods. There are no tasks, channels, locks, or timers
+_inside_ `noq-proto`; timing is expressed as `Instant` deadlines returned via the `TimerTable`, and the
+only QNT timer is the `ConnTimer::NatTraversalProbeRetry` entry ([`timer.rs`][timer]), fired by whoever
+drives `handle_timeout`.
+
+The concurrency lives one and two layers up. The async `noq` crate exposes QNT via
+`tokio::sync::broadcast` channels (cap 32) for `path_events` and `nat_traversal_updates`, a
+`watch::Sender<Option<SocketAddr>>` for `observed_external_addr`, and a `FxHashMap<PathId, watch::Sender<…>>`
+resolving each `OpenPath` future ([`noq/src/connection.rs`][conn-async]). iroh's `RemoteStateActor` is a
+tokio task (spawned in a `JoinSet`) with an `mpsc::channel(16)` inbox, a biased `tokio::select!` loop,
+`MergeUnbounded` over per-connection broadcast streams, `FuturesUnordered` for connection-close
+notifications, and two `MaybeFuture<sleep_until>` deferral timers ([`remote_state.rs`][remote-state]).
+There is **no** `Mutex`/`RwLock` on the QNT path beyond the connection's internal `lock_and_wake`
+single-threaded ownership handoff, and **no** `spawn_blocking` anywhere in the subsystem. See the full
+[Tokio Concurrency Inventory][concurrency] for how these primitives are counted across iroh.
+
+One I/O requirement is unusual: QNT off-path probes must be sent to **arbitrary candidate destinations**
+(not the connection's normal remote), and the `FourTuple` carries an optional `local_ip` for source-IP
+control. That needs per-packet destination override and (for `local_ip`) `sendmsg` with `IP_PKTINFO`.
+
+### Mapping to event-horizon
+
+The QNT core is close to an ideal fit for a sans-io D port: `ClientState`/`ServerState` are
+value-mutating structs whose methods return "frames to send" and "next deadline", the `retry_delay`
+math is pure integer arithmetic on `Duration`, and there is no allocation on the hot path once the maps
+are sized. Under [event-horizon][eh-spec]'s default `single` topology, one fiber owns the `Connection`
+value outright; the six pump methods become plain method calls, and the whole `TimerTable` collapses
+(as the noq async wrapper already proves) to **one** in-ring `TIMEOUT` op re-armed to `timers.peek()`,
+with `handle_timeout(now)` after each wake.
+
+**The proto state ports 1:1 into `@nogc` D structs.** The Rust `ClientState`
+([`n0_nat_traversal.rs:346`][nat]) alongside a proposed D shape:
+
+```rust
+// noq-proto/src/n0_nat_traversal.rs:346 (trimmed)
+pub(crate) struct ClientState {
+    max_remote_addresses: usize,
+    max_local_addresses: usize,
+    remote_addresses: FxHashMap<VarInt, (CanonicalIpPort, ProbeState)>,
+    local_addresses: FxHashSet<CanonicalIpPort>,
+    round: VarInt,
+    attempt: u8,
+    sent_challenges: FxHashMap<u64, IpPort>,
+    pending_probes: FxHashSet<IpPort>,
+    paths_to_be_opened: Vec<FourTuple>,
+}
+```
+
+```d
+// proposed / sketch — a plain value type owned by the connection fiber.
+// Path counts are <= 8 (MAX_MULTIPATH_PATHS) and addresses <= 32
+// (MAX_QNT_ADDRESSES), so fixed-capacity SmallBuffers beat hashmaps and
+// keep the whole struct @nogc.
+struct ClientState
+{
+    size_t maxRemoteAddresses;
+    size_t maxLocalAddresses;
+    SmallBuffer!(RemoteCandidate, 32) remoteAddresses;   // keyed by seqNo, linear scan
+    SmallBuffer!(CanonicalIpPort, 32) localAddresses;
+    VarInt round;
+    ubyte attempt;
+    SmallBuffer!(SentChallenge, 32) sentChallenges;      // token -> IpPort
+    SmallBuffer!(IpPort, 32) pendingProbes;
+    SmallBuffer!(FourTuple, 8) pathsToBeOpened;          // validated, awaiting openPath
+}
+
+struct RemoteCandidate { VarInt seqNo; CanonicalIpPort addr; ProbeState probe; }
+struct SentChallenge   { ulong token; IpPort remote; }
+```
+
+**The retry schedule is `@safe pure nothrow @nogc` verbatim** — pure `Duration` arithmetic, ideal for
+a [`TestClock`][eh-spec]-driven deterministic test that walks the backoff without any real time:
+
+```d
+// proposed / sketch — mirrors n0_nat_traversal.rs:306-343.
+// Returns the delay before the given 1-based attempt, or none() to stop.
+enum Duration MAX_INTERVAL = 2.seconds;
+enum ubyte MAX_BACKOFF_EXPONENT = 8;
+
+Nullable!Duration retryDelay(Duration initialRtt, ubyte attempt) @safe pure nothrow @nogc
+{
+    if (attempt == 0) return typeof(return).init;           // nothing to probe -> stop
+    const base = initialRtt / 10;                           // 33.3 ms at the 333 ms default
+    const exp = cast(uint) min(attempt - 1, MAX_BACKOFF_EXPONENT);
+    const interval = base * (1UL << exp);                   // base * 2^(attempt-1)
+    return nullable(interval < MAX_INTERVAL ? interval : MAX_INTERVAL);
+}
+```
+
+The `NatTraversalProbeRetry` timer becomes an in-ring `TIMEOUT` op or a `withDeadline` cancel scope on
+the connection fiber: the fiber sleeps until the deadline, then calls `queueRetries` and re-arms.
+Panics-as-invariants (`path_data()` panics on an unknown `PathId`, state transitions assert legality)
+map to `assert`/contract `in`-clauses, **not** `Expected` — these are defects (`Cause: die`), not
+retryable errors.
+
+**What has no event-horizon equivalent and needs new design:**
+
+- **`tokio::sync::broadcast(32)` (`path_events`, `nat_traversal_updates`) and `watch` cells** — the
+  cross-fiber channel gap ([open-issue O20][eh-spec]). Under `single` topology, everything runs on one
+  loop, so the cleanest port replaces the broadcast with **direct method calls / a small single-threaded
+  observer registry**: the connection fiber synchronously invokes the driver's handler instead of
+  pushing to a channel. The `Lagged` back-pressure semantics (drop + report count) exist only because
+  tokio has a cross-thread producer; a single-threaded port can drop the bounded buffer entirely. The
+  `watch::Sender<Option<SocketAddr>>` for `observed_external_addr` becomes a single-value cell plus a
+  `Waker`/notify list the reader awaits.
+- **The `RemoteStateActor`'s `tokio::select!` over many merged streams** maps to **one fiber running a
+  [`race`][eh-spec]/first-completion over its event sources** inside a [`Scope`][eh-spec]. Under
+  single-thread ownership the actor can call directly into each connection's state instead of merging
+  broadcast streams — there is no thread boundary to cross. `MaybeFuture<sleep_until>` → arm/disarm a
+  deadline; `time::interval(UPGRADE_INTERVAL)` → a `repeat`/`Schedule` driver; the `JoinSet` of
+  per-remote actors → one `Scope.fork` per `EndpointId`, joined at endpoint shutdown, with the actor
+  idle-timeout expressed as a `withDeadline`. The `mpsc::channel(16)` inbox is the same O20 gap: for
+  synchronous messages a capability-method call (endpoint fiber → remote-state handler) replaces the
+  mailbox; only genuinely deferred work needs a queue.
+
+```rust
+// iroh: the actor loop (shape) — remote_state.rs:272-332
+loop {
+    tokio::select! { biased;
+        msg = inbox.recv()          => { /* AddConnection, SendDatagram, NetworkChange, … */ }
+        Some(ev) = path_events.next() => { /* Established -> register + replicate path */ }
+        Some(ev) = addr_events.next() => { /* AddressAdded/Removed -> holepunch trigger */ }
+        _ = &mut scheduled_holepunch  => { self.trigger_holepunching(); }
+        _ = &mut scheduled_open_path  => { self.drain_pending_open_paths(); }
+        _ = upgrade_interval.tick()   => { self.check_connections(); }
+    }
+}
+```
+
+```d
+// proposed / sketch — one fiber owns the remote's state; no channels needed
+// because every producer runs on the same loop under `single` topology.
+void runRemote(ref Scope scope, ref RemoteState st) @safe
+{
+    scope.withDeadline(ACTOR_MAX_IDLE_TIMEOUT, {
+        for (;;)
+        {
+            // race over the remote's event sources; the loser branches are cancelled.
+            final switch (race(
+                st.inbox.recv(),               // capability-method call, not mpsc
+                st.nextPathEvent(),            // direct call into owned connections
+                st.holepunchDeadline(),        // arm/disarm, replaces MaybeFuture
+                st.upgradeTick()))             // Schedule.recurs(UPGRADE_INTERVAL)
+            {
+                case Inbox:      st.handleMessage(); break;
+                case PathEvent:  st.registerAndReplicatePath(); break;
+                case Holepunch:  st.triggerHolepunching(); break;
+                case Upgrade:    st.checkConnections(); break;
+            }
+        }
+    });
+}
+```
+
+**Single-threaded implications.** No `Arc<Mutex<Connection>>` is needed: noq's `lock_and_wake` guard
+exists only because tokio may poll the connection from arbitrary threads. Under `single` topology the
+connection is owned by one fiber; the lock is zero code. But the **CPU cost stays on the loop thread** —
+off-path probe construction, AEAD sealing of each probe packet, and path validation all run inline on
+the single event-loop fiber, with no `spawn_blocking` escape hatch (event-horizon has no thread pool;
+this is fine here because QNT is not CPU-heavy). The one genuine gap is **UDP off-path sends**: probes
+need per-packet destination override, and `FourTuple.local_ip` needs source-IP control. Event-horizon's
+`msghdr`-based `sendmsg`/`recvmsg` is [open-issue O19][eh-spec], so the NAT-probe path is a concrete
+motivating case for closing it — the current tier-B verbs cannot express a per-datagram destination or
+`IP_PKTINFO` source. The broader tokio → event-horizon translation is in
+[D Architecture Migration][d-migration].
+
+---
+
+## Strengths
+
+- **One security domain.** Hole-punching frames are ordinary QUIC frames on the encrypted, authenticated
+  1-RTT dataplane — no separate DISCO keys, no unauthenticated magic packets, no STUN. An attacker
+  cannot forge a `REACH_OUT` or `ADD_ADDRESS` without breaking the QUIC session.
+- **Sans-io core.** `noq-proto`'s QNT engine is a pure state machine (no tasks, channels, locks, or
+  timers), deterministically testable with injected time and RNG — an excellent fit for a single-fiber
+  D port and `TestClock`-driven simulation.
+- **A punched hole is a first-class path.** A successful probe yields a real multipath `PathId` with its
+  own validation, congestion control, and idle timeout, that the connection can fail over to or run in
+  parallel with the relayed path — not a bolted-on side-channel.
+- **Reuses QUIC's amplification defenses.** Per-path 3× anti-amplification, the unpadded-probe /
+  padded-response asymmetry, and existing address-validation machinery bound abuse without new
+  protocol surface.
+- **Economical orchestration.** iroh hole-punches on only the lowest-`ConnId` client connection and
+  replicates opened paths onto the others without re-punching, keeping probe volume low.
+
+## Weaknesses
+
+- **QUIC is now load-bearing for connectivity.** Because QNT/QAD/MP live inside the QUIC state machine,
+  a port cannot use an off-the-shelf QUIC library — it must reimplement a multipath QUIC stack with
+  custom frames and transport parameters. This is the port's dominant cost.
+- **Private, non-interoperable codepoints.** The QNT transport-parameter id (`0x3d7f91120401`) and frame
+  ids (`0x3d7f90…`) are n0-private; QNT is "simplified to n0's own protocol", so there is no external
+  spec to conform to — only the source is authoritative, and it can change between minor versions.
+- **Amplification vs. speed is a live tension.** Unpadded probes validate only the address, and probes
+  are sent to arbitrary candidate addresses (possibly "innocent bystanders on the internet"); the safety
+  argument rests on the 9-attempt cap and per-path 3× limit rather than a proof.
+- **Concurrency-heavy driver.** The iroh `RemoteStateActor` leans on `broadcast`/`watch`/`mpsc`/`JoinSet`
+  and stream-merging combinators with no direct event-horizon equivalents — the redesign is real work,
+  even though single-threading simplifies it.
+- **Unbounded `paths_to_be_opened`.** There is an acknowledged `TODO` that validated-but-unopened paths
+  are bounded only by the candidate-set size, with no time limit ([`n0_nat_traversal.rs:399`][nat]).
+- **Server single-shot probes are not locally retried** to un-advertised client addresses — the peer is
+  expected to keep retrying its challenges ([`n0_nat_traversal.rs:642-646`][nat]), so behaviour under
+  correlated loss is subtle.
+
+## Key design decisions and trade-offs
+
+| Decision                                                              | Rationale                                                                               | Trade-off                                                                                               |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| NAT traversal entirely inside QUIC (no DISCO/STUN)                    | One authenticated/encrypted security domain; no side-protocol to secure separately      | QUIC becomes load-bearing for connectivity; a port must own a multipath QUIC stack                      |
+| QAD (`OBSERVED_ADDRESS`) replaces STUN                                | Learn reflexive address from the peer/relay in-band; no separate STUN server or packets | Requires the peer/relay to support QAD; a dedicated `/iroh-qad/0` relay path is still needed            |
+| QNT roles fixed by QUIC client/server side                            | No role negotiation; only the client opens paths (multipath rule)                       | Who's behind NAT is irrelevant to who initiates; both must still probe simultaneously                   |
+| Both peers probe simultaneously (simultaneous open)                   | Punches both NATs at once; each NAT sees the outbound as an expected reply              | Needs coordinated timing (rounds); a lost `REACH_OUT` delays the whole round                            |
+| Probe `PATH_CHALLENGE` unpadded; response padded to 1200              | Cheap probes; validate the address fast without paying full-MTU cost per attempt        | Only the address (not the path MTU) is validated; response is the amplification-bounded side            |
+| Capped exponential backoff scaled to `initial_rtt` (≈4 s, 9 attempts) | Recovers from loss and NAT quirks without hammering bystanders                          | Fixed budget; very lossy or slow paths may exhaust attempts before punching                             |
+| QNT auto-enables multipath (8 paths) when set                         | A punched hole must become a real path; MP is a hard prerequisite                       | Turning on QNT silently turns on MP with its CID/path overhead                                          |
+| iroh punches only on the lowest-`ConnId` client connection            | Minimizes probe volume; opened paths are replicated to other connections                | A single connection's failure to punch blocks the shared result until re-triggered                      |
+| Sans-io proto core, concurrency in the wrapper/driver                 | Deterministic, portable engine; async model is swappable                                | The wrapper's `broadcast`/`watch`/`mpsc`/`select!` layer is bespoke and must be re-designed per runtime |
+
+---
+
+## Sources
+
+Primary source — `noq-proto` (QNT/QAD/MP core):
+
+- [`noq-proto/src/n0_nat_traversal.rs`][nat] — the QNT sans-io state machine: `State`/`ClientState`/`ServerState`, `ProbeState`, rounds, `retry_delay`, `MAX_NAT_PROBE_ATTEMPTS`.
+- [`noq-proto/src/address_discovery.rs`][qad] — QAD `Role` (send/receive) and its transport-parameter varint mapping.
+- [`noq-proto/src/frame.rs`][frame] — `FrameType` id table and the `ObservedAddr`/`AddAddress`/`ReachOut`/`RemoveAddress`/`PathChallenge`/`PathResponse`/multipath frame structs.
+- [`noq-proto/src/transport_parameters.rs`][tparams] — QAD/MP/QNT parameter ids and (de)serialization.
+- [`noq-proto/src/config/transport.rs`][cfg-transport] — QNT/MP config knobs, MP auto-enable, default `initial_rtt`.
+- [`noq-proto/src/config/mod.rs`][cfg-mod] — token/validation config defaults (`bloom`-gated).
+- [`noq-proto/src/connection/mod.rs`][conn-proto] — the driver: `send_nat_traversal_path_challenge`, off-path sends, `open_nat_traversed_paths`, frame handling, `NatTraversalProbeRetry`.
+- [`noq-proto/src/connection/paths.rs`][paths] — `PathData`, `PathStatus`, `PathEvent`, path validation, anti-amplification, off-path `PathResponses`.
+- [`noq-proto/src/connection/spaces.rs`][spaces] — `OpenStatus`, `PendingReachOutFrames`, pending QNT frame sets.
+- [`noq-proto/src/connection/timer.rs`][timer] — `ConnTimer::NatTraversalProbeRetry` and the `TimerTable`.
+- [`noq-proto/src/token.rs`][token] — `TokenLog`/`TokenStore` traits, anti-replay contract (RFC 9000 §8.1.4).
+
+Primary source — iroh & relay:
+
+- [`iroh/src/socket/remote_map/remote_state.rs`][remote-state] — the `RemoteStateActor` hole-punch driver.
+- [`iroh/src/endpoint/quic.rs`][iroh-quic] — `QuicTransportConfigBuilder` wiring QNT/QAD/MP defaults.
+- [`iroh/src/socket.rs`][iroh-socket] — `MAX_MULTIPATH_PATHS`, `MAX_QNT_ADDRESSES`, timeouts.
+- [`iroh/src/net_report.rs`][iroh-netreport] — QAD probe consumers.
+- [`iroh-relay/src/quic.rs`][relay-quic] — the QAD server (`ALPN_QUIC_ADDR_DISC = "/iroh-qad/0"`).
+
+Specs & drafts:
+
+- [`draft-seemann-quic-nat-traversal`][draft-qnt] (QNT inspiration, `-02`), [`draft-ietf-quic-multipath`][draft-multipath], [`draft-seemann-quic-address-discovery`][draft-qad]; [RFC 9000][rfc9000] §8.1 (amplification), §8.2 (path validation); [RFC 9002][rfc9002] (loss/PTO).
+
+Related pages: [Concepts & Vocabulary][concepts] · [QUIC Transport][quic-transport] · [The Multipath Socket][socket] · [The Relay Protocol][relay] · [Address Lookup][discovery] · [Net Report][net-report] · [Identity & Cryptography][identity-crypto] · [Wire Formats][wire] · [Endpoint & Protocol Router][endpoint] · [Tokio Concurrency Inventory][concurrency] · [D Architecture Migration][d-migration] · umbrella: [Iroh survey][index] · [event-horizon spec][eh-spec] · async-io: [Tokio][tokio], [Glommio][glommio].
+
+<!-- References -->
+
+[sec-qad]: #sec-qad
+[nat]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/n0_nat_traversal.rs
+[qad]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/address_discovery.rs
+[frame]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/frame.rs
+[tparams]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/transport_parameters.rs
+[cfg-transport]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/config/transport.rs
+[cfg-mod]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/config/mod.rs
+[conn-proto]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/mod.rs
+[paths]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/paths.rs
+[spaces]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/spaces.rs
+[timer]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/timer.rs
+[token]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/token.rs
+[conn-async]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq/src/connection.rs
+[remote-state]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs
+[iroh-quic]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/quic.rs
+[iroh-socket]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs
+[iroh-netreport]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs
+[relay-quic]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/quic.rs
+[noq-readme]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/README.md
+[iroh-repo]: https://github.com/n0-computer/iroh/tree/22cac742ca
+[docs-noq-proto]: https://docs.rs/noq-proto/1.0.1/noq_proto/
+[docs-iroh]: https://docs.rs/iroh/1.0.1/iroh/
+[rfc9000]: https://www.rfc-editor.org/rfc/rfc9000.html
+[rfc9002]: https://www.rfc-editor.org/rfc/rfc9002.html
+[draft-multipath]: https://datatracker.ietf.org/doc/draft-ietf-quic-multipath/
+[draft-qad]: https://datatracker.ietf.org/doc/draft-seemann-quic-address-discovery/
+[draft-qnt]: https://datatracker.ietf.org/doc/draft-seemann-quic-nat-traversal/
+[index]: ./index.md
+[concepts]: ./concepts.md
+[identity-crypto]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[quic-transport]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[net-report]: ./net-report.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[tokio]: ../async-io/tokio.md
+[glommio]: ../async-io/glommio.md

--- a/docs/research/iroh/net-report.md
+++ b/docs/research/iroh/net-report.md
@@ -1,0 +1,527 @@
+# Net Report, Interface Watching & Port Mapping
+
+iroh's connectivity-sensing layer — the descendant of Tailscale's `netcheck` that answers "what does the network look like from here right now": does UDP work over IPv4/IPv6, what public address does the world see, is the NAT mapping endpoint-dependent (symmetric), which relay is closest, and is there a captive portal — measured entirely through QUIC Address Discovery and HTTPS (STUN and ICMP are **gone**), fed by per-OS interface/route watching (`netwatch`) and UPnP/PCP/NAT-PMP port mapping (`portmapper`).
+
+| Field               | Value                                                                                                                                                                                                                                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)            | `iroh` module `net_report` (`net_report/{reportgen,probes,report,options,defaults,metrics}`) + the `portmapper` wrapper module; standalone `netwatch` and `portmapper` crates (the [`net-tools`][nettools] workspace)                                                                                   |
+| Version             | iroh **v1.0.1** (git `v1.0.1-6-g22cac742ca`, commit `22cac742ca`); `netwatch` **0.19.1** + `portmapper` **0.19.1** (net-tools commit `051ab876`, = tags `netwatch-v0.19.1` / `portmapper-v0.19.1`)                                                                                                      |
+| Repository          | [`n0-computer/iroh`][repo] (module `iroh/src/net_report/`), [`n0-computer/net-tools`][nettools] (`netwatch/`, `portmapper/`)                                                                                                                                                                            |
+| Documentation       | [docs.rs/iroh][docs] — `net_report` is `pub(crate)`, surfaced only through `Endpoint::net_report()`; [docs.rs/netwatch][docs-netwatch], [docs.rs/portmapper][docs-portmapper]                                                                                                                           |
+| ALPN(s)             | `/iroh-qad/0` — the QUIC Address Discovery probe ALPN ([`ALPN_QUIC_ADDR_DISC`][qad-alpn], via [`iroh-relay`][relay]). HTTPS/captive-portal probes are plain HTTP(S), no ALPN of iroh's own                                                                                                              |
+| Approx. size (LoC)  | ~2.8k `net_report` module + ~0.1k `portmapper` wrapper (iroh); ~4.9k `netwatch` (`udp.rs` 1218, `interfaces*` ~1.8k, `netmon*` ~0.7k); ~2.7k `portmapper` crate (`lib.rs` 794 + PCP/NAT-PMP/UPnP + wire codecs) — ≈**10.5k** total                                                                      |
+| Category            | Connectivity                                                                                                                                                                                                                                                                                            |
+| Upstream spec/draft | QAD = [draft-seemann-quic-address-discovery][qad-draft] (in [`noq-proto`][quic]); [RFC 6887][rfc6887] (PCP); [RFC 6886][rfc6886] (NAT-PMP); [UPnP-IGD][igd] `WANIPConnection` (SSDP + SOAP); captive-portal via the `generate_204` convention. Descends from Tailscale [`netcheck`][tailscale-netcheck] |
+
+> [!NOTE]
+> This is iroh's connectivity-sensing tier, restructured for 1.0. The subsystem is **three cooperating pieces**: `net_report` (the report generator, owned by [`socket`][socket]), `netwatch` (interface enumeration + route-change monitoring + the rebindable `UdpSocket`), and `portmapper` (UPnP/PCP/NAT-PMP). In iroh 0.x this was `netcheck` + `portmapper` and probed with **STUN** (UDP v4/v6) and **ICMP**; in 1.0 both are gone — the only probes are QUIC Address Discovery ("QAD") over the _main_ [`noq`][quic] endpoint and HTTPS. `NodeId` → [`EndpointId`][identity], "discovery" → `address_lookup` (see [`discovery`][discovery]); vocabulary in [Concepts][concepts]. Part of the [iroh survey][index].
+
+---
+
+## Overview
+
+### What it solves
+
+A peer that wants direct connectivity must first understand its own vantage point. `net_report` measures it: it decides whether the host has working UDP on each address family, what public `SocketAddr` a remote observer assigns it (the raw material for a direct-address candidate), whether that mapping is stable across destinations or varies per-peer (a symmetric NAT that defeats naive hole-punching), which configured relay is lowest-latency (the _home relay_), and whether a captive portal is intercepting traffic. Those findings drive two decisions in the [`socket`][socket] layer above it: **which relay to camp on** and **which direct-address candidates to advertise** for [NAT traversal][nat].
+
+Two sibling subsystems supply the inputs. `netwatch` enumerates network interfaces, finds the default gateway, and watches the OS for link changes so a report is re-run when the network moves underfoot; it also owns the rebindable `UdpSocket` through which every QUIC datagram actually flows. `portmapper` asks the local router (via UPnP, PCP, or NAT-PMP) to install an explicit port mapping and keep it renewed, yielding a fourth kind of direct-address candidate (`Portmapped`). Together they are the layer where a native port learns exactly which raw OS surface — netlink sockets, `AF_ROUTE` routing sockets, `sysctl` route dumps, `/proc/net/route`, Win32 IP Helper notifications, `getifaddrs`, and the PCP/NAT-PMP datagram codecs — it must bind.
+
+### Design philosophy
+
+`net_report` states its remit at the top of the module ([`net_report.rs:3`][nr-doc]):
+
+> _"NetReport is responsible for finding out the network conditions of the current host, like whether it is connected to the internet via IPv4 and/or IPv6, what the NAT situation is etc and reachability to the configured relays."_
+
+It is explicitly _"Based on `https://github.com/tailscale/tailscale/blob/main/net/netcheck/netcheck.go`"_ ([`net_report.rs:6`][nr-doc]), and the 1.0 rewrite keeps `netcheck`'s _shape_ — a periodic, timeout-bounded, best-effort report merged into rolling history with hysteresis on the preferred relay — while replacing its _substrate_ wholesale. Three convictions follow, each with a direct consequence for a port:
+
+1. **Probe with the transport you already have.** Rather than a bespoke STUN/ICMP probe socket, QAD rides the _main_ [`noq`][quic] endpoint (`ep: endpoint.clone()`, [`socket.rs:1046`][sk-ep]). Because the probe originates from the very UDP socket whose mapping it measures, the discovered `global_v4` is a _valid direct-address candidate_ — there is no "the probe socket saw a different mapping than the data socket" class of bug. Address discovery is a QUIC extension ([draft-seemann-quic-address-discovery][qad-draft]) implemented in [`noq-proto`][quic]; `net_report` merely consumes `conn.observed_external_addr()` and `conn.rtt(PathId::ZERO)`.
+
+2. **Fail soft, always.** Every probe is racing and cancellable; the whole report is bounded by `OVERALL_REPORT_TIMEOUT` = 5 s ([`defaults.rs`][defaults]) and the socket wraps `get_report` in `NET_REPORT_TIMEOUT` = 10 s ([`defaults.rs:129`][sk-nettimeout]). HTTPS exists only as a fallback for QUIC-blocked networks ([`net_report.rs:97`][nr-https]):
+
+   > _"Disabling them is harmless on networks that do allow QUIC traffic, but will completely prevent finding the home relay on networks that do block QUIC."_
+
+3. **Reuse, don't re-probe.** A successful QAD connection is kept alive (25 s keep-alive, 35 s idle timeout) and its observed-address updates streamed into a watcher, so subsequent _incremental_ reports read a live NAT-refreshing connection instead of dialing again — report generation is partly passive observation, not active probing.
+
+Within the survey this page is the connectivity-sensing counterpart to [`socket`][socket] (which _consumes_ its output), [`nat-traversal`][nat] (which uses the discovered candidates and symmetric-NAT flag), and [`relay`][relay] (whose home-relay selection this drives). The io_uring/kqueue/IOCP surface a port needs is surveyed in the [async-io tree][async-io].
+
+---
+
+## How it works
+
+### Three probe kinds (STUN and ICMP are gone)
+
+The `Probe` enum has exactly three variants ([`probes.rs:25`][probes]) — down from 0.x's six (STUN v4/v6, ICMP v4/v6, HTTPS, plus HTTP):
+
+```rust
+// iroh/src/net_report/probes.rs:25
+pub enum Probe {
+    Https,
+    #[cfg(not(wasm_browser))] QadIpv4,
+    #[cfg(not(wasm_browser))] QadIpv6,
+}
+```
+
+**QAD probe.** The client dials each relay's QUIC address-discovery listener at the relay's QUIC port (default `DEFAULT_RELAY_QUIC_PORT` = **7842**, [`defaults.rs:7`][qad-port]) with ALPN `/iroh-qad/0` ([`quic.rs:10`][qad-alpn]), resolving the relay host via a _staggered_ A/AAAA DNS lookup (delays `[200, 300, 600, 1000, 2000, 3000]` ms, `DNS_TIMEOUT` 3 s — see [`discovery`][discovery]). The client transport config is tuned for a probe, not a bulk transfer: `initial_rtt(111 ms)`, `receive_observed_address_reports(true)`, `keep_alive_interval(25 s)`, `max_idle_timeout(35 s)` ([`quic.rs:283`][qad-rtt]):
+
+> _"Setting the initial RTT estimate to a low value means we're sacrificing initial throughput, which is fine for QAD, which doesn't require us to have good initial throughput. It also implies a 999ms probe timeout, which means that if the packet gets lost (e.g. because we're probing ipv6, but ipv6 packets always get lost in our network configuration) we time out closing the connection after only 999ms."_
+
+The server side is a plain `noq` endpoint with `send_observed_address_reports(true)` and zero allowed streams ([`quic.rs:102`][qad-server]). A probe _completes_ when the first `OBSERVED_ADDRESS` frame arrives; the result is a `QadProbeReport { relay, latency = conn.rtt(PathId::ZERO), addr }` where `addr` is canonicalized (an IPv4-mapped IPv6 observation collapses to v4) ([`reportgen.rs:447`][qad-report]).
+
+**QAD connection caching.** Winners are _not_ closed. The first v4 winner and first v6 winner are parked in `QadConns { v4, v6 }` ([`net_report.rs:157`][nr-qadconns]); losers are closed with code `1` / reason `b"finished"` ([`quic.rs:14`][qad-alpn]). A per-connection task streams observed-address updates into a `Watchable<Option<QadProbeReport>>`, so incremental reports call `current_v4()`/`current_v6()` (which just refresh the RTT) with no new probe. The 25 s keep-alive doubles as a NAT-binding refresher. On a _full_ report the cache is cleared and re-probed; connections whose `close_reason` is set are evicted.
+
+**HTTPS probe.** `GET {relay_url}/ping` (`RELAY_PROBE_PATH`, [`http.rs:15`][relay-http]) with redirects disabled and DNS overridden by the staggered resolver; latency = time-to-response-headers, body drained ≤ 8 KiB ([`reportgen.rs`][reportgen]). It is the only way to measure relay latency (hence pick a home relay) when QUIC is blocked.
+
+**Captive-portal check.** Only on the first (full) report, delayed `CAPTIVE_PORTAL_DELAY` = 200 ms so a healthy QAD run can cancel it, timeout 2 s. It `GET`s `http://{host}/generate_204` with request header `X-Iroh-Challenge: ts_{host}` and treats anything other than `204` + response header `X-Iroh-Response: response ts_{host}` as a captive portal ([`reportgen.rs:619`][reportgen-captive]).
+
+### Probe plan and scheduling
+
+`Options::as_protocols()` turns config into a `BTreeSet<Probe>` of `{QadIpv4, QadIpv6, Https}` ([`options.rs:49`][options]). Crucially, **the `ProbePlan` only ever schedules HTTPS** — QAD is scheduled outside the plan. `ProbePlan::initial` emits, per relay, one `ProbeSet` of three HTTPS probes at delays 200/300/400 ms (`HTTPS_OFFSET` 200 ms + `DEFAULT_INITIAL_RETRANSMIT` 100 ms × attempt); the duplicates are racing retries ([`probes.rs:38`][probes-set]):
+
+> _"The probes are to the same Relayer and of the same [`Probe`] but will have different delays. The delays are effectively retries, though they do not wait for the previous probe to be finished. The first successful probe will cancel all other probes in the set."_
+
+`ProbePlan::with_last_report` returns an **empty plan** when the last report has any latencies (incremental runs skip HTTPS entirely, marked `// TODO: is this good?`), else falls back to the initial plan.
+
+QAD probes fan out directly from `Client::spawn_qad_probes`: up to `MAX_RELAYS` = 5 relays (map order, `// TODO: randomize choice?`), one task per address family the interface state supports and that "needs probing" (v4 whenever there is no cached v4 report; v6 when cached-v6-presence disagrees with `if_state.have_v6`), each wrapped in `PROBES_TIMEOUT` = 3 s and a per-family child `CancellationToken` ([`net_report.rs:493`][nr-fanout]). The join loop early-cancels once `reports.len() >= enough_relays` (`min(3, num_relays)`, `ENOUGH_ENDPOINTS` = 3) _and_ at least one result per started family has landed.
+
+`Client::get_report` (one long-lived struct per endpoint, owned by the socket) decides full vs incremental. A **full** report runs iff a `is_major` link change occurred, or it is the first run (`next_full`), or `> 5 min` since the last full report (`FULL_REPORT_INTERVAL`), or the last report saw a captive portal with no UDP ([`net_report.rs:303`][nr-full]). It then (1) runs QAD probes inline, (2) spawns the `reportgen` actor for HTTPS + captive portal, (3) merges `ProbeFinished` messages and live QAD watcher updates in a **biased** `select!`, updating the `Report` incrementally, and (4) stops early when `have_enough_reports` is satisfied — for a full report, with both families available: `(ipv4 ≥ 2 ∧ ipv6 ≥ 1) ∨ (ipv6 ≥ 2 ∧ ipv4 ≥ 1)`; single-family `≥ 2`; or `num_https ≥ num_relays`. Incremental thresholds drop to `≥ 1` per available family.
+
+### Symmetric-NAT ("mapping varies by dest") detection
+
+`Report::update` stores the first observed global v4 address in `global_v4`; each subsequent v4 QAD report _from a different relay_ is compared. Equal ⇒ `mapping_varies_by_dest_ipv4 = Some(false)` (only if still `None`); different ⇒ `Some(true)` + a warning ([`report.rs:88`][report-mapvaries]; v6 is symmetric). Because a full report probes up to 5 relays per family, two observations are normally available, so a symmetric (endpoint-dependent) NAT is detected within one report. `mapping_varies_by_dest()` ORs the two flags; if a new report learned nothing, the flags carry forward from the previous one. The socket uses the flag to synthesize an extra candidate (below).
+
+### Report contents, history & preferred-relay selection
+
+```rust
+// iroh/src/net_report/report.rs:18
+pub struct Report {
+    pub udp_v4: bool,
+    pub udp_v6: bool,
+    pub mapping_varies_by_dest_ipv4: Option<bool>,
+    pub mapping_varies_by_dest_ipv6: Option<bool>,
+    pub preferred_relay: Option<RelayUrl>,
+    pub relay_latency: RelayLatencies,       // 3 BTreeMap<RelayUrl, Duration>, min-latency per relay
+    pub global_v4: Option<SocketAddrV4>,
+    pub global_v6: Option<SocketAddrV6>,
+    pub captive_portal: Option<bool>,
+}
+```
+
+`RelayLatencies` keeps three `BTreeMap<RelayUrl, Duration>` (`ipv4`, `ipv6`, `https`), each retaining the _minimum_ latency seen ([`report.rs:136`][report-latencies]). `add_report_history_and_set_preferred_relay` maintains `Reports { prev: BTreeMap<Instant, Report>, last, last_full, next_full }`, prunes entries older than `MAX_AGE` = 5 min, merges recent latencies into a `best_recent` map, and picks the relay in the _current_ report with the lowest best-recent latency ([`net_report.rs:747`][nr-preferred]). **Hysteresis:** if the previous preferred relay is still present and the challenger is not faster than ⅔ of the old relay's current latency (`best_any > old_relay_cur_latency / 3 * 2`), the old relay is kept — preventing home-relay flapping between near-equal servers. Note `Report` has **no port-mapping fields** in 1.0 (0.x's did); port mapping is a sibling subsystem whose watch channel feeds the socket directly.
+
+### How the socket consumes it (and when it runs)
+
+The socket owns `net_reporter: Arc<AsyncMutex<net_report::Client>>` inside `DirectAddrUpdateState` ([`socket.rs:706`][sk-dau]). A report is (re-)run on one of several `UpdateReason`s ([`socket.rs:719`][sk-reason]):
+
+| `UpdateReason`    | Trigger                                                                                                                                                        | Full?   |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `Periodic`        | a `time::Interval` randomized to **20..=26 s** ("just under 30s, a common UDP NAT timeout"), reset after each completed report ([`socket.rs:2004`][sk-restun]) | no      |
+| `PortmapUpdated`  | the portmapper's external-address watch changed                                                                                                                | no      |
+| `LinkChangeMinor` | `netmon` reported a non-major interface change                                                                                                                 | no      |
+| `LinkChangeMajor` | `netmon` reported a major change (default route / v4-v6 availability / interesting iface)                                                                      | **yes** |
+| `RelayMapChange`  | the configured relay set changed                                                                                                                               | **yes** |
+
+`schedule_run` uses `try_lock_owned`: if a report is already running, the reason is parked in `want_update` and re-fired when the running one signals completion via a `run_done` mpsc — the whole "only one report at a time" invariant is encoded as a lock-failure signal, not a queue. Each run first calls `port_mapper.procure_mapping()`.
+
+The finished report lands in `Watchable<(Option<Report>, UpdateReason)>`. `handle_net_report_report` ([`socket.rs:1554`][sk-handle]): (a) stores `udp_v6` in an `AtomicBool ipv6_reported` used by relay dialing, (b) backfills `preferred_relay` with the current home relay if absent, (c) forwards the report so the relay transport actor **switches the home relay** if `preferred_relay` changed ([`relay/actor.rs:1124`][sk-homerelay], see [`relay`][relay]), and (d) recomputes **direct-address candidates**. `update_direct_addresses` ([`socket.rs:1814`][sk-uda]) merges, in priority order into a `BTreeMap<SocketAddr, DirectAddrType>`: the portmapper external address (`Portmapped`), `global_v4`/`global_v6` (`Qad`), then — when `mapping_varies_by_dest` is true and a socket is bound to a fixed non-zero port — the guess `global_v4_ip:local_port` (`Qad4LocalPort`, [`socket.rs:1841`][sk-qad4]):
+
+> _"If they're behind a hard NAT and are using a fixed port locally, assume they might've added a static port mapping on their router to the same explicit port that we are running with. Worst case it's an invalid candidate mapping."_
+
+then local interface addresses (expanding unspecified binds across every interface IP; loopback only if nothing else exists), then user-configured addresses. IPv6 addresses whose netmon flags say `deprecated` are filtered out.
+
+### netwatch: interface state + change monitoring
+
+`netmon::Monitor` spawns one actor owning a `Watchable<State>` fed by a per-OS `RouteMonitor` over a `NetworkMessage::Change` mpsc (cap 16). The actor **debounces for `DEBOUNCE` = 250 ms** ([`actor.rs:93`][nm-actor]), then rebuilds the whole `State::new()` snapshot and republishes only if it differs. It also polls wall time every 15 s (1 h on iOS/Android) and treats a jump `> 1.5×` the interval as an _unsuspend_ event, force-publishing with `last_unsuspend` set — a monotonic-vs-wall-clock skew test that detects the machine waking from sleep. External code can inject a hint via `Monitor::network_change()` (iroh surfaces this as `Endpoint::network_change`).
+
+```rust
+// netwatch/src/interfaces.rs:200 (trimmed)
+pub struct State {
+    pub interfaces: HashMap<String, Interface>,   // Interface wraps netdev::Interface
+    pub local_addresses: LocalAddresses,          // { loopback: Vec<IpAddr>, regular: Vec<IpAddr> }
+    pub have_v6: bool,                             // any 2000::/3 or fc00::/7 up
+    pub have_v4: bool,                             // any non-loopback v4 up
+    pub is_expensive: bool,                        // declared, compared, NEVER populated (dead)
+    pub default_route_interface: Option<String>,
+    pub last_unsuspend: Option<Instant>,
+}
+```
+
+`is_major_change` fires on differing `have_v4`/`have_v6`/`is_expensive`/default-route-interface, or any _interesting_ interface added/removed/changed (flags, MAC, index) or its non-link-local, non-loopback, non-multicast prefixes changing ([`interfaces.rs:319`][nw-ismajor]). On macOS the `llw*`, `awdl*`, `ipsec*` interfaces are _uninteresting_; Linux and Windows treat everything as interesting.
+
+The **per-OS route-monitoring facilities a port must bind** are the heart of this subsystem:
+
+| OS                | Facility                                                                                                                                                                    | Notes for a port                                                                                                                                                                               |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linux**         | `AF_NETLINK`/`NETLINK_ROUTE` socket bound to `RTNLGRP_{IPV4,IPV6}_{IFADDR,ROUTE,RULE}` multicast groups ([`netmon/linux.rs:61`][nm-linux])                                  | parse `RTM_*` (`NewAddress`/`DelAddress`/`New`/`DelRoute`/`New`/`DelRule`); dedupe addrs per iface; ignore route table 254/255 + multicast/link-local dst; reconnect 1 s→30 s doubling backoff |
+| **macOS/iOS/BSD** | raw `AF_ROUTE` socket (`socket(AF_ROUTE, SOCK_RAW)`) read nonblocking; RIB parsed with a Go `x/net`-derived parser ([`netmon/bsd.rs:95`][nm-bsd])                           | **must drain with `try_read` until `WouldBlock`** — registration is edge-triggered; backoff 50 ms→30 s                                                                                         |
+| **Windows**       | `NotifyUnicastIpAddressChange(AF_UNSPEC, cb)` + `NotifyRouteChange2(AF_UNSPEC, cb)` from IP Helper; `CancelMibChangeNotify2` on drop ([`netmon/windows.rs:32`][nm-windows]) | callbacks fire on **foreign OS threads** and `try_send` into the channel                                                                                                                       |
+| **Android**       | none ([`netmon/android.rs:16`][nm-android]): _"Very sad monitor. Android doesn't allow us to do this"_                                                                      | only the 250 ms-debounced external hints + wall-time polling                                                                                                                                   |
+
+The macOS drain discipline is worth quoting because it maps precisely onto a completion-first runtime ([`netmon/bsd.rs:95`][nm-bsd]):
+
+> _"Drains with `try_read` until `WouldBlock`. Do not read via `AsyncRead::read` one message per await: the fd is registered edge-triggered, so leaving data queued can lose the next readiness notification and permanently stall the monitor."_
+
+**Default-route detection** ([`interfaces.rs:411`][nw-defroute]) is separately per-OS: Linux parses `/proc/net/route` for destination `00000000` mask `00000000` (read with an 8 KiB one-shot buffer because gVisor/Cloud Run requires it), falling back to a netlink `GetRoute` dump of `RT_TABLE_MAIN` selecting a `Gateway` attribute with `destination_prefix_length == 0`, then `GetLink` for the name ([`interfaces/linux.rs:62`][nw-linux-route]); Android shells out to `ip route show table 0`; BSD/macOS fetch the RIB via `sysctl([CTL_NET, AF_ROUTE, 0, af, NET_RT_DUMP2, 0])` (ENOMEM-retry ≤3) and select routes with `RTF_GATEWAY` set, `RTF_IFSCOPE` clear, all-zero dst+netmask ([`interfaces/bsd.rs:73`][nw-bsd-route]); Windows queries WMI `Win32_IP4RouteTable` inside `spawn_blocking` ("WMI uses COM which can deadlock on a tokio worker thread", [`interfaces/windows.rs:29`][nw-win-route]). `HomeRouter::new()` (gateway IP + own LAN IP, the portmapper target) uses `netdev`'s default-gateway on Linux/Android/Windows and the RIB scan on BSD.
+
+### The rebindable `UdpSocket`
+
+`netwatch::UdpSocket` is the socket every QUIC datagram flows through ([`udp.rs:20`][udp]):
+
+```rust
+// netwatch/src/udp.rs:20 (trimmed)
+pub struct UdpSocket {
+    socket: RwLock<SocketState>,
+    recv_waker: AtomicWaker,
+    send_waker: AtomicWaker,
+    is_broken: AtomicBool,   // set on NotConnected(read)/BrokenPipe(write) -> lazy rebind
+}
+enum SocketState {
+    Connected { socket: tokio::net::UdpSocket, state: noq_udp::UdpSocketState, addr: SocketAddr },
+    Closed    { addr: SocketAddr, last_max_gso_segments: NonZeroUsize,
+                last_gro_segments: NonZeroUsize, last_may_fragment: bool },
+}
+```
+
+Buffers are 7 MiB each way ("the max supported by a default configuration of macOS", [`udp.rs:28`][udp-buf]); IPv6 sockets set `IPV6_V6ONLY` (no dualstack); bind verifies the requested nonzero port was actually obtained. **Rebind logic:** a read error `NotConnected` or write error `BrokenPipe` marks the socket broken; every subsequent operation first runs `maybe_rebind()`, which double-checks under the write lock, closes, and re-binds to the _same_ addr (preserving the port) ([`udp.rs:281`][udp-rebind]); the transport layer can also force `rebind()` on a major link change. Transient read errors are swallowed on **all** platforms ([`udp.rs:518`][udp-transient]):
+
+> _"We treat `ConnectionReset` as transient on every platform, not only Windows: ECONNRESET is undefined in QUIC and can be injected by an attacker, so it must never tear down the receive path."_
+
+(`WSAENETRESET` = 10052 is additionally swallowed on Windows.) **GSO/GRO** is delegated entirely to `noq_udp::UdpSocketState` (the quinn-udp fork): `try_send_noq`/`poll_send_noq` take a segmented `noq_udp::Transmit`; `poll_recv_noq` fills `IoSliceMut` + `RecvMeta` arrays with a per-datagram `stride` for GRO; `max_gso_segments`/`gro_segments`/`may_fragment` are cached across the `Closed` state ([`udp.rs:332`][udp-gso]). `close()` moves the fd to `spawn_blocking` because `libc::close` may block ([`udp.rs:192`][udp-close]).
+
+### portmapper: probes, leases & renewal
+
+One `Service` actor per client drives an mpsc(32) of `{ProcureMapping, UpdateLocalPort, Probe}` and emits a `watch::Receiver<Option<SocketAddrV4>>` of the current external address ([`lib.rs:434`][pm-lib]):
+
+```rust
+// portmapper/src/mapping.rs:18
+pub enum Mapping { Upnp(upnp::Mapping), Pcp(pcp::Mapping), NatPmp(nat_pmp::Mapping) }
+```
+
+**Probe trust is cached** ([`lib.rs:40`][pm-trust]): a protocol seen within `AVAILABILITY_TRUST_DURATION` = 10 min is trusted without re-probe; a _mapping_ attempt against an unavailable protocol is tried only if the last probe is older than `UNAVAILABILITY_TRUST_DURATION` = 5 s. A probe runs the three protocol probes concurrently in a `select!` ([`lib.rs:280`][pm-probe]): **UPnP** SSDP `search_gateway` (igd-next, 1 s timeout, double-wrapped "because igd_next doesn't respect the set timeout"); **PCP** ANNOUNCE to `gateway:5351`, wait ≤500 ms; **NAT-PMP** DetermineExternalAddress to `gateway:5351`, wait ≤500 ms.
+
+**Mapping strategy** ([`lib.rs:632`][pm-strategy]): prefer **PCP**, then **NAT-PMP**, then **UPnP** ("the most unreliable, but possibly the most deployed one"); if none is known-available, fall back to UPnP-if-enabled, then blind PCP, then blind NAT-PMP, else give up. Local IP + gateway come from `netwatch::interfaces::HomeRouter`.
+
+**Lease renewal** is a small timer state machine in `CurrentMapping` ([`current_mapping.rs:122`][pm-current]): a stored mapping arms a sleep of `half_lifetime()`; on firing it emits `Event::Renew` and rearms for another half-lifetime with `expire_after = true`; the second firing emits `Event::Expired` and clears the mapping (and the watch). The service reacts to _both_ events identically — request a new mapping for the same external address/port. Requested lifetimes: PCP `MAPPING_REQUESTED_LIFETIME_SECONDS = 60 * 60` (**3600 s**, though the comment claims "2 hours" — a genuine bug, [`pcp.rs:14`][pm-pcp]); NAT-PMP `60 * 60 * 2` (**7200 s**, [`nat_pmp.rs:16`][pm-natpmp]); UPnP `2 * 60 * 60` (**7200 s**) with a fixed 1 h half-lifetime and description string `"iroh-portmap"` ([`upnp.rs:19`][pm-upnp]); PCP/NAT-PMP renew at `lifetime_seconds / 2` _as returned by the server_. iroh calls `procure_mapping()` at the start of every direct-address update, `update_local_port()` after binding, and `deactivate()` on shutdown ([`portmapper.rs:69`][iroh-portmapper]).
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+The subsystem owns four distinct wire surfaces (QAD's frames are _not_ one of them — they live in [`noq-proto`][quic]):
+
+**QAD (consumed, not framed here).** No custom framing in `net_report`; it is the [draft-seemann-quic-address-discovery][qad-draft] QUIC extension in [`noq-proto`][quic] — a transport parameter carrying a `Role` varint (0 send-only, 1 receive-only, 2 both) and `OBSERVED_ADDRESS` frames. `net_report` sees only `observed_external_addr()` (a watcher) and `rtt(PathId::ZERO)`. Identifiers a port must match: ALPN `/iroh-qad/0`, close code `1` / reason `b"finished"`, default port 7842. Frame-level encoding is deferred to [`quic-transport`][quic] and [`nat-traversal`][nat].
+
+**HTTP probes.** `GET {relay}/ping` (2xx = success, drain ≤ 8 KiB) and `GET http://{host}/generate_204` with `X-Iroh-Challenge: ts_{host}` / expected `X-Iroh-Response: response ts_{host}`. Trivial HTTP/1.1 GETs — over TLS ([`rustls`][docs]) for `/ping`, plaintext for the portal check — with redirects disabled and a custom DNS resolver.
+
+**PCP** ([RFC 6887][rfc6887], UDP port 5351, version 2). The 24-byte request header, then the 36-byte MAP opcode data, both fully in-tree (no external protocol crate) and directly portable:
+
+```text
+PCP request header — 24 bytes  (portmapper/src/pcp/protocol/request.rs)
+ off size field
+   0    1  version = 2
+   1    1  opcode  (Announce = 0, Map = 1; response sets bit 0x80)
+   2    2  reserved
+   4    4  requested lifetime, u32 BE  (announce 0; map 3600; release 0)
+   8   16  client IP as IPv4-mapped IPv6
+MAP opcode data — 36 bytes appended
+   0   12  mapping nonce
+  12    1  protocol (UDP = 17, TCP = 6)
+  13    3  reserved
+  16    2  internal port, u16 BE
+  18    2  suggested external port, u16 BE
+  20   16  suggested external IP, v4-mapped
+```
+
+The client validates the echoed nonce, protocol, and internal port, and rejects external port 0 or a non-v4-mapped external address.
+
+**NAT-PMP** ([RFC 6886][rfc6886], UDP port 5351, version 0). External-address request is 2 bytes `[0, 0]`; a mapping request is 12 bytes `[0, opcode(UDP=1,TCP=2), 0, 0, internal_port BE, suggested_external_port BE, lifetime u32 BE]`. Responses OR the opcode with `RESPONSE_INDICATOR = 1<<7`: the public-address response is 12 bytes `(ver, opcode, result u16, epoch u32, IPv4)`, the mapping response 16 bytes `(ver, opcode, result u16, epoch u32, private u16, public u16, lifetime u32)`. Obtaining a mapping is a **two-request dance**: MAP, then DetermineExternalAddress.
+
+**UPnP.** SSDP M-SEARCH multicast to `239.255.255.250:1900` + SOAP `WANIPConnection` actions (`AddPortMapping`/`AddAnyPortMapping`/`DeletePortMapping`/`GetExternalIPAddress`), entirely inside the [`igd-next`][igd] crate — the single biggest reimplementation chunk for a port.
+
+**Linux netlink / BSD routing / `/proc` formats** are described under [netwatch](#netwatch-interface-state--change-monitoring). The BSD RIB parser hardcodes per-OS struct offsets from Go `x/net` `zsys` files (e.g. Darwin `SIZEOF_RT_MSGHDR_DARWIN15 = 0x5c`, `if_msghdr2 = 0xa0`, kernel alignment 4, [`interfaces/bsd/macos.rs`][nw-bsd-macos]).
+
+### Cryptography & identity
+
+Near-absent — and the absence is a finding. `net_report` performs **no** cryptography of its own: QAD packet protection is [`noq`][quic]'s TLS/QUIC, and the HTTPS probe uses a stock `rustls::ClientConfig`. There is **no** DISCO shared secret, **no** STUN transaction ID, and **no** ICMP identifier — the 0.x side-channel handshakes are gone. The only identity-shaped values are: the captive-portal challenge token `ts_{host}` (an unauthenticated liveness nonce, not a secret) and the PCP mapping _nonce_ (a 12-byte anti-spoofing value the client echoes-checks — the closest thing to a security primitive here). Reachability decisions are keyed on [`EndpointId`][identity] and `RelayUrl` at the layers above; this subsystem carries neither key material nor MACs. A port must not look for a crypto handshake in the probe path — there is none.
+
+### State machines & lifecycle
+
+Eleven small state machines cooperate; the load-bearing ones for a port:
+
+1. **Full-vs-incremental cycle** ([`net_report.rs:303`][nr-full]): `do_full = is_major ∨ next_full ∨ (now − last_full > 5 min) ∨ (last.captive_portal ∧ ¬last.has_udp())`. Entering full clears `reports.last` (⇒ initial `ProbePlan`) and the QAD cache, sets `last_full = now`.
+2. **QAD fan-out** ([`net_report.rs:493`][nr-fanout]): per family `Idle → (needs probe ∧ family available) → ≤5 tasks → first success caches the conn, losers closed → exit when reports ≥ enough_relays ∧ ¬pending (cancel family tokens) or shutdown`; per-task 3 s timeout.
+3. **`reportgen` actor** (one-shot): `Start → spawn plan tasks + delayed captive-portal task → forward each ProbeFinished → when all regular probes done ∧ any was UDP, cancel captive portal → exit on JoinSet drain / 5 s overall timeout / parent drops handle`.
+4. **DirectAddrUpdateState**: invariant "only one update at a time"; `{idle, running, running+queued}`; `schedule_run` `try_lock` → running or queued (`want_update`, later reasons overwrite); `run_done` drains the queued reason.
+5. **netmon debounce** ([`actor.rs:93`][nm-actor]): `{quiet, pending}`; any event/hint arms a 250 ms reset-able sleep; on fire rebuild `State`, publish if changed; a wall-clock jump > 22.5 s forces a publish with `last_unsuspend`.
+6. **Route-monitor reconnect** loops: Linux netlink 1 s→30 s, BSD `AF_ROUTE` 50 ms→30 s doubling backoff.
+7. **`UdpSocket` break/rebind** ([`udp.rs`][udp]): `{healthy, broken, closed}`; read `NotConnected` / write `BrokenPipe` ⇒ broken; next op runs `maybe_rebind` (double-check under write lock) ⇒ healthy (same port) or stays broken.
+8. **Portmapper lease** ([`current_mapping.rs:122`][pm-current]): `Empty →(mapping)→ Active(deadline ½·lifetime) →(deadline, emit Renew)→ Renewing(deadline ½·lifetime, expire_after) →(new mapping)→ Active | →(deadline, emit Expired, clear watch)→ Empty`.
+9. **Portmapper probe trust** ([`lib.rs:40`][pm-trust]): per protocol `{fresh (<10 min), stale}`; probe requests short-circuit if all three fresh; blind mapping only if last probe > 5 s old.
+
+### Dependencies & coupling
+
+| Crate                                                          | Depth                    | What a D port inherits                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`noq`/`noq-proto`/`noq-udp`][quic]                            | **load-bearing**         | QAD is a QUIC transport extension — `observed_external_addr()`, `rtt(PathId)`, the `Role` transport parameter, `OBSERVED_ADDRESS` frames. No separate probe protocol exists; the port's QUIC stack must implement [draft-seemann-quic-address-discovery][qad-draft]. `noq_udp` supplies GSO/GRO/segmented `sendmsg`/`recvmsg`, `may_fragment`, ECN. |
+| `netdev`                                                       | **load-bearing**         | _all_ interface enumeration (names, indices, flags, MACs, v4/v6 nets, v6 scope-ids + address flags, gateway discovery). A port reimplements per-OS: `getifaddrs`+`/proc` (Linux), `getifaddrs`+`sysctl` (BSD/macOS), `GetAdaptersAddresses` (Windows).                                                                                              |
+| `netlink-packet-*`, `netlink-proto`, `netlink-sys`             | **load-bearing** (Linux) | route-monitor multicast groups + default-route dump. Port: raw `AF_NETLINK` socket + a small `RTM_*` subset.                                                                                                                                                                                                                                        |
+| `windows` (Win32 IP Helper) + `wmi`                            | **load-bearing** (Win)   | `NotifyUnicastIpAddressChange`/`NotifyRouteChange2`/`CancelMibChangeNotify2`; WMI `Win32_IP4RouteTable` for the default route (replaceable by `GetBestRoute2`/`GetIpForwardTable2` to avoid COM).                                                                                                                                                   |
+| [`igd-next`][igd]                                              | **load-bearing**         | the full UPnP IGD client (SSDP M-SEARCH, device-description fetch, SOAP). Biggest single reimplementation chunk in `portmapper`.                                                                                                                                                                                                                    |
+| `reqwest` + `rustls` + `hickory` (via [`iroh-dns`][discovery]) | mixed                    | HTTPS probe & captive portal — trivial HTTP GETs over TLS, but with custom DNS (`resolve_to_addrs`) and redirects disabled. Port supplies its own HTTP client + staggered DNS.                                                                                                                                                                      |
+| `n0-watcher` (`Watchable`/`Watcher`)                           | API-surface              | value-latest watch cells with async `updated()`; used for reports, QAD observers, netmon state, portmap addr. **No event-horizon equivalent** (see Mapping).                                                                                                                                                                                        |
+| `n0-future` (`AbortOnDropHandle`, `MaybeFuture`, time)         | API-surface              | structured-cancellation glue → `Scope`-owned fibers.                                                                                                                                                                                                                                                                                                |
+| `tokio-util` `CancellationToken` (+ child tokens)              | API-surface              | → `CancelContext` tree.                                                                                                                                                                                                                                                                                                                             |
+| `socket2`                                                      | API-surface              | raw socket options (buffer sizes, `IPV6_V6ONLY`, nonblocking, the `AF_ROUTE` raw socket).                                                                                                                                                                                                                                                           |
+
+PCP and NAT-PMP codecs are **in-tree** and directly portable from the byte layouts above; only UPnP is a heavy external dependency. The full concurrency inventory is enumerated in [`concurrency`][concurrency].
+
+### Concurrency & I/O model
+
+The subsystem is a **web of tokio actors and watch channels** — the recon counted **26 distinct concurrency primitives** across `net_report`, `netwatch`, and `portmapper` (all in [`concurrency`][concurrency]). The shape: `net_report::Client` is a plain `&mut self` struct driven by one async `get_report`, serialized by `Arc<AsyncMutex<…>> + try_lock_owned` (the lock _is_ the "already running" flag); the `reportgen` actor is a one-shot `AbortOnDropHandle` task; QAD fan-out uses two `JoinSet`s (v4/v6) with per-family child `CancellationToken`s; results flow over an `mpsc(32) ProbeFinished` and are merged with live QAD watchers in a biased `select!`. `netmon` is one actor owning a `Watchable<State>` fed by an OS `RouteMonitor` (netlink task / `AF_ROUTE` reader / Windows foreign-thread callbacks) through an mpsc(16) into a 250 ms debouncer. `UdpSocket` uses `RwLock<SocketState>` + two `AtomicWaker`s + an `AtomicBool` to swap an fd under concurrent pollers. `portmapper` is one `Service` actor with an mpsc(32), a `watch<Option<SocketAddrV4>>`, one in-flight `mapping_task` and one `probing_task` (each `AbortOnDropHandle`), and `CurrentMapping` implemented as a `Stream` with a stored `Waker` + boxed `time::Sleep`.
+
+The critical observation for a port: **almost none of this needs true parallelism**. The `Arc`/`AsyncMutex`/`RwLock`/atomics/`JoinSet` machinery exists because tokio is multi-thread and `Send + Sync`, not because the algorithm is concurrent. The two genuinely cross-thread facts are (a) Windows `Notify*Change2` callbacks arriving on OS threads iroh does not own, and (b) `spawn_blocking` for `libc::close` and the WMI COM query — both artifacts of blocking APIs, not of the design.
+
+### Mapping to event-horizon
+
+This is a rich translation target: much of the concurrency dissolves under [event-horizon][eh-spec]'s `single` topology (one loop, one thread, [fibers][eh-spec] + [algebraic effects][algeff]), but three things demand _new_ design — cross-fiber watch/notify (open-issue O20), `sendmsg`/`recvmsg` for GSO/GRO (O19), and the platform route-monitor bindings.
+
+**1. The two-actor report shape collapses.** `net_report::Client` is already `&mut self`; the `reportgen` actor is a one-shot fiber whose handle-drop-cancels maps to a child [`Scope`][eh-spec] under [`withDeadline`][eh-spec]`(5.seconds)` — Scope exit cancels the probe fibers. The `Arc<AsyncMutex<Client>> + try_lock_owned` trick degenerates, single-threaded, to a plain `bool running` + `Nullable!UpdateReason wantUpdate` on the socket fiber — no lock. The `mpsc(32) ProbeFinished` is the one real channel; on the same thread it becomes a direct method call on a `Report` accumulator plus a wake (contingent on O20), or a bounded SPSC queue owned by the report fiber:
+
+```rust
+// Rust: iroh/src/net_report/report.rs:18 — a serde-serializable value handed back over a channel
+pub struct Report {
+    pub udp_v4: bool,
+    pub udp_v6: bool,
+    pub mapping_varies_by_dest_ipv4: Option<bool>,
+    pub mapping_varies_by_dest_ipv6: Option<bool>,
+    pub preferred_relay: Option<RelayUrl>,
+    pub relay_latency: RelayLatencies,
+    pub global_v4: Option<SocketAddrV4>,
+    pub global_v6: Option<SocketAddrV6>,
+    pub captive_portal: Option<bool>,
+}
+```
+
+```d
+// D (proposed / sketch): a plain accumulator the probe fibers mutate directly on the
+// report fiber's own thread — no serde round-trip, no channel to hand it back.
+struct Report {
+    bool udpV4, udpV6;
+    Nullable!bool mappingVariesByDestV4, mappingVariesByDestV6;   // 3-state: unknown / false / true
+    Nullable!RelayUrl preferredRelay;
+    RelayLatencies relayLatency;                                  // 3 sorted maps, min-latency per relay
+    Nullable!SocketAddrV4 globalV4;
+    Nullable!SocketAddrV6 globalV6;
+    Nullable!bool captivePortal;
+
+    // called by each probe fiber; symmetric-NAT detection folds in here
+    void update(in QadProbeReport r) @safe nothrow { /* set global_v*, compare, set mappingVaries */ }
+}
+```
+
+**2. QAD fan-out = a scope with race-to-quorum.** Spawn ≤5 fibers per family in a child scope, each `withDeadline(3.seconds)`; the collector parks on the next completion and cancels the scope once quorum (`enough_relays` + per-family flag) is met. The per-family `CancellationToken` hierarchy is exactly a [`CancelContext`][eh-spec] subtree:
+
+```rust
+// Rust: iroh/src/net_report.rs:493 — JoinSet + per-family CancellationToken, early-cancel on quorum
+let mut v4_buf = JoinSet::new();
+// ... spawn ≤ MAX_RELAYS tasks, each timed out at PROBES_TIMEOUT ...
+while let Some(res) = buf.join_next().await {
+    if reports.len() >= enough_relays && !pending { family_token.cancel(); break; }
+}
+```
+
+```d
+// D (proposed / sketch): a per-family CancelContext subtree; forked fibers; quorum cancels.
+Outcome!void probeFamilyQad(ref Scope sc, Family fam, ref Report acc) {
+    auto famCtx = sc.childContext();                              // per-family CancelContext
+    JoinHandle!QadProbeReport[MAX_RELAYS] hs;  size_t n;
+    foreach (relay; relaysNeedingProbe(fam).take(MAX_RELAYS))
+        hs[n++] = sc.fork(() => withDeadline(3.seconds, () => qadProbe(relay, fam)));
+    size_t landed;
+    while (landed < n) {
+        auto r = raceNext(hs[0 .. n]);                            // next completion; ties by fork order
+        if (r.hasValue) { acc.update(r.value); ++landed; }
+        if (acc.enoughRelays && !acc.pending(fam)) { famCtx.cancel(); break; }
+    }
+    return ok();
+}
+```
+
+**3. Watchables are the one real gap.** Five of them live here — the report handoff `Watchable<(Option<Report>, UpdateReason)>`, each cached QAD conn's `Watchable<Option<QadProbeReport>>`, `netmon`'s `Watchable<State>`, and portmapper's `watch<Option<SocketAddrV4>>`. Event-horizon has no watch primitive (the [brief][eh-spec] flags `tokio::sync::watch` as [open-issue O20][eh-spec]). Minimal D design: a `Watchable!T` = `{ value, ulong version, waiterList }`; `updated()` parks the calling fiber until `version` changes. Single-threaded means no lock, but the cross-fiber wake still needs the missing notify primitive. This subsystem alone justifies building it once.
+
+**4. The portmapper lease timer is a plain fiber.** Rust models it as a `Stream` with a stored `Waker` and a boxed `time::Sleep` because it must integrate with a poll loop; on event-horizon it is one fiber sleeping on in-ring `TIMEOUT` ops keyed to [`MonoTime`][eh-spec]:
+
+```rust
+// Rust: portmapper/src/current_mapping.rs:122 — a Stream emitting Renew at ½·lifetime, then Expired
+pub enum Event { Renew { external_ip: Ipv4Addr, external_port: NonZeroU16 }, Expired { /* .. */ } }
+// impl Stream for CurrentMapping { ... boxed time::Sleep + stored Waker ... }
+```
+
+```d
+// D (proposed / sketch): a single lease fiber; sleeps are cancellable via the enclosing scope.
+Outcome!void leaseLoop(ref Scope sc, Mapping m) {
+    for (;;) {
+        sc.sleep(m.lifetime / 2);              // in-ring TIMEOUT (MonoTime); cancel = scope cancel
+        if (!renewMapping(m.external))          // ask for the same external addr/port
+            { expireMapping(m); return ok(); }
+        sc.sleep(m.lifetime / 2);
+    }
+}
+```
+
+**5. Timers everywhere → in-ring `TIMEOUT`.** The 250 ms netmon debounce (reset-able), the 20–26 s randomized re-report interval, the 15 s wall-clock poll, the 3 s/5 s probe/report budgets, and the ½-lifetime lease sleeps are all in-ring `TIMEOUT` ops. The wall-clock _jump_ detector compares monotonic `Instant` deltas against the poll interval; [`MonoTime`][eh-spec] preserves the semantics exactly — a monotonic clock freezes during suspend on Linux, which is _why_ a 1.5× jump means "we just woke up."
+
+**6. Route monitors are the platform-specific hard part** — and each maps cleanly onto a completion-first backend:
+
+- **Linux netlink** is just an fd: an io*uring multishot `recv` fits perfectly; parse `RTM*\*` messages in the completion path. See the [io_uring surface][io-uring].
+- **macOS `AF_ROUTE`** under the [kqueue backend][async-io]: the Rust "drain until `WouldBlock` because edge-triggered" rule is exactly event-horizon's _readiness-synthesized-into-completions_ discipline — keep reading after a completion until `EAGAIN`.
+- **Windows `Notify*Change2`** callbacks run on **foreign OS threads**; the only legal cross-thread entry is [`Waker.wake()`][eh-spec] / MSG_RING (per the brief), so a callback must enqueue into a lock-free cell and wake — precisely what the Rust code does with `try_send`.
+- The WMI `spawn_blocking` default-route query has **no equivalent** (no thread pool); a port should prefer `GetBestRoute2`/`GetIpForwardTable2` (plain, non-blocking Win32) over WMI/COM.
+- `spawn_blocking(libc::close)` for the UDP fd is replaced by `IORING_OP_CLOSE` — strictly better, no thread hop.
+
+**7. `UdpSocket` rebind, single-threaded.** The `RwLock` + two `AtomicWaker`s exist to swap an fd under concurrent pollers. Single-threaded this becomes: mark broken → `ASYNC_CANCEL` in-flight ops on that fd → close/rebind (same port) → resubmit. The transient-read-error policy (swallow `ECONNRESET` everywhere, `WSAENETRESET` on Windows) must be preserved **verbatim** — it is a QUIC-security requirement, not a convenience.
+
+**8. GSO/GRO waits on O19; blocking reads stay synchronous.** `poll_send_noq`/`poll_recv_noq` need `sendmsg`/`recvmsg` with `UDP_SEGMENT`/`UDP_GRO`/PKTINFO/ECN cmsgs — event-horizon [open-issue O19][eh-spec]. `net_report` itself only needs plain send/recv (portmapper datagrams; QAD rides the main QUIC path). The blocking `sysctl`/`/proc/net/route` reads are fast and can stay synchronous on the loop thread; `/proc/net/route` must be one large read (gVisor), which an io_uring `read` handles naturally.
+
+**Cadence knobs to keep identical:** 5 min full-report interval, 5 s report budget, 3 s probe budget, 200/300/400 ms HTTPS ladder, 200 ms captive delay, 20–26 s re-report, 250 ms netmon debounce, 10 min / 5 s portmap trust windows, ½-lifetime renewal.
+
+---
+
+## Strengths
+
+- **One probe transport.** QAD reuses the main [`noq`][quic] endpoint, so the discovered public address is measured on the same socket the data uses — no probe-vs-data mapping skew — and there is no separate STUN/ICMP attack surface or side-protocol to secure.
+- **Fail-soft by construction.** Every probe is racing, cancellable, and timeout-bounded (3 s probe, 5 s report, 10 s outer); an unreachable relay or blocked family degrades the report rather than hanging it.
+- **Cheap incremental reports.** Long-lived QAD connections turn most reports into passive observation of a live NAT-refreshing connection — no re-dial, and the 25 s keep-alive doubles as a binding refresher.
+- **Symmetric-NAT detection falls out for free** from probing ≥2 relays per family and comparing observed addresses — no extra round trips.
+- **Sensible home-relay hysteresis** (challenger must beat ⅔ of the incumbent's latency) prevents flapping between near-equal relays.
+- **Clean per-OS route-monitor abstraction** with an honest edge-triggered-drain contract and reconnect backoff — a solid template for a port.
+
+## Weaknesses
+
+- **QAD ties sensing to a bespoke QUIC fork.** A port cannot sense the network without first implementing [draft-seemann-quic-address-discovery][qad-draft] inside its QUIC stack — there is no standalone probe protocol to lean on.
+- **Watch-channel-heavy.** Five `Watchable`s with no completion-first analogue; a faithful port must build a watch/notify primitive ([O20][eh-spec]) before this subsystem runs.
+- **Incremental reports may run zero probes.** `ProbePlan::with_last_report` returns an empty plan (`// TODO: is this good?`), leaning entirely on cached QAD watchers — a stale cached conn can report UDP works for up to ~35 s after the network actually broke (an open question the recon could not fully resolve from `net_report` alone).
+- **Platform-binding breadth.** netlink, `AF_ROUTE`, `sysctl(NET_RT_DUMP2)`, `/proc/net/route`, Win32 IP Helper + WMI, `getifaddrs`, plus PCP/NAT-PMP codecs and a full UPnP IGD client — a large, OS-specific surface to reimplement.
+- **Known defects/asymmetries.** The PCP lifetime constant contradicts its comment (3600 s vs "2 hours"); `State::is_expensive` is declared and compared in `is_major_change` but never populated; Windows uses WMI/COM for the default route while using IP Helper for change notifications; the captive-portal check always passes `preferred_relay = None` (the relay is chosen at random). A port should fix, not copy, these.
+- **`spawn_blocking` leaks in** (`libc::close`, WMI) — small, but with no thread-pool analogue on event-horizon they force per-site redesign.
+
+## Key design decisions and trade-offs
+
+| Decision                                                                 | Rationale                                                                                            | Trade-off                                                                                                        |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| QAD over the main endpoint instead of STUN/ICMP                          | Probe socket = data socket ⇒ the observed address is a valid direct-addr candidate; no side-protocol | Sensing depends on a QUIC extension in [`noq`][quic]; no probing before a QUIC stack exists                      |
+| Keep QAD connections alive between reports (25 s keep-alive, 35 s idle)  | Incremental reports become passive observation; keep-alive refreshes the NAT binding                 | A dead network can be masked until the cached conn's close-reason lands (~35 s window)                           |
+| `ProbePlan` schedules only HTTPS; QAD fans out separately (≤5 relays)    | QAD has no retransmit-ladder semantics; HTTPS is a pure fallback for QUIC-blocked networks           | Two scheduling paths with different limits; the elaborate 0.x STUN-ladder plan shrank to "3 HTTPS tries or none" |
+| `Arc<AsyncMutex<Client>> + try_lock_owned` as the "already running" flag | Encodes the single-report invariant without a queue                                                  | Concurrency-as-state-machine; opaque to read; pure overhead single-threaded (becomes a `bool`)                   |
+| Symmetric NAT = compare observed addrs across relays                     | Free with multi-relay probing; no extra round trips                                                  | Needs ≥2 successful observations per family; single-relay networks can't detect it                               |
+| Home-relay hysteresis (beat ⅔ of incumbent latency)                      | Avoids flapping between near-equal relays                                                            | A genuinely-better-but-marginal relay is ignored until it wins by a third                                        |
+| Swallow `ECONNRESET` on every platform in the UDP recv path              | ECONNRESET is undefined in QUIC and attacker-injectable; must never tear down recv                   | Hides genuine unreachable-destination signals; a security requirement, not a convenience                         |
+| Per-OS native route monitors (netlink / `AF_ROUTE` / IP Helper)          | Push-based link-change detection is far cheaper than polling                                         | A large, fiddly, OS-specific binding surface (edge-triggered drain, foreign-thread callbacks, COM avoidance)     |
+| Prefer PCP → NAT-PMP → UPnP, with cached trust windows                   | PCP/NAT-PMP are cleaner in-tree codecs; UPnP is unreliable-but-ubiquitous                            | Three protocols to maintain; UPnP drags in a heavy SSDP/SOAP dependency                                          |
+
+---
+
+## Sources
+
+Primary sources — the pinned iroh `net_report` module and `portmapper` wrapper (`iroh` v1.0.1, commit `22cac742ca`), and the `netwatch` / `portmapper` crates (net-tools commit `051ab876` = `netwatch-v0.19.1` / `portmapper-v0.19.1`):
+
+- [`iroh/src/net_report.rs`][nr-doc] — `Client`, QAD conn cache, full-vs-incremental cycle, `get_report`, preferred-relay history/hysteresis.
+- [`iroh/src/net_report/reportgen.rs`][reportgen] — the one-shot reportgen actor, HTTPS probe, captive-portal check, `QadProbeReport`, `QuicConfig`.
+- [`iroh/src/net_report/probes.rs`][probes] — the three-variant `Probe` enum, `ProbeSet`, `ProbePlan` (HTTPS-only).
+- [`iroh/src/net_report/report.rs`][report] — `Report`, `RelayLatencies`, symmetric-NAT detection.
+- [`iroh/src/net_report/{options.rs,defaults.rs,metrics.rs}`][options] — protocol-set derivation, all timeouts, counters.
+- [`iroh-relay/src/quic.rs`][qad-rtt], [`iroh-relay/src/defaults.rs`][qad-port], [`iroh-relay/src/http.rs`][relay-http] — the QAD client/server config, ALPN `/iroh-qad/0`, port 7842, HTTPS probe path.
+- [`iroh/src/socket.rs`][sk-dau] and [`iroh/src/portmapper.rs`][iroh-portmapper] — `DirectAddrUpdateState`, `UpdateReason`, re-report interval, `handle_net_report_report`, `update_direct_addresses`, the `Enabled`/`Disabled` portmapper wrapper.
+- [`netwatch/src/interfaces.rs`][nw-interfaces] + [`interfaces/{linux,bsd,bsd/macos,windows}.rs`][nw-linux-route] — `State`, `is_major_change`, default-route detection, `HomeRouter`, the BSD RIB parser.
+- [`netwatch/src/netmon/{actor.rs,linux.rs,bsd.rs,windows.rs,android.rs}`][nm-actor] — the debouncer and per-OS route monitors.
+- [`netwatch/src/udp.rs`][udp] — the rebindable `UdpSocket`, GSO/GRO delegation, transient-error policy.
+- [`portmapper/src/{lib.rs,current_mapping.rs,mapping.rs,pcp.rs,nat_pmp.rs,upnp.rs}`][pm-lib] + `pcp/protocol/*`, `nat_pmp/protocol/*` — the Service actor, probe trust, mapping strategy, lease renewal, and the PCP/NAT-PMP byte codecs.
+
+Related pages: [the multipath socket][socket] (which consumes the report — home-relay + direct-addr candidates), [NAT traversal & address discovery][nat] (symmetric-NAT flag + QAD frames), [the relay protocol][relay] (home-relay selection + QUIC-address-discovery listener), [address lookup][discovery] (staggered DNS + where direct addresses are republished), [QUIC transport (`noq`)][quic] (QAD/`OBSERVED_ADDRESS` framing), [concepts & vocabulary][concepts], [identity & cryptography][identity], [wire formats & serialization][wire], [the concurrency inventory][concurrency] (all 26 primitives), and [D architecture migration][d-migration]. Runtime target: the [event-horizon spec][eh-spec] (`Scope`, `CancelContext`, `Watchable` gap O20, msghdr gap O19); I/O surface in the [async-io survey][async-io] and [io_uring deep-dive][io-uring]; concurrency-model contrast in [tokio][tokio].
+
+<!-- References -->
+
+[repo]: https://github.com/n0-computer/iroh/tree/22cac742ca
+[docs]: https://docs.rs/iroh/1.0.1/iroh/
+[nettools]: https://github.com/n0-computer/net-tools/tree/051ab876
+[docs-netwatch]: https://docs.rs/netwatch/0.19.1/netwatch/
+[docs-portmapper]: https://docs.rs/portmapper/0.19.1/portmapper/
+[nr-doc]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs#L3
+[nr-https]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs#L88
+[nr-qadconns]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs#L157
+[nr-fanout]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs#L493
+[nr-full]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs#L303
+[nr-preferred]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report.rs#L747
+[reportgen]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/reportgen.rs#L206
+[reportgen-captive]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/reportgen.rs#L619
+[qad-report]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/reportgen.rs#L447
+[probes]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/probes.rs#L25
+[probes-set]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/probes.rs#L38
+[report]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/report.rs#L18
+[report-latencies]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/report.rs#L136
+[report-mapvaries]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/report.rs#L88
+[options]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/options.rs#L49
+[defaults]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/net_report/defaults.rs#L17
+[qad-alpn]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/quic.rs#L10
+[qad-rtt]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/quic.rs#L283
+[qad-server]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/quic.rs#L102
+[qad-port]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/defaults.rs#L7
+[relay-http]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/http.rs#L15
+[sk-dau]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L706
+[sk-reason]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L719
+[sk-restun]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L2004
+[sk-handle]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1554
+[sk-uda]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1814
+[sk-qad4]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1841
+[sk-ep]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1046
+[sk-nettimeout]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/defaults.rs#L129
+[sk-homerelay]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports/relay/actor.rs#L1124
+[iroh-portmapper]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/portmapper.rs#L69
+[nw-interfaces]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/interfaces.rs#L200
+[nw-ismajor]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/interfaces.rs#L319
+[nw-defroute]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/interfaces.rs#L411
+[nw-linux-route]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/interfaces/linux.rs#L62
+[nw-bsd-route]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/interfaces/bsd.rs#L73
+[nw-win-route]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/interfaces/windows.rs#L29
+[nw-bsd-macos]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/interfaces/bsd/macos.rs#L4
+[nm-actor]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/netmon/actor.rs#L93
+[nm-linux]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/netmon/linux.rs#L61
+[nm-bsd]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/netmon/bsd.rs#L95
+[nm-windows]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/netmon/windows.rs#L32
+[nm-android]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/netmon/android.rs#L16
+[udp]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/udp.rs#L20
+[udp-buf]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/udp.rs#L28
+[udp-transient]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/udp.rs#L518
+[udp-rebind]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/udp.rs#L281
+[udp-gso]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/udp.rs#L332
+[udp-close]: https://github.com/n0-computer/net-tools/blob/051ab876/netwatch/src/udp.rs#L192
+[pm-lib]: https://github.com/n0-computer/net-tools/blob/051ab876/portmapper/src/lib.rs#L434
+[pm-trust]: https://github.com/n0-computer/net-tools/blob/051ab876/portmapper/src/lib.rs#L40
+[pm-strategy]: https://github.com/n0-computer/net-tools/blob/051ab876/portmapper/src/lib.rs#L632
+[pm-probe]: https://github.com/n0-computer/net-tools/blob/051ab876/portmapper/src/lib.rs#L280
+[pm-current]: https://github.com/n0-computer/net-tools/blob/051ab876/portmapper/src/current_mapping.rs#L122
+[pm-pcp]: https://github.com/n0-computer/net-tools/blob/051ab876/portmapper/src/pcp.rs#L14
+[pm-natpmp]: https://github.com/n0-computer/net-tools/blob/051ab876/portmapper/src/nat_pmp.rs#L16
+[pm-upnp]: https://github.com/n0-computer/net-tools/blob/051ab876/portmapper/src/upnp.rs#L19
+[socket]: ./socket.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[quic]: ./quic-transport.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[concepts]: ./concepts.md
+[index]: ./index.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[algeff]: ../algebraic-effects/index.md
+[async-io]: ../async-io/index.md
+[io-uring]: ../async-io/io-uring/index.md
+[tokio]: ../async-io/tokio.md
+[qad-draft]: https://datatracker.ietf.org/doc/draft-seemann-quic-address-discovery/
+[rfc6887]: https://www.rfc-editor.org/rfc/rfc6887
+[rfc6886]: https://www.rfc-editor.org/rfc/rfc6886
+[igd]: https://docs.rs/igd-next/
+[tailscale-netcheck]: https://github.com/tailscale/tailscale/blob/main/net/netcheck/netcheck.go

--- a/docs/research/iroh/quic-transport.md
+++ b/docs/research/iroh/quic-transport.md
@@ -1,0 +1,771 @@
+# QUIC Transport (`noq`)
+
+`noq` is n0's maintained fork of [`quinn`][quinn] — a sans-io QUIC v1 state machine (`noq-proto`), a synchronous platform-UDP layer (`noq-udp`), and a thin async façade (`noq`) — extended with QUIC Multipath, QUIC Address Discovery, and an in-QUIC NAT-traversal protocol; it is the single largest dependency a native D port of iroh must replace.
+
+| Field               | Value                                                                                                                                                                                                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Crate(s)            | `noq`, `noq-proto`, `noq-udp`                                                                                                                                                                                                                                |
+| Version             | `1.0.1` (git tag `noq-v1.0.1`, HEAD `340e9c7`, released 2026-06-29)                                                                                                                                                                                          |
+| Repository          | [`n0-computer/noq`][noq-readme]                                                                                                                                                                                                                              |
+| Documentation       | [docs.rs/noq][docs-noq] · [docs.rs/noq-proto][docs-noq-proto] · [docs.rs/noq-udp][docs-noq-udp]                                                                                                                                                              |
+| ALPN(s)             | none — `noq` is application-agnostic; ALPN is chosen by iroh's [Endpoint][endpoint], not by the transport                                                                                                                                                    |
+| Approx. size (LoC)  | `noq-proto` 49,395 (38,221 non-test); `noq` + `noq-udp` 10,563 — ≈48k of protocol logic                                                                                                                                                                      |
+| Category            | Foundations                                                                                                                                                                                                                                                  |
+| Upstream spec/draft | [RFC 9000][rfc9000]/[9001][rfc9001]/[9002][rfc9002] (QUIC v1); [RFC 9221][rfc9221] (datagrams); [RFC 8899][rfc8899] (DPLPMTUD); drafts: [multipath][draft-multipath], [QAD][draft-qad], [QNT][draft-qnt], [ack-frequency][draft-ackfreq], [BBRv3][draft-bbr] |
+
+> [!NOTE]
+> The [NAT-traversal frame semantics][nat-traversal] (`ADD_ADDRESS`/`REACH_OUT`/`REMOVE_ADDRESS`,
+> the probe timeline, hole-punch orchestration) live in [NAT Traversal & Address Discovery][nat-traversal].
+> This page covers the transport plumbing: how those frames ride the QUIC dataplane, how
+> paths are validated, and how the whole state machine is driven.
+
+---
+
+## Overview
+
+### What it solves
+
+iroh's connectivity story is "a QUIC connection to a stable [EndpointId][identity-crypto], no matter
+where the peer is or how many network paths reach it." QUIC is the transport that carries that
+promise: authenticated, encrypted, multiplexed streams over UDP, with connection identity
+decoupled from the 4-tuple so a connection survives NAT rebinds and network changes. iroh needs
+three things stock QUIC libraries do not provide together: (1) **multipath**, so one logical
+connection can use a direct hole-punched path and a relayed path simultaneously and fail over
+between them; (2) **QUIC Address Discovery**, so a peer learns its own public address from the
+other end without a separate STUN side-protocol; and (3) **in-QUIC NAT traversal**, replacing
+iroh 0.x's DISCO-over-UDP side-channel with `ADD_ADDRESS`/`REACH_OUT` frames carried inside the
+encrypted connection itself. `noq` is the fork of [`quinn`][quinn] that adds all three.
+
+Architecturally the decisive property is that the protocol logic is **sans-io**: `noq-proto`
+"contains a fully deterministic implementation of QUIC protocol logic. It contains no networking
+code and does not get any relevant timestamps from the operating system" ([`noq-proto/src/lib.rs:3-5`][lib-proto]).
+Time, randomness, and buffers are all injected; the core is a pure function of `(now, event) →
+(transmits, next-deadline)`. That is exactly the shape [`sparkles:event-horizon`][eh-spec] wants to
+drive — see [Design philosophy](#design-philosophy) and [Mapping to event-horizon](#mapping-to-event-horizon).
+
+### Design philosophy
+
+The crate is split identically to `quinn` into three layers, and the split is the whole point.
+From the `noq-proto` crate root ([`noq-proto/src/lib.rs:1-8`][lib-proto]):
+
+> _"noq-proto contains a fully deterministic implementation of QUIC protocol logic. It contains no
+> networking code and does not get any relevant timestamps from the operating system. Most users may
+> want to use the futures-based noq API instead. The noq-proto API might be of interest if you want
+> to use it from a C or C++ project through C bindings **or if you want to use a different event loop
+> than the one tokio provides.**"_
+
+That last clause is the licence for the D port. `noq` (the async crate) exists solely to weld the
+sans-io core to `tokio` or `smol`: `Arc<Mutex<State>>` around the protocol machine, a spawned driver
+future per endpoint and per connection, and waker maps to bridge `Future`/`Waker` back onto the
+poll-based core. **None of that is intrinsic to QUIC.** A D port on event-horizon drives `noq-proto`'s
+design directly — one fiber owning the `Connection` value, an in-ring `TIMEOUT` op for its single
+collapsed deadline, tier-B `recv`/`send` verbs where `noq` calls `poll_recv`/`poll_send` — and the
+two `Mutex<State>` cells, the mpsc channels, the `Notify`s, and the self-wakes all become zero code.
+
+The fork's stated mission ([`README.md:14-21`][noq-readme]):
+
+> _"Noq started out as a fork of the excellent Quinn project. The main focus of development has been
+> towards adding support for more QUIC (draft) extensions: QUIC Multipath, QUIC Address Discovery
+> (QAD), Using QUIC to traverse Nat's (QNT)."_
+
+Two consequences shape everything downstream. First, a D port targeting interop with iroh 1.0 peers
+**cannot skip the extensions**: iroh negotiates multipath, QAD, and QNT via transport parameters at
+handshake, and — unlike iroh 0.x — there is no DISCO/STUN fallback if they are absent. Second, the
+extensions are not cleanly separable modules; `PathId` plumbing reaches into the packet-number
+spaces, the loss recovery, the frame registry, and even the AEAD nonce (see
+[Cryptography & identity](#cryptography--identity)).
+
+`noq` sits beside the other async-I/O prior art the Sparkles survey tracks: it is a `tokio`-first
+poll-based runtime adapter ([Tokio][tokio]) over a sans-io core, the opposite pole from a
+completion-first thread-per-core design ([Glommio][glommio], [Monoio][monoio]). The interesting
+observation is that the _core_ is runtime-neutral by construction, so the adapter — not the protocol —
+is what event-horizon replaces.
+
+---
+
+## How it works
+
+### The three-crate stack
+
+```text
+┌──────────────────────────────────────────────────────────────────────┐
+│ noq        async façade: Endpoint / Connection / SendStream / …        │
+│            Arc<Mutex<State>> + spawned driver futures + waker maps      │
+│            plugs into a runtime via Runtime / AsyncUdpSocket / AsyncTimer│
+├──────────────────────────────────────────────────────────────────────┤
+│ noq-udp    synchronous platform UDP: GSO / GRO / ECN / pktinfo / cmsg   │
+│            UdpSocketState::{send,recv}; Transmit / RecvMeta currency    │
+├──────────────────────────────────────────────────────────────────────┤
+│ noq-proto  SANS-IO: Endpoint::handle / Connection pump methods          │
+│            pure (now, event) → (transmits, deadline); no I/O, no clock  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+`noq-proto` is ~38k non-test lines of pure state machine. `noq-udp` (10k with `noq`) is the only
+part that touches sockets, and `noq` is the ~4k-line adapter that a different runtime replaces.
+
+### The platform UDP layer (`noq-udp`)
+
+`UdpSocketState::new` ([`noq-udp/src/unix.rs:69-201`][udp-unix]) takes a borrowed non-blocking socket
+and enables every UDP "superpower" the platform offers: `IP_RECVTOS`/`IPV6_RECVTCLASS` (read ECN),
+`IP_PKTINFO`/`IPV6_RECVPKTINFO` (report the destination address of received datagrams and select the
+source IP on send — load-bearing for multipath), `IP_MTU_DISCOVER=IP_PMTUDISC_PROBE` + `IPV6_DONTFRAG`
+(turn fragmentation off; on failure `may_fragment` flips true), and `SOL_UDP/UDP_GRO` (receive
+coalescing, `gro_segments=64` on success). **GSO** is probed once per process by a Linux ≥ 4.18
+version check plus a trial `UDP_SEGMENT` `setsockopt`, yielding `max_gso_segments=64`; it is then
+applied **per transmit** via a `UDP_SEGMENT` control message, never set globally
+([`unix.rs:1021-1067`][udp-unix]). A single `sendmsg` carries up to three cmsgs — ECN
+(`IP_TOS`/`IPV6_TCLASS`), segment size, and source address (`in_pktinfo`) — in an 88-byte aligned
+control buffer (`CMSG_LEN = 88`). Receives use `recvmmsg` with `BATCH_SIZE = 32` on Linux.
+
+The currency types are `Transmit` (an outgoing datagram or GSO batch) and `RecvMeta` (per-buffer
+receive metadata):
+
+```rust
+// noq-udp/src/lib.rs:95-151 (comments condensed)
+pub struct Transmit<'a> {
+    pub destination: SocketAddr,
+    pub ecn: Option<EcnCodepoint>,
+    pub contents: &'a [u8],
+    pub segment_size: Option<usize>, // Some => GSO batch of equal-size datagrams
+    pub src_ip: Option<IpAddr>,
+}
+#[non_exhaustive]
+pub struct RecvMeta {
+    pub addr: SocketAddr,       // source of the datagram(s)
+    pub len: usize,             // bytes in the buffer
+    pub stride: usize,          // one datagram's size; len may be n*stride under GRO
+    pub ecn: Option<EcnCodepoint>,
+    pub dst_ip: Option<IpAddr>,
+    pub interface_index: Option<u32>,
+}
+```
+
+Runtime error hardening is pervasive and interop-relevant: `EMSGSIZE` on send is swallowed (expected
+for MTU probes); GSO **dynamically self-disables** (drops to `max_gso_segments=1`) on `EIO`/`EINVAL`
+from unsupported drivers; and "UDP transmission errors are considered non-fatal because higher-level
+protocols must employ retransmits and timeouts anyway" ([`unix.rs:207-210`][udp-unix]). Windows
+mirrors the design via `WSASendMsg`/`WSARecvMsg` with `UDP_SEND_MSG_SIZE`/`UDP_RECV_MAX_COALESCED_SIZE`
+and `SIO_UDP_CONNRESET`+`SIO_UDP_NETRESET` ioctls; `posix_minimal.rs` is the graceful floor — plain
+`send_to`/`recv_from`, no cmsgs.
+
+### The trait seam: `Runtime`, `AsyncUdpSocket`, `AsyncTimer`
+
+`noq/src/runtime/mod.rs` defines the four traits that make the async layer runtime-independent. **This
+is precisely where iroh plugs its multipath [Socket][socket] in, and precisely what a D port replaces
+with event-horizon.** `Runtime` supplies timers, task spawning, socket wrapping, and — crucially for
+deterministic testing — the clock:
+
+```rust
+// noq/src/runtime/mod.rs:17-33
+pub trait Runtime: Send + Sync + Debug + 'static {
+    /// Construct a timer that will expire at `i`
+    fn new_timer(&self, i: Instant) -> Pin<Box<dyn AsyncTimer>>;
+    /// Drive `future` to completion in the background
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>);
+    /// Convert `t` into the socket type used by this runtime
+    fn wrap_udp_socket(&self, t: std::net::UdpSocket) -> io::Result<Box<dyn AsyncUdpSocket>>;
+    /// Look up the current time. Allows simulating the flow of time for testing.
+    fn now(&self) -> Instant { Instant::now() }
+}
+```
+
+Sending is deliberately factored into per-task `UdpSender` objects rather than a `poll_send` on the
+socket, because "a `poll_send` method on a single object can usually store only one `Waker` at a time,
+i.e. allow at most one caller to wait for an event. This method allows any number of interested tasks
+to construct their own `UdpSender` object" ([`runtime/mod.rs:48-52`][runtime]). The endpoint driver
+and every connection driver each own a `UdpSender` so they can all block on write-readiness concurrently:
+
+```rust
+// noq/src/runtime/mod.rs:43-107 (doc comments trimmed)
+pub trait AsyncUdpSocket: Send + Sync + Debug + 'static {
+    fn create_sender(&self) -> Pin<Box<dyn UdpSender>>;
+    fn poll_recv(&mut self, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>],
+                 meta: &mut [RecvMeta]) -> Poll<io::Result<usize>>;
+    fn local_addr(&self) -> io::Result<SocketAddr>;
+    fn max_receive_segments(&self) -> NonZeroUsize { NonZeroUsize::MIN }
+    fn may_fragment(&self) -> bool { true }
+}
+pub trait UdpSender: Send + Sync + Debug + 'static {
+    fn poll_send(self: Pin<&mut Self>, transmit: &Transmit<'_>,
+                 cx: &mut Context<'_>) -> Poll<io::Result<()>>;
+    fn max_transmit_segments(&self) -> NonZeroUsize { NonZeroUsize::MIN }
+}
+```
+
+iroh implements `AsyncUdpSocket` with its own `Transport` whose `poll_send` demultiplexes
+`Transmit.destination` — a _mapped_ fake-IPv6 address — into a real UDP socket, a [relay][relay]
+connection, or a custom transport, and whose `local_addr` fabricates a `DEFAULT_FAKE_ADDR` when only
+relay transports exist ([`iroh/src/socket/transports.rs`][iroh-transports]). So the seam iroh occupies
+_is_ the seam a D port occupies; reproducing this interface is reproducing iroh's connection API.
+
+### The sans-io core: six pump methods
+
+Below the seam, `noq-proto` exposes a tiny, purely synchronous surface. `Endpoint::handle` routes an
+incoming datagram; `Connection` has exactly six pump methods:
+
+```rust
+// noq-proto: the sans-io Connection surface (signatures)
+// noq-proto/src/connection/mod.rs:460,470,488,1018,2183,2394
+impl Connection {
+    fn handle_event(&mut self, event: ConnectionEvent);              // feed a routed datagram/rebind
+    fn handle_timeout(&mut self, now: Instant);                      // a deadline fired
+    fn poll_transmit(&mut self, now: Instant, max_datagrams: usize,
+                     buf: &mut Vec<u8>) -> Option<Transmit>;         // produce one datagram/GSO batch
+    fn poll_timeout(&mut self) -> Option<Instant>;                   // single collapsed next deadline
+    fn poll(&mut self) -> Option<Event>;                             // application events (poll-pull)
+    fn poll_endpoint_events(&mut self) -> Option<EndpointEvent>;     // CID needs, draining/drained
+}
+```
+
+The endpoint side is equally spare. A single `handle` method takes the routed datagram and returns an
+`Option<DatagramEvent>`; `connect`/`accept`/`refuse`/`retry`/`ignore` drive lifecycle. `DatagramEvent`
+is the routing verdict:
+
+```rust
+// noq-proto/src/endpoint.rs:1220-1227
+pub enum DatagramEvent {
+    ConnectionEvent(ConnectionHandle, ConnectionEvent), // redirect to a Connection
+    NewConnection(Incoming),                            // may start a new Connection
+    Response(Transmit),                                 // stateless response from the endpoint
+}
+```
+
+A `FourTuple` is deliberately a _two_-tuple — remote `SocketAddr` plus an optional local IP, no local
+port, because "when we send, we can only specify the `src_ip`, not the source port"
+([`noq-proto/src/lib.rs:371-380`][lib-proto]) — with IPv6 flowinfo and (usually) scope_id normalized
+away so path-identity comparisons are stable.
+
+### Streams, flow control, and datagrams
+
+Stream data never crosses a channel: the mpsc channels between drivers carry only _events_; payload
+bytes go straight into the shared `proto::Connection` under the mutex. Each send-stream owns a
+`SendBuffer` ([`send_buffer.rs`][send-buffer]) — a base offset, a `VecDeque<Bytes>` of frozen segments,
+and a `BytesMut last_segment` that coalesces writes ≤ `MAX_COMBINE = 1452` bytes; larger `Bytes` are
+stored zero-copy. Its `poll_transmit(max_len)` is the only scheduler: lost ranges (`retransmits:
+ArrayRangeSet`) are served before fresh `unsent..offset()` data. The send half is a three-state
+machine — `Ready`, `DataSent{finish_acked}`, `ResetSent` ([`send.rs:293-301`][streams-send]) — with a
+non-obvious rule: a peer `STOP_SENDING` only records `stop_reason` and emits an event; it does **not**
+change the send state. The _application_ is expected to call `reset()` in response, which the async
+layer does on `SendStream` drop.
+
+The receive half reassembles into an `Assembler` ([`assembler.rs`][assembler]): a `BinaryHeap<Buffer>`
+ordered min-offset-first, with an over-allocation defence because chunks refcount-pin their decrypted
+packet buffers. When over-allocation exceeds `max(32768, buffered * 3/2)` the heap is defragmented into
+fresh contiguous buffers. Reading happens through a `Chunks` guard that _removes_ the `Recv` from the
+map for the duration of the read, so state cannot change mid-read; its `finalize()` (run by `Drop`)
+issues connection flow-control credit exactly once. Per-stream flow control re-announces `MAX_STREAM_DATA`
+when the window has moved ≥ 1/8 of `stream_receive_window` (default 1,250,000 bytes); **connection-level
+flow control is disabled by default** — `receive_window` defaults to `VarInt::MAX` and the `MAX_DATA`
+emitter goes silent above `VarInt::MAX`, so only the 1.25 MB per-stream window and the 10 MB local
+`send_window` throttle ([`config/transport.rs:545-601`][cfg-transport]).
+
+Unreliable [RFC 9221][rfc9221] `DATAGRAM` frames ([`datagrams.rs`][datagrams]) are queued in
+`VecDeque`s; the receive queue drops _oldest_ silently when full, and `Event::DatagramReceived` fires
+only on the empty→non-empty edge, so an application must drain exhaustively per event.
+
+### Loss recovery, congestion control, and MTU discovery
+
+All recovery and congestion state is **per-path** — one `RttEstimator`, `Box<dyn Controller>`, `Pacer`,
+`MtuDiscovery`, and `InFlight` counter per `PathData` ([`paths.rs:162-286`][paths]). RTT is textbook
+[RFC 6298][rfc6298]/[9002][rfc9002] (7/8 smoothed, 3/4 variance); `pto_base() = srtt + max(4*rttvar,
+TIMER_GRANULARITY)` with `TIMER_GRANULARITY = 1ms`. Loss detection ([`mod.rs:3253-3352`][conn-proto])
+is the RFC 9002 §6.1 dual threshold — `packet_threshold = 3` or `time_threshold = 9/8·RTT`.
+
+`noq` deviates hardest from `quinn` in **PTO backoff**: instead of unbounded `pto * 2^n` exponential
+backoff it computes an _interval-capped_ backoff — each doubling step is limited to at most
+`max_interval` more than the previous deadline, where `max_interval` is `MAX_PTO_INTERVAL = 2s` normally
+(`1s` under short idle timeouts, `1.5*srtt` on links with `srtt > 1333ms`)
+([`mod.rs:3539-3634`][conn-proto]). With iroh's default 30s idle timeout, a stalled connection therefore
+sends tail-loss probes at least every ~2s indefinitely rather than backing off toward the idle timeout.
+
+Three congestion controllers ship. **Cubic is the default** — `CubicConfig::default()`
+([`config/transport.rs:581`][cfg-transport]), and iroh does not override it — with NewReno and an
+experimental **BBRv3** ([draft-ietf-ccwg-bbr-05][draft-bbr]) available; the widely-repeated claim that
+"iroh runs BBR" is wrong at this pin. BBRv3 ([`bbr3/mod.rs`][bbr3], 1,743 lines) is a fresh
+implementation keeping its own shadow packet ledger for delivery-rate sampling, with a
+Startup → Drain → ProbeBw ⟲ / ProbeRtt state machine. The `Controller` trait is 13 hooks
+([`congestion.rs:17-124`][congestion]); anti-amplification, MTU updates, and ECN all feed through it.
+
+MTU discovery is [DPLPMTUD, RFC 8899][rfc8899] ([`mtud.rs`][mtud]): a per-path binary search from
+`INITIAL_MTU = 1200` toward `min(1452, peer max_udp_payload_size)`, probes being lone padded PING
+datagrams (+ `IMMEDIATE_ACK` if the peer supports ack-frequency, converging at RTT speed). A
+`BlackHoleDetector` collapses `current_mtu` back to 1200 after > 3 "suspicious" loss bursts — bursts
+whose smallest packet exceeds both `min_mtu` and any more-recently-acked packet size.
+
+### Multipath, connection IDs, and packetization
+
+Multipath is negotiated only when both sides send the `initial_max_path_id` transport parameter and the
+handshake completes. A `PathId` (varint `u32`) names a **QUIC-Multipath packet-number space** — its own
+packet numbers, ACK state, dedup window, and loss timers — while a `PathData` names a **4-tuple in use**
+— RTT, congestion controller, pacer, MTU, anti-amplification counters, validation state. One `PathId`
+can migrate across 4-tuples (successive `PathData` _generations_); every `SentPacket` records its
+`path_generation` so ACK/loss accounting attributes to the correct controller across migrations
+([`paths.rs:138-153`][paths]):
+
+> _"With QUIC-Multipath a path is identified by a `PathId` … a single QUIC-Multipath path can migrate to
+> a different 4-tuple … There are thus two states we keep for paths: `PacketNumberSpace` … which remains
+> in place across path migrations … `PathData`: The state we keep for each unique 4-tuple within a space."_
+
+Path scheduling is a **strict two-tier priority, not a spraying scheduler**. `poll_transmit` walks the
+`paths: BTreeMap<PathId, PathState>` in ascending `PathId` order (the ordering _is_ the policy) and
+sends on the lowest-`PathId` validated `Available` path that is not congestion/pacing/amplification
+blocked; `Backup` paths carry data only when no `Available` path exists ([`paths.rs:1022-1031`][paths]):
+
+> _"Paths marked with as available will be used when scheduling packets. If multiple paths are available,
+> packets will be scheduled on whichever has capacity. … Paths marked as backup will only be used if
+> there are no available paths."_
+
+iroh configures 8 concurrent paths, a 5s heartbeat, and a 15s per-path idle timeout
+([`iroh/src/socket.rs`][iroh-socket]). All smarter path selection (RTT-weighting, failover policy)
+lives above `noq`, in iroh's [Socket][socket] remote-state actor.
+
+Connection IDs are per-`PathId` in both directions. Locally, the _endpoint_ owns CID generation
+(`NeedIdentifiers → NewIdentifiers`), issuing `min(peer active_connection_id_limit, LOCAL_CID_COUNT=12)`
+per path and deriving the 16-byte stateless-reset token as `HMAC(reset_key, cid)`. Remotely, a
+`CidQueue` is a 5-slot sliding window with one active CID. Packetization runs through `TransmitBuf`
+(a GSO batch over the caller's `Vec<u8>`) and `PacketBuilder`, which enforce AEAD budgets before writing,
+draw packet numbers via a `PacketNumberFilter` that **deliberately skips numbers at random** (an
+optimistic-ACK defence — ACKing a skipped number is a `PROTOCOL_VIOLATION`), pad Initials to
+`MIN_INITIAL_SIZE = 1200`, and coalesce ([RFC 9000][rfc9000] §12.2) only on `PathId::ZERO` during the
+handshake. Frame emission order within a packet is fixed
+([`mod.rs:6061-6540`][conn-proto]) — `HANDSHAKE_DONE`, `PING`, `IMMEDIATE_ACK`, `(PATH_)ACK` per path,
+`ACK_FREQUENCY`, path-management frames, NAT-traversal frames, `CRYPTO`, control frames, `DATAGRAM`,
+`NEW_TOKEN`, then `STREAM` data last.
+
+### Address validation and anti-replay
+
+Amplification defence is pure byte accounting on `PathData`
+([`paths.rs:407-409`][paths]):
+
+```rust
+// noq-proto/src/connection/paths.rs:407-409 — the anti-amplification invariant
+pub(super) fn anti_amplification_blocked(&self, bytes_to_send: u64) -> bool {
+    !self.validated && self.total_recvd * 3 < self.total_sent + bytes_to_send
+}
+```
+
+The check is enforced only for servers and only at datagram-creation time; any remaining budget admits
+one full MTU ([quinn#1082 behaviour][conn-proto]). Two token mechanisms ([RFC 9000][rfc9000] §8.1)
+supply validation across the 3× gate: **Retry tokens** (bind ip+port, ~15s lifetime, minted in a Retry
+packet — the only token that can _kill_ a handshake, via `INVALID_TOKEN`) and **Validation tokens**
+(bind IP only, ~2-week lifetime, minted in `NEW_TOKEN` frames, redeemable in a later connection — every
+failure path only degrades to _unvalidated_). Both ride one AEAD-sealed `Token` container with the
+nonce appended in the clear. A subtlety a port must reproduce: the server stores _addresses, not tokens_
+in its pending `NEW_TOKEN` queue, so a lost `NEW_TOKEN` is retransmitted as a **freshly minted token**
+and a client that receives both copies cannot double-spend ([`spaces.rs:570-586`][spaces]).
+
+> [!IMPORTANT]
+> **The entire `NEW_TOKEN` half is dormant in stock iroh 1.0.1.** iroh depends on `noq` with
+> `default-features = false, features = ["rustls"]`, so the `bloom` feature is off, `BloomTokenLog`
+> is not compiled, and `ValidationTokenConfig::default()` degrades to `NoneTokenLog` + `sent: 0`
+> ([`config/mod.rs:519-531`][cfg-mod]): default servers send zero `NEW_TOKEN` frames. A D port can
+> ship `NoneTokenLog`/`NoneTokenStore` semantics first and stay behaviour-identical to upstream,
+> keeping the trait seams. The Retry half (mint/validate) is always live and is _mandatory_ for interop.
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+`noq` speaks [RFC 9000][rfc9000]/[9001][rfc9001]/[9002][rfc9002] QUIC v1 (plus draft versions
+`0xff00001d..0xff000022`). Load-bearing constants a port must reproduce byte-for-byte
+([`noq-proto/src/lib.rs:350-359`][lib-proto]): `MAX_CID_SIZE = 20`, `RESET_TOKEN_SIZE = 16`,
+`MIN_INITIAL_SIZE = 1200`, `INITIAL_MTU = 1200`, `MAX_UDP_PAYLOAD = 65527`, `LOCAL_CID_COUNT = 12`,
+`TIMER_GRANULARITY = 1ms`. Integers are QUIC 2-bit-prefix varints (max `2^62−1`, max 8 encoded bytes) —
+the same encoding surveyed in [Wire Formats & Serialization][wire-serialization]. `StreamId` bit layout
+is `(index << 2) | (dir << 1) | initiator`.
+
+The **frame-type registry carries the fork extensions** ([`frame.rs:41-136`][frame]): standard frames
+`0x00`–`0x1e`, plus `ImmediateAck = 0x1f` and `AckFrequency = 0xaf`; **QAD** `ObservedIpv4Addr = 0x9f81a6`
+/ `ObservedIpv6Addr = 0x9f81a7`; **[Multipath][draft-multipath]** `PathAck = 0x3e`, `PathAckEcn = 0x3f`,
+`PathAbandon = 0x3e75`, `PathStatusBackup = 0x3e76`, `PathStatusAvailable = 0x3e77`,
+`PathNewConnectionId = 0x3e78`, `PathRetireConnectionId = 0x3e79`, `MaxPathId = 0x3e7a`,
+`PathsBlocked = 0x3e7b`, `PathCidsBlocked = 0x3e7c`; and **n0's NAT traversal** (`AddIpv4Address =
+0x3d7f90` … `RemoveAddress = 0x3d7f94`), which the source labels "IROH'S NAT TRAVERSAL" and explicitly
+calls "n0's own protocol", _not_ [draft-seemann-quic-nat-traversal][draft-qnt] semantics — see
+[NAT Traversal & Address Discovery][nat-traversal].
+
+The **transport-parameter registry** likewise ([`transport_parameters.rs:700-734`][tparams]): standard
+`0x00`–`0x10`, `MaxDatagramFrameSize = 0x20` ([RFC 9221][rfc9221]), `GreaseQuicBit = 0x2AB2`
+([RFC 9287][rfc9287]), `MinAckDelayDraft07 = 0xFF04DE1B`, plus the negotiation gates `ObservedAddr =
+0x9f81a176` (QAD role), `InitialMaxPathId = 0x3e` (multipath), and `N0NatTraversal = 0x3d7f91120401`
+(value = `max_remote_nat_traversal_addresses`). The dataplane frame layouts (`STREAM` `0x08`–`0x0f`
+with OFF/LEN/FIN bits; `RESET_STREAM` `0x04`; `MAX_DATA` `0x10`; `DATAGRAM` `0x30`/`0x31`) match
+[RFC 9000][rfc9000] §19 exactly; the fork changes are additive.
+
+### Cryptography & identity
+
+TLS 1.3 is provided by [`rustls`][rfc9001] (0.23.33 mainline — not a fork) behind a clean `crypto`
+seam ([`crypto.rs`][crypto]): a `Session` trait wrapping `read_handshake`/`write_handshake` over
+`CRYPTO`-frame bytes, and separate `PacketKey`/`HeaderKey`/`HmacKey`/`HandshakeTokenKey` traits. The
+**decisive fork change is that packet protection is path-aware** — `PacketKey::encrypt`/`decrypt` take
+a `PathId` ([`crypto.rs:157-175`][crypto]), because QUIC-Multipath separates the AEAD nonce space per
+path:
+
+```rust
+// noq-proto/src/crypto.rs:157-175
+pub trait PacketKey: Send + Sync {
+    fn encrypt(&self, path_id: PathId, packet: u64, buf: &mut [u8], header_len: usize);
+    fn decrypt(&self, path_id: PathId, packet: u64, header: &[u8], payload: &mut BytesMut)
+        -> Result<(), CryptoError>;
+    fn tag_len(&self) -> usize;
+    fn confidentiality_limit(&self) -> u64;
+    fn integrity_limit(&self) -> u64;
+}
+```
+
+The `path_id` is folded into the nonce _inside_ mainline `rustls` 0.23 via
+`encrypt_in_place_for_path(path_id.as_u32(), pn, …)` ([`crypto/rustls.rs:635-657`][crypto-rustls]) —
+the nonce bytes never appear in `noq-proto`, so a clean-room D port must source the exact
+QUIC-Multipath nonce construction from the [multipath draft][draft-multipath] and `rustls`. A stock
+`quinn`/`rustls` `PacketKey` is therefore **not** drop-in.
+
+Beyond packet keys, three more keyed constructions matter: the retry integrity tag (verifies a Retry
+packet), the stateless-reset token `HMAC(reset_key, cid)`, and the token AEAD. iroh installs its own
+`RustlsTokenKey` (a fixed random 32-byte key with the low 96 bits of the nonce as the IV, run through
+the provider's first TLS 1.3 AEAD) — deliberately the construction `noq`'s own `RetryTokenKey`
+(HKDF-per-nonce) avoids, and freshly randomized at every `Endpoint::bind`, so **tokens never survive a
+process restart**. Randomness is injected throughout (`rng: StdRng` seeded from
+`EndpointConfig::rng_seed`) for deterministic replay; a port needs a CSPRNG capability with a
+deterministic test double. The peer-identity story — X.509-over-raw-public-keys, the synthetic SNI
+`"{base32(endpoint_id)}.iroh.invalid"`, [EndpointId][identity-crypto] ↔ certificate binding — is a TLS
+concern documented in [Identity & Cryptography][identity-crypto]; this page stops at the QUIC key seam.
+
+### State machines & lifecycle
+
+The connection lifecycle is `Handshake → Established → Closed → Draining → Drained`
+([`state.rs`][state-proto]); `Draining` is reached directly on receiving `CONNECTION_CLOSE` (skipping
+`Closed`), and `kill()` jumps straight to `Drained` on idle timeout, stateless-reset receipt, or AEAD
+limit — with no wire traffic. Close is sent on exactly **one** path even under multipath, and closing
+resets every timer, arming only a single `Close` timer at `3 × max-PTO` per [multipath draft][draft-multipath] §2.6.
+
+The server's incoming-handshake decision is a four-way branch on an `Incoming`: `accept()`, `refuse()`
+(sends `CLOSE`), `retry()` (address-validation Retry; errors if a token already validated the address),
+or `ignore()` (silent) — and it **implicitly refuses on drop**. The per-`PathId` lifecycle is a
+five-state progression — _unknown → open_ (`open_status: Pending`), _→ validated_ (`Sent → Informed` on
+a matching on-path `PATH_RESPONSE`, emitting `PathEvent::Established`), _→ abandoned_ (`PATH_ABANDON`),
+_→ draining_ (on abandon receipt, `PathDrained` armed at `3×PTO`), _→ discarded_. Critically, even after
+a NAT-traversal hole-punch succeeds, the new `PathId` **still undergoes full [RFC 9000][rfc9000] §8.2
+on-path validation** with a `3×PTO` deadline before iroh sees `Established` and can promote it to
+`Available` (see the [NAT-traversal timeline][nat-traversal]). PathIds are never reused
+(`max(max_abandoned, max_used) + 1`), and a remote abandon _increments_ `local_max_path_id`, always
+replenishing the peer's path-open credit.
+
+The masterstroke for a driver is **timer collapse**. `noq-proto` internally maintains a `TimerTable` of
+7 connection timers (`Idle, Close, KeyDiscard, KeepAlive, PushNewCid, NoAvailablePath,
+NatTraversalProbeRetry`) plus 9 per-path timers (`LossDetection, PathIdle, PathValidationFailed,
+PathChallengeLost, AbandonFromValidation, PathKeepAlive, Pacing, MaxAckDelay, PathDrained`), keeping 4
+paths inline before heap spill ([`timer.rs`][timer]). But `poll_timeout()` reduces _all_ of them to one
+earliest `Instant`, and `noq` holds exactly **one** `AsyncTimer`, resetting it only when that value
+changes. A port re-arms a single in-ring `TIMEOUT` op — never one timer per space or per stream.
+
+### Dependencies & coupling
+
+`noq-proto` is the load-bearing algorithm — all of QUIC — with a handful of infrastructural deps:
+
+| Crate                             | Depth                         | D-port implication                                                                                                              |
+| --------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `noq-proto` (self)                | the algorithm                 | ≈38.2k non-test LoC to reimplement; the big rock                                                                                |
+| `rustls` (+ `ring`/`aws-lc-rs`)   | load-bearing (TLS 1.3 + AEAD) | Behind the `crypto` traits; `PacketKey` is **`PathId`-aware**, so the multipath nonce must be ported exactly                    |
+| `bytes` (`Bytes`/`BytesMut`)      | load-bearing data model       | Refcounted zero-copy slices pervade stream reads and datagram I/O; the assembler defrag logic exists _only_ because of aliasing |
+| `tokio` (`sync`/`io`/`time`/`rt`) | structural (in `noq` only)    | `Notify`/mpsc/watch/broadcast/oneshot — replaced wholesale by event-horizon idioms                                              |
+| `socket2`, `libc`/`windows-sys`   | API-surface                   | cmsg/`sendmsg`/`recvmmsg` — ~1–2k LoC of D syscalls per platform                                                                |
+| `sorted-index-buffer` (n0)        | load-bearing container        | `sent_packets`/`lost_packets` ordered-by-pn map with range iteration below `largest_acked`                                      |
+| `rand` (`StdRng`) / `rand_pcg`    | mixed                         | CSPRNG (pn-skip filter, tokens, CID grease) must be injectable; BBR3 probe jitter can be any PRNG                               |
+| `tinyvec`, `rustc-hash`, `slab`   | perf detail                   | `ArrayRangeSet` ≈ `SmallBuffer`; `FxHashMap`; connection-handle arena                                                           |
+
+There is **no external QUIC/CC/recovery library to bind** — BBRv3, Cubic, the pacer, MTUD, the dedup
+window, and the reassembler are all in-tree and must be reimplemented. A planning split of the ~38.2k
+non-test lines:
+
+| Bucket                             | LoC (approx.) | Contents                                                                                                                                                                       |
+| ---------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| RFC-mandatory QUIC v1 core         | ~27–29k       | packets, frames, streams (2,230-line state machine + 846-line assembler + 762-line send buffer), loss/CC (Cubic/NewReno), MTUD (982), pacing (444), endpoint, tokens, TLS glue |
+| n0 / draft extensions              | ~6–8k         | multipath machinery (`paths.rs` 1,187 + pervasive `PathId` plumbing), QNT (`n0_nat_traversal.rs` 1,075), QAD (`address_discovery.rs` 73), BBRv3 (`bbr3/` 1,894)                |
+| qlog observability (feature-gated) | ~1.5k         | `connection/qlog.rs` + `config/qlog.rs`                                                                                                                                        |
+
+Multipath is **not separable** — `PathId` appears 216 times in the 7,798-line `connection/mod.rs` and
+reaches into `spaces.rs`, `frame.rs`, `cid_state.rs`, `packet_crypto.rs`, and the crypto trait. **iroh
+couples to `noq` extremely tightly**: `iroh/src/endpoint/quic.rs` re-exports ~25 `noq` types and ~30
+`noq_proto` types directly into iroh's public API (149 `noq::` references across 15 iroh modules), so
+`noq`'s stream/error/varint types _are_ iroh's. Reimplementing the `noq` surface _is_ reimplementing
+iroh's connection API — see [Endpoint & Protocol Router][endpoint].
+
+### Concurrency & I/O model
+
+`noq` (unlike iroh 0.x's actor-based magicsock) uses **no `select!`, no `JoinSet`, no `spawn_blocking`**
+anywhere — the drivers are hand-rolled `Future::poll` implementations over two mutex-protected state
+cells. All endpoint state lives in one `std::sync::Mutex<State>`; all connection state in another
+(optionally a `lock_tracking` wrapper that warns when a lock is held > 1ms). A spawned `EndpointDriver`
+future and one `ConnectionDriver` future per connection lock the state on each poll and pump the sans-io
+machine; user-facing handles are `Arc` clones that take the same lock. The endpoint↔connection channels
+carry only _events_ (datagrams pre-decoded); the full concurrency inventory (20 primitives — two
+mutexes, unbounded mpscs, `oneshot`s, `watch` cells, `broadcast(32)` event streams, `Notify`s, per-stream
+`FxHashMap<StreamId, Waker>` maps, refcount atomics) is enumerated in [Tokio Concurrency Inventory][concurrency].
+
+Fairness is hand-managed because a `tokio` task must yield voluntarily: the endpoint caps at
+`IO_LOOP_BOUND = 160` datagram-batches per poll and an adaptive `WorkLimiter` bounds recv work at
+`RECV_TIME_BOUND = 50µs`/cycle ("This helps ensure we don't starve anything when the CPU is slower than
+the link"); the connection caps at `MAX_TRANSMIT_DATAGRAMS = 20` and `MAX_TRANSMIT_SEGMENTS = 10` per
+poll. When work remains, the driver self-wakes (`cx.waker().wake_by_ref()`) rather than looping.
+Stateless endpoint responses are sent best-effort with a hand-rolled noop `Waker` and silently dropped
+when the socket is full — deliberate load-shedding, "morally equivalent to the packet getting lost due
+to congestion". The I/O model is thus **completion-agnostic readiness**: `noq-udp` does the syscalls
+synchronously and the runtime bridges readiness to the sans-io core.
+
+### Mapping to event-horizon
+
+The entire `noq` crate is an adapter from a poll-based sans-io core to work-stealing `tokio`. Under
+event-horizon's `single` topology ([spec][eh-spec]) that adapter dissolves. The sans-io _design_ of
+`noq-proto` is what a D port keeps; `noq`'s `Arc<Mutex<State>>`, waker maps, `Notify`s, and self-wakes
+become zero code because there is no preemption and no cross-thread sharing to guard.
+
+**The `Runtime` trait maps to a capability row, not a trait object.** `Runtime::now` is [`isClock`][eh-spec]
+(with `TestClock` giving the same virtual-time determinism `noq` gets via `Runtime::now`);
+`new_timer`/`reset` become a single in-ring `TIMEOUT` op keyed on the collapsed `poll_timeout()`
+deadline; `spawn` becomes `Scope.spawn`; `wrap_udp_socket` becomes an `isNet` capability. Dispatch is
+monomorphized — no vtable:
+
+```rust
+// noq: authority arrives as a boxed trait object shared across threads
+pub trait Runtime: Send + Sync + Debug + 'static { /* new_timer, spawn, wrap_udp_socket, now */ }
+// noq/src/runtime/mod.rs:17-33 (see above)
+```
+
+```d
+// proposed / sketch — authority is a value row handed to the root fiber;
+// dispatch monomorphizes, no Send/Sync/'static, no vtable.
+struct QuicEnv(Clock, Net)
+if (isClock!Clock && isNet!Net)
+{
+    Clock clock;   // clock.now() -> MonoTime; TestClock supplies virtual time
+    Net   net;     // sendmsg / recvmsg  (needs O19 msghdr support — see below)
+    // no `spawn` field: children are opened on the ambient `Scope`
+}
+```
+
+**Each driver becomes one fiber owning its state by value.** The connection driver's pump sequence
+(`process events → transmit → timer → forward events`) maps to a plain fiber loop; the six pump methods
+are plain method calls, and the two mutexes vanish:
+
+```rust
+// noq: connection state behind a lock, pumped by a spawned Future
+pub(crate) struct State {
+    pub(crate) inner: proto::Connection,          // the sans-io machine
+    driver: Option<Waker>,
+    timer: Option<Pin<Box<dyn AsyncTimer>>>,
+    blocked_writers: FxHashMap<StreamId, Waker>,  // parked stream ops
+    blocked_readers: FxHashMap<StreamId, Waker>,
+    sender: Pin<Box<dyn UdpSender>>,
+    buffered_transmit: Option<proto::Transmit>,   // stashed when the socket would block
+    // ... + oneshots, watches, broadcasts, Notifys
+}   // noq/src/connection.rs:1403-1447 (trimmed)
+```
+
+```d
+// proposed / sketch — one fiber owns the Connection value outright.
+// No lock, no Waker maps: parked stream ops are fibers in an intrusive wait-list.
+Outcome!void driveConnection(ref QuicEnv env, ref Connection conn, Scope sc)
+{
+    for (;;)
+    {
+        while (auto ev = conn.nextInboundEvent())        // plain queue, same thread
+            conn.handleEvent(ev);
+
+        Buf dg = env.pool.acquire();                     // pinned, io_uring-registered
+        while (auto t = conn.pollTransmit(env.clock.now(), maxDatagrams: 1, dg))
+            env.net.sendmsg(t.destination, dg[]).await;  // tier-B verb; parks THIS fiber
+
+        auto deadline = conn.pollTimeout();              // single collapsed Instant
+        auto ev = sc.race(env.net.recvReady(),           // whichever fires first
+                          env.clock.sleepUntil(deadline)).await;
+        if (ev.isTimeout) conn.handleTimeout(env.clock.now());
+    }
+}
+```
+
+**Channels have no v1 equivalent (open issue O20)** but need none _inside_ the proto layer: the
+endpoint↔connection mpscs carry events that, on one thread, `Endpoint::handle` can deliver by calling
+directly into the target connection's `VecDeque` — `quinn`'s channel hop exists only for `Send`/lock
+ordering. `tokio::sync::watch` (observed-address, open-path) and `broadcast(32)` (`path_events`,
+`nat_traversal_updates`) also have no direct equivalent; a versioned cell + waiter list and a bounded
+per-subscriber ring reproduce the lossy `Lagged(n)` semantics if API compatibility matters. Per-stream
+`blocked_writers`/`blocked_readers: FxHashMap<StreamId, Waker>` become a `StreamId → FiberHandle`
+table; `Notify::notify_waiters` becomes a wake-all of a parked-fiber list.
+
+**Drop-glue is protocol-visible and must be reproduced deliberately.** `Incoming` drop ⇒ refuse;
+`SendStream` drop ⇒ finish-or-reset; `RecvStream` drop ⇒ `stop(0)`; last connection handle drop ⇒
+implicit `close(0)`. The peer observes `STOP_SENDING`/`RESET_STREAM`/`CONNECTION_CLOSE`, so a port maps
+these to `Scope.onExit` LIFO hooks attached at handle creation — iroh-blobs' "drop-to-finish" provider
+behaviour is literally the `SendStream::drop` impl.
+
+**The hard prerequisite is O19 (msghdr-based `sendmsg`/`recvmsg`).** GSO/GRO/ECN/pktinfo all ride
+control messages, and multipath _requires_ source-IP selection (pktinfo on send) and destination-IP
+reporting (pktinfo on recv). event-horizon v1 lacks msghdr I/O, so wire-compatible transport is blocked
+on O19. The mitigation is graceful: `noq-proto` explicitly supports `enable_segmentation_offload=false`
+(forcing `max_datagrams = 1`), which removes the entire segment-size/padding-truncation branch — pass
+`maxDatagrams: 1` and revisit with O19. Two more items have **no equivalent and need new design**: a
+`WallClock` capability beside `isClock` (tokens use `SystemTime`/UNIX time, not `MonoTime`), and a
+CSPRNG capability with a deterministic double (for the pn-skip filter and token nonces).
+
+Two D-idiom wins fall out. The recovery/CC subsystem is a pure, allocation-light state machine — ideal
+for a `@nogc`-leaning `SumType!(Cubic, NewReno, Bbr3)` in place of `Box<dyn Controller>`, `clone_box`
+becoming a struct copy. And the buffer model has a clean choice: `noq`'s recv path _retains_ refcounted
+aliases into decrypted packets (hence the assembler defragmenter), but a D port can instead **copy out
+of the `Buf` at `STREAM`-frame ingest** into a per-stream buffer, deleting the entire `allocation_size`
+bookkeeping and the 32 KiB defrag threshold for one memcpy — likely the right call for v1. See
+[D Architecture Migration][d-migration] for the cross-subsystem plan.
+
+---
+
+## Strengths
+
+- **Sans-io core is runtime-neutral by construction.** The one architectural fact that makes a D port
+  tractable: no `Future`/`Waker` machinery is intrinsic to the protocol; event-horizon fibers drive the
+  same `poll_transmit`/`handle_event`/`handle_timeout` shape directly.
+- **Deterministic and testable.** Time, randomness, and buffers are injected; `noq` reproduces its full
+  test harness with fake time via `Runtime::now`, exactly what a `TestClock` + `SimNet` gives in D.
+- **Timer collapse.** 16 internal timer classes reduce to one `poll_timeout()` deadline and one runtime
+  timer — a single in-ring `TIMEOUT` op suffices.
+- **Genuine multipath + QAD + QNT** in one negotiated connection, with per-path CC/RTT/MTU and a clean
+  `Available`/`Backup` priority — the capability set iroh's whole connectivity model rests on.
+- **Battle-tested lineage.** A `quinn` fork inherits a mature, interop-tested QUIC v1 implementation;
+  the fork surface is additive extensions, not a rewrite of the core.
+- **Careful DoS hardening** throughout: optimistic-ACK pn-skip defence, assembler over-allocation cap,
+  3× amplification limit, stateless-reset rate limiting, capped path-response memory.
+
+## Weaknesses
+
+- **Enormous.** ≈38k non-test lines of protocol logic with no external library to lean on — BBRv3,
+  Cubic, pacer, MTUD, reassembler, token machinery all in-tree. This is the single largest port item.
+- **Extensions are inseparable.** `PathId` pervades the core (216 mentions in one file); a port cannot
+  ship "plain QUIC first, multipath later" and still interop with iroh, which negotiates multipath at
+  handshake with no fallback.
+- **Path-aware AEAD nonce lives in `rustls`, not `noq`.** The exact multipath nonce bytes never appear
+  in the readable sources; a clean-room port must derive them from the draft and `rustls` source.
+- **Tight iroh coupling.** 149 `noq::` references and ~55 re-exported types mean the transport API and
+  iroh's public API are the same surface — you cannot swap the QUIC layer in isolation.
+- **`tokio`-shaped concurrency** (`Arc<Mutex>`, mpsc, watch, broadcast, per-stream waker maps) is
+  entirely incidental complexity that a single-threaded port must recognize as _removable_, not port.
+- **Divergences from `quinn` are undocumented as a set** (pooled `Recv` objects, `sorted-index-buffer`,
+  interval-capped PTO, BBRv3, `SendBufferData` coalescing) — a port cannot fully lean on `quinn` docs.
+- **Two documented footguns to reproduce or fix**: `Controller::on_ack_frequency_update` is dead code,
+  and BBRv3's default initial window is ~10× intended (a `MAX_DATAGRAM_SIZE` unit slip).
+
+## Key design decisions and trade-offs
+
+| Decision                                                       | Rationale                                                                                   | Trade-off                                                                                          |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Sans-io core + thin async adapter (fork `quinn`'s split)       | Runtime-neutral, deterministic, C-bindable; drives any event loop                           | The adapter must re-implement fairness (`IO_LOOP_BOUND`, `WorkLimiter`) the executor won't provide |
+| `Arc<Mutex<State>>` + spawned driver futures (in `noq`)        | Bridges a poll core to work-stealing `tokio`; concurrent senders via per-task `UdpSender`   | All incidental to `tokio`; a single-threaded port deletes it wholesale                             |
+| Multipath as first-class `PathId` packet-number spaces         | Per-path CC/RTT/dedup/loss; connection survives path failover; enables QNT + relay fallback | `PathId` is inseparable from the core; per-path AEAD nonce reaches into the crypto trait           |
+| In-QUIC NAT traversal (n0 frames), no DISCO/STUN side-channel  | One encrypted, authenticated channel; no separate side-protocol to secure                   | n0-proprietary frames diverge from the draft; no fallback if a peer lacks the TP                   |
+| Interval-capped PTO backoff (not `quinn`'s `2^n`)              | Bounds tail-loss-probe cadence to ≤ 2s; steadier recovery on stalled links                  | Diverges from RFC-typical exponential backoff; more probes on a truly dead path                    |
+| Cubic default, BBRv3 opt-in and "experimental"                 | Safe, well-understood default; BBRv3 available for high-BDP links                           | BBRv3's disjoint calling convention (ECN vs per-packet loss) hides behind one trait                |
+| Refcounted `Bytes` recv path + assembler defragmenter          | Zero-copy stream reads; bounded over-allocation vs one-byte-frame attacks                   | Complex `allocation_size` bookkeeping; a copy-on-ingest port can delete it for one memcpy          |
+| Single collapsed `poll_timeout()` deadline + one `AsyncTimer`  | 16 timer classes → one runtime timer; trivial to map to an in-ring `TIMEOUT`                | The internal `TimerTable` scan is linear (acknowledged TODO); fine at ≤ 8 paths                    |
+| Token config off by default in iroh (`bloom` feature disabled) | Smaller dependency graph; NEW_TOKEN unneeded for iroh's connectivity model                  | The whole `NEW_TOKEN`/`BloomTokenLog` half is dormant; a port ships `NoneTokenLog` and matches     |
+
+---
+
+## Sources
+
+- [`n0-computer/noq` — repository & README][noq-readme] (fork mission, extension list)
+- [`noq-proto/src/lib.rs`][lib-proto] — sans-io crate doc, constants, `FourTuple`, versions
+- [`noq/src/runtime/mod.rs`][runtime] — `Runtime`/`AsyncUdpSocket`/`UdpSender`/`AsyncTimer` seam
+- [`noq/src/endpoint.rs`][ep-async] · [`noq/src/connection.rs`][conn-async] — driver architecture, `State`, fairness
+- [`noq-udp/src/lib.rs`][udp-lib] · [`noq-udp/src/unix.rs`][udp-unix] — `Transmit`/`RecvMeta`, GSO/GRO/ECN/pktinfo
+- [`noq-proto/src/endpoint.rs`][ep-proto] — `handle`, `DatagramEvent`, incoming decision, stateless reset
+- [`noq-proto/src/connection/mod.rs`][conn-proto] — pump methods, scheduling, recovery, close/drain
+- [`noq-proto/src/connection/streams/`][streams-state] ([`send.rs`][streams-send], [`recv.rs`][streams-recv], [`mod.rs`][streams-mod]) · [`assembler.rs`][assembler] · [`send_buffer.rs`][send-buffer] · [`datagrams.rs`][datagrams] — dataplane
+- [`noq-proto/src/connection/spaces.rs`][spaces] · [`paths.rs`][paths] · [`timer.rs`][timer] — packet-number spaces, per-path state, timers
+- [`noq-proto/src/congestion.rs`][congestion] ([`cubic.rs`][cubic], [`new_reno.rs`][newreno], [`bbr3/mod.rs`][bbr3]) · [`pacing.rs`][pacing] · [`mtud.rs`][mtud] · [`ack_frequency.rs`][ackfreq] — recovery/CC/MTUD
+- [`noq-proto/src/connection/packet_builder.rs`][pktbuilder] · [`transmit_buf.rs`][transmitbuf] · [`packet.rs`][packet] · [`cid_state.rs`][cidstate] · [`cid_queue.rs`][cidqueue] — packetization & CIDs
+- [`noq-proto/src/crypto.rs`][crypto] · [`crypto/rustls.rs`][crypto-rustls] · [`crypto/ring_like.rs`][ringlike] — path-aware AEAD, token keys
+- [`noq-proto/src/token.rs`][token] · [`token_memory_cache.rs`][tokencache] · [`bloom_token_log.rs`][bloomlog] — Retry/NEW_TOKEN, anti-replay
+- [`noq-proto/src/frame.rs`][frame] · [`transport_parameters.rs`][tparams] · [`config/transport.rs`][cfg-transport] · [`config/mod.rs`][cfg-mod] — registries & defaults
+- [`iroh/src/endpoint/quic.rs`][iroh-quic] · [`iroh/src/socket.rs`][iroh-socket] · [`iroh/src/socket/transports.rs`][iroh-transports] — how iroh plugs in
+- Standards: [RFC 9000][rfc9000], [RFC 9001][rfc9001], [RFC 9002][rfc9002], [RFC 9221][rfc9221], [RFC 9287][rfc9287], [RFC 8899][rfc8899], [RFC 8312][rfc8312], [RFC 6298][rfc6298]; drafts [multipath][draft-multipath], [QAD][draft-qad], [QNT][draft-qnt], [ack-frequency][draft-ackfreq], [BBRv3][draft-bbr]
+- Related Sparkles pages: [Iroh survey (umbrella)][index] · [Concepts & Vocabulary][concepts] · [Wire Formats & Serialization][wire-serialization] · [Identity & Cryptography][identity-crypto] · [Endpoint & Protocol Router][endpoint] · [The Multipath Socket][socket] · [NAT Traversal & Address Discovery][nat-traversal] · [The Relay Protocol][relay] · [Tokio Concurrency Inventory][concurrency] · [D Architecture Migration][d-migration] · [event-horizon spec][eh-spec] · [async-io survey][async-io]
+
+<!-- References -->
+
+[noq-readme]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/README.md
+[lib-proto]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/lib.rs
+[runtime]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq/src/runtime/mod.rs
+[ep-async]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq/src/endpoint.rs
+[conn-async]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq/src/connection.rs
+[udp-lib]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-udp/src/lib.rs
+[udp-unix]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-udp/src/unix.rs
+[ep-proto]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/endpoint.rs
+[conn-proto]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/mod.rs
+[streams-state]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/streams/state.rs
+[streams-send]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/streams/send.rs
+[streams-recv]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/streams/recv.rs
+[streams-mod]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/streams/mod.rs
+[assembler]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/assembler.rs
+[send-buffer]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/send_buffer.rs
+[datagrams]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/datagrams.rs
+[spaces]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/spaces.rs
+[paths]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/paths.rs
+[timer]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/timer.rs
+[pacing]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/pacing.rs
+[mtud]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/mtud.rs
+[ackfreq]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/ack_frequency.rs
+[pktbuilder]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/packet_builder.rs
+[transmitbuf]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/transmit_buf.rs
+[packet]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/packet.rs
+[cidstate]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/cid_state.rs
+[cidqueue]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/cid_queue.rs
+[state-proto]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/connection/state.rs
+[congestion]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/congestion.rs
+[cubic]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/congestion/cubic.rs
+[newreno]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/congestion/new_reno.rs
+[bbr3]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/congestion/bbr3/mod.rs
+[crypto]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/crypto.rs
+[crypto-rustls]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/crypto/rustls.rs
+[ringlike]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/crypto/ring_like.rs
+[token]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/token.rs
+[tokencache]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/token_memory_cache.rs
+[bloomlog]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/bloom_token_log.rs
+[frame]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/frame.rs
+[tparams]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/transport_parameters.rs
+[cfg-transport]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/config/transport.rs
+[cfg-mod]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/config/mod.rs
+[iroh-quic]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/endpoint/quic.rs
+[iroh-socket]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs
+[iroh-transports]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs
+[docs-noq]: https://docs.rs/noq/1.0.1/noq/
+[docs-noq-proto]: https://docs.rs/noq-proto/1.0.1/noq_proto/
+[docs-noq-udp]: https://docs.rs/noq-udp/1.0.1/noq_udp/
+[quinn]: https://github.com/quinn-rs/quinn
+[rfc9000]: https://www.rfc-editor.org/rfc/rfc9000.html
+[rfc9001]: https://www.rfc-editor.org/rfc/rfc9001.html
+[rfc9002]: https://www.rfc-editor.org/rfc/rfc9002.html
+[rfc9221]: https://www.rfc-editor.org/rfc/rfc9221.html
+[rfc9287]: https://www.rfc-editor.org/rfc/rfc9287.html
+[rfc8899]: https://www.rfc-editor.org/rfc/rfc8899.html
+[rfc8312]: https://www.rfc-editor.org/rfc/rfc8312.html
+[rfc6298]: https://www.rfc-editor.org/rfc/rfc6298.html
+[draft-multipath]: https://datatracker.ietf.org/doc/draft-ietf-quic-multipath/
+[draft-qad]: https://datatracker.ietf.org/doc/draft-ietf-quic-address-discovery/
+[draft-qnt]: https://datatracker.ietf.org/doc/draft-seemann-quic-nat-traversal/
+[draft-ackfreq]: https://datatracker.ietf.org/doc/draft-ietf-quic-ack-frequency/
+[draft-bbr]: https://datatracker.ietf.org/doc/draft-ietf-ccwg-bbr/
+[index]: ./index.md
+[concepts]: ./concepts.md
+[identity-crypto]: ./identity-crypto.md
+[wire-serialization]: ./wire-serialization.md
+[endpoint]: ./endpoint.md
+[socket]: ./socket.md
+[nat-traversal]: ./nat-traversal.md
+[relay]: ./relay.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[async-io]: ../async-io/index.md
+[tokio]: ../async-io/tokio.md
+[glommio]: ../async-io/glommio.md
+[monoio]: ../async-io/monoio.md

--- a/docs/research/iroh/relay.md
+++ b/docs/research/iroh/relay.md
@@ -1,0 +1,469 @@
+# The Relay Protocol
+
+A revised [DERP][derp]: an authenticated WebSocket packet-forwarder that rendezvouses endpoints and blindly relays encrypted [QUIC][quic-transport] datagrams by [`EndpointId`][concepts] until direct [NAT traversal][nat-traversal] succeeds — plus a bare QUIC endpoint that hands each client its observed public address in lieu of STUN.
+
+| Field                 | Value                                                                                                                                                                                                                                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)              | `iroh-relay` (server + client + QAD); the client reconnect state machine lives in the `iroh` crate under `iroh/src/socket/transports/relay/`                                                                                                                                                               |
+| Version               | `1.0.1` (iroh workspace `v1.0.1`, git `22cac742ca`)                                                                                                                                                                                                                                                        |
+| Repository            | [`n0-computer/iroh` · `iroh-relay/`][repo]                                                                                                                                                                                                                                                                 |
+| Documentation         | [docs.rs/iroh-relay][docs]                                                                                                                                                                                                                                                                                 |
+| Protocol id / ALPN    | Relay data path negotiates a WebSocket subprotocol — `iroh-relay-v2` (default) / `iroh-relay-v1` — via `Sec-Websocket-Protocol` at path `/relay`; the co-hosted QUIC Address Discovery endpoint uses ALPN `/iroh-qad/0` ([`http.rs`][http], [`quic.rs`][quic])                                             |
+| Approx. size (LoC)    | ~12,300 (`iroh-relay`) + ~2,150 (relay client actor + transport in `iroh`)                                                                                                                                                                                                                                 |
+| Category              | Connectivity                                                                                                                                                                                                                                                                                               |
+| Upstream spec / draft | No formal spec — a revision of Tailscale's [DERP][derp]. Sub-protocols: [RFC 6455][rfc6455] (WebSocket), [RFC 8305][rfc8305] (Happy Eyeballs), [RFC 5705][rfc5705] (TLS keying-material export), [RFC 9729][rfc9729] (Concealed HTTP Auth, the model for header auth), [QUIC Address Discovery][qad-draft] |
+
+> [!NOTE]
+> This page covers the **relay** subsystem in isolation: the wire protocol, the server, the client, and the QUIC Address Discovery (QAD) side-endpoint. How the relay is chosen and multiplexed against direct UDP paths belongs to [The Multipath Socket][socket]; how the observed address feeds hole-punching belongs to [NAT Traversal & Address Discovery][nat-traversal]; how a home relay is selected from measurements belongs to [Net Report][net-report].
+
+---
+
+## Overview
+
+### What it solves
+
+Two peers that both sit behind NATs cannot always reach each other directly, and even when they eventually can, hole-punching takes time and sometimes fails outright. iroh's answer is a **relay**: a public, always-reachable server that both peers connect to and that forwards opaque datagrams between them by destination `EndpointId`. The relay is simultaneously the _rendezvous_ (a fixed address both peers know how to reach) and the _fallback data path_ (traffic flows through it whenever a direct path is unavailable). It is a store-and-forward switch keyed on 32-byte public keys, never a decryptor: the bytes it forwards are already-encrypted QUIC packets from the [noq][quic-transport] stack, so the relay operator learns who talks to whom but never what they say.
+
+The relay carries a **second, unrelated job** in iroh 1.0: **QUIC Address Discovery (QAD)** replaces the STUN protocol that iroh 0.x used to learn a node's public `IP:port`. There is no STUN code anywhere in the crate. Instead the relay binary optionally runs a bare [noq][quic-transport] QUIC endpoint on UDP port `7842` whose only function is to tell each connecting client the public address the server observed, using the QUIC Address Discovery transport extension implemented inside `noq-proto` ([`quic.rs`][quic]). This is a completely separate socket, ALPN, and code path from the WebSocket relay — they merely share a binary and a `RelayUrl`.
+
+### Design philosophy
+
+The relay is deliberately dumb and deliberately blind. From the crate root ([`iroh-relay/src/lib.rs`][lib]):
+
+> _"The relay server helps establish connections by temporarily routing encrypted traffic until a direct, P2P connection is feasible. Once this direct path is set up, the relay server steps back, and the data flows directly between devices. This approach allows Iroh to maintain a secure, low-latency connection, even in challenging network situations."_
+
+Three commitments follow from that, and they shape the whole crate:
+
+1. **The relay never sees plaintext.** It maps a 32-byte destination key to a live connection and copies bytes; congestion control, retransmission, and encryption all live in the peers' QUIC layer. The relay forwards even ECN bits and GSO-style segment sizes verbatim so it does not disturb the end-to-end congestion controller.
+2. **Everything rides one commodity transport.** The data plane is nothing but **binary WebSocket messages over HTTP(S)** — no DERP-era magic strings, no bespoke length framing, no server-key frame. This is what lets the identical protocol run unmodified in a browser over `ws_stream_wasm` ([`protos/streams.rs`][protos-streams]).
+3. **Structured concurrency throughout.** From [`server.rs`][server]:
+
+   > _"This code is fully written in a form of structured-concurrency: every spawned task is always attached to a handle and when the handle is dropped the tasks abort. So tasks can not outlive their handle."_
+
+   That is a near-verbatim description of an [event-horizon `Scope`][eh-spec], and it makes the server unusually clean to port.
+
+---
+
+## How it works
+
+### Transport stack, bottom-up
+
+A relay connection is a stack of standard layers, each thin:
+
+```text
+TCP  →  (optional) TLS/rustls  →  HTTP/1.1  →  RFC 6455 WebSocket upgrade at GET /relay
+     →  binary WebSocket messages, one message == exactly one relay frame
+```
+
+There is **no separate length-delimited framing**: the WebSocket message boundary _is_ the frame boundary. Each frame begins with a QUIC variable-length integer `FrameType` tag (in practice a single byte, since every defined type is `< 2^6`; [`protos/common.rs`][protos-common]). Non-binary WebSocket messages are skipped with a warning; WebSocket `ping`/`pong`/`close` control frames are handled by the WebSocket layer itself ([`protos/streams.rs`][protos-streams]). Two size ceilings apply: the raw WebSocket payload is capped at `MAX_FRAME_SIZE = 1024 * 1024` (1 MiB, _"also the minimum burst size that a rate-limiter has to accept"_), and a decoded relay frame's content after the tag is capped at `MAX_PACKET_SIZE = 64 * 1024` ([`protos/relay.rs`][protos-relay]).
+
+### The connect + WebSocket upgrade dance
+
+The client (`ClientBuilder::connect`, [`client.rs`][client]) rewrites the relay URL — path becomes `/relay`; scheme `http`→`ws`, `ws`→`ws`, anything else →`wss` — then dials TCP through a **Happy Eyeballs ([RFC 8305][rfc8305]) race** ([`client/tls.rs`][client-tls]): addresses stream in from DNS (`DNS_TIMEOUT = 3 s`), interleaved by address family; the preferred family gets a `RESOLUTION_DELAY = 50 ms` head start; each subsequent attempt starts `CONNECTION_ATTEMPT_DELAY = 250 ms` after the previous (or immediately on a failure); each individual attempt is capped at `DIAL_ENDPOINT_TIMEOUT = 1500 ms` ([`defaults.rs`][defaults]). `TCP_NODELAY` is set. An optional HTTP `CONNECT` proxy with basic-auth passthrough is supported.
+
+On top of the (optionally TLS-wrapped) stream, the client issues an RFC 6455 upgrade request carrying up to three relay-specific headers:
+
+- `Sec-Websocket-Protocol: iroh-relay-v2, iroh-relay-v1` — **version negotiation via WebSocket subprotocols** ([`http.rs`][http], `ProtocolVersion::all_as_header_value`).
+- optional `Authorization: Bearer <token>` (in wasm, where browsers cannot set headers, the token moves to a `?token=` query parameter instead — [`http.rs`][http]).
+- optional `x-iroh-relay-client-auth-v1` carrying a base64url `KeyMaterialClientAuth` for 0-RTT auth (below).
+
+Automatic WebSocket flushing is disabled (`flush_threshold(usize::MAX)`) so the sender controls batching explicitly ([`client.rs`][client]). The client asserts a `101 Switching Protocols` response and reads the negotiated version back out of the response's `Sec-Websocket-Protocol` header.
+
+The server, on `GET /relay` ([`server/http_server.rs`][http-server]), requires `Upgrade: websocket` and `Sec-WebSocket-Version: 13`, computes the RFC 6455 accept key (SHA-1 of the client key concatenated with the GUID `258EAFA5-E914-47DA-95CA-C5AB0DC85B11`), picks `max()` of the offered protocol versions it supports (the `Ord` impl on `ProtocolVersion` is ordered newest-last precisely so `max` selects the best), spawns an upgrade-wait task, and replies `101`.
+
+### Authentication: two mechanisms
+
+The handshake exists to _"1. Inform the relay of the client's EndpointId 2. Check that the connecting client owns the secret key for its EndpointId … 3. Possibly check that the client has access to this relay"_ ([`protos/handshake.rs`][protos-handshake]). Two mechanisms achieve step 2, and the design is a study in trading round-trips for portability:
+
+1. **Signed TLS keying material (0-RTT, header-based).** Modelled on [RFC 9729][rfc9729] Concealed HTTP Auth using [RFC 5705][rfc5705] exporters. The client exports 32 bytes from the live TLS session (label `b"iroh-relay handshake v1"`, context = its own public-key bytes), signs the **first 16** bytes with its ed25519 secret key, and passes the **last 16** through verbatim so the server can distinguish an exporter mismatch (a broken TLS middlebox) from a genuine bad signature. The `KeyMaterialClientAuth` struct is `postcard`-encoded then base64url-nopad-encoded into the `x-iroh-relay-client-auth-v1` request header — so authentication completes in the very first HTTP request, saving a round-trip. Its own doc-comment states the catch:
+
+   > _"The second way can save a full round trip, because the challenge doesn't have to be sent to the client first, however, it won't always work, as it relies on the keying material extraction feature of TLS, which is not available in browsers … and might break when there's an HTTPS proxy that doesn't properly deal with this TLS feature."_ — [`protos/handshake.rs`][protos-handshake]
+
+2. **Challenge / response (1 extra RTT, in-band frames).** The always-available fallback. The server sends a `ServerChallenge` (16 random CSPRNG bytes). Crucially the client signs **not** the raw challenge but `blake3::derive_key("iroh-relay handshake v1 challenge signature", challenge)`, for domain separation:
+
+   > _"We're signing a key instead of the direct challenge. This gives us domain separation protecting from multiple possible attacks … Assume a malicious relay. If the protocol required the client to sign the challenge directly, this would allow the relay to obtain an arbitrary 16-byte signature, if it maliciously choses the challenge instead of generating it randomly."_ — [`protos/handshake.rs`][protos-handshake]
+
+   The client replies `ClientAuth { public_key, signature }` and the server verifies it.
+
+After authentication succeeds, **authorization** runs: `AccessControl::on_connect(&ClientRequest)` — an async trait object — inspects the endpoint id, negotiated version, URI, headers, and auth token (read from `Authorization: Bearer` first, else the `?token=` query param) and returns `Access::Allow` (server sends `ServerConfirmsAuth`) or `Access::Deny { reason }` (server sends `ServerDeniesAuth` and errors out) ([`server.rs`][server]). An `OnDisconnectGuard` created at admission and dropped when the connection actor ends guarantees exactly one `AccessControl::on_disconnect` per admitted connection. The server binary ships five access backends: `Everyone`, `Allowlist`, `Denylist`, an HTTP-POST hook (posts `X-Iroh-NodeId`, expects `200` + body `"true"`), and shared-token bearer auth ([`main.rs`][main]).
+
+### Steady state: datagrams, batching, keepalive
+
+Once admitted, the protocol is small ([`protos/relay.rs`][protos-relay]): _"server occasionally sends Ping; client responds to any Ping with a Pong; client sends ClientToRelayDatagram or ClientToRelayDatagramBatch; server then sends RelayToClientDatagram or RelayToClientDatagramBatch to recipient; server sends EndpointGone when the other client disconnects."_
+
+The datagram frames are shaped after the QUIC transmit type — they carry an ECN codepoint and, in the batch variant, a `u16` segment size — so the relay forwards GSO-style batches of equal-size segments (last possibly shorter) without disturbing the peers' congestion control:
+
+```rust
+// iroh-relay/src/protos/relay.rs — modelled after `noq_proto::Transmit`
+pub struct Datagrams {
+    /// Explicit congestion notification bits
+    pub ecn: Option<noq_proto::EcnCodepoint>,
+    /// The segment size if this transmission contains multiple datagrams.
+    /// This is `None` if the transmit only contains a single datagram
+    pub segment_size: Option<NonZeroU16>,
+    /// The contents of the datagram(s)
+    pub contents: Bytes,
+}
+```
+
+Keepalive is a `Ping`/`Pong` pair of 8 opaque bytes each. The server pings every `PING_INTERVAL = 15 s` plus 1–5 s of random jitter — half the QUIC `max_idle_timeout` of 30 s, and jittered _"to avoid all pings being sent at the same time"_ — and resets the interval whenever any frame arrives from the client ([`protos/relay.rs`][protos-relay], [`server/client.rs`][srv-client]).
+
+### Server architecture: registry, per-client actors, broadcast
+
+One accept loop per listener runs in a spawned task holding a `JoinSet` of per-connection tasks ([`server/http_server.rs`][http-server]). Each accepted TCP connection gets Nagle disabled and a `clearable_timeout` of `ESTABLISH_TIMEOUT = 30 s` that aborts connections which fail to complete TLS + WebSocket upgrade + handshake; a `Notify` disarms (does not _complete_) that timeout once the relay protocol takes over. The upgraded stream is wrapped in `RateLimited` (below), then the WebSocket server codec, then `handshake::serverside` + authorization run, then `Clients::register` spawns the per-client actor.
+
+The registry is a pair of concurrent maps ([`server/clients.rs`][clients]):
+
+```rust
+// iroh-relay/src/server/clients.rs
+pub struct Clients(Arc<Inner>);
+struct Inner {
+    clients: DashMap<EndpointId, ClientState>,
+    /// Map of which client has sent where
+    sent_to: DashMap<EndpointId, HashSet<EndpointId>>,
+}
+struct ClientState { active: Client, inactive: Vec<Client> }
+```
+
+Two behaviours here are load-bearing and non-obvious:
+
+- **A duplicate `EndpointId` does not evict the incumbent.** The old connection is demoted onto an `inactive` stack and told `Status::SameEndpointIdConnected`; when the active one disconnects the most-recent inactive is promoted and told `Status::Healthy`. Only when the _last_ connection for a key unregisters does the server fan out `EndpointGone` to every peer recorded in that key's `sent_to` set.
+- **Forwarding is lossy and silent.** `Clients::send_packet` does a `try_send` onto the destination's bounded queue (`PER_CLIENT_SEND_QUEUE_DEPTH = 512`). A full queue drops the packet — the sender is _not_ notified on the wire, only server-side metrics tick — because _"we should still keep succeeding to send, even if the packet won't be forwarded by the relay server because the server's send queue for b fills up"_ ([`server.rs`][server]). There is no wire-level NACK anywhere in the protocol; the only negative signal is `EndpointGone`.
+
+Each admitted connection is owned by exactly one per-client **actor** task ([`server/client.rs`][srv-client]) that holds the socket exclusively, drains two bounded `mpsc` queues (a `packet_send_queue` and a `message_send_queue`, both capacity 512), tracks pings, and runs a `biased` `select!` in strict priority order: cancellation → inbound frames → packet queue → message queue → ping-timeout (break, killing the connection) → keepalive tick. Every write is wrapped in a `SERVER_WRITE_TIMEOUT = 2 s` timeout so a stalled client is evicted rather than allowed to back the server up, and the stream is flushed after each loop iteration.
+
+### Rate limiting
+
+Only **client→server receive** traffic is rate-limited, and the limiter sits _below_ the WebSocket codec, inside `poll_read` of the raw byte stream ([`server/streams.rs`][srv-streams]). It is a hand-rolled token `Bucket` (`i64` fill, refill every 100 ms, default burst = `bytes_per_second / 10`); when the bucket runs dry the underlying stream is simply not polled until a `time::sleep_until(refill)` elapses, which applies natural **TCP backpressure** rather than dropping data. The `Bucket` type is `pub` so embedders on custom HTTP servers can rate-limit at the frame layer.
+
+Since commit [`c23446ce2e`][commit-ratelimit] (_"feat(relay): allow updating the per-client rate limit live"_, #4381), the limit is **live-updatable**: the config is distributed through a `tokio::sync::watch` channel checked on every `poll_read` via a cheap atomic `has_changed`, and `RelayService::set_client_rate_limit` reconfigures every current and future connection without dropping any. The connection-_accept_ rate limits (`accept_conn_limit` / `accept_conn_burst`) exist in the config but are explicitly _"Not currently implemented"_ ([`server.rs`][server]).
+
+### QUIC Address Discovery (QAD) — the `quic.rs` role
+
+QAD is **not relay-over-QUIC**; it is STUN's replacement ([`quic.rs`][quic]). The relay binary optionally runs a bare noq QUIC endpoint (default port `7842` — _"QUIC" typed on a phone keypad_) with ALPN `/iroh-qad/0`. The server-side transport config is stripped to the bone and one flag turned on:
+
+```rust
+// iroh-relay/src/quic.rs — QAD server transport config
+transport_config
+    .max_concurrent_uni_streams(0_u8.into())
+    .max_concurrent_bidi_streams(0_u8.into())
+    // enable sending quic address discovery frames
+    .send_observed_address_reports(true);
+```
+
+Clients open _zero_ streams; the QUIC transport itself emits the client's observed public address via the address-discovery extension in `noq-proto` (see [QUIC Transport][quic-transport]). The server's accept loop simply waits for the client to close the connection (close code `1`, reason `b"finished"`). The client (`QuicClient`) enables `receive_observed_address_reports(true)`, sets `initial_rtt(111 ms)` (which _"implies a 999ms probe timeout"_ for fast failure), `keep_alive_interval(25 s)`, and `max_idle_timeout(35 s)`, then reads `conn.observed_external_addr()` (a watcher) and `conn.rtt(PathId::ZERO)`, canonicalizing IPv4-mapped IPv6. The observed address then feeds [NAT traversal][nat-traversal] and [net-report][net-report]; how the relay is _chosen_ is out of scope here.
+
+### `RelayMap` and home-relay selection
+
+The set of known relays is a runtime-mutable `RelayMap` — `Arc<RwLock<BTreeMap<RelayUrl, Arc<RelayConfig>>>>` supporting insert/remove/extend at runtime ([`relay_map.rs`][relay-map]). Each `RelayConfig { url, quic: Option<RelayQuicConfig { port }>, auth_token }` records whether that relay offers QAD and on which port; parsing a bare URL assumes QAD on `7842`. Home-relay _selection_ is not in this crate: the socket's [net-report][net-report] produces `report.preferred_relay`, and the client-side `RelayActor` reacts by publishing the new home URL to a `HomeRelayWatch` and sending `SetHomeRelay(bool)` to every `ActiveRelayActor` ([`actor.rs`][actor]).
+
+### The client reconnect state machine
+
+On the client side (in the `iroh` crate, [`actor.rs`][actor]) a single `RelayActor` owns a `BTreeMap<RelayUrl, ActiveRelayHandle>` and a `JoinSet`, with one `ActiveRelayActor` per relay URL in use. Each active actor alternates **Dialing ↔ Connected**: dial with `CONNECT_TIMEOUT = 10 s`; on failure retry with jittered exponential backoff from 10 ms to 16 s, unbounded — but if a connection was ever "established" (≥1 pong received) before failing, the backoff _resets_ and reconnect is immediate. While dialing, queued outbound datagrams are flushed and dropped every `UNDELIVERABLE_DATAGRAM_TIMEOUT = 3 s` (_"3 times the QUIC initial Probe Timeout"_):
+
+> _"We regularly flush the relay_datagrams_send queue so it is not full of stale packets while reconnecting. Those datagrams are dropped and the QUIC congestion controller will have to handle this (DISCO packets do not yet have retry)."_ — [`actor.rs`][actor]
+
+The Connected state pings every 15 s, treats any received frame as a ping-interval reset, sends datagram batches of up to `SEND_DATAGRAM_BATCH_SIZE = 20` items, and enters a **Sending** sub-state while awaiting a sink flush (during which inboxes are not consumed but the receive path stays live). Non-home actors self-terminate after `RELAY_INACTIVE_CLEANUP_TIME = 60 s` without outbound traffic; the home-relay actor never exits. A `CheckConnection { local_ips }` message (delivered on interface change) pings if the connection's local IP is still valid, otherwise forces a reconnect.
+
+### TLS
+
+Client-side trust is `CaTlsConfig` ([`tls.rs`][rtls]): embedded webpki (Mozilla) roots by default, optionally the OS platform verifier, custom roots only, a custom `ServerCertVerifier` callback, or (test only) skip verification. These CAs _"don't need to be trusted for the integrity or authenticity of native iroh connections"_ — the relay only carries already-encrypted QUIC, so relay TLS protects the _metadata channel_, not the payload. Server-side cert acquisition offers Let's Encrypt via `tokio-rustls-acme` (TLS-ALPN-01 answered inline in the accept path), a manual `rustls::ServerConfig`, or a `Reloading` resolver that re-reads PEM cert/key from disk every `DEFAULT_CERT_RELOAD_INTERVAL = 24 h` ([`server/resolver.rs`][resolver]).
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+Every relay frame rides inside one binary WebSocket message; the message boundary is the frame boundary. A frame is `varint(FrameType) ‖ payload`. All 14 frame types are `< 2^6`, so the tag is one byte in practice. Frame ids 0–3 are handshake-only; the data plane starts at 4 ([`protos/common.rs`][protos-common]):
+
+```rust
+// iroh-relay/src/protos/common.rs — #[repr(u32)], #[non_exhaustive]
+pub enum FrameType {
+    ServerChallenge = 0,            ClientAuth = 1,
+    ServerConfirmsAuth = 2,         ServerDeniesAuth = 3,
+    ClientToRelayDatagram = 4,      ClientToRelayDatagramBatch = 5,
+    RelayToClientDatagram = 6,      RelayToClientDatagramBatch = 7,
+    EndpointGone = 8,               Ping = 9,   Pong = 10,
+    Health = 11,   // REMOVED since relay-protocol-v2, use Status
+    Restarting = 12,
+    Status = 13,   // added in iroh-relay-v2
+}
+```
+
+Byte layouts after the varint tag ([`protos/relay.rs`][protos-relay]):
+
+| Frame                            | Layout after tag                                                                      |
+| -------------------------------- | ------------------------------------------------------------------------------------- |
+| `ClientToRelayDatagram` (4)      | 32 B dst `EndpointId` ‖ 1 B ECN ‖ contents                                            |
+| `ClientToRelayDatagramBatch` (5) | 32 B dst ‖ 1 B ECN ‖ `u16` BE segment size ‖ contents (n segments, last may be short) |
+| `RelayToClientDatagram` (6)      | 32 B src `EndpointId` ‖ 1 B ECN ‖ contents                                            |
+| `RelayToClientDatagramBatch` (7) | 32 B src ‖ 1 B ECN ‖ `u16` BE segment size ‖ contents                                 |
+| `EndpointGone` (8)               | 32 B `EndpointId` (exactly)                                                           |
+| `Ping` (9) / `Pong` (10)         | exactly 8 opaque bytes                                                                |
+| `Health` (11, v1 only)           | UTF-8 `problem` string (rest of frame)                                                |
+| `Restarting` (12)                | `u32` BE `reconnect_in` ms ‖ `u32` BE `try_for` ms                                    |
+| `Status` (13, v2 only)           | 1 B discriminant: `0` = Healthy, `1` = SameEndpointIdConnected, `n` = Unknown(n)      |
+
+The single-datagram frames (4/6) carry _no_ segment-size field; the batch-vs-single distinction is the frame type itself. The ECN byte is `noq_proto::EcnCodepoint::from_bits` (`0` decodes to `None`). A concrete snapshot from the crate's own tests: a `RelayToClientDatagramBatch` to key `19 7f…`, ECN `Ce = 0x03`, segment size 6, contents `"Hello World!"` serializes to `07 ‖ <32-byte key> ‖ 03 ‖ 00 06 ‖ 48 65 6c 6c 6f 20 57 6f 72 6c 64 21` ([`protos/relay.rs`][protos-relay]).
+
+The four **handshake** frames are different: their payload is [`postcard`][postcard]-encoded ([`protos/handshake.rs`][protos-handshake]). `ServerChallenge` is 16 raw bytes (17-byte frame); `ClientAuth` is a 32 B public key ‖ varint length `0x40` ‖ 64 B signature (98-byte frame); `ServerConfirmsAuth` is an empty unit struct; `ServerDeniesAuth` is a postcard string. The header-based `KeyMaterialClientAuth` is `postcard(32 B pk ‖ 0x40 ‖ 64 B sig ‖ 16 B suffix)` = 113 bytes, base64url-nopad-encoded — it is _not_ a frame, it travels in the `x-iroh-relay-client-auth-v1` request header. All of these are shared with the general [wire-serialization][wire-serialization] survey; postcard's fixed-array-raw / byte-slice-length-prefixed rules are what make the layouts predictable.
+
+Absolute limits: decoded frame content ≤ `MAX_PACKET_SIZE = 65 536` bytes; WebSocket payload ≤ `MAX_FRAME_SIZE = 1 048 576` bytes; datagram frames must be non-empty (rejected at the Sink layer on both sides — [`client/conn.rs`][client-conn], [`server/streams.rs`][srv-streams]).
+
+### Cryptography & identity
+
+The relay is identity-aware but payload-blind. Two independent key systems are in play:
+
+- **Endpoint identity (ed25519).** Every client is its `EndpointId` — a 32-byte ed25519 public key ([Identity & Cryptography][identity-crypto]). The handshake proves ownership by signing either a TLS-exporter value or a `blake3::derive_key`-domain-separated challenge (never the raw 16 bytes, to deny a malicious relay an arbitrary-message signing oracle). `EndpointGone`, the datagram addressing, and the registry are all keyed on this 32-byte value.
+- **Transport TLS (rustls / webpki).** Relay TLS authenticates the _relay_, not the peers, and encrypts the metadata channel (who is connecting, auth tokens). Because the relayed payload is already end-to-end-encrypted QUIC, the doc-comment can honestly say the relay's CAs _"don't need to be trusted for the integrity or authenticity of native iroh connections"_ ([`tls.rs`][rtls]).
+
+Two supporting pieces: `blake3::derive_key` provides the challenge domain separation ([`protos/handshake.rs`][protos-handshake]) and — separately — the TLS keying-material export ([RFC 5705][rfc5705]) is the _only_ thing that enables the 0-RTT auth path. A server maintains a `key_cache`: an LRU cache of parsed ed25519 public keys (`DEFAULT_KEY_CACHE_CAPACITY = 1 048 576` entries, _"sized for 1 million concurrent clients … ≈56 MB on 64-bit"_ — [`key_cache.rs`][key-cache], [`defaults.rs`][defaults]) to amortize the cost of re-parsing 32-byte keys off the wire into verified curve points.
+
+### State machines & lifecycle
+
+The subsystem is a lattice of six interacting state machines:
+
+1. **Server connection lifecycle** (per TCP conn): `accepted` → [`clearable_timeout` 30 s armed] → `TLS` → `HTTP/1.1` → on `GET /relay` with valid headers → `101` + upgrade task → `handshake::serverside` → `authorize` → `Clients::register` (timeout disarmed via `Notify`) → per-client actor runs → exit → `unregister` → `OnDisconnectGuard` drop → `on_disconnect`. Any failure before `register` aborts; timeout expiry returns `EstablishTimeout` ([`server/http_server.rs`][http-server]).
+2. **Same-`EndpointId` active/inactive stack**: `Vacant → active`; a new conn for the same key demotes `active → inactive` and installs the newcomer, telling the demoted one `Status::SameEndpointIdConnected`; on active disconnect the most-recent inactive is promoted with `Status::Healthy`, or if none remain the entry is removed and `EndpointGone` fans out to `sent_to` peers ([`server/clients.rs`][clients]).
+3. **Server per-client actor loop**: a `biased` `select!` — cancel > read > packets > messages > pong-timeout > keepalive-tick — pinging every 15 s + jitter with `MissedTickBehavior::Delay`, interval reset on any inbound frame; a missed pong tears the connection down ([`server/client.rs`][srv-client]).
+4. **Client `ActiveRelayActor`**: **Dialing** → **Connected** → **Sending** (a Connected sub-state), with jittered exponential backoff on failure, immediate reconnect after an "established" failure, and self-termination after 60 s of inactivity for non-home relays ([`actor.rs`][actor]).
+5. **`PingTracker`** (shared client/server): `idle` –new ping→ `awaiting { data, deadline }`; a matching `pong_received` returns to `idle` and records RTT; the deadline fires `timeout()` once. The next ping's timeout is `3 × last_rtt` clamped to `[500 ms, 5 s]` (`MIN_HEALTH_CHECK_TIMEOUT` / `PING_TIMEOUT` — [`ping_tracker.rs`][ping-tracker]).
+6. **Handshake** (both sides): server takes `[header present? verify → done]` else `challenge → await ClientAuth → verify → await access → confirm/deny`; client takes `await first frame → { ServerChallenge → send ClientAuth → await verdict | ServerConfirmsAuth → done | ServerDeniesAuth → error }`, enforcing per-state frame-type expectations via `read_frame(expected_types)` ([`protos/handshake.rs`][protos-handshake]).
+
+Notable dead/vestigial edges: the `Restarting` frame is defined but the current client just logs and ignores it; the `Health` frame is gone in v2 but the server still translates `Status → Health { problem }` when speaking v1 to old clients ([`server/client.rs`][srv-client]).
+
+### Dependencies & coupling
+
+| Crate                                      | Role in the relay                                                        | Port impact                                                                                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tokio-websockets`                         | WebSocket client + server codec, payload limits, flush control, RFC 6455 | **Load-bearing.** The D port must implement RFC 6455 both ways (masking, control frames, 1 MiB payload cap). No `permessage-deflate` is used. |
+| `hyper` / `http` / `http-body-util`        | HTTP/1.1 + `Upgrade` mechanics + `CONNECT` proxy                         | Needs a minimal HTTP/1.1 with upgrade — `sparkles:http` territory                                                                             |
+| `rustls` / `tokio-rustls` / `webpki-roots` | TLS both sides **plus RFC 5705 keying-material export**                  | The D TLS binding must expose `export_keying_material`, or clients always pay the challenge RTT                                               |
+| `tokio-rustls-acme`                        | Server-only ACME / Let's Encrypt (TLS-ALPN-01)                           | Optional for a port; manual / reloading cert modes suffice                                                                                    |
+| `noq` / `noq-proto`                        | QAD endpoint, `EcnCodepoint`, `VarInt` codec, observed-address reports   | QUIC varint is trivial; QAD needs the address-discovery extension from [QUIC Transport][quic-transport]                                       |
+| `blake3`                                   | `derive_key` for challenge domain separation                             | Must match byte-for-byte (test vectors exist)                                                                                                 |
+| `iroh-base` (`ed25519-dalek`)              | `EndpointId` keys, sign / verify                                         | ed25519 required ([Identity & Cryptography][identity-crypto])                                                                                 |
+| `postcard` + `serde_bytes`                 | The 4 handshake frames + the auth header                                 | Small: fixed arrays raw, byte slices varint-length-prefixed ([wire-serialization][wire-serialization])                                        |
+| `data-encoding`, `sha1`                    | base64url / base64 (WS accept) / base32hex; SHA-1 accept key             | Trivial                                                                                                                                       |
+| `dashmap`, `lru`                           | Concurrent registry, key-parse cache                                     | Collapse to plain single-threaded structures under `single` topology                                                                          |
+| `n0-future` / `tokio-util`                 | `CancellationToken`, `AbortOnDropHandle`, structured-concurrency glue    | Maps to event-horizon [`Scope`][eh-spec] / `CancelContext`                                                                                    |
+| `backon`                                   | Client-side exponential backoff (`iroh` crate)                           | Maps to event-horizon `Schedule.exponential.jittered`                                                                                         |
+| `governor`                                 | **Not used** — rate limiting is the hand-rolled `Bucket`                 | Port the ~90-line `Bucket` directly                                                                                                           |
+
+The relay is unusually self-contained on the _protocol_ axis (no bespoke serialization framework, no custom crypto) but heavily coupled on the _transport_ axis: it wants a full HTTP/1.1-with-upgrade stack, a full RFC 6455 WebSocket, and a TLS library that surfaces keying-material export. That is the real porting cost.
+
+### Concurrency & I/O model
+
+The server is a fan of tokio tasks glued by `JoinSet` + `CancellationToken` + `AbortOnDropHandle`, i.e. exactly the structured-concurrency shape the source doc-comment advertises ([full inventory in the Tokio Concurrency page][concurrency]). The salient primitives:
+
+- **One task per layer**: a root supervisor (`relay_supervisor`, first-task-exit stops all), an accept loop per listener, a per-TCP-connection task, and a per-registered-client actor.
+- **Two bounded `mpsc` channels per client** (`packet_send_queue`, `message_send_queue`, cap 512 each) fed by `try_send` — the drop-on-full backpressure decision that is the relay's entire QoS policy.
+- **`watch` channels** for live state: the rate-limit config, `HomeRelayWatch`, and other `n0_watcher::Watchable` cells (current-value + wake-on-change).
+- **Shared concurrent structures**: `DashMap` ×2 for the registry, `Arc<Mutex<lru::LruCache>>` for the key cache, `Arc<RwLock<BTreeMap>>` for the relay map, an `AtomicU64` connection-id counter.
+- **Timers everywhere**: 15 s + jitter keepalive, 2 s per-write timeout, 30 s establish timeout, 100 ms bucket-refill sleeps, 24 h cert reload, and the client's exponential-backoff schedule.
+- **`spawn_blocking`** appears exactly once, for one-shot cert/key file loading at startup ([`main.rs`][main]) — every hot-path operation is already async I/O.
+
+Every `select!` in the crate is `biased`, so priority order is explicit and deterministic — a property a port must preserve.
+
+### Mapping to event-horizon
+
+The server's shape is almost perfectly fiber-native. The `JoinSet` + `CancellationToken` + `AbortOnDropHandle` triple _is_ an [event-horizon `Scope`][eh-spec]: exit joins children, first failure cancels siblings, `onExit` LIFO teardown. `relay_supervisor` becomes the root scope; each listener is a `spawnDaemon` fiber; each connection and each registered client is a `fork`ed child fiber. Under the default `single` topology there is no `Send`/`Sync` tax and no locks: `DashMap`, `Arc<Mutex<LruCache>>`, `AtomicU64`, and `Arc<RwLock<BTreeMap>>` all collapse to plain hash maps, an `lru` cache, a `size_t`, and a `BTreeMap` owned by one fiber.
+
+The **hard part** is the per-client actor's two `mpsc` queues, because event-horizon has **no cross-fiber channel primitive** ([open issue O20][eh-spec]). The Rust side:
+
+```rust
+// iroh-relay/src/server/client.rs — per-client actor (trimmed)
+struct Actor<S> {
+    stream: RelayedStream<S>,
+    timeout: Duration,                                     // 2 s write timeout
+    packet_send_queue: mpsc::Receiver<Packet>,            // cap 512
+    message_send_queue: mpsc::Receiver<RelayToClientMsg>, // cap 512
+    guard: OnDisconnectGuard,
+    clients: Clients,
+    ping_tracker: PingTracker,
+    metrics: Arc<Metrics>,
+}
+```
+
+A workable single-threaded D shape replaces the two channels with intrusive bounded ring buffers the owning fiber drains, plus a resume hook the registry pokes after a push — preserving the crucial `try_send` semantics (drop-on-full, never block the _sender's_ fiber, since that is the relay's core backpressure decision):
+
+```d
+// proposed / sketch — one fiber owns the connection; no Send/Sync, no locks.
+struct RelayClientActor
+{
+    ByteStream        stream;         // the upgraded WebSocket transport
+    EndpointId        endpoint;
+    PingTracker       pingTracker;
+    Duration          writeTimeout;   // 2 s
+    // No mpsc: the registry pushes into bounded rings this fiber drains.
+    Ring!(Packet, 512)          packets;   // drop-on-full == try_send
+    Ring!(RelayToClientMsg, 512) messages;  // Status / EndpointGone
+    Waker             resume;         // registry wakes this fiber after a push
+}
+
+// Registry-side push, single-threaded: no atomics, no locking.
+@safe nothrow
+bool trySend(ref RelayClientActor dst, Packet p)
+{
+    if (dst.packets.full) return false;   // drop; caller "succeeds" anyway
+    dst.packets.pushBack(p);
+    dst.resume.wake();                    // resume the drain fiber
+    return true;
+}
+```
+
+The `biased select!` loop maps to a fiber that `race`s cancellation, a persistent multishot recv (Tier A) feeding an inbound queue, its two outbound rings, the ping deadline, and the keepalive tick — but with `race` cancelling losers, re-arming the recv each iteration is wasteful, so the recv should be a standing multishot op with the fiber polling the rings between completions ([SPEC § multishot backpressure, open issue O16][eh-spec]). Every timer (keepalive, 2 s write, 30 s establish, refill) becomes an in-ring `TIMEOUT` op or a `withDeadline` cancel scope. The `clearable_timeout` is the interesting one: a `CancelContext` armed at accept and _disarmed_ (not completed) when the upgrade hands off — model it as a deadline you cancel on an event.
+
+Rate limiting sits below the WebSocket decoder; in a completion model apply it _between_ completions. The `Bucket` is a clean `@nogc` value type:
+
+```rust
+// iroh-relay/src/server/streams.rs
+pub struct Bucket {
+    fill: i64,
+    max: i64,
+    last_fill: time::Instant,
+    refill_period: time::Duration,   // 100 ms
+    refill: i64,
+}
+```
+
+```d
+// proposed / sketch — @nogc token bucket, consulted between recv completions.
+struct Bucket
+{
+    long      fill;          // current tokens
+    long      max;           // burst ceiling
+    MonoTime  lastFill;
+    Duration  refillPeriod;  // 100 ms
+    long      refill;        // tokens added per period
+
+    @safe nothrow @nogc
+    bool tryConsume(size_t n, MonoTime now)
+    {
+        immutable periods = (now - lastFill) / refillPeriod;
+        if (periods > 0) { fill = min(max, fill + periods * refill); lastFill += periods * refillPeriod; }
+        if (fill < cast(long) n) return false;   // caller parks a timer before resubmitting recv
+        fill -= cast(long) n;
+        return true;
+    }
+}
+```
+
+After each recv completion of `n` bytes, `bucket.tryConsume(n)`; on refusal, park the read fiber on a `TIMEOUT` until the next refill instant before resubmitting the recv (with provided buffer rings, simply do not resubmit until then). The live-update `watch` channel becomes a plain shared config struct read each iteration — single-threaded, so no atomic `has_changed` is needed. The other `watch` cells (`HomeRelayWatch`, `n0_watcher::Watchable`) have **no** event-horizon equivalent and need a small "current value + list of parked fibers" cell; flag this as a reusable primitive the port must design ([open issue O20][eh-spec]).
+
+Two more mappings: **Happy Eyeballs** is a poster child for `race` + `Schedule` — spawn dial fibers staggered by 250 ms timers inside a scope, first success cancels siblings, each attempt is a `withDeadline` of 1500 ms. The **client reconnect actor** is a `retry` driven by `Schedule.exponential(10.msecs, 16.seconds).jittered`, except the "reset the backoff if we ever received a pong" rule is not a stock combinator and needs custom schedule state. Finally, the RFC 5705 TLS **exporter** is a hard dependency of the fast-path auth: whatever TLS library the D port binds _must_ expose `export_keying_material` on both client and server sessions, or the port can only implement the challenge flow (which is mandatory to support anyway, since plain-HTTP and browser clients cannot export). `spawn_blocking` has no thread-pool analogue and needs none — io_uring covers the one startup file read natively.
+
+---
+
+## Strengths
+
+- **Blind by construction.** The relay never decrypts; it forwards 32-byte-keyed opaque QUIC datagrams (with ECN and segment metadata preserved), so a compromised relay leaks connection metadata but never payload, and it cannot disturb the peers' end-to-end congestion control.
+- **One commodity transport.** Binary WebSocket over HTTP(S) with no bespoke framing means the identical protocol runs unmodified in a browser, traverses HTTP proxies, and reuses off-the-shelf TLS/HTTP/WS stacks.
+- **0-RTT auth when possible, always-correct fallback.** Signing TLS-exported keying material folds authentication into the first HTTP request; the challenge/response path guarantees the protocol still works where exporters are unavailable.
+- **Graceful duplicate handling.** A second connection for the same `EndpointId` parks the incumbent on an inactive stack rather than killing it, smoothing reconnect races.
+- **QAD unifies address discovery with the relay.** Reusing a QUIC endpoint's observed-address extension retires an entire second protocol (STUN) and its packet formats.
+- **Structured concurrency, stated as such.** The source is written so every task is handle-owned and cancel-on-drop — which ports almost mechanically to fibers + scopes.
+- **Live-tunable, backpressure-based rate limiting.** The token bucket applies TCP backpressure instead of dropping, and the limit is now reconfigurable without dropping connections.
+
+## Weaknesses
+
+- **Lossy and silent forwarding.** A full destination queue drops the packet with no wire-level NACK; the only negative signal is `EndpointGone` on full disconnect. Correct for QUIC (which retransmits) but opaque to any non-QUIC embedder.
+- **Heavy transport dependency surface.** A port needs a full HTTP/1.1-with-upgrade stack, a full RFC 6455 WebSocket (client _and_ server, masking + control frames), and a TLS library exposing keying-material export — far more infrastructure than the ~1 KB protocol itself.
+- **Fixed, undocumented queue depths.** `PER_CLIENT_SEND_QUEUE_DEPTH = 512` is reused for both the packet and message queues with no documented rationale; there is no per-client memory accounting beyond it.
+- **Vestigial protocol edges.** `Restarting` is defined but ignored by the current client; `Health`/v1 support lingers with no stated deprecation timeline; `accept_conn_limit` is a config field that does nothing.
+- **Single-relay bottleneck for a pair.** Two peers that both fall back to the relay funnel all traffic through one server's per-client 512-slot queues and 2 s write timeout; the relay is a throughput and latency choke until direct connectivity succeeds.
+- **`watch`-cell idioms have no simple single-threaded equivalent** — a port must build a bespoke "value + wake-on-change" primitive it does not yet have.
+
+## Key design decisions and trade-offs
+
+| Decision                                                       | Rationale                                                                            | Trade-off                                                                              |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| Relay is payload-blind; forwards opaque QUIC by `EndpointId`   | Operator learns metadata only; peers keep end-to-end encryption + congestion control | Relay cannot dedup, cache, or apply app-layer policy; it is pure switch fabric         |
+| Data plane = binary WebSocket over HTTP(S), no custom framing  | Runs in browsers, through proxies; reuses commodity TLS/HTTP/WS stacks               | A port inherits a large transport dependency surface for a tiny protocol               |
+| Two auth mechanisms (TLS-exporter 0-RTT + challenge fallback)  | Save a round trip where TLS exporters work; stay correct where they don't (browsers) | Server must implement both; the fast path depends on a niche TLS feature               |
+| Sign `derive_key(challenge)`, never the raw challenge          | Domain separation denies a malicious relay an arbitrary-message signing oracle       | One extra BLAKE3 call per handshake; a subtlety a naive port could get wrong           |
+| `try_send` with drop-on-full, no wire NACK                     | Sender's fiber never blocks on a slow peer; QUIC will retransmit                     | Silent loss; opaque to non-QUIC embedders; no explicit congestion signal to the sender |
+| Duplicate `EndpointId` demotes incumbent to an inactive stack  | Survives reconnect races without dropping the still-working old connection           | Unbounded-ish inactive vector; extra bookkeeping and `Status` signalling               |
+| QAD replaces STUN via a QUIC observed-address extension        | Retires a whole second protocol; reuses the QUIC transport already present           | Couples address discovery to a running noq endpoint on a second UDP port (`7842`)      |
+| Per-client actor owns the socket; `biased select!`             | One owner ⇒ no socket locking; deterministic priority (cancel > read > send > tick)  | Priority order is load-bearing and must be preserved bit-for-bit by a port             |
+| Live-updatable rate limit via `watch`, TCP-backpressure bucket | Reconfigure without dropping connections; backpressure instead of loss               | Needs a wake-on-change cell; a single-threaded port must reinvent that primitive       |
+| Structured concurrency (`JoinSet` + `CancellationToken`)       | Handle-owned, cancel-on-drop tasks; clean teardown                                   | Depends on the runtime supplying scope + cancel semantics (event-horizon does)         |
+
+---
+
+## Sources
+
+- [`iroh-relay` on docs.rs (`1.0.1`)][docs]
+- [`iroh-relay/src/lib.rs` — crate root; relay purpose, DERP lineage][lib]
+- [`iroh-relay/src/protos/common.rs` — `FrameType` enum + varint codec][protos-common]
+- [`iroh-relay/src/protos/relay.rs` — frames, `Datagrams`, size limits, snapshot tests][protos-relay]
+- [`iroh-relay/src/protos/handshake.rs` — both auth mechanisms, domain separation][protos-handshake]
+- [`iroh-relay/src/protos/streams.rs` — `WsBytesFramed` WebSocket adapter][protos-streams]
+- [`iroh-relay/src/http.rs` — paths, headers, `ProtocolVersion`][http]
+- [`iroh-relay/src/client.rs` — `ClientBuilder`, upgrade dance][client]
+- [`iroh-relay/src/client/conn.rs` — `Conn` Stream/Sink][client-conn]
+- [`iroh-relay/src/client/tls.rs` — Happy Eyeballs dialer, CONNECT proxy][client-tls]
+- [`iroh-relay/src/server.rs` — `ServerConfig`, `AccessControl`, supervisor][server]
+- [`iroh-relay/src/server/http_server.rs` — HTTP/WS upgrade, accept path][http-server]
+- [`iroh-relay/src/server/client.rs` — per-client actor][srv-client]
+- [`iroh-relay/src/server/clients.rs` — registry, packet routing][clients]
+- [`iroh-relay/src/server/streams.rs` — `RelayedStream`, `RateLimited`, `Bucket`][srv-streams]
+- [`iroh-relay/src/server/resolver.rs` — reloading TLS cert resolver][resolver]
+- [`iroh-relay/src/quic.rs` — QUIC Address Discovery server + client][quic]
+- [`iroh-relay/src/relay_map.rs` — `RelayMap` / `RelayConfig`][relay-map]
+- [`iroh-relay/src/ping_tracker.rs` — `PingTracker`][ping-tracker]
+- [`iroh-relay/src/key_cache.rs` — LRU pubkey parse cache][key-cache]
+- [`iroh-relay/src/defaults.rs` — ports, timeouts, cache size][defaults]
+- [`iroh-relay/src/tls.rs` — `CaTlsConfig` CA-root policy][rtls]
+- [`iroh-relay/src/main.rs` — server binary: TOML config, access backends][main]
+- [`iroh/src/socket/transports/relay/actor.rs` — client reconnect state machine][actor]
+- [`c23446ce2e` — feat(relay): allow updating the per-client rate limit live (#4381)][commit-ratelimit]
+- Related iroh pages: [The Multipath Socket][socket] · [NAT Traversal & Address Discovery][nat-traversal] · [Net Report][net-report] · [Address Lookup (Discovery)][discovery] · [QUIC Transport (noq)][quic-transport] · [Identity & Cryptography][identity-crypto] · [Wire Formats & Serialization][wire-serialization] · [Tokio Concurrency Inventory][concurrency]
+- External: [DERP (Tailscale)][derp] · [RFC 6455 (WebSocket)][rfc6455] · [RFC 8305 (Happy Eyeballs)][rfc8305] · [RFC 5705 (TLS keying-material export)][rfc5705] · [RFC 9729 (Concealed HTTP Auth)][rfc9729] · [QUIC Address Discovery draft][qad-draft] · [postcard][postcard] · [event-horizon SPEC][eh-spec]
+
+<!-- References -->
+
+[repo]: https://github.com/n0-computer/iroh/tree/22cac742ca/iroh-relay
+[docs]: https://docs.rs/iroh-relay/1.0.1/iroh_relay/
+[lib]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/lib.rs
+[protos-common]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/protos/common.rs
+[protos-relay]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/protos/relay.rs
+[protos-handshake]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/protos/handshake.rs
+[protos-streams]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/protos/streams.rs
+[http]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/http.rs
+[client]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/client.rs
+[client-conn]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/client/conn.rs
+[client-tls]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/client/tls.rs
+[server]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/server.rs
+[http-server]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/server/http_server.rs
+[srv-client]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/server/client.rs
+[clients]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/server/clients.rs
+[srv-streams]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/server/streams.rs
+[resolver]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/server/resolver.rs
+[quic]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/quic.rs
+[relay-map]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/relay_map.rs
+[ping-tracker]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/ping_tracker.rs
+[key-cache]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/key_cache.rs
+[defaults]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/defaults.rs
+[rtls]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/tls.rs
+[main]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/main.rs
+[actor]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports/relay/actor.rs
+[commit-ratelimit]: https://github.com/n0-computer/iroh/commit/c23446ce2e
+[socket]: ./socket.md
+[nat-traversal]: ./nat-traversal.md
+[net-report]: ./net-report.md
+[discovery]: ./discovery.md
+[quic-transport]: ./quic-transport.md
+[identity-crypto]: ./identity-crypto.md
+[wire-serialization]: ./wire-serialization.md
+[concepts]: ./concepts.md
+[concurrency]: ./concurrency.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[derp]: https://github.com/tailscale/tailscale/blob/main/derp/derp.go
+[rfc6455]: https://datatracker.ietf.org/doc/html/rfc6455
+[rfc8305]: https://datatracker.ietf.org/doc/html/rfc8305
+[rfc5705]: https://datatracker.ietf.org/doc/html/rfc5705
+[rfc9729]: https://datatracker.ietf.org/doc/rfc9729/
+[qad-draft]: https://datatracker.ietf.org/doc/draft-ietf-quic-address-discovery/
+[postcard]: https://docs.rs/postcard/latest/postcard/

--- a/docs/research/iroh/socket.md
+++ b/docs/research/iroh/socket.md
@@ -1,0 +1,510 @@
+# The Multipath Socket
+
+iroh's connectivity layer — the module formerly called `magicsock` — that multiplexes kernel UDP sockets, one relay transport, and arbitrary custom carriers under a single `noq::AsyncUdpSocket`, addresses every peer by a stable [`EndpointId`][identity] through a synthetic-IPv6 mapped-address scheme, and drives QUIC-native path selection, hole-punching, and relay↔direct upgrade on top of `noq` multipath.
+
+| Field               | Value                                                                                                                                                                                                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)            | `iroh` — module `socket` (ex-`magicsock`): `transports` (`ip`/`relay`/`custom`), `remote_map` → `remote_state` → `path_state`/`path_watcher`, `mapped_addrs`, `biased_rtt_path_selector`, `concurrent_read_map`                                                                                                             |
+| Version             | iroh **v1.0.1** (git `v1.0.1-6-g22cac742ca`, commit `22cac742ca`); QUIC stack `noq` tag `noq-v1.0.1`                                                                                                                                                                                                                        |
+| Repository          | [`n0-computer/iroh`][repo] (module `iroh/src/socket/`)                                                                                                                                                                                                                                                                      |
+| Documentation       | [docs.rs/iroh][docs] — the module is `pub(crate)`; its only public surface is via [`Endpoint`][endpoint], `Connection::paths()`, and `RemoteInfo`                                                                                                                                                                           |
+| ALPN(s)             | None — the socket layer sits **below** QUIC/TLS and moves opaque QUIC datagrams; `ALPN`s are negotiated one layer up in [`endpoint`][endpoint]                                                                                                                                                                              |
+| Approx. size (LoC)  | ~11.4k across the `socket` module tree (`socket.rs` 2871, `transports.rs` 1502 + `ip.rs` 541 / `relay.rs` 369 / `relay/actor.rs` 1787 / `custom.rs` 99, `remote_map.rs` 468 + `remote_state.rs` 1530 / `path_state.rs` 689 / `path_watcher.rs` 556, `mapped_addrs.rs` 383, `biased_rtt_path_selector.rs` 323); ≈8k non-test |
+| Category            | Connectivity                                                                                                                                                                                                                                                                                                                |
+| Upstream spec/draft | None of its own; the mapped-address scheme uses IPv6 Unique-Local-Addresses ([RFC 4193][rfc4193]). Multipath / QAD / NAT-traversal drafts live in [`noq`][quic] (see [`quic-transport`][quic] and [`nat-traversal`][nat])                                                                                                   |
+
+> [!NOTE]
+> This module **is** the 0.x `magicsock`, restructured for iroh 1.0. The type is now `Socket` (`pub(crate)`), not `MagicSock`; `NodeId` → [`EndpointId`][identity]; "discovery" → `address_lookup` (see [`discovery`][discovery]) — vocabulary in [Concepts][concepts]. The `DISCO` UDP side-protocol and STUN are **gone**: hole-punching is `conn.initiate_nat_traversal_round()` on the QUIC connection (see [`nat-traversal`][nat]) and address discovery is QUIC Address Discovery inside [`noq`][quic] (see [`net-report`][netreport]). A stale doc-comment still mentions "DISCO packets" ([`socket.rs:579`][socket-procdgram]); the body does no such thing. This page is part of the [iroh survey][index].
+
+---
+
+## Overview
+
+### What it solves
+
+A QUIC library speaks to a UDP socket and addresses peers by 4-tuple. iroh needs the opposite contract: address a peer by its stable [`EndpointId`][identity] and let the connection ride whatever mix of paths currently reaches it — a hole-punched direct IPv4 path, an IPv6 path, a relayed path, or several at once — failing over transparently as the network changes underfoot. The socket layer is the adapter that makes those two contracts meet. It presents [`noq`][quic] with a single object that _looks_ like one UDP socket (`noq::AsyncUdpSocket`), while underneath it fans datagrams across up to three transport families, rewrites addresses so QUIC can name a peer that has no fixed IP, and runs the policy machinery — path selection, hole-punch scheduling, relay lifecycle, network-change reaction — that keeps the "always the best available path" promise.
+
+The layer owns almost no wire format of its own. Everything above it (QUIC packets, streams, multipath frames, NAT-traversal frames, address-discovery observations) is [`noq`][quic]'s; everything the relay carries is the [relay protocol][relay]'s. What the socket _does_ own is the **routing fabric**: a synthetic address space that lets QUIC point at non-IP destinations, a per-remote actor that decides which paths exist and which is preferred, and the demultiplexing that turns "one abstract socket" back into "N real carriers." From the module's own framing ([`socket.rs:325`][socket-doc]):
+
+> _"This is responsible for routing packets to endpoints based on endpoint IDs, it will initially route packets via a relay and transparently try and establish an endpoint-to-endpoint connection and upgrade to it. It will also keep looking for better connections as the network details of both endpoints change."_
+
+### Design philosophy
+
+Three convictions shape the module, and each has a direct consequence for a D port.
+
+1. **Everything is a QUIC path; there is no separate "relay mode."** In iroh 0.x the socket duplicated each datagram onto UDP _and_ the relay and let DISCO ping/pong pick a winner. In 1.0 the relay and every direct address are **concurrent QUIC multipath paths on one connection**. "Switching from relay to direct" is nothing more than flipping a path's QUIC `PathStatus` from `Backup` to `Available` and letting [`noq`][quic] route ([`remote_state.rs:682`][rs-apply]). The socket never duplicates payload datagrams — the only surviving fan-out is for QUIC Initials, and only through one synthetic address (below).
+
+2. **The socket must never kill the QUIC endpoint driver.** `noq` treats a send error from its `AsyncUdpSocket` as fatal and tears the endpoint down. So the send path **blackholes** almost everything — unroutable addresses, parked transports, transient errors all return `Poll::Ready(Ok(()))` and let QUIC's loss detection recover ([`transports.rs:1369`][tp-blackhole]):
+
+   > _"On errors this methods prefers returning `Ok(())` to Noq. Returning an error should only happen if the error is permanent and fatal and it will never be possible to send anything again. Doing so kills the Noq `EndpointDriver`. Most send errors are intermittent errors, returning `Ok(())` in those cases will mean Noq eventually considers the packets that had send errors as lost and will try and re-send them."_
+
+3. **A selected path is a working path, not a preference.** The socket only marks a path selected once `noq` reports it functional, and demotes it to `None` the instant it looks broken ([`remote_state.rs:147`][rs-selected]):
+
+   > _"**We expect this path to work.** If we become aware this path is broken then it is set back to `None`. Having a selected path does not mean we may not be able to get a better path: e.g. when the selected path is a relay path we still need to trigger holepunching regularly. We only select a path once the path is functional in Noq."_
+
+The whole module is a **policy shell around `noq` multipath**: `noq` owns path validation, keep-alives, loss detection, and congestion; the socket owns _which_ paths exist, _which_ is preferred, and _when_ to hole-punch. Keeping that split clean is the single most important thing a port must preserve — it is what lets the connectivity logic be reasoned about without re-deriving QUIC.
+
+---
+
+## How it works
+
+### The layer cake
+
+From bottom to top, four objects stack up:
+
+```text
+noq::Endpoint  (QUIC state machine; sees ONE abstract socket)
+   │  create_sender() / poll_recv(bufs, metas)
+   ▼
+Transport            wraps Arc<Socket> + Transports; impl noq::AsyncUdpSocket   (transports.rs:1249)
+   ▼
+Transports           owns IpTransports + Vec<RelayTransport> + Vec<Box<dyn CustomEndpoint>>   (transports.rs:52)
+   ▼
+{ IpTransport , RelayTransport , CustomEndpoint }   — each a poll_recv / poll_send datagram carrier
+   ▼
+kernel UDP sockets   /   RelayActor→ActiveRelayActor→WebSocket   /   user carrier
+```
+
+`Transport` is the seam handed to `noq`. It is installed once, at bind, as an _abstract_ socket ([`socket.rs:1027`][socket-abstract]):
+
+```rust
+// iroh/src/socket.rs:1027 — the QUIC endpoint talks to an abstract socket, not an fd
+let endpoint = noq::Endpoint::new_with_abstract_socket(
+    endpoint_config,
+    Some(server_config),
+    Box::new(Transport::new(sock.clone(), transports)),
+    runtime.clone(),
+)
+```
+
+`noq` then drives exactly two verbs on it — a batched `poll_recv` and `create_sender()` — plus capability queries (`local_addr`, `max_receive_segments`, `may_fragment`, and on the sender `max_transmit_segments`) ([`transports.rs:1260`][tp-transport]):
+
+```rust
+// iroh/src/socket/transports.rs:1260 — the entire noq↔iroh seam
+impl noq::AsyncUdpSocket for Transport {
+    fn create_sender(&self) -> Pin<Box<dyn noq::UdpSender>> { /* Sender { sock, transports.create_sender() } */ }
+    fn poll_recv(&mut self, cx: &mut Context, bufs: &mut [IoSliceMut<'_>], meta: &mut [noq_udp::RecvMeta])
+        -> Poll<io::Result<usize>> { self.transports.poll_recv(cx, bufs, meta, &self.sock) }
+    fn local_addr(&self) -> io::Result<SocketAddr> { /* first IPv6, else IPv4→v6-mapped, else DEFAULT_FAKE_ADDR */ }
+    fn max_receive_segments(&self) -> NonZeroUsize { self.transports.max_receive_segments() }
+    fn may_fragment(&self) -> bool { self.transports.may_fragment() }
+}
+```
+
+`local_addr` never returns a raw v4 address: mapped addresses are IPv6, so a v4 socket is reported as its IPv4-mapped-IPv6 form, and a relay/custom-only endpoint reports the placeholder `DEFAULT_FAKE_ADDR` = `[fd15:70a:510b:0:ffff:ffff:ffff:ffff]:12345` ([`mapped_addrs.rs:35`][mapped-default]).
+
+### Transport families
+
+`Transports` ([`transports.rs:52`][tp-struct]) owns three carrier families, all sharing the same poll-based shape:
+
+- **`IpTransports`** — one `IpTransport` per bind config, split into v4/v6 vectors sorted descending by prefix length, with an optional per-family default index ([`ip.rs:384`][ip-transports]). Only one relay `TransportConfig` is accepted ([`socket.rs:906`][socket-onerelay]) despite `relay` being a `Vec`.
+- **`RelayTransport`** — zero or one, wrapping the relay actor tree (below).
+- **`CustomEndpoint`** — any number of user-supplied `Box<dyn CustomEndpoint>` ([`custom.rs:36`][custom]).
+
+Each exposes `poll_recv(cx, bufs, metas, recv_infos)` — filling `noq_udp::RecvMeta` plus an iroh-side `RecvInfo` (remote as `transports::Addr`, optional local `CustomAddr`) — and a cheap clonable _sender_ with `is_valid_send_addr(...)` + `poll_send(...)`. A network path is named by `FourTuple` and a source address by `Addr` ([`transports.rs:742`][tp-addr], [`transports.rs:970`][tp-fourtuple]):
+
+```rust
+// iroh/src/socket/transports.rs:742,970
+pub enum Addr {                          pub enum FourTuple {
+    Ip(SocketAddr),                          Ip     { remote: SocketAddr, local: Option<IpAddr> },
+    Relay(RelayUrl, EndpointId),             Relay  { url: RelayUrl, endpoint_id: EndpointId },
+    Custom(CustomAddr),                      Custom { remote: CustomAddr, local: Option<CustomAddr> },
+}                                        }
+```
+
+GSO/GRO is plumbed end-to-end: `max_transmit_segments` is the **min** over IP+custom transports and `max_receive_segments` the **max** over IP transports ([`transports.rs:420`][tp-segments]), and `Transmit.segment_size` / `RecvMeta.stride` carry the segment size all the way through (the relay re-batches to fit `noq`'s buffer).
+
+### Mapped addresses: naming non-IP peers to QUIC
+
+`noq` only understands `SocketAddr`. So every non-IP destination is represented as a fake IPv6 Unique-Local-Address in `fd15:70a:510b::/48` ([`mapped_addrs.rs:1`][mapped-doc]):
+
+> _"We use non-IP transports to carry datagrams. Yet Noq needs to address those transports using IPv6 addresses. These defines mappings of several IPv6 Unique Local Address ranges we use to keep track of the various 'fake' address types we use."_
+
+The 16-byte layout ([`mapped_addrs.rs:19`][mapped-doc]) is `[0]=0xfd` prefix · `[1..6]=15 07 0a 51 0b` (n0 global ID) · `[6..8]` subnet ID · `[8..16]` big-endian `u64` counter (process-global, starting at 1; a `portable_atomic::AtomicU64` per family):
+
+| Subnet ID | `/64` range            | Type                   | One entry per            | Role                                   |
+| --------- | ---------------------- | ---------------------- | ------------------------ | -------------------------------------- |
+| `00 00`   | `fd15:70a:510b::/64`   | `EndpointIdMappedAddr` | remote `EndpointId`      | `Mixed` — Initial-only fan-out address |
+| `00 01`   | `fd15:70a:510b:1::/64` | `RelayMappedAddr`      | `(RelayUrl, EndpointId)` | one relay path                         |
+| `00 03`   | `fd15:70a:510b:3::/64` | `CustomMappedAddr`     | `CustomAddr`             | one custom path                        |
+
+Subnet `2` is unused (a vestige of the 0.x "IP mapped" subnet, retired now that real IP addresses pass through unmapped). The port is always the dummy `MAPPED_PORT` = 12345. `MultipathMappedAddr::from(SocketAddr)` classifies a destination by prefix match; `Mixed` carries the per-`EndpointId` address ([`mapped_addrs.rs:89`][mapped-enum]):
+
+```rust
+// iroh/src/socket/mapped_addrs.rs:89
+pub(crate) enum MultipathMappedAddr {
+    Mixed(EndpointIdMappedAddr),  // per-EndpointId, Initial-only fan-out addr
+    Relay(RelayMappedAddr),       // per-(RelayUrl, EndpointId)
+    Ip(SocketAddr),
+    Custom(CustomMappedAddr),
+}
+pub(crate) struct EndpointIdMappedAddr(Ipv6Addr);
+```
+
+Bidirectional lookup uses `AddrMap<K,V>` — two `FxHashMap`s behind one `std::sync::Mutex` — generating a fresh mapped address on `get` and reversing on `lookup`. Crucially, **entries are never removed** ([`mapped_addrs.rs:342`][mapped-addrmap]): every `(relay, endpoint)` pair ever seen holds a slot for process lifetime.
+
+### Recv path
+
+`Transports::poll_recv` ([`transports.rs:298`][tp-pollrecv]) polls every transport in sequence; a counter reverses the polling order on every other call for fairness. The first transport with data wins and returns immediately. The subtle part is the failure accounting: a per-transport error does **not** short-circuit, or a single always-failing transport would hot-loop the reactor; instead errors are counted, and only if _all_ polled transports error does `poll_recv` bump `consecutive_total_recv_failures` and — after `MAX_CONSECUTIVE_RECV_ERRORS` = 8 — surface a fatal `NetworkDown` to `noq`. Otherwise it returns `Ready(Ok(0))` (as both an error-suppression signal and a genuine zero-datagram result) or `Pending`.
+
+After a batch, `Socket::process_datagrams` ([`socket.rs:583`][socket-procdgram]) rewrites `RecvMeta.addr` for non-IP transports: a relay datagram gets `noq_meta.addr = relay_mapped_addrs.get(&(url, src_endpoint))` (a synthetic ULA), a custom datagram similarly. IP datagrams keep their kernel address, except the AF_INET6 recv path converts IPv4 peers to IPv4-mapped-IPv6 for `noq` while keeping the canonical form in `RecvInfo`. Per-datagram metrics count GRO batches, including a repair for the degenerate `stride==0 && len>0` case.
+
+### Send path
+
+`noq` calls `Sender::poll_send(transmit)` ([`transports.rs:1363`][tp-pollsend]). The destination `SocketAddr` is decoded into `MultipathMappedAddr` and routed:
+
+| Class      | Routing                                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Ip**     | canonicalize, then `v4/v6` iterate → `is_valid_send_addr(src, dst)` → `poll_send`, falling back to the family default socket                                  |
+| **Relay**  | reverse-lookup to `(RelayUrl, EndpointId)`, then reserve a slot in a `PollSender`-wrapped `mpsc(256)` to the `RelayActor`                                     |
+| **Custom** | reverse-lookup, delegate to the first `CustomSender` accepting the address                                                                                    |
+| **Mixed**  | the packet cannot be routed to a single path — copy the whole `Transmit` into an `OwnedTransmit` and `try_send` it as `SendDatagram(...)` to the remote actor |
+
+The `Mixed` case is the _only_ fan-out left. The remote's `RemoteStateActor` sends it to the currently selected path, or — when none exists yet — **fans it out to every known candidate path** ([`remote_state.rs:788`][rs-fanout]), which is acceptable _only_ for QUIC Initials. Everything else on the send path deliberately swallows failure per the blackholing rule above.
+
+### `RemoteMap` and per-remote actors
+
+`RemoteMap` ([`remote_map.rs:56`][rm-struct]) owns a `ConcurrentReadMap<EndpointId, mpsc::Sender<RemoteStateMessage>>` — a `papaya` lock-free hashmap with one `&mut` writer (the socket actor) and cheap `ReadOnlyMap` clones for concurrent readers like the send path ([`concurrent_read_map.rs:13`][crm]) — plus a `JoinSet` of per-remote actor tasks. `send_to_actor` lazily spawns a `RemoteStateActor` (inbox `mpsc(16)`) on first message to a remote. Because a `mpsc::Sender` can outlive its receiver, a failed send means the actor is terminating: the map drains the joined task and **restarts the actor with the leftover messages** ([`remote_map.rs:287`][rm-restart]). `RemoteMap::cleanup()`, pumped from the socket actor's select loop, reaps joined tasks — removing the sender if the actor drained cleanly, restarting it if messages arrived during shutdown.
+
+### `RemoteStateActor`: one actor per remote endpoint
+
+`RemoteStateActor` ([`remote_state.rs:98`][rs-actor]) manages _all_ connections to one remote:
+
+```rust
+// iroh/src/socket/remote_map/remote_state.rs:98 (trimmed)
+struct State {
+    endpoint_id: EndpointId,
+    local_direct_addrs: n0_watcher::Direct<BTreeSet<DirectAddr>>,
+    relay_mapped_addrs: AddrMap<(RelayUrl, EndpointId), RelayMappedAddr>,
+    custom_mapped_addrs: AddrMap<CustomAddr, CustomMappedAddr>,
+    address_lookup: AddressLookupServices,
+    connections_close: FuturesUnordered<OnClosed>,
+    path_events: PathEvents,   // MergeUnbounded of per-conn noq PathEvent streams
+    addr_events: AddrEvents,   // MergeUnbounded of per-conn QNT candidate streams
+    paths: RemotePathState,
+    last_holepunch: Option<HolepunchAttempt>,
+    selected_path: Option<transports::FourTuple>,
+    scheduled_holepunch: Option<Instant>,
+    scheduled_open_path: Option<Instant>,
+    pending_open_paths: VecDeque<transports::FourTuple>,
+    address_lookup_stream: Option<BoxStream<Result<AddressLookupItem, AddressLookupFailed>>>,
+    path_selector: Arc<dyn PathSelector>,
+}
+```
+
+Its **biased** `select!` loop ([`remote_state.rs:272`][rs-loop]) consumes, in priority order: a shutdown token; the `mpsc(16)` inbox; merged `noq` `PathEvent` streams; merged NAT-traversal candidate streams (remote QNT announcements → trigger hole-punching); connection-closed futures; the local direct-address watcher; a scheduled path-open timer; a scheduled hole-punch timer; an optional address-lookup stream; a 60 s `UPGRADE_INTERVAL` quality check; and a 60 s `ACTOR_MAX_IDLE_TIMEOUT` that terminates the actor when it has no connections, an empty inbox, and no pending resolves.
+
+`AddConnection` wires those three streams for a connection, seeds local QNT candidates (diff-based against `conn.get_local_nat_traversal_addresses()`), registers `PathId::ZERO`, and — client-side only — re-adds known relay addresses as paths if the initial path came out direct. **Path opening is client-only** ([`remote_state.rs:1036`][rs-openpath]); the server learns paths from QUIC frames and reacts to `PathEvent::Established`. If `noq` refuses to open (`RemoteCidsExhausted` / `MaxPathIdReached`), the address is queued in `pending_open_paths` and retried after 333 ms.
+
+Per-remote _candidate_ knowledge lives in `RemotePathState`: a map `transports::Addr → PathState{sources, status}` with status `Open` / `Inactive(when)` / `Unusable` / `Unknown` ([`path_state.rs:43`][ps-status]), pruned to ≤30 non-relay paths — keeping the 10 most-recently-inactive hole-punch-proven ones and always dropping hole-punch-failed ones.
+
+### Path selection: the biased-RTT algorithm
+
+On every `Established` / `Abandoned` path event (and on `AddConnection`), `select_path()` runs the pluggable `PathSelector` ([`remote_state.rs:1419`][rs-selectortrait]) over a `PathSelectionContext` — the current selected `FourTuple` plus an iterator of `(FourTuple, PathId, Connection)` across _all_ connections:
+
+```rust
+// iroh/src/socket/remote_map/remote_state.rs:1419
+pub trait PathSelector: Send + Sync + std::fmt::Debug + 'static {
+    fn select(&self, ctx: &PathSelectionContext<'_>) -> PathSelection;
+}
+```
+
+The default `BiasedRttPathSelector` ([`biased_rtt_path_selector.rs`][selector]) sorts candidates by a two-level key `(TransportType, biased_rtt)`:
+
+- `TransportType` is `Primary` (IPv4 / IPv6 / custom) or `Backup` (relay). This is a strict **tier**, not an RTT penalty: a 1000 ms direct path beats a 1 ms relay path (the selector's own tests assert this).
+- `biased_rtt` is the measured RTT plus a per-kind bias; IPv6 gets a `IPV6_RTT_ADVANTAGE` = 3 ms _subtracted_ so it wins ties against IPv4.
+
+The switch conditions have deliberate hysteresis ([`biased_rtt_path_selector.rs:170`][selector-switch]):
+
+```rust
+// iroh/src/socket/biased_rtt_path_selector.rs (abridged select())
+if current_tier != best_tier {
+    selection.set(&best_psd);                                          // always switch across tiers
+} else if best_biased + RTT_SWITCHING_MIN.as_nanos() as i128 <= current_biased {
+    selection.set(&best_psd);                                          // same tier: only if ≥5 ms better
+}
+```
+
+`RTT_SWITCHING_MIN` = 5 ms is the stickiness threshold: within a tier, a candidate must be at least 5 ms better before the socket abandons the current path; across tiers (relay → primary) it switches immediately. An empty selection keeps the current path.
+
+`apply_selected_path()` ([`remote_state.rs:682`][rs-apply]) is where selection becomes routing. For each connection it opens the selected path if missing, sets QUIC `PathStatus::Available` on the selected path and `Backup` on all others (that is how "the data goes over the selected path" is _enforced_ — `noq` transmits on `Available` paths and keeps `Backup` paths alive with keep-alives), and **closes redundant non-selected IP paths so at most one IP path remains** ([`remote_state.rs:703`][rs-close]):
+
+> _"Closes redundant IP paths so that at most one remains per connection. Relay and custom paths are kept open. Only the client closes paths, to avoid the client and server independently closing different paths and racing to abandon the last one."_
+
+### Hole-punching: QUIC-native, not DISCO
+
+`trigger_holepunching` ([`remote_state.rs:504`][rs-holepunch]) picks the lowest-`ConnId` _client-side_ connection (both endpoints may hold a client connection and both may initiate), diffs the current local+remote candidate sets against the last attempt, and skips (scheduling `last.when + 5 s` `HOLEPUNCH_ATTEMPTS_INTERVAL`) if no new candidates appeared. The actual punch is `conn.initiate_nat_traversal_round()` — the n0 NAT-traversal QUIC extension implemented in [`noq-proto`][quic] (see [`nat-traversal`][nat]) — retrying transient errors in 100 ms and giving up on fatal ones. A 60 s quality check re-triggers hole-punching unless every connection already has an IP path with RTT ≤ 10 ms (`GOOD_ENOUGH_LATENCY`). Candidates propagate as QNT add/remove-address frames driven from the socket-level `DiscoveredDirectAddrs` watcher. There is no DISCO ping/pong/call-me-maybe anywhere.
+
+### The relay transport actor tree
+
+`RelayTransport::new` spawns a `RelayActor` (as an `AbortOnDropHandle`) that multiplexes N relay servers, spawning one `ActiveRelayActor` per URL into a `JoinSet` ([`relay/actor.rs:853`][ra-spawn]). The channel topology is the busiest in the module ([`relay.rs:46`][rt-channels]): the `RelaySender` `mpsc(256)` feeds the `RelayActor`, which `try_send`s into a per-relay `mpsc(64)`; when full it parks a completion future and stops pulling new datagrams (backpressure). **Receive bypasses the `RelayActor` entirely**: each `ActiveRelayActor` `try_send`s inbound datagrams straight into a shared `mpsc(512)` consumed by `RelayTransport::poll_recv`, which re-batches GRO segments to fit `noq`'s buffer. Only the _send_ path funnels through the `RelayActor`, for routing and lazy actor-spawning — including asking existing `ActiveRelayActor`s (via a priority inbox) whether they have recently heard from a given `EndpointId`, to reuse a relay rather than dial a new one.
+
+Each `ActiveRelayActor` maintains one WebSocket/TLS relay connection through `Dialing` → `Connected` → `Sending` states, pings every 15 s, drops queued datagrams after 3 s while disconnected, and exits after 60 s of send-inactivity — unless it is the home relay. Home-relay status is published through a URL-guarded `HomeRelayWatch` so a demoted actor cannot clobber the new home relay's status.
+
+### The socket actor (top level) and shutdown
+
+One `Actor` task per endpoint ([`socket.rs:1442`][socket-actor]) runs the outermost `select!` loop, handling: actor messages (network change, relay-map change, `ResolveRemote`, `AddConnection`, direct-address refresh); a re-STUN interval randomized **20–26 s** (just under the 30 s NAT-binding timeout); the local-address, net-report, portmapper, and netmon interface watchers; `remote_map.cleanup()`; and a default-route poll with exponential backoff 100 ms → 1 s cap (5 s max) before calling `endpoint.handle_network_change(hint)` into `noq`. The `NetworkChangeHint` tells `noq` which established paths are recoverable — relay paths always (the relay actor transparently reconnects), IP paths only if their local IP still exists, `Mixed` never, custom assumed unrecoverable. Direct-address updates merge portmapper + QAD (see [`net-report`][netreport]) + local interface addresses + user-configured addresses into `DiscoveredDirectAddrs` and republish `EndpointData` to the address-lookup services on change (see [`discovery`][discovery]).
+
+Shutdown ([`socket.rs:276`][socket-shutdown]) is two `CancellationToken`s plus an `AtomicBool`: `close()` cancels `at_close_start` (stops net-reports), clears address lookup, calls `noq_endpoint.close(0, b"")`, then awaits `wait_all_draining()` — a call whose comment records being removed and re-added three times ([`socket.rs:1148`][socket-drain]):
+
+> _"In the history of this code, this call had been removed … then added back in … then removed again … and finally added back in together with this comment. … this call tries its best to make sure that any queued close frames … are flushed out to the sockets *and acknowledged* (or time out with the 'probe timeout' of usually 3 seconds)."_
+
+It then cancels `at_endpoint_closed` (all actors' tokens are children), gives the actor task 100 ms, awaits the `noq` `Runtime`'s task tracker, and sets `closed`. After closing, `poll_recv` returns `Pending` forever and senders error `NotConnected`.
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+The socket sits mostly _below_ framing — it moves opaque QUIC datagrams, and iroh's application-level wire formats (tickets, `postcard` structures) live in [wire formats & serialization][wire] — but it defines several byte-level conventions of its own:
+
+- **Mapped-address ULA layout** (16 bytes, [`mapped_addrs.rs:19`][mapped-doc]): `0xfd` · `15 07 0a 51 0b` · 2-byte subnet · 8-byte big-endian counter; port always 12345. This is the address space QUIC uses to name relay/custom/per-endpoint destinations. It ports verbatim (pure data).
+- **GSO/GRO segmentation**: outgoing `Transmit { ecn, contents, segment_size }` with `datagram_count = contents.len().div_ceil(segment_size)`; incoming `RecvMeta.stride` is the segment size. The relay recv path re-batches with `num_segments = buf_len / segment_size` and drops datagrams larger than the offered buffer ("let MTU discovery take over").
+- **Relay datagram envelope**: `Datagrams { ecn, segment_size: Option<NonZeroU16>, contents: Bytes }` inside `ClientToRelayMsg::Datagrams` / `RelayToClientMsg::Datagrams`; ECN maps 1:1 between `noq_udp::EcnCodepoint` and `noq_proto::EcnCodepoint`. The envelope is owned by the [relay protocol][relay].
+- **QUIC grease-bit hack** ([`socket.rs:1013`][socket-grease]): `endpoint_config.grease_quic_bit(false)` makes `noq` _require_ the fixed bit, so a non-QUIC UDP packet is passed to `noq` with its first byte zeroed and dropped **without a buffer rewrite**.
+- **Size/limit constants**: `MAX_MULTIPATH_PATHS` = 8 concurrent QUIC paths/connection; `MAX_QNT_ADDRESSES` = 32 NAT-traversal addresses; `PATH_MAX_IDLE_TIMEOUT` = 15 s (relay 30 s); `noq_udp::BATCH_SIZE` = 32 recv buffers (unix) / 1 (Windows, wasm).
+
+### Cryptography & identity
+
+The socket performs **no cryptography**. TLS/QUIC handshakes, packet protection, and the `EndpointId` ↔ Ed25519 key relationship all live in [`noq`][quic] and [`identity-crypto`][identity]; the socket only carries the ciphertext. Its single identity-shaped responsibility is _addressing by_ [`EndpointId`][identity]: the mapped-address scheme and `RemoteMap` are keyed on `EndpointId`, and the relay-reuse query matches remotes by `EndpointId`. The relay's own `Blake3HmacKey` for endpoint-config token keying is constructed here ([`socket.rs:1013`][socket-grease]) but consumed by `noq`. Absence is the finding: a port must not look for a DISCO shared-secret or STUN handshake here — there is none.
+
+### State machines & lifecycle
+
+Eight interacting state machines drive the module; the load-bearing ones for a port are:
+
+1. **Candidate-path lifecycle** (`RemotePathState`): `Unknown` → (path established) `Open` → (abandoned) `Inactive(now)`; `Unknown|Unusable` + failed hole-punch → `Unusable`; any → (re-established) `Open`. Pruned on every insert (≤30 non-relay, keep 10 most-recently-inactive).
+2. **Selected-path state**: `Option<FourTuple>`, `None` at start; set whenever the `PathSelector` returns a selection; cleared when the last connection closes. Hysteresis lives in the selector (5 ms same-tier, immediate cross-tier).
+3. **Hole-punch scheduling**: a stateless trigger with a `last_holepunch` memo; skip-and-schedule (+5 s) if candidates ⊆ last attempt; retry in 100 ms on transient `noq` errors; give up on fatal ones (`Closed`, `TooManyAddresses`, `WrongConnectionSide`, `ExtensionNotNegotiated`).
+4. **`RemoteStateActor` lifecycle**: `NotRunning` → (first message) `Running` → (idle 60 s) `Terminating` → (drains inbox) → restarted-with-leftovers _or_ removed. The restart-with-leftover-messages dance exists only because a `mpsc::Sender` can outlive its receiver.
+5. **`ActiveRelayActor`**: `Dialing` (exponential backoff, min 10 ms / max 16 s / jittered) → `Connected` (ping every 15 s) → `Sending` → back to `Connected`; `Established` failures reconnect immediately with a fresh backoff, others back off; exit on stop token / closed inboxes / 60 s send-inactivity (unless home relay).
+6. **Socket shutdown**: `Open` → (`close()`/`abort()`) `Closing` → (endpoint drained) cancel `at_endpoint_closed` → `closed`.
+
+### Dependencies & coupling
+
+The socket is a thin shell over a very deep dependency:
+
+| Dependency                                  | Depth                 | What a D port inherits                                                                                                                                                                                                                                                         |
+| ------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [`noq`/`noq-proto`/`noq-udp`][quic]         | load-bearing          | The entire QUIC stack incl. multipath (`PathId`, `Path::set_status/close/ping`, `open_path_ensure`, `path_events`), QUIC-native NAT traversal (`initiate_nat_traversal_round`), and the `AsyncUdpSocket`/`UdpSender`/`Runtime` seams. The socket layer is a shell around this. |
+| [`iroh-relay`][relay]                       | load-bearing          | relay client (`ClientBuilder`, split Stream/Sink), `ClientToRelayMsg`/`RelayToClientMsg`, `Datagrams`, `PingTracker`.                                                                                                                                                          |
+| `netwatch` / `net-tools`                    | load-bearing platform | `UdpSocket` with GSO/GRO + rebind, `netmon::Monitor` interface watching, `interfaces::State`. A port needs `sendmsg`/`recvmmsg` + `UDP_SEGMENT`/`UDP_GRO` and netlink/route monitoring (see [`net-report`][netreport]).                                                        |
+| `n0-watcher`                                | load-bearing pattern  | `Watchable`/`Watcher` + `Join`/`Tuple`/`Map`/`or` combinators — a versioned last-value cell with change notification. **No event-horizon equivalent** (see Mapping).                                                                                                           |
+| `tokio` / `tokio-util`                      | load-bearing runtime  | `mpsc`/`oneshot`/`broadcast`/`Notify`/`Mutex`/`RwLock`, biased `select!`, `JoinSet`, `CancellationToken` (+ child tokens), `PollSender`, `AbortOnDropHandle`.                                                                                                                  |
+| `papaya`                                    | API-surface           | lock-free hashmap behind `ConcurrentReadMap`. Collapses to a plain hashmap under single-threaded D.                                                                                                                                                                            |
+| `backon`, `rustc-hash`, `smallvec`, `bytes` | trivial               | exponential backoff; `FxHashMap`; `SmallVec`; ref-counted byte buffers. Backoff → event-horizon `Schedule`.                                                                                                                                                                    |
+
+The full concurrency inventory (26 primitives) is enumerated in [`concurrency`][concurrency].
+
+### Concurrency & I/O model
+
+The module is a **constellation of tokio actors** communicating over channels, running on a work-stealing multi-thread runtime with `Arc`/`Mutex`/atomics guarding every shared datum. There are three actor tiers — one socket `Actor`, one `RemoteStateActor` per remote, one `RelayActor` + N `ActiveRelayActor`s — plus the `noq` endpoint driver, all potentially on different threads. The I/O model is `noq`'s poll-driven `AsyncUdpSocket`: `noq` calls `poll_recv`/`poll_send` and the socket threads its own actor events through tokio channels and `n0-watcher` watchables. Every `select!` here is **biased** (deterministic priority — shutdown token first), and that ordering is load-bearing, not incidental. There is **no `spawn_blocking` anywhere** in the subsystem, and the only `std::sync::Mutex`es (the `AddrMap` bimap, the `PathStateSender` shared state, the `actor_task` handle) hold short critical sections. That is the crucial fact for a port: nothing here needs true parallelism — the multi-thread machinery exists because tokio is multi-thread, not because the algorithm is.
+
+### Mapping to event-horizon
+
+This subsystem is where the tokio→[event-horizon][eh-spec] translation pays off most, because almost all of its concurrency is _accidental_ — a consequence of tokio's `Send + Sync` model, not of the connectivity algorithm. Under event-horizon's default `single` topology (one loop, one thread, [fibers][eh-spec] + [algebraic effects][algeff]) the `Arc<Mutex<…>>` scaffolding collapses to plain fields.
+
+**1. The `AsyncUdpSocket` poll seam disappears.** The entire `poll_recv`/`poll_send` + `Waker` choreography exists because `noq` is a poll-driven state machine on tokio. On event-horizon the seam should be **completion-shaped**: each transport is a fiber doing `recv` (ideally multishot into a [`BufRing`][eh-spec]) and feeding a demux point, plus a `send(FourTuple, segments)` verb. The `poll_recv` fairness counter becomes unnecessary (each transport is its own fiber); the "all transports failed 8×" fatal escalation stays as policy.
+
+```rust
+// Rust: iroh/src/socket/transports.rs:1260 — poll-driven seam noq drives
+impl noq::AsyncUdpSocket for Transport {
+    fn poll_recv(&mut self, cx: &mut Context, bufs: &mut [IoSliceMut<'_>], meta: &mut [noq_udp::RecvMeta])
+        -> Poll<io::Result<usize>> { self.transports.poll_recv(cx, bufs, meta, &self.sock) }
+    fn create_sender(&self) -> Pin<Box<dyn noq::UdpSender>> { /* ... */ }
+}
+```
+
+```d
+// D (proposed / sketch): a completion-shaped multipath datagram carrier over event-horizon.
+// Each transport is its own recv fiber feeding one demux mailbox; send is a direct verb.
+struct MultipathSocket(Net) if (isNet!Net)
+{
+    Net net;                                   // RingNet capability (io_uring/kqueue/IOCP)
+    IpTransport[] ip;                          // was IpTransports; sorted by prefix len
+    RelayTransport* relay;                     // 0..1
+    CustomTransport[] custom;
+    MappedAddrs mapped;                         // plain bidi hashmaps — no Mutex under `single`
+
+    // recv: one fiber per transport; on completion, tag with Addr and post to the demux.
+    void spawnRecvFibers(ref Scope sc) {
+        foreach (ref t; ip)     sc.spawn(() => t.recvLoop(&demux));   // multishot recv into a BufRing
+        if (relay) sc.spawn(() => relay.recvLoop(&demux));
+        foreach (ref t; custom) sc.spawn(() => t.recvLoop(&demux));
+    }
+
+    // send: never fails the QUIC stack — blackhole transient errors (load-bearing invariant).
+    void send(FourTuple dst, scope const(Segment)[] segs) @safe nothrow {
+        auto r = routeAndSend(dst, segs);      // IoResult!void
+        if (r.hasError) { metrics.sendDrops++; /* drop: let noq loss detection recover */ }
+    }
+}
+```
+
+**2. Mapped addresses port verbatim.** The ULA scheme is pure data; `AddrMap` under `single` topology is a plain bidirectional hashmap with **no `Mutex`**. Keep the never-GC'd growth in mind — it is a real leak the port should bound (the Rust code has a `// TODO: use this` for remote-state pruning). `EndpointIdMappedAddr` is a 16-byte value that can be a `@safe pure nothrow @nogc` struct.
+
+```rust
+// Rust: iroh/src/socket/mapped_addrs.rs:135
+pub(crate) struct EndpointIdMappedAddr(Ipv6Addr);   // fd15:70a:510b::/64 + AtomicU64 counter
+```
+
+```d
+// D (proposed / sketch): the same 16 bytes, no atomic under single-threaded ownership.
+struct EndpointIdMappedAddr { ubyte[16] octets; }   // 0xfd | 15 07 0a 51 0b | 00 00 | u64 counter (BE)
+
+EndpointIdMappedAddr nextEndpointIdAddr(ref ulong counter) @safe pure nothrow @nogc {
+    ubyte[16] o = [0xfd, 0x15, 0x07, 0x0a, 0x51, 0x0b, 0x00, 0x00, 0,0,0,0,0,0,0,0];
+    o[8 .. 16] = nativeToBigEndian(++counter);       // plain field ++, not AtomicU64 under `single`
+    return EndpointIdMappedAddr(o);
+}
+```
+
+**3. Actor topology → fibers owning state; the restart dance evaporates.** The socket `Actor` becomes one fiber in the endpoint's [`Scope`][eh-spec]; each `RemoteStateActor` becomes one fiber spawned via `Scope.spawn`, keeping a `JoinHandle`. The reap/restart-with-leftover-messages machinery in `RemoteMap` exists **only** because a tokio `mpsc::Sender` can outlive its receiver across threads. In a single-threaded loop, enqueue-and-spawn is atomic — the port can drop the restart machinery entirely, contingent on a cross-fiber channel primitive (event-horizon [open-issue O20][eh-spec], the recognized gap this subsystem most needs).
+
+**4. `select!` loops → `race` / first-completion, preserving bias.** Every loop here is a biased `select!`. Map each to event-horizon [`race`][eh-spec] over a small fixed set of awaitables; the biased orderings (shutdown token first) must be reproduced as **deterministic priority** when several completions are ready simultaneously.
+
+**5. `CancellationToken` tree → `CancelContext` tree.** A direct fit: `at_close_start` / `at_endpoint_closed` and their `child_token()`s are nested cancel scopes; `run_until_cancelled(fut)` is `race(cancelled, fut)`; the 100 ms actor grace is [`withDeadline`][eh-spec].
+
+**6. `PathSelector` → a DbI capability, not a `dyn` trait object.** The selector is a **pure function** of a context; it needs no allocation and no `Arc`. In D it is a compile-time capability (design-by-introspection), monomorphized at zero cost:
+
+```rust
+// Rust: iroh/src/socket/remote_map/remote_state.rs:1419
+pub trait PathSelector: Send + Sync + std::fmt::Debug + 'static {
+    fn select(&self, ctx: &PathSelectionContext<'_>) -> PathSelection;
+}
+```
+
+```d
+// D (proposed / sketch): a DbI trait — any struct exposing `select` qualifies; no vtable, no Arc.
+enum isPathSelector(S) = is(typeof((S s, in PathSelectionContext ctx) => s.select(ctx)) : PathSelection);
+
+struct BiasedRttPathSelector {
+    // TransportType is a strict tier (relay = Backup); relay never wins on RTT.
+    // sort key = (tier, rttNanos + bias);  IPv6 bias = -3 ms.  Switch same-tier only if ≥5 ms better.
+    PathSelection select(in PathSelectionContext ctx) @safe pure nothrow @nogc {
+        // single pass: best-by-(tier, biasedRtt); switch across tiers immediately,
+        // within a tier only when `best + 5ms <= current` (hysteresis).
+    }
+}
+static assert(isPathSelector!BiasedRttPathSelector);
+```
+
+**7. `n0-watcher` needs a new design — the one real gap.** Watchables are _the_ backbone here (local addrs, net-report, home relay, direct addrs, portmapper), and event-horizon has no watch equivalent. Minimal D design: a versioned value cell + a waiter list that wakes parked fibers; the `Join`/`Tuple`/`Map` combinators can be lazy structs recomputing on `get()`. Single-threaded means no lock, but the cross-fiber wakeup still needs the missing channel/`Notify`-like primitive (again O20). The `broadcast(8)` + `Lagged { missed }` path-event overflow semantics must be reproduced faithfully — the actor treats lag as "state possibly stale."
+
+**8. Blackholing is load-bearing.** `send` must never propagate a transient error or backpressure to the QUIC stack. In D, a failed/parked transport send drops the datagram (increment a metric) rather than failing the endpoint fiber — see the `send` sketch above.
+
+**9. GSO/GRO waits on O19.** `Transmit.segment_size` / `RecvMeta.stride` require `sendmsg`/`recvmmsg` with `UDP_SEGMENT`/`UDP_GRO` cmsgs — exactly event-horizon [open-issue O19][eh-spec] (msghdr ops). Until then a port is limited to one datagram per op (matching `noq-udp`'s `BATCH_SIZE = 1` fallback platforms: protocol-correct, slower). No `spawn_blocking` appears here, so there is nothing to flag for a missing thread pool; DNS resolution is async and lives elsewhere.
+
+The net effect: under `single` topology this subsystem shrinks from a lock-and-channel constellation to a handful of state-owning fibers plus one new primitive (the watch/channel of O20). The mapped-address scheme, the biased-RTT selector, the hole-punch schedule, and the blackholing rule port almost verbatim; the concurrency scaffolding is what melts away.
+
+---
+
+## Strengths
+
+- **Clean layering.** The socket is a policy shell; QUIC path validation, keep-alives, and loss detection are all `noq`'s. The connectivity logic can be read without re-deriving QUIC.
+- **Uniform path model.** Relay and direct are the same thing — QUIC multipath paths. Relay↔direct "switching" is one `PathStatus` flip, eliminating the 0.x per-datagram duplication.
+- **Robust failure handling.** The blackholing invariant, the 8-consecutive-error escalation, the never-kill-the-driver discipline, and the always-recover-via-loss-detection stance make the socket resilient to transient transport faults.
+- **Pluggable selection.** `PathSelector` is a trait; the biased-RTT policy with 5 ms hysteresis and a strict relay-is-backup tier is a sensible, testable default.
+- **Careful shutdown.** The `wait_all_draining()` history comment and the two-token + grace-period teardown reflect hard-won correctness around QUIC close frames.
+- **QUIC-native NAT traversal.** Dropping DISCO/STUN for in-connection `initiate_nat_traversal_round()` removes an entire encrypted-side-channel protocol.
+
+## Weaknesses
+
+- **Deep `noq` coupling.** The socket is inseparable from a bespoke QUIC fork (multipath + QAD + QNT). A D port must reimplement or bind ~48k lines of `noq` before this shell does anything useful.
+- **Unbounded mapped-address growth.** `AddrMap` has no removal API; every `(relay, endpoint)` pair ever seen leaks for process lifetime, and remote-state pruning is a `// TODO`.
+- **Accidental concurrency tax.** `Arc`/`Mutex`/atomics/`papaya`/multi-thread actors exist for tokio's model, not the algorithm — pure overhead a single-threaded design removes but that a faithful Rust reader must wade through.
+- **Stale artifacts.** A doc-comment still claims DISCO packets are processed; symbols like `re_stun` / `periodic_re_stun_timer` survive though STUN is gone (now QAD). Easy to mislead a port author.
+- **Subtle poll semantics.** `Ready(Ok(0))` is overloaded (error-suppression _and_ zero datagrams); the reverse-order fairness counter and `pending_item` relay starvation are non-obvious invariants a port must not "simplify."
+- **Asymmetric path control.** Only the client opens and closes paths; the server follows. Correct, but a source of confusion (both sides may hold client connections).
+
+## Key design decisions and trade-offs
+
+| Decision                                                                | Rationale                                                                                     | Trade-off                                                                                          |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Relay + direct as concurrent QUIC multipath paths (not modes)           | One connection, one uniform routing model; failover is a `PathStatus` flip                    | Requires a multipath QUIC (`noq`); "switch" logic moves into path-status bookkeeping               |
+| Synthetic IPv6 ULA mapped addresses for non-IP peers                    | Lets stock QUIC address relay/custom/per-endpoint destinations with plain `SocketAddr`s       | A second address space to maintain; `AddrMap` leaks entries for process lifetime                   |
+| Blackhole send errors — always return `Ok(())` to `noq`                 | A send error kills the `noq` `EndpointDriver`; loss detection recovers intermittent failures  | Silent drops; no error surfaced to the app; masks genuine misconfiguration until QUIC times out    |
+| One `RemoteStateActor` per remote, lazily spawned                       | Localizes all per-remote path/hole-punch state; natural unit of cancellation and idle-timeout | Restart-with-leftover-messages dance needed because `mpsc::Sender` outlives its receiver           |
+| Biased-RTT selector: relay strictly `Backup`, 5 ms same-tier hysteresis | Relay is a fallback regardless of RTT; hysteresis avoids flapping between near-equal paths    | A very fast relay still loses to a slow direct path; policy is a default, tunable via the trait    |
+| Client-only path open/close                                             | Avoids client and server racing to abandon the last path                                      | Asymmetric control flow; server reacts to frames only; "initiator" is per-connection, not per-peer |
+| QUIC-native NAT traversal (no DISCO/STUN)                               | Candidates and probes ride the encrypted connection; one fewer side-protocol                  | Ties hole-punching to the QUIC extension in `noq-proto`; no out-of-band punch before a connection  |
+| Abstract-socket seam (`new_with_abstract_socket`)                       | `noq` stays UDP-agnostic; the socket can multiplex any datagram carrier                       | Poll/`Waker` choreography that a completion-first runtime must invert (event-horizon O19/O20)      |
+
+---
+
+## Sources
+
+Primary sources — the pinned iroh `socket` module (`iroh` v1.0.1, commit `22cac742ca`):
+
+- [`iroh/src/socket.rs`][socket-doc] — `Socket`, `EndpointInner`, the top-level `Actor`, `process_datagrams`, shutdown, constants.
+- [`iroh/src/socket/transports.rs`][tp-struct] — `Transports`, `Transport` (`noq::AsyncUdpSocket` impl), `Sender`, `Addr`, `FourTuple`, recv/send paths, blackholing.
+- [`iroh/src/socket/transports/ip.rs`][ip-transports], [`relay.rs`][rt-channels], [`relay/actor.rs`][ra-spawn], [`custom.rs`][custom] — the three transport families and the relay actor tree.
+- [`iroh/src/socket/mapped_addrs.rs`][mapped-doc] — the ULA mapped-address scheme and `AddrMap`.
+- [`iroh/src/socket/remote_map.rs`][rm-struct] and [`remote_state.rs`][rs-actor] — `RemoteMap`, `RemoteStateActor`, path bookkeeping, hole-punch scheduling, `select_path`/`apply_selected_path`.
+- [`iroh/src/socket/remote_map/remote_state/path_state.rs`][ps-status], [`path_watcher.rs`][pw] — candidate-path lifecycle and the public path-event stream.
+- [`iroh/src/socket/biased_rtt_path_selector.rs`][selector] — the default `PathSelector`.
+- [`iroh/src/socket/concurrent_read_map.rs`][crm] — the `papaya`-backed single-writer/multi-reader map.
+
+Related pages: [QUIC transport (`noq`)][quic] (multipath, the `AsyncUdpSocket` contract), [NAT traversal & address discovery][nat] (the QNT frames this layer triggers), [the relay protocol][relay] (the datagram envelope), [net report][netreport] (QAD / interface watching / port mapping), [address lookup][discovery] (where direct addresses are republished), [endpoint & protocol router][endpoint] (the public surface above this layer), [concurrency inventory][concurrency] (all 26 primitives), and [D architecture migration][d-migration]. Runtime target: the [event-horizon spec][eh-spec]; concurrency-model contrast in [tokio][tokio] and the [async-io survey][async-io].
+
+<!-- References -->
+
+[repo]: https://github.com/n0-computer/iroh/tree/22cac742ca
+[docs]: https://docs.rs/iroh/1.0.1/iroh/
+[socket-doc]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L325
+[socket-procdgram]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L583
+[socket-abstract]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1027
+[socket-grease]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1013
+[socket-onerelay]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L906
+[socket-actor]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1442
+[socket-shutdown]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L276
+[socket-drain]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket.rs#L1148
+[tp-struct]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs#L52
+[tp-transport]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs#L1260
+[tp-addr]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs#L742
+[tp-fourtuple]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs#L970
+[tp-segments]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs#L420
+[tp-pollrecv]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs#L298
+[tp-pollsend]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs#L1363
+[tp-blackhole]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports.rs#L1369
+[ip-transports]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports/ip.rs#L384
+[rt-channels]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports/relay.rs#L46
+[ra-spawn]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports/relay/actor.rs#L853
+[custom]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/transports/custom.rs#L36
+[mapped-doc]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/mapped_addrs.rs#L19
+[mapped-default]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/mapped_addrs.rs#L35
+[mapped-enum]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/mapped_addrs.rs#L89
+[mapped-addrmap]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/mapped_addrs.rs#L342
+[rm-struct]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map.rs#L56
+[rm-restart]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map.rs#L287
+[crm]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/concurrent_read_map.rs#L13
+[rs-actor]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L98
+[rs-loop]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L272
+[rs-selected]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L147
+[rs-fanout]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L788
+[rs-openpath]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L1036
+[rs-apply]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L682
+[rs-close]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L703
+[rs-holepunch]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L504
+[rs-selectortrait]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state.rs#L1419
+[ps-status]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state/path_state.rs#L43
+[pw]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/remote_map/remote_state/path_watcher.rs#L53
+[selector]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/biased_rtt_path_selector.rs#L19
+[selector-switch]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/src/socket/biased_rtt_path_selector.rs#L170
+[quic]: ./quic-transport.md
+[nat]: ./nat-traversal.md
+[relay]: ./relay.md
+[netreport]: ./net-report.md
+[discovery]: ./discovery.md
+[endpoint]: ./endpoint.md
+[identity]: ./identity-crypto.md
+[wire]: ./wire-serialization.md
+[concurrency]: ./concurrency.md
+[d-migration]: ./d-architecture-migration.md
+[concepts]: ./concepts.md
+[index]: ./index.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[algeff]: ../algebraic-effects/index.md
+[tokio]: ../async-io/tokio.md
+[async-io]: ../async-io/index.md
+[rfc4193]: https://www.rfc-editor.org/rfc/rfc4193

--- a/docs/research/iroh/wire-serialization.md
+++ b/docs/research/iroh/wire-serialization.md
@@ -1,0 +1,404 @@
+# Wire Formats & Serialization
+
+The single reference for how every iroh value becomes bytes: [`postcard`][postcard] over QUIC/WebSocket streams, base32-wrapped tickets, the ALPN registry, and the per-protocol framing that delimits it all.
+
+| Field               | Value                                                                                                                                                                        |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Crate(s)            | [`iroh-tickets`][tickets-lib] (string/byte codec), [`iroh-base`][endpoint-addr-rs] (addressing value types), plus `postcard` / `data-encoding` (external, format algorithms) |
+| Version             | `iroh-tickets` 1.0.0 · `iroh-base` 1.0.1 (commit `22cac742`) · `postcard` 1.1.3 · `data-encoding` 2.9                                                                        |
+| Repository          | [`n0-computer/iroh-tickets`][tickets-repo] · [`n0-computer/iroh`][iroh-repo]                                                                                                 |
+| Documentation       | [docs.rs/postcard][postcard] · [docs.rs/iroh-tickets][tickets-docs] · [docs.rs/data-encoding][de-docs]                                                                       |
+| ALPN(s)             | This page **is** the registry — see [The ALPN registry](#the-alpn-registry). No single ALPN belongs to the serialization layer.                                              |
+| Approx. size (LoC)  | `iroh-tickets` ~345 (`lib.rs` 109 + `endpoint.rs` 235); `iroh-base` addressing ~440 (`endpoint_addr.rs`). The `postcard` codec itself is external.                           |
+| Category            | Foundations                                                                                                                                                                  |
+| Upstream spec/draft | [postcard wire spec][postcard-wire]; [RFC 4648 §6][rfc4648] (base32); LEB128; the coexisting QUIC varint is [RFC 9000 §16][rfc9000-varint]                                   |
+
+---
+
+## Overview
+
+### What it solves
+
+iroh has exactly **one** application-level serialization format — [`postcard`][postcard], a compact, non-self-describing binary encoding for [`serde`][serde]-derived types — and a small set of conventions layered above it: a canonical string form for shareable addresses ([tickets](#tickets-string-form-and-the-three-wire-layouts)), a registry of [ALPN][alpn] protocol identifiers, and a handful of per-protocol [framing](#the-alpn-registry) rules that carve `postcard` blobs out of a QUIC stream or a [relay][relay] WebSocket message. There is no `protobuf`, no `bincode`, and no JSON on any hot path: a `grep -rln bincode` over every pinned `src/` tree returns nothing, and JSON appears only where a human-readable format is explicitly requested. A D reimplementation therefore needs **one** codec — a `postcard`-compatible reader/writer — plus five table-driven base codecs, and it can reproduce the entire iroh wire surface. This page is the byte-level contract every other protocol page ([blobs][blobs], [docs][docs-sync], [gossip][gossip], [relay][relay], [discovery][discovery]) points back to.
+
+`postcard` is _not_ self-describing: the bytes carry no field names, no type tags, and no lengths beyond what the schema implies. Both peers must agree on the struct layout at compile time. That is a deliberate size win — an [`EndpointId`][identity-crypto] is 32 raw bytes with zero framing overhead — but it means the wire format _is_ the Rust type declaration order, and any D port must freeze the same declaration order to stay byte-compatible.
+
+### Design philosophy
+
+The governing idea is that a wire format should be **the minimal encoding of a fixed schema**, with forward-compatibility bought explicitly (a leading discriminant) rather than paid for on every message (self-description). Every shareable value — a ticket — wraps its `postcard` payload in a single-variant Rust `enum` for exactly this reason ([`iroh-blobs/src/ticket.rs`][blobs-ticket], lines 36–38):
+
+> "In the future we might have multiple variants (not versions, since they might be both equally valid), so this is a single variant enum to force postcard to add a discriminator."
+
+Because a `postcard` `enum` encodes its discriminant as a varint of the _declaration index_, that single variant serializes as a leading `0x00`, which every current ticket carries and which future formats can bump — a de-facto version byte bought for one byte. The same discipline explains the `Slot2`..`Slot7` placeholder variants in the [blobs `Request`][blobs-protocol] enum: they pin `Push` to discriminant `8` and `GetMany` to `9` so the wire numbering never shifts when new request types land.
+
+The [`Ticket`][tickets-lib] trait is explicit that the byte format is a policy choice, not a mandate (`iroh-tickets/src/lib.rs`, lines 17–18):
+
+> "The serialization format for converting the ticket from and to bytes is left to the implementer. We recommend using [postcard] for serialization."
+
+All three concrete tickets take that recommendation, so `postcard` is universal in practice even though the trait is codec-agnostic.
+
+---
+
+## How it works
+
+### The `postcard` data model
+
+`postcard` serializes a `serde` type by walking its fields in declaration order and concatenating each field's encoding with no separators. The primitive rules a codec author must implement:
+
+| Rust type                                | `postcard` encoding                                                        |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| `u8`                                     | one raw byte                                                               |
+| `u16` / `u32` / `u64` / `u128` / `usize` | LEB128 varint: little-endian 7-bit groups, MSB of each byte = continuation |
+| `i8` … `i128` / `isize`                  | zigzag-mapped to unsigned, then LEB128 varint                              |
+| `bool`                                   | one byte, `00` = false / `01` = true                                       |
+| `[u8; N]` (fixed array / newtype)        | N raw bytes, **no** length prefix                                          |
+| `String`, `Vec<u8>`, `&[u8]`             | varint byte-length, then the raw bytes                                     |
+| `Vec<T>`, `BTreeSet<T>`                  | varint element count, then each element                                    |
+| `Option<T>`                              | `00` = `None` / `01` + payload = `Some`                                    |
+| `enum`                                   | varint discriminant (declaration index), then the variant's payload        |
+| `struct` / tuple                         | fields concatenated in declaration order, no tags, no count                |
+
+The varint rule is documented in-tree, in the blobs stream reader ([`iroh-blobs/src/util/stream.rs`][blobs-stream], lines 403–406):
+
+> "In Postcard's varint format (LEB128): Each byte uses 7 bits for the value; The MSB (most significant bit) of each byte indicates if there are more bytes (1) or not (0); Values are stored in little-endian order (least significant group first)."
+
+Two consequences dominate a port:
+
+- **Signed integers use zigzag.** `postcard` maps `i64` through zigzag (`(n << 1) ^ (n >> 63)`) before varint-encoding, so small-magnitude negatives stay short. No iroh wire struct surveyed here actually uses a signed integer — but a general `postcard` codec must implement it.
+- **`BTreeSet` order is the wire order.** A `BTreeSet<T>` iterates in `Ord` order, so its serialization is canonical and deterministic. For [`TransportAddr`][endpoint-addr-rs] the derived `Ord` follows variant declaration order — all `Relay` (discriminant 0) sort before `Ip` (1) before `Custom` (2), then by inner value — which is exactly the byte order a ticket must reproduce for stable ticket strings. A D port must sort by `(variant index, payload)` to match.
+
+### Walking a golden vector
+
+The [`EndpointTicket`][tickets-endpoint] test at `iroh-tickets/src/endpoint.rs` (lines 178–234) pins an exact byte sequence for the id `ae58…02b6` with a relay `http://derp.me./` and `127.0.0.1:1024`. Decoding it byte-by-byte exercises most of the model at once:
+
+```text
+00                                  TicketWireFormat::Variant1  (enum discriminant, index 0)
+ae58ff88…a75502b6                   EndpointId: 32 raw bytes, no length
+02                                  addrs: BTreeSet count = 2 (varint)
+  00                                  TransportAddr::Relay      (enum discriminant 0)
+  10                                    RelayUrl: string length 16 (varint)
+  687474703a2f2f646572702e6d652e2f    "http://derp.me./" (16 UTF-8 bytes)
+  01                                  TransportAddr::Ip         (enum discriminant 1)
+  00                                    SocketAddr::V4          (enum discriminant 0)
+  7f000001                              127.0.0.1 (4 address octets)
+  8008                                  port 1024 (varint u16: 0x80,0x08 → 0|8<<7 = 1024)
+```
+
+Note that the `BTreeSet` emitted `Relay` before `Ip` because the derived `Ord` puts variant 0 first; the port `1024` round-trips through the varint `80 08`; and the `EndpointId` and IP octets carry no length because they are fixed-width. `SocketAddr` is itself an `enum` (`V4` = 0, `V6` = 1); the V4 body is four address octets then the varint port, as shown. The V6 body is the sixteen address octets and the port; std's `serde` additionally serializes the V6 `flowinfo`/`scope_id`, which iroh's vectors do not exercise.
+
+### The single-variant version byte in practice
+
+Because every ticket wraps its payload in a `TicketWireFormat` enum, byte `0x00` opens every ticket. The [`EndpointTicket`][tickets-endpoint] variant is _named_ `Variant1` (signalling "layout differs from the 0.x `Variant0`") yet still encodes as index `0` — `postcard` numbers by declaration position, not by the name — so the leading byte stays `0x00`. Treating that byte as a literal version number is a trap: it is a discriminant that only advances when a genuinely new format variant is added.
+
+---
+
+## Analysis
+
+### Wire format & framing
+
+Everything above QUIC is a `postcard` payload; what differs per protocol is only the **envelope** that delimits it. There are two envelope families: shareable **ticket strings** (base32 of `postcard`), and **stream frames** (length-prefixed or FIN-delimited `postcard` on a QUIC bidi stream, or one WebSocket binary message on a [relay][relay] connection).
+
+#### Tickets: string form and the three wire layouts
+
+A ticket string is `lowercase(KIND) ++ lowercase(BASE32_NOPAD(encode_bytes()))` ([`iroh-tickets/src/lib.rs`][tickets-lib], lines 44–49). `BASE32_NOPAD` is [RFC 4648][rfc4648] base32 (alphabet `A–Z2–7`, no padding); it is emitted lowercase and the decoder uppercases the tail before decoding ([`decode_string`][tickets-lib], lines 57–64). Three `KIND` prefixes are in use: `endpoint`, `blob`, `doc`.
+
+The three tickets do **not** agree on how they encode an address — a real interop hazard:
+
+| Ticket           | `KIND`     | Wire enum  | Address encoding                                                                                 | Citation                          |
+| ---------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `EndpointTicket` | `endpoint` | `Variant1` | new: `EndpointId` + `BTreeSet<TransportAddr>` (relay, then ip, then custom, folded into one set) | [`endpoint.rs`][tickets-endpoint] |
+| `DocTicket`      | `doc`      | `Variant0` | new: `Capability` + `Vec<EndpointAddr>` (each with the unified `BTreeSet<TransportAddr>`)        | [`docs ticket.rs`][docs-ticket]   |
+| `BlobTicket`     | `blob`     | `Variant0` | **legacy 0.x**: `EndpointId` + `Option<RelayUrl>` + `BTreeSet<SocketAddr>`                       | [`blobs ticket.rs`][blobs-ticket] |
+
+`BlobTicket` still ships the pre-1.0 address shape and converts at its edges: on encode it takes only `relay_urls().next()` (the first relay) and `ip_addrs()`, so **`Custom` transport addresses and all but the first relay are silently dropped** from a blob ticket ([`ticket.rs`][blobs-ticket], lines 67–79). A port must special-case blob tickets rather than reuse the unified `EndpointAddr` encoder.
+
+The three byte-exact golden vectors (all sharing the id `ae58…02b6`):
+
+```text
+EndpointTicket (endpoint.rs:203-233) — relay http://derp.me./ + 127.0.0.1:1024
+  00  ae58…02b6  02  00 10 687474703a2f2f646572702e6d652e2f  01 00 7f000001 8008
+
+BlobTicket (blobs ticket.rs:226-233) — id-only, BlobFormat::Raw
+  00              Variant0
+  ae58…02b6       endpoint id, 32 bytes
+  00              relay_url: None            (Option tag)
+  00              direct_addresses count = 0 (BTreeSet<SocketAddr>)
+  00              format = Raw               (HashSeq = 01)
+  0b84…4a072      blake3 hash, 32 bytes
+
+DocTicket (docs ticket.rs:102-109) — read capability, one id-only node
+  00              Variant0
+  01              Capability = Read          (Write = 00, then a 32-byte NamespaceSecret)
+  ae58…02b6       namespace id, 32 bytes
+  01              nodes: Vec length 1
+  ae58…02b6       EndpointAddr.id
+  00              EndpointAddr.addrs: empty set
+```
+
+`BlobFormat` is `Raw` = 0 / `HashSeq` = 1 ([`hash.rs`][blobs-hash]); a `Hash` is 32 raw bytes in binary `serde`. A `DocTicket` whose `Capability` is `Write` embeds a **raw 32-byte namespace secret key** in the copy-pasteable string — tickets are bearer credentials, not just addresses ([docs `ticket.rs`][docs-ticket]); the decoder also rejects an empty `nodes` list, the only place any ticket uses the `Verify` stage of [`ParseError`][tickets-lib].
+
+#### The ALPN registry
+
+Every connection is opened under an [ALPN][alpn] byte string; the accepting side's [protocol router][endpoint] dispatches on it. The production identifiers, verbatim with their hex, sweeping all pinned repos:
+
+| ALPN (verbatim)  | Hex                                         | Owner crate              | Notes                                                                          | Citation                          |
+| ---------------- | ------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------ | --------------------------------- |
+| `DUMBPIPEV0`     | `44 55 4d 42 50 49 50 45 56 30`             | `dumbpipe`               | raw byte pipe; V0 since inception                                              | [`dumbpipe lib.rs`][dumbpipe-lib] |
+| `/iroh-bytes/4`  | `2f 69 72 6f 68 2d 62 79 74 65 73 2f 34`    | [`iroh-blobs`][blobs]    | content-addressed transfer; `4` is the current version                         | [`protocol.rs`][blobs-protocol]   |
+| `/iroh-sync/1`   | `2f 69 72 6f 68 2d 73 79 6e 63 2f 31`       | [`iroh-docs`][docs-sync] | document range-sync                                                            | [`docs net.rs`][docs-net]         |
+| `/iroh-gossip/1` | `2f 69 72 6f 68 2d 67 6f 73 73 69 70 2f 31` | [`iroh-gossip`][gossip]  | epidemic broadcast                                                             | [`gossip net.rs`][gossip-net]     |
+| `/iroh-qad/0`    | `2f 69 72 6f 68 2d 71 61 64 2f 30`          | [`iroh-relay`][relay]    | QUIC Address Discovery listener on relays (see [nat-traversal][nat-traversal]) | [`relay quic.rs`][relay-quic]     |
+| `/iroh/ssh`      | `2f 69 72 6f 68 2f 73 73 68`                | `iroh-ssh` (third-party) | pins `iroh = "0.94"` — pre-1.0 API, an evolution contrast, not a 1.0 trace     | [`iroh-ssh ssh.rs`][iroh-ssh]     |
+
+Everything else found is example- or test-only and carries no stable protocol id: the example ALPNs (`n0/iroh/transfer/example/1`, `iroh-example/echo/0`, `iroh-example/auth/0`, `0rtt-pingpong`, the post-quantum-TLS demos, `lz4//iroh-bytes/4`), the bench ALPNs (`n0/iroh-bench/0`, `n0/noq-bench/0`), and the test ALPNs (`n0/test/1`, `alpn/1`, `noop`, `TEST`, `my-gossip-alpn`, …). The [iroh-dns-server][discovery] serves standard HTTPS ALPNs `h2` / `http/1.1` for its DoH endpoint, which are not iroh protocols.
+
+Three ALPN-adjacent identifiers a codec needs but which are _not_ ALPNs:
+
+- **Relay protocol version** is negotiated through the WebSocket subprotocol header `Sec-Websocket-Protocol`, values `iroh-relay-v1` / `iroh-relay-v2`; the server picks the best it supports ([`relay http.rs`][relay-http]). V2 removed the `Health` frame (id 11) and added `Status` (id 13). Relay HTTP paths are `RELAY_PATH = /relay` and `RELAY_PROBE_PATH = /ping`.
+- **QUIC extension transport parameters** in [`noq-proto`][quic-transport]: `ObservedAddr = 0x9f81a176` and `N0NatTraversal = 0x3d7f91120401` ([`transport_parameters.rs`][noq-tp]) — these ride the QUIC handshake, encoded as [QUIC varints][rfc9000-varint], not `postcard`. See [nat-traversal][nat-traversal].
+- **Relay handshake domain-separation strings**: the blake3 `derive_key` context `"iroh-relay handshake v1 challenge signature"` and the TLS-exporter label `"iroh-relay handshake v1"` ([`handshake.rs`][relay-handshake]).
+
+#### Framing conventions per protocol
+
+Above QUIC, the delimiter varies; the payload is nearly always `postcard`:
+
+| Protocol                        | Frame delimiter                                                                           | Payload    | Citation                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------- | ---------- | --------------------------------- |
+| `dumbpipe`                      | fixed 5-byte `hello` handshake written by the `open_bi()` caller, then a raw byte pipe    | raw        | [`dumbpipe lib.rs`][dumbpipe-lib] |
+| blobs `Get`/`GetMany`/`Observe` | 1 raw request-type byte, then a `postcard` body delimited by the **stream FIN**           | `postcard` | [`stream.rs`][blobs-stream]       |
+| blobs `Push`                    | 1 raw type byte, then a **`postcard`-varint (LEB128) length prefix** + body               | `postcard` | [`stream.rs`][blobs-stream]       |
+| blobs `Observe` response        | `postcard`-varint length prefix per `ObserveItem`                                         | `postcard` | [`protocol.rs`][blobs-protocol]   |
+| blobs data phase                | a [`bao-tree`][bao-tree]-encoded verified stream                                          | bao        | [`protocol.rs`][blobs-protocol]   |
+| [iroh-docs][docs-sync] sync     | **`u32` big-endian** length prefix + `postcard` `Message`                                 | `postcard` | [`docs codec.rs`][docs-codec]     |
+| [iroh-gossip][gossip]           | first frame `StreamHeader { topic_id }`, then **`u32` big-endian** LP + `postcard` frames | `postcard` | [`gossip util.rs`][gossip-util]   |
+| [relay][relay] data phase       | one WebSocket binary message per frame: **QUIC-varint** `FrameType` + hand-rolled layout  | manual     | [`relay.rs`][relay-relay]         |
+| [relay][relay] handshake        | one WebSocket message: **QUIC-varint** `FrameType` + `postcard` body                      | `postcard` | [`handshake.rs`][relay-handshake] |
+
+Two things to internalize. First, **blobs `Get` requests carry no length prefix at all** — the request body is terminated by the QUIC stream FIN and validated with an explicit `expect_eof`; only `Push` is length-prefixed because its payload follows on the same stream ([`stream.rs`][blobs-stream], the `read_to_end_as` vs `read_length_prefixed` split). Second, **iroh uses two different varint dialects on the wire**: `postcard`'s LEB128 (little-endian 7-bit groups) for serialized structures, and the [QUIC varint][rfc9000-varint] (RFC 9000 §16: big-endian, 2-bit length tag in the top bits) for relay frame types and QUIC-native fields. A port must implement both and never confuse them.
+
+Relay datagram layouts, after the `FrameType` varint (hand-rolled, not `postcard`; see [relay][relay] for detail):
+
+```text
+ClientToRelayDatagram:       [32B dst EndpointId][1B ECN][contents…]
+ClientToRelayDatagramBatch:  [32B dst EndpointId][1B ECN][2B BE segment_size][contents…]
+RelayToClientDatagram(+Batch): the same, with a src EndpointId
+EndpointGone: [32B EndpointId]     Ping/Pong: [8B payload]
+Restarting: [4B BE reconnect_in ms][4B BE try_for ms]     Status: [1B discriminant]
+```
+
+#### Size limits
+
+The bounds a decoder enforces (a hostile peer must not be able to make a reader allocate unboundedly):
+
+| Limit                               | Value                        | Where                                                  | Citation                            |
+| ----------------------------------- | ---------------------------- | ------------------------------------------------------ | ----------------------------------- |
+| blobs `MAX_MESSAGE_SIZE`            | `1024 * 1024` = 1 MiB        | request read paths (doc comment says "100MiB" — stale) | [`protocol.rs`][blobs-protocol]     |
+| docs `MAX_MESSAGE_SIZE`             | `1024 * 1024 * 1024` = 1 GiB | `SyncCodec` decode/encode ("likely too large")         | [`docs codec.rs`][docs-codec]       |
+| gossip `DEFAULT_MAX_MESSAGE_SIZE`   | 4096 B                       | config default                                         | [`gossip proto.rs`][gossip-proto]   |
+| gossip `MIN_MAX_MESSAGE_SIZE`       | 512 B                        | asserted at state init                                 | [`gossip proto.rs`][gossip-proto]   |
+| relay `MAX_PACKET_SIZE`             | `64 * 1024` = 64 KiB         | per relayed frame, both directions                     | [`relay.rs`][relay-relay]           |
+| relay `MAX_FRAME_SIZE`              | `1024 * 1024` = 1 MiB        | server rate limiting                                   | [`relay.rs`][relay-relay]           |
+| relay `PER_CLIENT_SEND_QUEUE_DEPTH` | 512 packets                  | server per-client buffer                               | [`relay.rs`][relay-relay]           |
+| pkarr `MAX_SIGNED_PACKET_SIZE`      | 1104 B (32 + 64 + 8 + 1000)  | [discovery][discovery] signed packet                   | [`pkarr.rs`][pkarr-rs]              |
+| pkarr `UserData`                    | ≤ 245 B                      | TXT character-string minus prefix                      | [`endpoint_info.rs`][endpoint-info] |
+
+Application-chosen caps also flow through the codec: sendme passes a `1024 * 1024 * 32` = 32 MiB cap to `get_hash_seq_and_sizes` to bound the hash-seq blob it will read ([`get/request.rs`][blobs-getreq]). `postcard`'s `MaxSize` derive computes a compile-time `POSTCARD_MAX_SIZE` upper bound for small fixed-shape headers, used as a header-length sanity check (e.g. the `u32`-LP example protocol in [`transfer.rs`][transfer-rs]) and for gossip `IHave` chunking.
+
+### Cryptography & identity
+
+The serialization layer transports cryptographic material but performs no cryptography — see [identity-crypto][identity-crypto] for the algorithms. The wire-relevant facts: an [`EndpointId`][identity-crypto] (an ed25519 public key) is **32 raw bytes with no length prefix** in binary `serde`, and a `Signature` is **64 raw bytes** (Rust needs `#[serde(with = "serde_bytes")]` or a hand-written 64-tuple visitor to stop `serde` treating the array as a 64-element sequence, but the _bytes_ are identical, so a D codec simply emits the raw array). Fixed-width raw-byte keys are the reason `postcard` addresses stay compact.
+
+Two subtleties bind identity to serialization. First, iroh key types split their `serde` on `is_human_readable()`: a JSON encoder receives a hex string, a `postcard` encoder receives the raw 32/64 bytes. A D port must mirror this per-type split rather than pick one representation. Second, the string encodings a codec must ship (all table-driven) are: lowercase hex for `Display`; RFC 4648 base32-no-pad for tickets and key `FromStr`; z-base-32 (alphabet `ybndrfg8ejkmcpqxot1uwisza345h769`) for [pkarr][discovery] DNS labels; base32hex (`BASE32_DNSSEC`) for the TLS server name; and `BASE64URL_NOPAD` for the relay auth header. The DISCO sealed-box encryption and x25519 conversion of iroh 0.x are **gone** — no key material rides the wire encrypted at this layer.
+
+### State machines & lifecycle
+
+The serialization layer is almost entirely stateless value code; its only lifecycles are decode pipelines. The ticket decode pipeline is four fail-fast stages mapping one-to-one onto [`ParseError`][tickets-lib] variants: strip the `KIND` prefix → `Kind`; base32-decode (after uppercasing) → `Encoding`; `postcard`-decode the single-variant enum → `Postcard`; semantic check → `Verify` (only `DocTicket`'s non-empty-`nodes` rule). The framed-read lifecycle on a stream is: read the type byte or length prefix → bounded `recv` up to the [size limit](#size-limits) → `postcard`-decode → (for FIN-delimited frames) assert EOF.
+
+The one genuine evolution hazard lives here: `TransportAddr` is `#[non_exhaustive]`, but `postcard` has **no skip-unknown mechanism**. A ticket minted by a future iroh with a fourth `TransportAddr` variant will hard-fail decoding on a 1.0 reader — the discriminant byte will exceed the known range and there is no length to skip past. Forward compatibility is therefore all-or-nothing per format version; the single-variant enum is the only escape hatch, and using it requires bumping the leading discriminant.
+
+### Dependencies & coupling
+
+The wire surface pulls in a deliberately tiny dependency set: `postcard` 1.1.3 (`use-std`), `data-encoding` 2.9 (`+ -macro` for the custom z-base-32 alphabet), `serde` 1 (`derive`) and `serde_bytes` for `[u8; 64]`. The coupling is that **every wire struct is `serde`-derive-bound to `postcard`'s binary profile** — the Rust declaration order is the wire order, so any field reordering is a silent wire break. There is no `bincode`, no `protobuf`, and no `capnp` anywhere in the pinned trees. Two families of struct sit _outside_ `postcard` and are hand-rolled: relay data frames and relay `Status` (byte layouts), and the QUIC-native transport parameters ([`noq-proto`][quic-transport]). A D port replaces `serde`'s reflection with compile-time introspection (`__traits(allMembers)`), so it needs no runtime reflection at all — the wire structs are few and frozen.
+
+### Concurrency & I/O model
+
+This dimension does not apply: the serialization layer is pure, synchronous, allocation-then-copy value code with **no concurrency and no I/O of its own**. Tickets are `Clone`/value types passed by value; encoders build a `Vec<u8>`; decoders parse a `&[u8]`. The framing _helpers_ (`read_varint_u64`, `read_to_end_as`, `read_length_prefixed`) drive an `async` stream, but the parsing itself is a straight-line loop. The absence is itself a finding: unlike [tokio-concurrency][concurrency], nothing in the codec needs a task, a channel, a lock, or a timer. The identity/ticket layer "spawns nothing" and introduces no `select!`, no `tokio::spawn`, no timers — the only shared-state artifacts are elsewhere (a relay `KeyCache` LRU, the pkarr monotonic-timestamp atomic), both of which belong to their own subsystems.
+
+### Mapping to event-horizon
+
+The codec maps onto [`sparkles:event-horizon`][eh-spec] as **pure value code**, not fibers or capabilities — it is `@safe pure nothrow @nogc`-friendly throughout, and needs none of the [async-io][async-io] machinery. The design work is concentrated in four places.
+
+**1. A CTFE-friendly, allocation-free `postcard` codec.** Encode by walking `tupleof` in declaration order; the varint and enum-discriminant rules are a handful of `@nogc` helpers over any owned output buffer (`SmallBuffer` or a [`BufRing`][eh-spec] lease). `POSTCARD_MAX_SIZE` becomes a compile-time `enum` computed by the same introspection.
+
+```rust
+// iroh-tickets/src/endpoint.rs:35-43, 129-137 (verbatim, the wire mirror structs)
+enum TicketWireFormat { Variant1(Variant1EndpointTicket) }   // discriminant 0x00
+struct Variant1EndpointTicket { addr: Variant1EndpointAddr }
+struct Variant1EndpointAddr  { id: EndpointId, info: Variant1AddrInfo }
+struct Variant1AddrInfo      { addrs: BTreeSet<TransportAddr> }
+```
+
+```d
+// proposed / sketch — declaration order IS the wire; introspection replaces serde-derive
+void encode(T, Buf)(in T value, ref Buf w)
+if (isOwnedIoBuf!Buf)
+{
+    static foreach (i, _; T.tupleof)
+        encodeField(value.tupleof[i], w);   // recurse: struct → fields, enum → varint tag + payload
+}
+
+void putVarint(Buf)(ref Buf w, ulong v) @safe pure nothrow @nogc
+{
+    while (v >= 0x80) { w ~= cast(ubyte)(v | 0x80); v >>= 7; }
+    w ~= cast(ubyte) v;                      // LEB128: little-endian 7-bit groups, MSB continuation
+}
+```
+
+**2. The addressing value types and their canonical order.** `EndpointAddr` becomes a plain struct; the `BTreeSet<TransportAddr>` becomes a small sorted array whose comparator is `(variant index, payload)` — reproducing the derived Rust `Ord` gives byte-stable tickets for free.
+
+```rust
+// iroh-base/src/endpoint_addr.rs:41-62 (verbatim)
+pub struct EndpointAddr {
+    pub id: EndpointId,
+    pub addrs: BTreeSet<TransportAddr>,
+}
+#[non_exhaustive]
+pub enum TransportAddr {
+    Relay(RelayUrl),      // postcard discriminant 0
+    Ip(SocketAddr),       // 1
+    Custom(CustomAddr),   // 2
+}
+```
+
+```d
+// proposed / sketch
+struct EndpointAddr
+{
+    EndpointId id;                    // ubyte[32]
+    SortedSet!TransportAddr addrs;    // canonical Ord = (kind, payload) → wire order for free
+}
+
+struct TransportAddr
+{
+    enum Kind : ubyte { relay = 0, ip = 1, custom = 2 }
+    Kind kind;
+    union { RelayUrl relay; SocketAddr ip; CustomAddr custom; }
+}
+```
+
+**3. Ticket string codecs and the fail-fast decode.** hex, two base32 alphabets, z-base-32, and base64url-nopad are one table-driven codec parameterized by alphabet (a template or DbI parameter). Ticket payloads are small with a computable max size (base32 output is `⌈8n/5⌉`), so a stack `SmallBuffer` suffices — no heap. The four-stage decode maps cleanly onto the project's [`Expected`][expected] idiom:
+
+```d
+// proposed / sketch — mirrors ParseError { Kind, Encoding, Postcard, Verify }
+Expected!(EndpointTicket, ParseError) decodeString(scope const(char)[] s) @safe
+{
+    // 1. strip lowercase KIND  → ParseError.kind
+    // 2. uppercase + BASE32_NOPAD decode → ParseError.encoding
+    // 3. postcard-decode single-variant enum → ParseError.postcard
+    // 4. semantic verify (e.g. non-empty nodes) → ParseError.verify
+}
+```
+
+**4. Framing verbs on Tier B fibers.** The `u32`-BE-length + body loops (docs, gossip) are sequenced `recv`s on a fiber — no channel, no task. The FIN-delimited blobs `Get` body needs a new **"read-until-stream-FIN with a byte cap"** verb (bounded by the 1 MiB `MAX_MESSAGE_SIZE`); size a provided-buffer-ring lease to that cap. Two codec pieces have no single-threaded shortcut and must be implemented from scratch: the LEB128 varint reader/writer _and_ a [QUIC varint][rfc9000-varint] reader/writer, since relay framing uses the latter. The `is_human_readable` split becomes a compile-time policy parameter (`HumanReadable` vs `Binary`) chosen at the call site, so JSON and `postcard` share one derive-free codec. Nothing here needs `Send`/`Sync`, a lock, or a `spawn_blocking` substitute — under the `single` topology the entire layer is inline value code on the loop fiber. `Arc<Url>` inside `RelayUrl` is single-threaded refcount noise and collapses to a plain reference-counted string or slice.
+
+---
+
+## Strengths
+
+- **One format, fully specified by three golden vectors.** A `postcard` reader/writer plus five base codecs reproduces the entire iroh wire surface; the endpoint/blob/doc ticket vectors are a ready-made `checkRoundTrip` conformance corpus.
+- **Maximally compact.** Fixed-width keys carry no framing (`EndpointId` = 32 bytes flat); varints keep small integers to one byte; no field names or type tags anywhere.
+- **Deterministic and canonical.** `BTreeSet` iteration order is the wire order, so identical addressing produces identical bytes — essential for stable, deduplicable tickets.
+- **Cheap, explicit forward compatibility.** The single-variant enum buys a version discriminant for exactly one byte, without paying self-description on every message.
+- **No reflection required in a port.** The wire structs are few and frozen; compile-time introspection replaces `serde`-derive with zero runtime cost.
+
+## Weaknesses
+
+- **Not self-describing — schema drift is a silent wire break.** Reordering a struct's fields, or renumbering an enum, corrupts the wire with no error at the type level. The `Slot2`..`Slot7` placeholders exist solely to defend against this.
+- **`#[non_exhaustive]` + no skip-unknown = brittle evolution.** A future `TransportAddr` variant hard-fails decoding on older readers; there is no partial-parse path.
+- **Three tickets, two address encodings.** `BlobTicket`'s legacy `Variant0` layout silently drops `Custom` transports and extra relays, so a port cannot use one address encoder everywhere.
+- **Two varint dialects coexist.** `postcard` LEB128 and QUIC varint sit side by side (blobs `Push` vs relay frame types); confusing them is an easy, silent bug.
+- **A misleading "version byte."** The leading `0x00` is an enum discriminant, and `EndpointTicket`'s variant is _named_ `Variant1` while encoding as `0` — a trap for anyone reading the first byte as a version number.
+- **Stale invariants in comments.** The blobs `MAX_MESSAGE_SIZE` doc says "100MiB" but the constant is 1 MiB; trust the constant, not the prose.
+
+## Key design decisions and trade-offs
+
+| Decision                                                          | Rationale                                                                                 | Trade-off                                                                                   |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `postcard` everywhere (no `protobuf`/`bincode`/JSON on hot paths) | Compact, `serde`-native, minimal codec surface; one format for the whole stack            | Not self-describing; the Rust declaration order _is_ the wire contract and must be frozen   |
+| Wrap every ticket in a single-variant enum                        | A one-byte leading discriminant gives explicit, cheap forward compatibility               | The byte reads like a version number but is an enum index; `Variant1` still encodes as `0`  |
+| `BTreeSet` for address sets (canonical `Ord` order)               | Deterministic, deduplicated, byte-stable ticket output                                    | A port must reproduce the derived `Ord` exactly (variant index, then payload)               |
+| Fixed `[u8; N]` for keys/hashes/signatures, no length prefix      | Zero framing overhead on the most common fields                                           | The decoder must know each field's width from the schema; no self-checking                  |
+| Keep `BlobTicket` on the legacy 0.x address layout                | Old `blob…` tickets keep working across the 1.0 restructure                               | Silently drops `Custom` transports and extra relays; a second address encoder to maintain   |
+| FIN-delimit blobs `Get` (length-prefix only `Push`)               | The QUIC stream end is a free frame boundary; no length to compute for the common request | Needs an `expect_eof` check and a "read-until-FIN with cap" reader distinct from LP readers |
+| Two varint dialects (`postcard` LEB128 + QUIC varint)             | Each layer reuses its own ecosystem's native encoding                                     | A port implements and must never confuse both; relay framing crosses the boundary           |
+| `is_human_readable` split (hex in JSON, raw bytes in `postcard`)  | One `serde` impl serves both a debuggable text form and a compact binary form             | Every key/ticket type carries two representations a port must mirror                        |
+
+---
+
+## Sources
+
+- [`iroh-tickets/src/lib.rs`][tickets-lib] — the `Ticket` trait, `ParseError`, string codec
+- [`iroh-tickets/src/endpoint.rs`][tickets-endpoint] — `EndpointTicket`, wire mirror structs, golden vector
+- [`iroh-blobs/src/ticket.rs`][blobs-ticket] — `BlobTicket`, legacy address layout, golden vector
+- [`iroh-blobs/src/protocol.rs`][blobs-protocol] — blobs ALPN, `Request` enum, `MAX_MESSAGE_SIZE`
+- [`iroh-blobs/src/util/stream.rs`][blobs-stream] — LEB128 varint reader, FIN-delimited vs length-prefixed framing
+- [`iroh-base/src/endpoint_addr.rs`][endpoint-addr-rs] — `EndpointAddr`, `TransportAddr`, `CustomAddr`
+- [`iroh-docs/src/net/codec.rs`][docs-codec] · [`iroh-docs/src/ticket.rs`][docs-ticket] — docs framing + `DocTicket`
+- [`iroh-gossip/src/net/util.rs`][gossip-util] · [`iroh-gossip/src/proto.rs`][gossip-proto] — gossip framing + size limits
+- [`iroh-relay/src/protos/`][relay-relay] — relay frame ids, datagram layouts, handshake
+- [`noq-proto/src/transport_parameters.rs`][noq-tp] — QUIC extension transport-parameter ids
+- [postcard wire spec][postcard-wire] · [RFC 4648 §6 (base32)][rfc4648] · [RFC 9000 §16 (QUIC varint)][rfc9000-varint]
+- Related pages: [Identity & Cryptography][identity-crypto] · [QUIC Transport (noq)][quic-transport] · [Endpoint & Protocol Router][endpoint] · [Blobs][blobs] · [bao-tree][bao-tree] · [Document Sync][docs-sync] · [Gossip][gossip] · [Relay][relay] · [Discovery][discovery] · [NAT Traversal][nat-traversal] · [Tokio Concurrency Inventory][concurrency] · [Concepts][concepts] · [survey umbrella][index]
+
+<!-- References -->
+
+[index]: ./index.md
+[concepts]: ./concepts.md
+[identity-crypto]: ./identity-crypto.md
+[quic-transport]: ./quic-transport.md
+[endpoint]: ./endpoint.md
+[blobs]: ./blobs.md
+[bao-tree]: ./bao-tree.md
+[docs-sync]: ./docs-sync.md
+[gossip]: ./gossip.md
+[relay]: ./relay.md
+[discovery]: ./discovery.md
+[nat-traversal]: ./nat-traversal.md
+[concurrency]: ./concurrency.md
+[eh-spec]: ../../specs/event-horizon/SPEC.md
+[async-io]: ../async-io/index.md
+[expected]: ../../guidelines/idioms/expected/index.md
+[postcard]: https://docs.rs/postcard/latest/postcard/
+[postcard-wire]: https://postcard.jamesmunns.com/wire-format.html
+[serde]: https://docs.rs/serde/latest/serde/
+[alpn]: https://datatracker.ietf.org/doc/html/rfc7301
+[rfc4648]: https://datatracker.ietf.org/doc/html/rfc4648#section-6
+[rfc9000-varint]: https://datatracker.ietf.org/doc/html/rfc9000#section-16
+[de-docs]: https://docs.rs/data-encoding/latest/data_encoding/
+[tickets-docs]: https://docs.rs/iroh-tickets/1.0.0/iroh_tickets/
+[tickets-repo]: https://github.com/n0-computer/iroh-tickets
+[iroh-repo]: https://github.com/n0-computer/iroh
+[tickets-lib]: https://github.com/n0-computer/iroh-tickets/blob/v1.0.0/src/lib.rs
+[tickets-endpoint]: https://github.com/n0-computer/iroh-tickets/blob/v1.0.0/src/endpoint.rs
+[endpoint-addr-rs]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-base/src/endpoint_addr.rs
+[relay-http]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/http.rs
+[relay-quic]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/quic.rs
+[relay-relay]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/protos/relay.rs
+[relay-handshake]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-relay/src/protos/handshake.rs
+[pkarr-rs]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns/src/pkarr.rs
+[transfer-rs]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh/examples/transfer.rs
+[iroh-ssh]: https://crates.io/crates/iroh-ssh
+[endpoint-info]: https://github.com/n0-computer/iroh/blob/22cac742ca/iroh-dns/src/endpoint_info.rs
+[dumbpipe-lib]: https://github.com/n0-computer/dumbpipe/blob/v0.39.0/src/lib.rs
+[blobs-protocol]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/protocol.rs
+[blobs-ticket]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/ticket.rs
+[blobs-stream]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/util/stream.rs
+[blobs-hash]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/hash.rs
+[blobs-getreq]: https://github.com/n0-computer/iroh-blobs/blob/v0.103.0/src/get/request.rs
+[docs-net]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/net.rs
+[docs-codec]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/net/codec.rs
+[docs-ticket]: https://github.com/n0-computer/iroh-docs/blob/v0.101.0/src/ticket.rs
+[gossip-net]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/net.rs
+[gossip-util]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/net/util.rs
+[gossip-proto]: https://github.com/n0-computer/iroh-gossip/blob/v0.101.0/src/proto.rs
+[noq-tp]: https://github.com/n0-computer/noq/blob/noq-v1.0.1/noq-proto/src/transport_parameters.rs

--- a/lychee.exclude
+++ b/lychee.exclude
@@ -76,3 +76,5 @@
 # links are valid canonical source citations, so exclude the flaky host rather than
 # rot-pin each tree URL.
 ^https?://cgit\.git\.savannah\.gnu\.org/
+# Ignore specs/event-horizon/ links until the feat/event-horizon branch is merged
+specs/event-horizon/


### PR DESCRIPTION
## What

A 17-page research catalog under `docs/research/iroh/` surveying the **iroh v1.0**
Rust peer-to-peer stack, written to inform a clean-room **native D** reimplementation
running on `sparkles:event-horizon` (single-threaded, completion-first
`io_uring`/`kqueue`/`IOCP`, fibers + algebraic effects).

Each subsystem deep-dive follows the fixed analysis spine from
[`research-docs.md`](docs/guidelines/research-docs.md) and ends with a
**Mapping to event-horizon** subsection; the tree is capped by a Tokio
concurrency inventory and a **D Architecture Migration** synthesis (the section
the task brief mandated).

> [!NOTE]
> Stacked on #82 (`feat/event-horizon`) — the docs cross-link
> `docs/specs/event-horizon/SPEC.md`, which lives on that branch, so this PR
> targets `feat/event-horizon` as its base. Retarget to `main` once #82 merges.

## Pages

| Group | Pages |
| ----- | ----- |
| Overview | `index`, `concepts` |
| Foundations | `identity-crypto`, `wire-serialization`, `quic-transport` (the `noq` QUIC fork) |
| Connectivity | `endpoint`, `socket` (multipath), `nat-traversal`, `relay`, `discovery`, `net-report` |
| Data protocols | `blobs`, `bao-tree` (BLAKE3 verified streaming), `docs-sync`, `gossip` |
| D migration | `concurrency` (Tokio inventory), `d-architecture-migration` |

~98k words. The survey reflects the **1.0 restructure**, not 0.x folklore:
`magicsock` → the socket layer, `discovery` → `address_lookup`, `NodeId` →
`EndpointId`, and the DISCO/STUN side-channels replaced by **QUIC-native** NAT
traversal + QUIC Address Discovery inside `noq-proto`.

## How it was produced

- **Reconnaissance:** 15 subsystem deep-reads + 8 gap-fills over the pinned
  sources (iroh `22cac742ca`, `noq` `1.0.1`, `bao-tree` `0.16.0`,
  `iroh-blobs`/`docs`/`gossip`, plus `iroh-util`/`irpc`), producing 23
  citation-dense dossiers.
- **Authoring:** one agent per page against the recon dossiers and the
  [`glommio.md`](docs/research/async-io/glommio.md) exemplar.
- **Verification:** an adversarial fact-check pass — **632 claims sampled** across
  the 17 pages against the Rust sources; **18 defects fixed** (a char-count, a
  dependency pin, a grep count, several citation line offsets, a miscount). No
  hallucinated APIs or fabricated quotes survived.

## Grounding & house style

- Every claim carries a `path:line` citation; every identifier is backticked;
  reference-style links throughout. Grounding is by citation (there is no D iroh
  to run yet), so — like the async-io deep-dives — there are no `[Output]`
  examples.
- `npm run docs:build` is **green** (no dead links, no Vue compile errors).
- Sidebar registered under Research → **Iroh (P2P / QUIC)**; the task `prompt.md`
  is excluded from the built site.

## Follow-ups

- `lychee` (external link check) and `verify-md-examples` were skipped locally per
  [`research-docs.md`](docs/guidelines/research-docs.md#hooks-committing) and are
  left for CI. A few external reference URLs (docs.rs pre-release versions, an
  `iroh-ssh` crates.io link) are best-effort and may need Wayback-pinning or an
  `lychee.exclude` entry if CI flags them.

https://claude.ai/code/session_01YF9tx5Q2TeZD8mfndfJt7b
