### PR TITLE
docs(research): CPU-PMU survey — perf_event hub, ISA mappings, OS backends, sparkles audit baseline + backend proposal

### DIFF
--- a/apps/ci/src/app.d
+++ b/apps/ci/src/app.d
@@ -29,7 +29,7 @@ $(LIST
     $(ITEM Default — run examples and display results in boxes)
     $(ITEM `--verify` — compare output against expected output blocks, report mismatches)
     $(ITEM `--update` — rewrite the markdown file with actual example output (golden snapshot update))
-    $(ITEM `--example-files` — build/run standalone example `.d` files, defaulting to `libs/base/examples/*.d`, `libs/build-primitives/examples/*.d`, `libs/core-cli/examples/*.d`, and `docs/research/async-io/io-uring/examples/*.d`)
+    $(ITEM `--example-files` — build/run standalone example `.d` files, defaulting to `libs/base/examples/*.d`, `libs/build-primitives/examples/*.d`, `libs/core-cli/examples/*.d`, `docs/research/async-io/io-uring/examples/*.d`, `docs/research/units-of-measure/examples/*.d`, and `docs/research/cpu-pmu/examples/*.d`)
     $(ITEM `--test` — run `dub test` for each sub-package defined in the root `dub.sdl`)
     $(ITEM `--files` — select explicit files or git-style globs; when omitted, each mode uses its tracked defaults)
     $(ITEM `--fail-fast` — stop on the first failing example and replay its output at the end)
@@ -148,7 +148,7 @@ struct CliParams
     @CliOption(`u|update`, "Rewrite the markdown file with actual example output.")
     bool update;
 
-    @CliOption(`x|example-files`, "Run standalone example .d files instead of markdown examples. With no files, defaults to libs/base/examples/*.d, libs/build-primitives/examples/*.d, libs/core-cli/examples/*.d, docs/research/async-io/io-uring/examples/*.d, and docs/research/units-of-measure/examples/*.d.")
+    @CliOption(`x|example-files`, "Run standalone example .d files instead of markdown examples. With no files, defaults to libs/base/examples/*.d, libs/build-primitives/examples/*.d, libs/core-cli/examples/*.d, docs/research/async-io/io-uring/examples/*.d, docs/research/units-of-measure/examples/*.d, and docs/research/cpu-pmu/examples/*.d.")
     bool exampleFiles;
 
     @CliOption(`t|test`, "Run dub test for each sub-package defined in the root dub.sdl.")
@@ -397,8 +397,8 @@ private string[] trackedMarkdownFiles()
 /// defaults `--example-files` uses when no `--files` selection is given: the
 /// `base`, `build-primitives`, and `core-cli` library demos plus the worked
 /// examples that accompany
-/// the research docs (`docs/research/async-io/io-uring/` and
-/// `docs/research/units-of-measure/`).
+/// the research docs (`docs/research/async-io/io-uring/`,
+/// `docs/research/units-of-measure/`, and `docs/research/cpu-pmu/`).
 @safe pure nothrow
 private string[] standaloneExampleGlobs()
 {
@@ -408,6 +408,7 @@ private string[] standaloneExampleGlobs()
         "libs/core-cli/examples/*.d",
         "docs/research/async-io/io-uring/examples/*.d",
         "docs/research/units-of-measure/examples/*.d",
+        "docs/research/cpu-pmu/examples/*.d",
     ];
 }
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -29,6 +29,7 @@ export default withMermaid(
     srcExclude: [
       '**/research/parsing/grounding/**',
       '**/research/units-of-measure/grounding/**',
+      '**/research/cpu-pmu/grounding/**',
       '**/research/iroh/prompt.md',
     ],
 
@@ -1087,6 +1088,81 @@ export default withMermaid(
                     {
                       text: 'Comparison & Recommendations',
                       link: '/research/async-io/comparison',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              text: 'CPU PMUs',
+              link: '/research/cpu-pmu/',
+              collapsed: true,
+              items: [
+                {
+                  text: 'Concepts',
+                  link: '/research/cpu-pmu/concepts',
+                },
+                {
+                  text: 'The Linux Stack',
+                  collapsed: true,
+                  items: [
+                    {
+                      text: 'perf_event_open (the hub)',
+                      link: '/research/cpu-pmu/linux-perf-events',
+                    },
+                    {
+                      text: 'elfutils (code space)',
+                      link: '/research/cpu-pmu/elfutils',
+                    },
+                    {
+                      text: 'libtraceevent (event space)',
+                      link: '/research/cpu-pmu/libtraceevent',
+                    },
+                    {
+                      text: 'libnuma (topology)',
+                      link: '/research/cpu-pmu/libnuma',
+                    },
+                    {
+                      text: 'Precise Sampling (IBS/PEBS/SPE)',
+                      link: '/research/cpu-pmu/precise-sampling',
+                    },
+                  ],
+                },
+                {
+                  text: 'ISA Mappings',
+                  collapsed: true,
+                  items: [
+                    { text: 'ARMv8+', link: '/research/cpu-pmu/arm' },
+                    { text: 'RISC-V', link: '/research/cpu-pmu/riscv' },
+                  ],
+                },
+                {
+                  text: 'OS Backends',
+                  collapsed: true,
+                  items: [
+                    { text: 'Windows', link: '/research/cpu-pmu/windows' },
+                    { text: 'macOS', link: '/research/cpu-pmu/macos' },
+                  ],
+                },
+                {
+                  text: 'Event Naming & Encoding',
+                  link: '/research/cpu-pmu/event-naming',
+                },
+                {
+                  text: 'Synthesis',
+                  collapsed: true,
+                  items: [
+                    {
+                      text: 'Capability Comparison',
+                      link: '/research/cpu-pmu/comparison',
+                    },
+                    {
+                      text: 'sparkles Baseline',
+                      link: '/research/cpu-pmu/sparkles-baseline',
+                    },
+                    {
+                      text: 'Backend Proposal',
+                      link: '/research/cpu-pmu/backend-proposal',
                     },
                   ],
                 },

--- a/docs/research/cpu-pmu/arm.md
+++ b/docs/research/cpu-pmu/arm.md
@@ -643,4 +643,4 @@ answered above (and which page owns the shared machinery).
 [pmu-events-arm64]: https://github.com/torvalds/linux/tree/e43ffb69e043/tools/perf/pmu-events/arch/arm64
 [arm-data]: https://github.com/ARM-software/data
 [applecpu]: https://github.com/dougallj/applecpu
-[ddi0487]: https://developer.arm.com/documentation/ddi0487/ak
+[ddi0487]: https://web.archive.org/web/20260309021822/https://developer.arm.com/documentation/ddi0487/ak

--- a/docs/research/cpu-pmu/arm.md
+++ b/docs/research/cpu-pmu/arm.md
@@ -1,0 +1,646 @@
+# ARM PMUv3 / SPE / BRBE (AArch64)
+
+The ARMv8-A/ARMv9-A mapping of the survey's [seven concerns][concepts]: a
+_specification-architected_ counting model (**PMUv3**) whose event space, counter
+count, and privilege filters are all discoverable from system registers, plus two
+hardware sampling engines — **SPE** for [precise, data-source-attributed
+sampling][precise-page] and **BRBE** for [branch records][branch-records] — and,
+as a deliberately-separated sidebar, Apple Silicon: an ARM core that is _not_
+PMUv3.
+
+| Field            | Value                                                                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ISA              | ARMv8-A / ARMv9-A (AArch64)                                                                                                                                         |
+| Counting API     | PMUv3 via [`perf_event_open(2)`][linux] (`type=PERF_TYPE_RAW`, `config`=event; a per-PMU `type` selects a cluster or uncore PMU)                                    |
+| Precise sampling | **SPE** (Statistical Profiling Extension) → perf [AUX ring][aux]                                                                                                    |
+| Branch records   | **BRBE** (Branch Record Buffer Extension) → perf `branch_stack`                                                                                                     |
+| Self-monitoring  | `PMEVCNTR<n>_EL0` reads gated by `PMUSERENR_EL0` + the `perf_user_access` sysctl (the [`rdpmc` analog][self-monitoring])                                            |
+| Event catalog    | [`ARM-software/data`][arm-data] JSON (per core) + in-tree [`tools/perf/pmu-events/arch/arm64`][pmu-events-arm64]                                                    |
+| Kernel read      | v7.1-rc6, [`linux@e43ffb69e043`][arm-pmuv3-c]                                                                                                                       |
+| Spec             | Arm ARM **DDI 0487** issue **K.a** — _"The Performance Monitors Extension"_ / _"The Statistical Profiling Extension"_ chapters (**GATED**, see [Sources](#sources)) |
+| Verification     | `[source-verified]` throughout; `[hw-verified: aarch64-darwin]` for the Apple microarch reference; **no `[hw-verified: aarch64-linux]`**                            |
+
+> [!IMPORTANT]
+> **No `aarch64-linux` hardware was available for this survey.** Every ARM-Linux
+> claim on this page is _source reading_ of the kernel driver at
+> [`linux@e43ffb69e043`][arm-pmuv3-c], tagged `[source-verified]` — never a
+> hardware observation. The only ARM silicon actually measured is Apple's, on
+> macOS (`mac-bsn`, M4 Max), and it is neither Linux nor PMUv3; it lives in the
+> [Apple Silicon sidebar](#apple-silicon-microarchitecture-reference) tagged
+> `[hw-verified: aarch64-darwin]`. Where a spec figure comes from the Arm ARM
+> (DDI 0487) it is tagged `[literature]` and cited by chapter name, because the
+> PDF is [gated](#sources).
+
+---
+
+## Overview
+
+### What it acquires
+
+On ARM-Linux the acquisition surface is the same [`perf_event_open(2)`][linux] hub
+as everywhere else — the ARM specificity is entirely in _what the hardware
+exposes and how it is discovered_. PMUv3 (the "Performance Monitors Extension,
+version 3") is the **architected** core-PMU model: a bank of event counters
+(`PMEVCNTR<n>_EL0`), one event-select register each (`PMEVTYPER<n>_EL0`), a
+control register (`PMCR_EL0`) that also reports the counter count, and two
+capability bitmaps (`PMCEID0/1_EL0`) that publish _which architected events this
+particular core actually implements_. A portable harness never has to guess: it
+reads the registers.
+
+The one place that discipline breaks is Apple Silicon, whose PMU is
+implementation-defined and undocumented — which the Linux driver author records
+with unusual candour ([`apple_m1_cpu_pmu.c:31-40`][apple-m1-c]):
+
+> _"Description of the events we actually know about, as well as those with a
+> specific counter affinity. Yes, this is a grand total of two known counters,
+> and the rest is anybody's guess."_
+
+That single sentence frames the whole page: everywhere PMUv3 is architected and
+self-describing; Apple is the reverse-engineered exception, and even its event
+_numbering_ [changed at M4](#apple-silicon-microarchitecture-reference).
+
+### Design philosophy: discoverable, not tabulated
+
+ARM's design bet is **capability discovery over static tables**. Intel needs a
+per-model event table to know what a core can count; PMUv3 lets the core answer
+for itself through `PMCEID*` and `PMCR.N`. The kernel driver leans on this
+directly — it will only expose a "common" event through sysfs or accept it in
+`map_event` if the corresponding `PMCEID` bit is set
+([`arm_pmuv3.c:1261-1264`][arm-pmuv3-c]: _"Only expose micro/arch events supported
+by this PMU"_). The trade-off is that _naming_ still needs
+[per-microarchitecture tables][event-naming] (`ARM-software/data`,
+`pmu-events/arch/arm64`), because discovery tells you an event _exists_, not what
+to _call_ it.
+
+---
+
+## How it works
+
+The AArch64 core PMU is a set of `EL0`/`EL1` system registers, wrapped by the
+`arm_pmu` framework and surfaced to userspace as one or more sysfs PMU devices
+(`/sys/bus/event_source/devices/armv8_*`). A `perf_event_open` with
+`type=PERF_TYPE_RAW` and `config`=event-number programs one `PMEVTYPER<n>`, arms
+the matching `PMEVCNTR<n>`, and — for sampling — routes counter overflow to a
+per-CPU interrupt. On big.LITTLE parts there is _more than one_ such device (one
+per microarchitecture cluster), so the `type` field, not just `config`, chooses
+the PMU. SPE and BRBE hang off this same core PMU: SPE as a separate sysfs device
+feeding an [AUX ring][aux], BRBE as a `branch_stack` capability probed _inside_
+the core-PMU probe. The rest of this page walks the register model concern by
+concern.
+
+---
+
+## PMUv3 event model
+
+### The event space and its two-boundary layout
+
+The `PMEVTYPER.EVENT` selector is **16-bit** (`ARMV8_PMU_EVTYPE_EVENT
+GENMASK(15,0)`, [`arm_pmuv3.h:239`][arm-pmuv3-h]). The number line has two
+boundaries, not one:
+
+| Range           | Meaning                                                                                                                                            | Discovery                     |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `0x0000–0x003F` | **common** architectural + microarchitectural events (64 slots)                                                                                    | `PMCEID0/1_EL0` bit per event |
+| `0x0040–0x3FFF` | **IMPDEF** ("recommended implementation-defined") events                                                                                           | vendor tables only            |
+| `0x4000+`       | **architected extensions** — SPE `0x4000–0x4003`, AMUv1 `0x4004–5`, long-latency-miss `0x4006–0x400B`, trace-buffer/-unit `0x400C+`, MTE `0x4024+` | `PMCEID` extended half        |
+
+`[source-verified]` `linux@e43ffb69e043 include/linux/perf/arm_pmu.h:125`
+(`ARMV8_PMUV3_MAX_COMMON_EVENTS 0x40`); [`arm_pmuv3.h:16-206`][arm-pmuv3-h]
+(the `0x00-0x3F` common block, then `ARMV8_IMPDEF_*` at `0x40+`) and `:82-119`
+(the `0x4000+` extension ranges).
+
+### PMCEID: per-core capability bitmaps
+
+`PMCEID0_EL0` and `PMCEID1_EL0` are the [capability-curation][curation] mechanism
+built into the ISA: each bit says _"this core implements common event N."_ The
+driver reads them into `pmceid_bitmap` (events `0x00–0x3F`) and
+`pmceid_ext_bitmap` (the `0x4000–0x403F` half) at probe time, and every later
+visibility/mapping decision consults them. `[source-verified]`
+[`arm_pmuv3.c:1333-1343`][arm-pmuv3-c] (read + `bitmap_from_arr32`), `:1261-1264`
+(the "only expose supported events" gate), `:281-289` (sysfs visibility gate).
+
+### The three-way taxonomy: a refinement of "common vs IMPDEF"
+
+The naïve reading is a two-way split at `0x40`: _common_ below, _IMPDEF_ above.
+That boundary is real and correct, but ARM's own machine-readable catalog
+([`ARM-software/data`][arm-data]) refines it into **three** tiers by carrying an
+explicit `architectural: true/false` flag on every event
+([architected-vs-implementation-defined][arch-vs-impdef]):
+
+| Tier                           | Example (arm-data)                                 | Membership                                    |
+| ------------------------------ | -------------------------------------------------- | --------------------------------------------- |
+| **architectural** (mandatory)  | `SW_INCR` code 0 → `architectural: true`           | a small mandatory subset _inside_ `0x00–0x3F` |
+| **common** (present-if-PMCEID) | `L1I_CACHE_REFILL` code 1 → `architectural: false` | most of `0x00–0x3F`; microarchitectural       |
+| **IMPDEF**                     | anything `0x0040+`                                 | vendor-specific                               |
+
+So `architectural ⊂ common ⊂ all`: the mandatory events are a stricter subset
+_within_ the common range, presence of the rest is a per-core `PMCEID` fact, and
+`0x40+` is vendor territory. `[source-verified]`
+`arm-data@0806afb1 pmu/neoverse-n1.json` (the `architectural` field;
+`counters: 6`; 110 events; `armv8.2-a`), `pmu/c1-ultra.json` (`armv9.2-a`).
+Linux's in-tree cross-reference lives under
+[`tools/perf/pmu-events/arch/arm64/{arm,ampere,hisilicon,nvidia,…}/`][pmu-events-arm64]
+plus `recommended.json` — and notably ships **no `apple/` directory**.
+
+### Generic-event mapping
+
+`armv8_pmuv3_perf_map` maps the portable `PERF_TYPE_HARDWARE` events onto common
+PMUv3 numbers: `CPU_CYCLES(0x11)`, `INST_RETIRED(0x08)`, `L1D_CACHE_REFILL(0x03)`
+for cache-misses, `BR_MIS_PRED(0x10)`, and `STALL_FRONTEND`/`STALL_BACKEND`.
+`BRANCH_INSTRUCTIONS` is special-cased to `BR_RETIRED(0x21)`, falling back to
+`PC_WRITE_RETIRED(0x0C)` when `PMCEID` says `BR_RETIRED` is absent — a discovery
+decision made at runtime. Older or irregular cores (A53/A57/A73/ThunderX/Vulcan)
+carry override cache maps. `[source-verified]` [`arm_pmuv3.c:45-160`][arm-pmuv3-c]
+(maps), `:1198-1214` (branch special-case), `:1275-1300` (per-uarch `map_event`).
+
+A `FEAT_PMUv3_TH` core additionally exposes **threshold counting**
+(`PMEVTYPER.TH`/`TC`: only count when the per-cycle event value crosses a
+threshold), surfaced through perf `config1` fields and capped by `PMMIR.THWIDTH`.
+`[source-verified]` `arm_pmuv3.c:311-360, 416-441, 1142-1152`.
+
+---
+
+## Counters and width evolution
+
+The counter _count_ is discoverable, and the counter _width_ has grown across
+PMUv3 revisions — the single most version-sensitive fact for a harness that wants
+to avoid [multiplexing][multiplexing] or counter overflow.
+
+- **Count.** `PMCR.N` (bits 15:11) reports the number of event counters;
+  `armv8pmu_probe_pmu` reads it with `FIELD_GET(ARMV8_PMU_PMCR_N, …)` and then
+  reserves the [fixed counters][fixed-counters]: cycle counter at index **31**,
+  and — on PMUv3p9 — a dedicated instruction counter at index **32**.
+  `[source-verified]` [`arm_pmuv3.c:1322-1331`][arm-pmuv3-c];
+  [`arm_pmuv3.h:9-11,219`][arm-pmuv3-h].
+- **Cycle counter** (idx 31) is **always 64-bit**.
+- **PMUv3p5 long event counters.** `is_pmuv3p5(pmuver)` (arm64 only) sets
+  `PMCR.LP`, making _event_ counters 64-bit ("long event"). `[source-verified]`
+  `arm_pmuv3.c:489-492` (`has_long_event`), `:1189-1190` (`PMCR_LP` at reset).
+- **Pre-p5 chaining.** Without long events, a 64-bit event is formed by
+  **chaining two adjacent 32-bit counters**; the driver reads the high/low pair
+  and biases the 32-bit-overflow interrupt point accordingly.
+  `[source-verified]` `arm_pmuv3.c:504-513` (`event_is_chained`), `:545-553`
+  (chained read), `:555-583` (overflow bias).
+- **PMUv3p9 dedicated instruction counter.** `FEAT_PMUv3_ICNTR` (Armv9.4) adds a
+  fixed `PMICNTR_EL0` at index 32, discovered via `ID_AA64DFR1_EL1.PMICNTR`.
+  `[source-verified]` [`arch/arm64/include/asm/arm_pmuv3.h:57-62,92-97`][arm64-pmuv3-h]
+  (`pmuv3_has_icntr`, `PMICNTR_EL0` access); [`arm_pmuv3.h:11`][arm-pmuv3-h]
+  (`INSTR_IDX 32`).
+
+> [!NOTE]
+> **Width is a milestone.** A pre-p5 core needs _two_ physical counters for one
+> 64-bit event (halving the group budget); a p5 core gets 64-bit event counters
+> for free; a p9 core additionally frees a general counter by moving instructions
+> to `PMICNTR`. A cross-generation harness must probe `PMCR.LP`/`ID_AA64DFR1` — it
+> cannot assume any of the three.
+
+---
+
+## Counting privilege, overflow sampling, and self-monitoring
+
+### EL-exclusion filters
+
+ARM's privilege axis is the **Exception Level**. The counter's event-filter bits
+select which EL it counts at — `EXCLUDE_EL0/EL1/NS_EL1/NS_EL0`, `INCLUDE_EL2`,
+`EXCLUDE_EL3` — and perf's `exclude_user`/`exclude_kernel`/`exclude_hv`/
+`exclude_host`/`exclude_guest` map onto them in a VHE-aware way. `exclude_idle`
+has no PMUv3 equivalent and returns `EOPNOTSUPP`. `[source-verified]`
+[`arm_pmuv3.h:246-251`][arm-pmuv3-h]; [`arm_pmuv3.c:1090-1160`][arm-pmuv3-c]
+(esp. `:1099-1102` for `exclude_idle`, `:1117-1136` for the EL mapping).
+
+### Overflow / IP sampling
+
+[Overflow sampling][overflow] is ordinary PMUv3: program a counter toward
+overflow, take the per-core [PMI][pmi] (a normal PPI, not an NMI), and read the
+interrupted IP from `pt_regs`. Everything downstream of the interrupt — the
+[precise-vs-skid][precise-page] story, ring-buffer consumption, and
+[symbolization][symbolization] — is Linux-generic and identical to x86; ARM's
+_precise_ answer is [SPE](#spe-the-statistical-profiling-extension), covered
+below, not the overflow path.
+
+### Self-monitoring: userspace counter reads (the `rdpmc` analog)
+
+> The cross-check pass asked whether arm64 has an equivalent of x86's
+> `cap_user_rdpmc` userpage. **It does** — this is the answer, source-verified at
+> `linux@e43ffb69e043`.
+
+arm64 supports direct EL0 counter reads without a syscall, the lowest-overhead
+[self-monitoring][self-monitoring] path, and it is **doubly gated**. First, a
+per-event opt-in: the `rdpmc` bit is `config1[1:1]`
+(`ATTR_CFG_FLD_rdpmc → config1`, [`arm_pmuv3.c:309-311,324,336-339`][arm-pmuv3-c]),
+and a user-readable event must be **task-bound** (`PERF_ATTACH_TASK`) and land in
+a **single, unchained** counter (`arm_pmuv3.c:1249-1258`). Second, a global
+sysctl `/proc/sys/kernel/perf_user_access` (default **0**, `mode 0644`, range
+`[0,1]`; `sysctl_perf_user_access`, `arm_pmuv3.c:329`, `:1412-1422`) — writing 0
+IPIs every CPU to slam the door (`armv8pmu_disable_user_access_ipi`, `:1396-1410`).
+When both gates pass and a user-access event is scheduled, `armv8pmu_start` calls
+`armv8pmu_enable_user_access`, which writes **`PMUSERENR_EL0`** with the
+`ER | CR | UEN` bits to open EL0 counter/cycle reads, first zeroing or masking
+(`PMUACR` on PMUv3p9) the _unused_ counters so their contents can't leak
+(`arm_pmuv3.c:790-821`, `:836-849`). Finally `arch_perf_update_userpage` publishes
+`cap_user_rdpmc` and `pmc_width` (32 or 64) in the mmap'd `perf_event_mmap_page`,
+exactly as x86 does (`arm_pmuv3.c:1605-1622`) — so the seqlock-protected
+[user page][self-monitoring] contract is byte-for-byte the same ABI. One
+deliberate asymmetry: the dedicated instruction counter is **never** exposed to
+userspace, _"as userspace may not know how to handle it"_ (`arm_pmuv3.c:1034-1045`).
+Feature history: arm64 userspace counter access landed in **Linux 5.17** (2022);
+the exact commit was not cheaply re-derivable within the source-check timebox
+(the shallow-history `-S` search surfaces only the v6.4 driver relocation), so the
+kernel _version_ is stated from known history while the _mechanism_ above is fully
+source-verified. `[source-verified]`
+
+---
+
+## SPE: the Statistical Profiling Extension
+
+SPE is the ARM analog of Intel **PEBS** / AMD **IBS**: instead of an interrupt
+handler sampling a skewed IP, the _hardware_ tags operations and writes richly
+attributed sample packets into a memory buffer, which perf surfaces as an
+[AUX ring][aux]. It is the source of ARM's [precise, data-source-attributed
+samples][precise-page]; W2's [precise-sampling page][precise-page] owns the
+cross-vendor data-source semantics, so this section stays on the ARM register
+mechanics.
+
+### The AUX-buffer model
+
+A hardware profiling buffer bounded by `PMBLIMITR_EL1`/`PMBPTR_EL1` is filled in
+memory and handed to perf through `arm_spe_perf_aux_output_begin`. Each record
+carries a PC, a data virtual address, an optional data physical address, access
+latency, a data-source code, and a timestamp. `[source-verified]`
+[`arm_spe_pmu.c:64-108`][arm-spe-c] (buffer regs), `:497-620` (AUX
+begin/pad/next-offset), `:880-923` (start: program filter/latency/interval/PMSCR).
+
+### The PMS\* register map (driven from perf `config`/`config1..4`)
+
+| Register                       | perf field carries                                                                     |
+| ------------------------------ | -------------------------------------------------------------------------------------- |
+| `PMSCR_EL1`                    | `TS` (timestamp), `PA` (phys-addr), `PCT` (phys-timestamp), `E0SPE`/`E1SPE` EL enables |
+| `PMSIRR_EL1`                   | sample interval + `RND` (interval jitter)                                              |
+| `PMSFCR_EL1`                   | filter by op class — branch / load / store / SIMD / FP + per-class masks               |
+| `PMSEVFR_EL1` / `PMSNEVFR_EL1` | event filter / inverse-event filter                                                    |
+| `PMSLATFR_EL1`                 | minimum-latency threshold                                                              |
+| `PMSDSFR_EL1`                  | data-source filter (`FEAT_SPE_FDS`)                                                    |
+
+`[source-verified]` `arm_spe_pmu.c:200-260` (field defs with register comments),
+`:367-386` (`to_pmscr`), `:388-421` (`to_pmsirr`), `:421-481` (filter builders),
+`:893-922` (register writes).
+
+### Feature probe (`PMSIDR_EL1`) and buffer ownership (`PMBIDR_EL1`)
+
+The driver discovers SPE's shape from `PMSIDR_EL1` — the presence of event
+filtering (`FE`), inverse (`FnE`), type (`FT`), latency (`FL`) filters,
+`ArchInst`, `LDS`, `ERnd`, SIMD-FP filtering (`EFT`), the data-source filter
+(`FDS`), the recommended minimum interval (256–4096), the max record size (≤2 KB),
+and the 12/16-bit latency-counter width. If `PMBIDR_EL1.P` is set the profiling
+buffer is _"owned by higher exception level"_ (a hypervisor or secure world) and
+the driver bails out. `[source-verified]` [`arm_spe_pmu.c:1105-1223`][arm-spe-c],
+esp. `:1122-1128` (`PMBIDR.P`, quoted below), `:1140-1169` (feature bits),
+`:1171-1201` (min-interval lookup).
+
+> _"profiling buffer owned by higher exception level"_ — [`arm_spe_pmu.c:1125-1126`][arm-spe-c]
+
+### The physical-address paranoia gate
+
+Physical-address and physical-timestamp collection is the ARM equivalent of the
+information that KPTI/Meltdown hardening restricts, so `event_init` refuses it
+unless kernel-level profiling is permitted: if the event sets `PMSCR.PA` or
+`PMSCR.PCT` the init returns [`perf_allow_kernel()`][gating] — governed by
+`perf_event_paranoid`. Context packets (`PMSCR.CX`, PID in `CONTEXTIDR`) are gated
+the same way. `[source-verified]` [`arm_spe_pmu.c:873-877`][arm-spe-c]
+(PA/PCT → `perf_allow_kernel()`), `:42-55` (`set_spe_event_has_cx`):
+
+> `if (reg & (PMSCR_EL1_PA | PMSCR_EL1_PCT))` / `return perf_allow_kernel();` —
+> [`arm_spe_pmu.c:874-875`][arm-spe-c]
+
+The data-address → NUMA-node classification built on those physical addresses is
+W2's territory — see [precise-sampling.md][precise-page].
+
+---
+
+## BRBE: the Branch Record Buffer Extension
+
+BRBE (`FEAT_BRBE`, Armv9.2) is the ARM analog of Intel **LBR**: a hardware ring of
+the last N taken control-flow transfers, frozen at sample time and surfaced
+through perf's `branch_stack` — the input [AutoFDO][branch-records] and bottleneck
+analyses consume.
+
+- **Banked records.** Up to **64** records in two banks of 32
+  (`BRBE_BANK_MAX_ENTRIES 32`), selected via `BRBFCR_EL1.BANK`. Each entry is
+  `BRBSRC` (source PC) + `BRBTGT` (target PC) + `BRBINF` (valid, branch type,
+  mispredict `MPRED`, cycle-count `CC`, EL, transaction/last-failed).
+  `[source-verified]` [`arm_brbe.c:29-61`][arm-brbe-c] (bank layout), `:144-212`
+  (field extractors), [`arm_brbe.h:14-24`][arm-brbe-h].
+- **Filtering + enable.** `BRBFCR_EL1` filters branch classes
+  (DIRECT/INDIRECT/RTN/INDCALL/DIRCALL/CONDDIR); `BRBCR_ELx` enables per-EL
+  recording (`E0BRE` at EL0, `ExBRE` at EL1/EL2) plus `CC` (cycle count), `MPRED`
+  (mispredict), `EXCEPTION`/`ERTN`, `FZP` (freeze on PMU overflow), and
+  `TS=VIRTUAL`. `brbe_branch_attr_valid` rejects `exclude_host` and requires user
+  or kernel recording. `[source-verified]` `arm_brbe.c:14-19, 371-425, 430-464`.
+- **Driven by the core PMU, not a standalone device.** BRBE is probed inside
+  `__armv8pmu_probe_pmu` (`brbe_probe`), its records are allocated per-CPU on the
+  PMU, and it is requested through perf's `branch_stack` (`has_branch_stack` in
+  `set_event_filter`) — not opened as its own event source. `[source-verified]`
+  [`arm_pmuv3.c:1104-1109, 1351, 1354-1368`][arm-pmuv3-c]; [`arm_brbe.h:14-24`][arm-brbe-h].
+
+---
+
+## big.LITTLE / DynamIQ and uncore
+
+This is where ARM's heterogeneity forces harness discipline. The
+[uncore][uncore]/topology concern has two halves: heterogeneous _core_ PMUs and
+genuinely shared _uncore_ PMUs.
+
+### Per-cluster core PMUs
+
+The `arm_pmu` framework tracks each PMU's `supported_cpus`, prints it via the
+sysfs `cpumask` attribute, and constrains a `cpu==-1` event to migrate only
+_within_ that mask. A big.LITTLE / DynamIQ system therefore surfaces **multiple
+CPU PMUs** (e.g. `armv8_cortex_a53` beside `armv8_cortex_a72`), one per
+microarchitecture cluster, and **a harness pinned to a core must open its events
+against the PMU whose `cpumask` contains that core** — a `LITTLE`-core event
+opened on the `big` PMU simply never counts. `[source-verified]`
+[`arm_pmu.c:566-573`][arm-pmu-c] (`cpumask_show`), `:519-524` (migration
+constraint), `:347,540-552` (per-CPU gating); affinity parsed from the
+devicetree `interrupt-affinity` in [`arm_pmu_platform.c:59-121`][arm-pmu-platform].
+Consumers name a specific PMU through `PERF_PMU_CAP_EXTENDED_HW_TYPE` (set
+alongside `PERF_PMU_CAP_EXTENDED_REGS`; `PERF_PMU_CAP_NO_EXCLUDE` is added when a
+PMU offers no EL-exclusion). `[source-verified]` [`arm_pmu.c:891-896, 935-940`][arm-pmu-c].
+
+### Uncore PMUs: system/cluster-scoped, device-specific encodings
+
+| Device                          | Scope                     | Counter block / encoding                                                                                                                                                                                             | Binding                                                            |
+| ------------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **CMN** (Coherent Mesh Network) | system-wide interconnect  | A tree of nodes; the DTC node holds `PMEVCNT`/`PMCCNTR`/`PMCR`/`PMOVSR`. `config` packs `TYPE[15:0]` \| `EVENTID[26:16]` \| `OCCUPID[30:27]` \| `BYNODEID[31]` \| `NODEID[47:32]` (distinct watchpoint sub-encoding) | single CPU via `cpumask`                                           |
+| **DSU** (DynamIQ Shared Unit)   | one cluster's L3/SCU      | `CLUSTERPMCR` mirrors `PMCR` (N counters, ≤32 HW, cycle idx 31 = `DSU_PMU_EVT_CYCLES 0x11`); `event=config:0-31`                                                                                                     | two masks: `associated_cpus` (cluster) + `active_cpu` (the reader) |
+| **DMC-620**                     | one DDR memory controller | 8-bit `eventid` + `clkdiv2`; several DMC instances share one IRQ via a driver list; each instance a separate PMU device                                                                                              | bound to a CPU                                                     |
+
+`[source-verified]` [`arm-cmn.c:123-147,163-187,664-688`][arm-cmn]
+(the DTC counter regs — _"The DTC node is where the magic happens"_,
+[`arm-cmn.c:123`][arm-cmn]), [`arm_dsu_pmu.c:35-67,97-160,164`][arm-dsu],
+[`arm_dmc620_pmu.c:70-91,110-128`][arm-dmc620].
+
+**Harness consequence.** Every uncore PMU is per-_domain_, never per-thread: its
+counts belong to a socket, cluster, or memory-controller aggregate and **cannot
+be attributed to one benchmarked thread**; on a UMA / single-cluster part they
+collapse to "whole chip". A harness that pins a thread and wants
+thread-attributable numbers must confine itself to that core's cluster PMU and
+treat uncore as ambient context — the ARM instance of the general
+[uncore][uncore] rule. `[source-verified]` (consequence of the three devices
+above).
+
+---
+
+## Code-space decode
+
+There is essentially **no ARM-specific decode path**: SPE and PMUv3 sampling emit
+the same `PERF_RECORD_MMAP2` + IP/branch/stack records as x86, and
+[symbolization][symbolization] runs through `libelf`/`libdw`/`libdwfl` exactly as
+[W1 describes][elfutils]. The one ARM wrinkle is that AAPCS64 keeps a frame chain
+by default, so frame-pointer [unwinding][symbolization] is usually viable without
+DWARF-CFI copies. Detail is deferred to [linux-perf-events.md][linux] and
+[elfutils.md][elfutils]. `[source-verified]` (absence of ARM-specific decode in
+`drivers/perf/`; the consumer side is `tools/perf/util/*`).
+
+---
+
+## Apple Silicon microarchitecture reference
+
+> [!WARNING]
+> **This section is a macOS-observed microarchitecture reference, not
+> ARM-Linux.** Apple Silicon is an AArch64 core that is _not_ PMUv3; the numbers
+> below are `[hw-verified: aarch64-darwin]` off `mac-bsn` (Apple **M4 Max**,
+> `Mac16,5`, SoC `T6041`, `hw.cpufamily 0x17d5b93a`, macOS **26.3.1** build
+> 25D771280a, SIP enabled, non-root) and `[source-verified]` against the Linux
+> `apple_m1_cpu_pmu.c` driver. It is placed here — a sidebar — precisely because
+> it does **not** generalize to ARM-Linux. For the full macOS acquisition story
+> (`kpc`/`kperf`/kpep), see [macos.md][macos].
+
+### The IMPDEF register model
+
+Apple's PMU uses proprietary system registers, not PMUv3: `PMCR0-4`
+(`S3_1_c15_c0..4_0`), `PMESR0/1` (`S3_1_c15_c5/6_0`) selecting events for counters
+2–5 and 6–9 respectively, `PMSR` (`S3_1_c15_c13_0`), and `PMC0-9`
+(`S3_2_c15_*`) — **10 counters**, #0/#1 fixed to cycles/instructions, an **8-bit
+event field per counter**, and per-event _counter-affinity_ constraints (some
+events only run on specific counters). Counter width is 48-bit on M1
+(`ARMPMU_EVT_47BIT`) and 64-bit on M2+ (`ARMPMU_EVT_63BIT`). `[source-verified]`
+[`apple_m1_cpu_pmu.c:22-168`][apple-m1-c] (event enum + affinity), `:227-270`
+(`PMC0-9`), `:379-419` (`PMESR0/1`), `:546-566` (width);
+[`apple_m1_pmu.h:10-50`][apple-m1-h]; `applecpu@0e6bc3f6 timer-hacks/PMCKext2.c:5-32`.
+
+### Linux exposes only a 4-event PMUv3-compat shim
+
+`m1_pmu_pmceid_map` maps exactly four PMUv3 names onto Apple numbers —
+`INST_RETIRED→INST_ALL`, `CPU_CYCLES→CORE_ACTIVE_CYCLE`, `BR_RETIRED→INST_BRANCH`,
+`BR_MIS_PRED_RETIRED→BRANCH_MISPRED_NONSPEC` — and every other event is a raw
+Apple number via `event=config:0-7`. `[source-verified]`
+[`apple_m1_cpu_pmu.c:170-187,215-220,568-586`][apple-m1-c]. The driver author
+anticipated exactly the break that follows:
+
+> _"If we eventually find out that the events are different across
+> implementations, we'll have to introduce per cpu-type tables."_ —
+> [`apple_m1_cpu_pmu.c:44-48`][apple-m1-c]
+
+### The M4 encoding change (`[hw-verified: aarch64-darwin]`)
+
+The real Apple event catalog is macOS's **kpep** database (`/usr/share/kpep/`,
+world-readable `-rw-r--r-- root wheel`, so no privilege was needed — plists were
+copied to `/tmp` and read with `python3`/`plutil`). This box's
+`hw.cpufamily 0x17d5b93a` resolves through the symlink
+`cpu_100000c_2_17d5b93a.plist → as4-1.plist` — the M4-Max P-core catalog.
+Comparing kpep across generations shows Apple **changed its event numbering at
+M4**: M1/A14/M3 (`as1`/`a14`/`as3`) use the Apple numbers the Linux driver
+reverse-engineered; M4/M5 (`as4`/`as5`) **remap the common subset onto PMUv3
+architected numbers** and add 12 `ARM_`-prefixed events. The break is
+unambiguous and monotone across the common subset:
+
+```text
+event                       as1     a14     as3     as4-1   as5
+INST_ALL                    0x8c    0x8c    0x8c    0x8     0x8
+CORE_ACTIVE_CYCLE           0x2     0x2     0x2     0x11    0x11
+INST_BRANCH                 0x8d    0x8d    0x8d    0x21    0x21
+RETIRE_UOP                  0x1     0x1     0x1     0x3a    0x3a
+BRANCH_MISPRED_NONSPEC      0xcb    0xcb    0xcb    0x22    0x22
+L1D_CACHE_MISS_LD           0x5a3   0xa3    0x5a3   0x5a3   0x5a3
+FETCH_RESTART               0x1de   0xde    0x1de   0x1de   0x1de
+ARM_L1D_CACHE               -       -       -       0x4     0x4
+ARM_BR_MIS_PRED             -       -       -       0x10    0x10
+n_events                    66      60      66      103     103
+n_ARM_prefixed              0       0       0       12      12
+fixed_counters              3       3       3       3       3
+config_counters             1020    1020    1020    1020    1020
+```
+
+(`as1`=M1, `a14`=A14, `as3`=M3, `as4-1`=M4 Max, `as5`=M5.) The full M4-Max
+catalog is 103 events with a large SME block (`SME_ENGINE_SM_ENABLE`,
+`INST_SME_ENGINE_ALU`, `LDST_SME_*`) reflecting M4's SME; a sample entry reads
+`INST_ALL => {'counters_mask': 252, 'number': 8, ...}` (mask 252 = counters 2–7).
+`[hw-verified: aarch64-darwin]` `mac-bsn:/usr/share/kpep/{as1,a14,as3,as4-1,as5}.plist`
+
+- `[source-verified]` for the driver's TODO ([`apple_m1_cpu_pmu.c:44-48`][apple-m1-c]).
+  The access _mechanism_ stays Apple-proprietary; only the low event _numbers_ now
+  overlap PMUv3, and no M4 Linux driver exists yet.
+
+### 8-bit under-exposure, and filtering Linux never programs
+
+Two consequences follow. First, `M1_PMU_CFG_EVENT = GENMASK(7,0)` and
+`event=config:0-7` cap the Linux driver at events `0x00–0xFF`, but kpep uses wider
+selectors even on M1 (`L1D_CACHE_MISS_LD=0x5a3`, `FETCH_RESTART=0x1de`,
+`L1I_CACHE_MISS_DEMAND=0x1db`) and up to `0x4006` on M4 — so Linux **structurally
+under-exposes** Apple's event space, and the reverse-engineered narrow values
+(`0xa3`, `0xde`) actually match Apple's _A14_ encoding, not M1's wide one.
+`[source-verified]` + `[hw-verified: aarch64-darwin]`
+[`apple_m1_cpu_pmu.c:24,215`][apple-m1-c]. Second, applecpu documents advanced
+filtering the Linux driver never touches — `OPMAT0/1` + `OPMSK0/1` (opcode
+match/mask) and `PMTRHLD2/4/6` (event thresholds) alongside `PMCR2-4`.
+`[source-verified]` `applecpu@0e6bc3f6 timer-hacks/PMCKext2.c:13-32`. And kpep
+reports **3** fixed counters on every Apple generation while the Linux driver
+models only **2** (idx 0 cycles, idx 1 instructions) — an unresolved
+discrepancy, carried as an open question in [the comparison][comparison-open].
+
+---
+
+## The seven concerns
+
+A compact map from the survey's [seven concerns][concepts] to where each is
+answered above (and which page owns the shared machinery).
+
+| #   | Concern                      | ARM answer                                                                               | Section / owner                                                                                                                                              |
+| --- | ---------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Scalar counting              | PMUv3 counters (`PMCR.N`, `PMCEID` discovery, p5/p9 width); EL0 `rdpmc` analog           | [event model](#pmuv3-event-model) · [counters](#counters-and-width-evolution) · [self-monitoring](#self-monitoring-userspace-counter-reads-the-rdpmc-analog) |
+| 2   | Overflow / IP sampling       | PMUv3 counter-overflow PPI; EL-exclusion filters; IP from `pt_regs`                      | [privilege & overflow](#counting-privilege-overflow-sampling-and-self-monitoring)                                                                            |
+| 3   | Precise data-source sampling | **SPE** → AUX ring; PA/PCT `perf_allow_kernel()` gate                                    | [SPE](#spe-the-statistical-profiling-extension) · [precise-sampling.md][precise-page]                                                                        |
+| 4   | Code-space decode            | Linux-generic (`libdwfl`); AAPCS64 keeps frame pointers                                  | [code-space decode](#code-space-decode) · [elfutils.md][elfutils]                                                                                            |
+| 5   | Event space & tracing        | **BRBE** branch records → `branch_stack`; trace-buffer/-unit events at `0x400C+`         | [BRBE](#brbe-the-branch-record-buffer-extension)                                                                                                             |
+| 6   | NUMA & topology              | per-cluster core PMUs + `cpumask`; CMN/DSU/DMC uncore, not thread-attributable           | [big.LITTLE & uncore](#big-little-dynamiq-and-uncore)                                                                                                        |
+| 7   | Event naming & encoding      | 16-bit selector; three-way architectural/common/IMPDEF; `ARM-software/data` + Apple kpep | [event model](#the-three-way-taxonomy-a-refinement-of-common-vs-impdef) · [event-naming.md][event-naming]                                                    |
+
+---
+
+## Strengths
+
+- **Architected discoverability.** `PMCEID*` + `PMCR.N` + `ID_AA64DFR1` let a
+  harness _read_ what a core can count and how wide its counters are — no
+  per-model table needed to know the shape of the machine.
+- **Three precise/branch engines with clean perf mappings.** SPE ([AUX][aux]) and
+  BRBE (`branch_stack`) map onto the same Linux ABIs as PEBS/IBS and LBR, so a
+  cross-vendor consumer sees uniform records.
+- **SPE is unusually rich** — per-op-class filtering, latency thresholds, event
+  and inverse-event filters, data-source filters — all discoverable from
+  `PMSIDR_EL1`.
+- **Low-overhead self-monitoring** via `PMUSERENR_EL0` + `perf_user_access`, the
+  same seqlock userpage ABI as x86 `rdpmc`.
+- **Machine-readable vendor catalog** (`ARM-software/data`) with an explicit
+  `architectural` flag, mirrored in-tree under `pmu-events/arch/arm64`.
+
+## Weaknesses
+
+- **No `aarch64-linux` hardware verification in this survey** — every ARM-Linux
+  claim is source-reading only.
+- **Heterogeneity is a harness burden.** big.LITTLE means multiple core PMUs;
+  pinning to the wrong cluster's PMU silently counts nothing.
+- **Uncore is not thread-attributable** — CMN/DSU/DMC counts are domain-scoped,
+  useless for per-thread benchmarking.
+- **Width and feature drift** (pre-p5 chaining vs p5 long vs p9 `PMICNTR`) force
+  version probes; assuming any one generation is wrong on the others.
+- **Apple Silicon is off-model**: not PMUv3, reverse-engineered, its encoding
+  [changed at M4](#apple-silicon-microarchitecture-reference), Linux
+  under-exposes it (8-bit field), and no M4 driver exists.
+- **The authoritative spec (DDI 0487) is gated** — all encodings here are grounded
+  in the in-kernel header and arm-data JSON, not the PDF (see [Sources](#sources)).
+
+## Key design decisions and trade-offs
+
+| Decision                                               | Rationale                                                                | Trade-off                                                                 |
+| ------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| Architected events + `PMCEID` discovery                | Core answers "what can I count?" itself; no per-model event table        | Naming still needs per-uarch tables; discovery ≠ human names              |
+| 16-bit selector, common/IMPDEF/extension layout        | Room for vendor + architected-extension (SPE/AMU/MTE) growth             | Portable names cover only the common `0x00–0x3F` subset                   |
+| Counter width by revision (chain → p5 long → p9 icntr) | Grows precision without a hard ABI break                                 | A harness must probe `PMCR.LP`/`ID_AA64DFR1`; group budget varies by gen  |
+| EL-based exclusion filters                             | Matches ARM's privilege model exactly (EL0/1/2/3, VHE-aware)             | `exclude_idle` unsupported; mapping is non-trivial under virtualization   |
+| SPE as a separate AUX-streaming device                 | Hardware writes attributed packets → skid-free, data-source-rich samples | PA/PCT gated by `perf_allow_kernel()`; buffer may be owned by a higher EL |
+| BRBE folded into the core PMU, not a standalone dev    | Branch capture is intrinsically per-CPU and PMU-synchronized             | Requested only via `branch_stack`; can't be opened independently          |
+| Per-cluster core PMUs + uncore `cpumask` servicing     | Correctly models heterogeneous cores + shared domains                    | Pin-to-PMU discipline; uncore not thread-attributable                     |
+| Apple: 4-event PMUv3 shim over an IMPDEF PMU           | Gets cycles/instructions/branches working with zero Apple tables         | Under-exposes the real event space; wrong across the M4 encoding change   |
+
+---
+
+## Sources
+
+- [`drivers/perf/arm_pmuv3.c`][arm-pmuv3-c] — PMUv3 core driver: event maps,
+  `PMCEID`/`PMCR.N` probe, EL-exclusion, chaining, `perf_user_access`, userpage.
+- [`include/linux/perf/arm_pmuv3.h`][arm-pmuv3-h] · [`arm_pmu.h`][arm-pmu-h] ·
+  [`arch/arm64/include/asm/arm_pmuv3.h`][arm64-pmuv3-h] — event enums, selector
+  mask, fixed-counter indices, `PMICNTR` access.
+- [`drivers/perf/arm_pmu.c`][arm-pmu-c] · [`arm_pmu_platform.c`][arm-pmu-platform]
+  — the `arm_pmu` framework: `cpumask`, migration, PMU caps, DT affinity.
+- [`drivers/perf/arm_spe_pmu.c`][arm-spe-c] — SPE: AUX buffer, `PMS*`/`PMB*`
+  register map, `PMSIDR` probe, PA/PCT gate.
+- [`drivers/perf/arm_brbe.c`][arm-brbe-c] · [`arm_brbe.h`][arm-brbe-h] — BRBE
+  banked records, filters, `branch_stack`.
+- [`drivers/perf/arm-cmn.c`][arm-cmn] · [`arm_dsu_pmu.c`][arm-dsu] ·
+  [`arm_dmc620_pmu.c`][arm-dmc620] — uncore: mesh, cluster L3, DDR controller.
+- [`drivers/perf/apple_m1_cpu_pmu.c`][apple-m1-c] ·
+  [`arch/arm64/include/asm/apple_m1_pmu.h`][apple-m1-h] — Apple IMPDEF PMU + 4-event shim.
+- [`tools/perf/pmu-events/arch/arm64/`][pmu-events-arm64] — in-tree per-uarch event tables (no `apple/`).
+- [`ARM-software/data`][arm-data] `pmu/*.json` — vendor event catalog with the
+  `architectural` flag (`neoverse-n1.json`, `c1-ultra.json`).
+- [`dougallj/applecpu`][applecpu] `timer-hacks/PMCKext2.c` — reverse-engineered
+  Apple PMU registers (opcode-match, thresholds).
+- `mac-bsn:/usr/share/kpep/*.plist` — macOS's Apple event catalog (`as1`/`a14`/
+  `as3`/`as4-1`/`as5`), the M4 encoding-change evidence. `[hw-verified: aarch64-darwin]`
+- Arm ARM **DDI 0487** issue **K.a** — _"The Performance Monitors Extension"_ and
+  _"The Statistical Profiling Extension"_ chapters. **GATED**: the [developer.arm.com
+  PDF][ddi0487] is a JavaScript SPA behind an Akamai CDN that returns HTTP 403 to
+  direct fetches, and the Internet Archive holds only ~7–8 KB HTML shells (no
+  `application/pdf` binary on any Arm CDN host). All ARM encodings on this page are
+  grounded in the in-kernel header (which mirrors that chapter) and the arm-data
+  JSON, not the PDF. `[literature]`
+
+> [!NOTE]
+> **No runnable CI example ships with this page.** The survey's convention is a
+> [CI-compiled probe][linux] per deep-dive, but there is no `aarch64-linux`
+> hardware in CI to run a PMUv3 probe against, and CI cannot reach `mac-bsn`. The
+> in-page **E2 kpep transcript** is the primary evidence for the Apple claims; the
+> ARM-Linux claims are source-verified against `linux@e43ffb69e043`. A
+> host-agnostic PMUv3 raw-`config` encoder would compile everywhere but could only
+> print a `SKIP:` line off-ARM, so it was omitted as non-load-bearing.
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[fixed-counters]: ./concepts.md#fixed-and-configurable-counters
+[multiplexing]: ./concepts.md#multiplexing-and-scaling
+[self-monitoring]: ./concepts.md#self-monitoring-and-user-space-counter-reads
+[pmi]: ./concepts.md#pmi-performance-monitoring-interrupt
+[overflow]: ./concepts.md#overflow-sampling
+[aux]: ./concepts.md#aux-buffer
+[branch-records]: ./concepts.md#branch-records
+[symbolization]: ./concepts.md#symbolization
+[uncore]: ./concepts.md#uncore-pmu
+[arch-vs-impdef]: ./concepts.md#architected-vs-implementation-defined-events
+[curation]: ./concepts.md#capability-curation
+[gating]: ./concepts.md#privilege-gating
+[linux]: ./linux-perf-events.md
+[precise-page]: ./precise-sampling.md
+[elfutils]: ./elfutils.md
+[event-naming]: ./event-naming.md
+[macos]: ./macos.md
+[comparison-open]: ./comparison.md#open-questions-gaps
+[arm-pmuv3-c]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm_pmuv3.c
+[arm-pmuv3-h]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/linux/perf/arm_pmuv3.h
+[arm-pmu-h]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/linux/perf/arm_pmu.h
+[arm64-pmuv3-h]: https://github.com/torvalds/linux/blob/e43ffb69e043/arch/arm64/include/asm/arm_pmuv3.h
+[arm-pmu-c]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm_pmu.c
+[arm-pmu-platform]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm_pmu_platform.c
+[arm-spe-c]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm_spe_pmu.c
+[arm-brbe-c]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm_brbe.c
+[arm-brbe-h]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm_brbe.h
+[arm-cmn]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm-cmn.c
+[arm-dsu]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm_dsu_pmu.c
+[arm-dmc620]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/arm_dmc620_pmu.c
+[apple-m1-c]: https://github.com/torvalds/linux/blob/e43ffb69e043/drivers/perf/apple_m1_cpu_pmu.c
+[apple-m1-h]: https://github.com/torvalds/linux/blob/e43ffb69e043/arch/arm64/include/asm/apple_m1_pmu.h
+[pmu-events-arm64]: https://github.com/torvalds/linux/tree/e43ffb69e043/tools/perf/pmu-events/arch/arm64
+[arm-data]: https://github.com/ARM-software/data
+[applecpu]: https://github.com/dougallj/applecpu
+[ddi0487]: https://developer.arm.com/documentation/ddi0487/ak

--- a/docs/research/cpu-pmu/backend-proposal.md
+++ b/docs/research/cpu-pmu/backend-proposal.md
@@ -1,0 +1,368 @@
+# Native CPU-PMU backends for sparkles: enhancement proposal
+
+A milestoned plan for a thin per-OS acquisition core under the sparkles
+benchmarking harness, sketched in D against the existing
+[`metrics.d` seam][baseline-seam] — `MetricDescriptor`/`MetricCell`/
+`MetricClass` plus the `CounterGroups` open/close/count contract. Each backend
+**advertises capabilities** aligned with the survey's [seven concerns][spine];
+the harness reports _"capability unavailable"_ instead of silently degraded
+results. Every milestone cross-links the prior art it borrows from.
+
+**Last reviewed:** July 11, 2026
+
+| Field            | Value                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------ |
+| Target           | `sparkles:test-runner --bench` + [`wired` runtime bench][wired-bench]                      |
+| Composition seam | [`MetricDescriptor`/`MetricCell`/`MetricClass`][baseline-seam] + `CounterGroups`           |
+| Baseline audited | [sparkles-baseline.md][baseline] (gap analysis §[Gap analysis][baseline-gaps])             |
+| Evidence base    | [comparison.md][comparison] capability matrix + the per-subject deep-dives                 |
+| Shape            | 6 milestones: seam → Linux depth → macOS floor → Windows floor → precise memory → sampling |
+
+---
+
+## 1. Abstract & problem statement
+
+The [baseline][baseline] is a Linux-only counting layer with a closed set of
+seven generic events and honest-but-empty stubs elsewhere. The survey found
+that (a) Linux exposes far more than the layer uses — per-microarchitecture
+[event vocabularies][naming], [multiplex-scaled estimates][c-multiplex],
+[user-space counter reads][c-rdpmc], [precise memory sampling][precise], and a
+complete decode stack; (b) macOS and Windows have real, _smaller_ floors — an
+unprivileged per-process instructions/cycles read on macOS
+([`proc_pid_rusage`][macos], `[hw-verified: aarch64-darwin]`) and a
+driver-free `CycleTime` plus admin-gated ETW counting on Windows
+([windows.md][windows]); and (c) no existing library spans these — [libpfm4
+has no RISC-V and no non-Linux OS layer, and nothing portable names events
+across OSes][naming-boundary].
+
+The conclusion the proposal operationalizes: **the harness must own a small
+capability-typed backend interface**, implement it per OS at whatever depth
+that OS permits, and make every absence explicit. Linux advertises the full
+set across ISAs; Windows/macOS advertise subsets; the reporting layer renders
+what is advertised and _names_ what is not.
+
+Non-goals: a general profiler UI; kernel-driver work on any OS; wrapping
+closed vendor drivers (VTune SEP / uProf).
+
+---
+
+## 2. Milestone 1: the capability-typed backend seam
+
+**Goal:** make "what can this host measure?" a first-class, reportable value,
+and turn `CounterGroups`'s implicit contract into an interface new backends
+implement.
+
+### 2.1 The capability model
+
+One flag per survey concern (plus sub-capabilities where the survey found
+real-world splits), advertised per backend instance _after_ its open
+handshake — capability is a **runtime probe result**, never a compile-time
+assumption ([privilege gating][c-privilege] varies per box: `paranoid`,
+tracefs modes, SIP, allowlists).
+
+```d
+/// What an opened backend can actually deliver on this host, this run.
+enum Capability : uint
+{
+    none            = 0,
+    counting        = 1 << 0,  /// concern 1: scalar counting
+    countingRaw     = 1 << 1,  ///   + raw/µarch-specific event selectors
+    countingScaled  = 1 << 2,  ///   + multiplexed estimates (labeled)
+    selfMonitoring  = 1 << 3,  ///   + user-space reads (rdpmc/PMUSERENR)
+    ipSampling      = 1 << 4,  /// concern 2: overflow/IP sampling
+    preciseMemory   = 1 << 5,  /// concern 3: data-source/address sampling
+    symbolization   = 1 << 6,  /// concern 4: address → symbol/line
+    eventTracing    = 1 << 7,  /// concern 5: OS-event gating (tracepoints/ETW)
+    numaAttribution = 1 << 8,  /// concern 6: page → node classification
+    eventNaming     = 1 << 9,  /// concern 7: name → encoding tables
+}
+
+struct CapabilityReport
+{
+    Capability available;
+    /// Why each absent capability is absent — rendered by --list-metrics
+    /// and the bench header, e.g. "preciseMemory: no IBS/PEBS PMU (cpu
+    /// max_precise=0)" or "eventTracing: tracefs ids unreadable (0700)".
+    string[Capability] unavailableBecause;
+}
+```
+
+### 2.2 The backend interface
+
+Design-by-Introspection like the rest of sparkles: a backend is any type with
+the required primitives; optional primitives unlock optional capabilities
+(same pattern as the [DbI guidelines][dbi]). The required surface is exactly
+what `CounterGroups` already demands of a tier, made nameable:
+
+```d
+enum isCounterBackend(B) =
+       is(typeof(B.init.tryOpen()) == CapabilityReport)
+    && is(typeof(B.init.close()))
+    && is(typeof(B.init.family(true)) == MetricDescriptor[])
+    && is(typeof((ref BenchStats row, scope void delegate() timed,
+                  scope void delegate() between, ulong iters)
+              => B.init.countInto(row, timed, between, iters)));
+// Optional: B.preciseSample(...), B.classifyPages(...), B.resolveName(...)
+// — presence detected by introspection, reflected in the CapabilityReport.
+```
+
+`BenchStats` grows one `Nullable!XStats` per backend exactly as today
+([the documented one-field-plus-three-lines contract][baseline-seam]); the
+catalog seam is untouched — a backend ships its `XCells`/`XFamily` pair and
+every downstream consumer (table, `--metrics`, `--list-metrics`,
+`--bench-json`) works unchanged.
+
+### 2.3 Reporting absences
+
+`--list-metrics` gains a per-backend capability block, and the bench header
+prints one line per _absent-but-requested_ capability from
+`unavailableBecause`. Acceptance: on the survey's own hosts the report matches
+the survey's findings — the Zen 4 box shows `preciseMemory` present via
+`ibs_op` but `eventTracing` absent (root-only tracefs, as
+[today's `--syscalls` correctly detects][baseline]); mac-bsn shows `counting`
+present-unprivileged only as process-scope rusage.
+
+**Borrows:** the availability handshake and status-string discipline of
+[`perf.d`][baseline]; the "absence is a finding" spine of the
+[comparison matrix][comparison].
+
+---
+
+## 3. Milestone 2: Linux counting depth (naming, scaling, self-monitoring)
+
+**Goal:** lift the three counting-tier gaps the audit found, in place, behind
+`Capability` flags.
+
+### 3.1 `countingRaw` + `eventNaming`
+
+Accept raw selectors (`--metrics 'raw:r04c2'`-style, mapping to
+`perf_event_attr{type: RAW, config: 0x…}`) and, optionally, _named_
+µarch events resolved through libpfm4 when present. Two survey findings
+constrain the design ([event-naming.md][naming]):
+
+- **Auto-detect lags silicon.** Stock libpfm 4.13.0 fails to detect the Zen 4
+  test box (family 25/model `0x61`) — the backend must resolve the PMU name
+  from CPUID itself and force it (`LIBPFM_FORCE_PMU` semantics via the API),
+  not trust `pfm_initialize` detection. `[hw-verified: x86_64-linux]`
+- **Modifiers ride `exclude_*`.** The `:u`/`:k` grammar maps to attr fields,
+  not config bits — the probe [pfm4-name-roundtrip.d][ex-pfm4] demonstrates
+  the exact round trip the backend needs, including the 40-byte
+  `pfm_perf_encode_arg_t` ABI check.
+
+libpfm4 stays a _soft_ dependency (dlopen or link-time optional): without it,
+`countingRaw` still works with numeric selectors; `eventNaming` is advertised
+absent with reason "libpfm unavailable".
+
+### 3.2 `countingScaled`
+
+Where a requested event set exceeds the PMU (the baseline's LLC-drop
+scenario), offer labeled estimates instead of silent column loss: read
+`time_enabled`/`time_running`, scale by the [kernel-documented
+formula][c-multiplex], and render scaled cells with an explicit marker (the
+survey's [counting probe][ex-counting] validates the estimate to ~1% on a
+10-events-on-6-PMCs oversubscription, and also shows the failure mode — a
+5.7× scale from a 0.58 ms slice is visibly noisy, hence _labeled_).
+Default stays exact-or-drop; scaling is opt-in.
+
+### 3.3 `selfMonitoring`
+
+For very short bodies where the per-iteration `ioctl`/`read` bracket dominates,
+add an rdpmc fast path: mmap the leader's `perf_event_mmap_page`, check
+`cap_user_rdpmc`, and read counters in-loop via the documented seqlock
+(`lock`/`index`/`offset`/`pmc_width` — [linux-perf-events.md][linux] quotes
+the uAPI pseudocode verbatim). On ARM the same userpage is gated by
+`PMUSERENR`/`perf_user_access` ([arm.md][arm]); on RISC-V by `scounteren`
+([riscv.md][riscv]) — same capability flag, per-ISA probe.
+
+**Borrows:** [`perf_group.d`][baseline]'s bracket (unchanged for the syscall
+path); the uAPI rdpmc contract; libpfm4's encoding pipeline; the
+[wired bench][wired-bench]'s need for per-byte normalization (raw events make
+`cyc/B` per-engine tables µarch-portable).
+
+---
+
+## 4. Milestone 3: the macOS floor
+
+**Goal:** replace the empty Darwin stub with the two things macOS actually
+permits unprivileged, per [macos.md][macos] (`[hw-verified: aarch64-darwin]`).
+
+- **`counting` (process scope):** `proc_pid_rusage(RUSAGE_INFO_V4)` →
+  `ri_instructions`/`ri_cycles` — true retired instructions and cycles with no
+  root and no entitlement (measured IPC 2.82 on mac-bsn). Delivered as a
+  tier-0-style backend: snapshot pairs around the counting pass, per-iteration
+  averages, `quantitative` class. Note the scope honestly: process-wide fixed
+  counters, not per-bracket configurable events.
+- **Capability ads for the rest:** configurable per-region events →
+  `unavailableBecause = "kpc requires root ('root or the blessed pid',
+xnu kern_kpc.c); event allowlist RESTRICT_TO_KNOWN"`; sampling/symbolication
+  → "via Instruments/xctrace only". An _optional_ root-mode `kpc` backend
+  (dlopen `kperf.framework`, kpep-plist naming) is sketched but explicitly
+  deferred — the survey shows even root cannot program unlisted selectors, and
+  the private-framework surface is unstable across releases.
+
+Build note: the mac toolchain path is `ldc2` driven directly (dub
+fork-ENOMEMs on the reference box); the backend is version-gated D in the same
+modules, no new packages.
+
+**Borrows:** the [three-tier privilege map][macos] (rusage / kpc / xctrace)
+and its EPERM matrix; [tier0.d][baseline]'s snapshot-pair shape.
+
+---
+
+## 5. Milestone 4: the Windows floor
+
+**Goal:** a Windows backend advertising exactly what an unelevated (and,
+separately, an elevated) process can get, per [windows.md][windows].
+
+- **`counting` (thread scope, driver-free):** `EnableThreadProfiling` /
+  `ReadThreadProfilingData` → `CycleTime` only — the sole hardware datum that
+  needs no kernel driver. Rendered as one `quantitative` column; the 16
+  `HwCounters` slots are advertised absent with reason "requires
+  KeSetHardwareCounterConfiguration driver (system-global, single-tenant)".
+- **`counting` under elevation (later, optional):** ETW kernel-logger PMC
+  counting on context switches (`TracePmcCounterListInfo`), admin +
+  `SeSystemProfilePrivilege` gated; consumption model per krabsetw.
+- **`numaAttribution` groundwork:** `GetLogicalProcessorInformationEx` +
+  `QueryWorkingSetEx` (the `move_pages`-query analog) — cheap, documented,
+  unprivileged.
+- **D bindings:** druntime `core.sys.windows` covers only DbgHelp+psapi;
+  the HCP/ETW/NUMA declarations are pulled from the `windows-d` generated
+  modules (`hardwarecounterprofiling.d`, `etw.d`, `systeminformation.d`,
+  `processstatus.d`) rather than hand-written `extern(Windows)` prototypes.
+
+**Borrows:** the [W1-role-replacement table][windows] (which Linux role each
+Windows surface substitutes); krabsetw's session/provider split for any future
+ETW work.
+
+---
+
+## 6. Milestone 5: precise memory tier (Linux)
+
+**Goal:** a `preciseMemory` backend delivering data-source / latency /
+address→node columns on hardware that has an engine, per
+[precise-sampling.md][precise].
+
+- **One decoder, three engines.** Target the vendor-neutral
+  [`perf_mem_data_src`][c-datasrc] union; open `ibs_op` on AMD (with the
+  **`swfilt` recipe** — bare `exclude_kernel` is `EINVAL` on Zen 4
+  `[hw-verified: x86_64-linux]`), `cpu` + `precise_ip` on Intel (PEBS), SPE on
+  ARM (deferred until aarch64-linux hardware exists to verify against —
+  advertised absent with reason until then).
+- **Node classification.** Sampled data addresses classified via the raw
+  `get_mempolicy(MPOL_F_NODE|MPOL_F_ADDR)` / `move_pages` query oracles (no
+  `libs "numa"` link — numactl ships no `numa.pc` and the syscalls aren't in
+  glibc; the probe [mem-latency-numa.d][ex-mem] is the reference
+  implementation). The IBS "remote" bit alone is _not_ node attribution —
+  hardware says remote/local, the oracle says which node.
+- **Rendering.** New `diagnostic` columns: latency percentiles
+  (`WEIGHT`), data-source level distribution, local/remote split. All absent
+  (with reasons) on hosts without an engine — exactly what the capability
+  seam exists for.
+
+**Borrows:** the IBS attr matrix and decode tables from the survey
+experiments; [libnuma.md][libnuma]'s missing-helper finding; the
+[single-NUMA-node caveat][precise] (cross-node classification remains
+`[literature]`-verified until multi-socket hardware is available — an open
+question carried in [comparison.md][comparison-open]).
+
+---
+
+## 7. Milestone 6: sampling & symbolization tier (Linux)
+
+**Goal:** `ipSampling` + `symbolization` — turn "IPC fell" into "IPC fell in
+`sumSquares` at `readers.d:137`".
+
+- **Ring-buffer consumption is pure D.** druntime's
+  `core.sys.linux.perf_event` already carries the mmap page, record headers,
+  and sample formats — the survey's [sampling probe][ex-sampling] consumes
+  `PERF_RECORD_SAMPLE`/`MMAP2` with no C shim.
+- **Address-space model + build-id discipline.** `PERF_RECORD_MMAP2` arrives
+  only for mappings created _while enabled_; pre-existing code comes from
+  `/proc/self/maps` (or `dwfl_linux_proc_report`, which reads the same file).
+  Build-ids are validated before symbolizing — the [stale-binary
+  hazard][c-buildid] is a bench-harness reality (rebuilt-binary + old-run
+  comparisons).
+- **Symbolization via libdwfl** (`dwfl_addrmodule` → `dwfl_module_addrinfo` →
+  `dwfl_module_getsrc`), with the survey's hw-hit gotcha encoded: `addrinfo`'s
+  `offset`/`sym` arguments must be non-NULL. Soft dependency like libpfm4:
+  absent libdw ⇒ `symbolization` advertised absent, samples still counted.
+- **Optional DWARF-CFI unwind** (`STACK_USER`+`REGS_USER` →
+  `dwfl_getthread_frames`) for frame-pointer-less builds — the
+  [unwind probe][ex-unwind] proved the full path in-process on a
+  `--frame-pointer=none` build.
+- **Output shape:** a per-case flat profile (top-N symbols by samples) as a
+  `diagnostic` table section, off by default (`--bench-profile`), never
+  polluting the timing pass.
+
+**Borrows:** perf's consumer ordering ([linux-perf-events.md][linux]);
+elfutils' documented call sequence ([elfutils.md][elfutils]); the counting/
+timing pass separation from [`bench.d`][baseline] (the profile pass is a third
+pass, like counting).
+
+---
+
+## 8. Milestone summary
+
+| #   | Milestone                | Capabilities unlocked                                            | Depends on | Evidence base                                                 |
+| --- | ------------------------ | ---------------------------------------------------------------- | ---------- | ------------------------------------------------------------- |
+| 1   | Capability seam          | reporting of absences (all backends)                             | —          | [baseline][baseline], [comparison][comparison]                |
+| 2   | Linux counting depth     | `countingRaw`, `eventNaming`, `countingScaled`, `selfMonitoring` | 1          | [linux][linux], [event-naming][naming], [probes][ex-counting] |
+| 3   | macOS floor              | `counting` (process scope) on Darwin                             | 1          | [macos][macos] `[hw-verified]`                                |
+| 4   | Windows floor            | `counting` (CycleTime), NUMA groundwork                          | 1          | [windows][windows]                                            |
+| 5   | Precise memory tier      | `preciseMemory`, `numaAttribution`                               | 1, 2       | [precise-sampling][precise] `[hw-verified]`                   |
+| 6   | Sampling & symbolization | `ipSampling`, `symbolization`                                    | 1          | [linux][linux], [elfutils][elfutils], probes                  |
+
+Sequencing rationale: M1 is pure refactoring value (better reporting today);
+M2 deepens the mode the harness already lives in; M3/M4 are small,
+independent, and kill the "all counters vanish off Linux" cliff; M5/M6 add the
+_where_ dimension and are the only milestones with new soft C dependencies
+(libdw, libpfm4) — both degrade to advertised absence.
+
+ISA notes carried across milestones: on big.LITTLE ARM the backend must open
+events on the PMU whose `cpumask` contains the pinned core
+([arm.md][arm]); on RISC-V the backend is a capability _subset_ by
+construction — counting always (SBI), sampling iff Sscofpmf, branch records
+never until a CTR consumer lands ([riscv.md][riscv]).
+
+## Sources
+
+- [sparkles-baseline.md][baseline] — the audited system and its gap analysis.
+- [comparison.md][comparison] — the capability matrix this proposal's flags
+  mirror, and the open questions its deferred items point at.
+- Per-subject deep-dives: [linux-perf-events][linux], [elfutils][elfutils],
+  [libnuma][libnuma], [precise-sampling][precise], [arm][arm], [riscv][riscv],
+  [windows][windows], [macos][macos], [event-naming][naming].
+- Runnable evidence: [counting-group.d][ex-counting],
+  [sampling-symbolize.d][ex-sampling], [unwind-stack-user.d][ex-unwind],
+  [mem-latency-numa.d][ex-mem], [pfm4-name-roundtrip.d][ex-pfm4].
+
+<!-- References -->
+
+[baseline]: ./sparkles-baseline.md
+[baseline-seam]: ./sparkles-baseline.md#the-metric-catalog-seam
+[baseline-gaps]: ./sparkles-baseline.md#gap-analysis-what-the-audit-starts-from
+[comparison]: ./comparison.md
+[comparison-open]: ./comparison.md#open-questions-gaps
+[spine]: ./#the-seven-concerns
+[linux]: ./linux-perf-events.md
+[elfutils]: ./elfutils.md
+[libnuma]: ./libnuma.md
+[precise]: ./precise-sampling.md
+[arm]: ./arm.md
+[riscv]: ./riscv.md
+[windows]: ./windows.md
+[macos]: ./macos.md
+[naming]: ./event-naming.md
+[naming-boundary]: ./event-naming.md
+[wired-bench]: ../../../libs/wired/bench/runtime/
+[dbi]: ../../guidelines/design-by-introspection-01-guidelines.md
+[ex-counting]: ./examples/counting-group.d
+[ex-sampling]: ./examples/sampling-symbolize.d
+[ex-unwind]: ./examples/unwind-stack-user.d
+[ex-mem]: ./examples/mem-latency-numa.d
+[ex-pfm4]: ./examples/pfm4-name-roundtrip.d
+[c-multiplex]: ./concepts.md#multiplexing-and-scaling
+[c-rdpmc]: ./concepts.md#self-monitoring-and-user-space-counter-reads
+[c-datasrc]: ./concepts.md#data-source-attribution
+[c-buildid]: ./concepts.md#build-id
+[c-privilege]: ./concepts.md#privilege-gating

--- a/docs/research/cpu-pmu/comparison.md
+++ b/docs/research/cpu-pmu/comparison.md
@@ -1,0 +1,246 @@
+# CPU-PMU capability comparison
+
+The survey's capstone: the **capability matrix** — the seven
+[analysis concerns][spine] against every ISA × OS combination surveyed — the
+consensus acquisition model, the architectural trade-offs behind the
+differences, and the **delta table** mapping each capability onto where the
+[sparkles baseline][baseline] stands today. Ends with the open questions the
+survey could not close from this hardware.
+
+**Last reviewed:** July 11, 2026
+
+Verification tags: `[hw-verified: x86_64-linux]` (AMD Ryzen 9 7940HX, kernel
+6.18.26) · `[hw-verified: aarch64-darwin]` (Apple M4 Max, macOS 26.3.1) ·
+`[source-verified]` (pinned repos, see the deep-dives' Sources) ·
+`[literature]`. There is **no** `aarch64-linux`, RISC-V, or Windows hardware
+bed — those columns carry no hardware tags by construction.
+
+---
+
+## The capability matrix
+
+One row per concern; each cell names the concrete mechanism (API / struct /
+driver), links the owning deep-dive, and carries its strongest verification
+tag. **Absent** cells are explicit — absence is a finding.
+
+### Concern 1: scalar counting
+
+| Platform       | Mechanism                                                                                                                                                                                                             | Tag                             |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| Linux · x86_64 | [`perf_event_open`][linux] + [event groups][c-group] (`PERF_FORMAT_GROUP`, all-or-nothing scheduling, [multiplex scaling][c-multiplex])                                                                               | `[hw-verified: x86_64-linux]`   |
+| Linux · ARMv8+ | same syscall over [PMUv3][arm] (`PMCEID*` capability bitmaps; one PMU **per big.LITTLE cluster**, events must open on the pinned core's PMU)                                                                          | `[source-verified]`             |
+| Linux · RISC-V | same syscall over the [SBI PMU indirection][riscv] (kernel → SBI `0x504D55` → M-mode firmware writes `mhpmevent`); legacy fallback = `cycle`/`instret` only                                                           | `[source-verified]`             |
+| Windows        | [HCP][windows] `EnableThreadProfiling`/`ReadThreadProfilingData` — driver-free datum is `CycleTime` **only**; 16 PMC slots require a WDK driver (system-global, single-tenant); ETW `-pmc` logs PMCs on kernel events | `[literature]`                  |
+| macOS          | [`kpc_set_thread_counting`][macos] (**root** — "root or the blessed pid"); unprivileged floor = `proc_pid_rusage(RUSAGE_INFO_V4)` → `ri_instructions`/`ri_cycles`                                                     | `[hw-verified: aarch64-darwin]` |
+
+### Concern 2: overflow / IP sampling
+
+| Platform       | Mechanism                                                                                                                                                                                                             | Tag                                                             |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Linux · x86_64 | `sample_period`/`sample_freq` → NMI → [`PERF_RECORD_SAMPLE` ring buffer][linux]                                                                                                                                       | `[hw-verified: x86_64-linux]`                                   |
+| Linux · ARMv8+ | PMUv3 overflow IRQ, same ring; EL-based privilege filters                                                                                                                                                             | `[source-verified]`                                             |
+| Linux · RISC-V | **iff `Sscofpmf`** (LCOFI interrupt 13, `scountovf` shadow); without it the PMU is `NO_INTERRUPT` and `NO_EXCLUDE`; sampled IP = trapped `xepc` (skidded); **guest** delivery additionally needs AIA (`HVIEN` bit 13) | `[source-verified]`                                             |
+| Windows        | ETW PMC-overflow: `TraceSetInformation(TraceProfileSourceConfigInfo)` → `PERF_PMC_PROFILE` events, `-stackwalk pmcinterrupt`; admin + `SeSystemProfilePrivilege`                                                      | `[literature]`                                                  |
+| macOS          | [kperf][macos] timer/PMI actions into the kperf buffer; hardware **PC-capture on overflow** (`S3_1_C15_C14_1`); reachable via root or Instruments/`xctrace` (which runs unprivileged)                                 | `[source-verified]` + `[hw-verified: aarch64-darwin]` (xctrace) |
+
+### Concern 3: precise data-source / address sampling
+
+| Platform               | Mechanism                                                                                                                                                                                                             | Tag                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| Linux · x86_64 (AMD)   | [IBS][precise]: `ibs_op` micro-op tagging, skid 0, fills [`perf_mem_data_src`][c-datasrc] + `WEIGHT` latency + data VA/PA; `swfilt` needed for privilege filtering on Zen 4                                           | `[hw-verified: x86_64-linux]`      |
+| Linux · x86_64 (Intel) | [PEBS][precise]: `precise_ip` 1–3, hardware DS-area records, per-µarch `pebs_data_source[]`; **no PEBS on AMD** (`cpu` PMU `max_precise = 0`)                                                                         | `[source-verified]`                |
+| Linux · ARMv8+         | [SPE][arm]: [AUX-buffer][c-aux] packets carrying PC + data VA/PA + latency; packet framing architected, **data-source decode implementation-defined** (MIDR-dispatched); PA collection gated by `perf_allow_kernel()` | `[source-verified]`                |
+| Linux · RISC-V         | **Absent** — no ratified PEBS/SPE analog anywhere in the ISA manual                                                                                                                                                   | `[source-verified]` (absence)      |
+| Windows                | **Absent publicly** — no data-address class in `TRACE_QUERY_INFO_CLASS`; kernel has internal-only PEBS plumbing (`EventTracePebsTracingInformation` in the undocumented enum); LBR is public but branch-only          | `[source-verified]`/`[literature]` |
+| macOS                  | **Absent** — CPMU PC-capture only; no data VA/PA/latency packet surface (hardware `PMTRHLD*` thresholds exist but are not exposed as an API)                                                                          | `[source-verified]`                |
+
+### Concern 4: code-space decode & symbolization
+
+| Platform         | Mechanism                                                                                                                                                                                                                                                                                                                         | Tag                                |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| Linux (all ISAs) | address-space model from [`PERF_RECORD_MMAP2`][linux] + `/proc/PID/maps` synthesis (MMAP2 is emitted **only for mappings created while enabled**); decode via [elfutils][elfutils] `libdwfl` (addr → module → symbol → line + inline); [build-id][c-buildid] validation; [DWARF-CFI unwind][c-unwind] of `STACK_USER`+`REGS_USER` | `[hw-verified: x86_64-linux]`      |
+| Windows          | ETW image-load events; [DbgHelp/DIA][windows] over out-of-band PDB; build-id analog = PDB **GUID+Age**; symbol servers                                                                                                                                                                                                            | `[literature]`/`[source-verified]` |
+| macOS            | [dyld image list][macos] (`_dyld_get_image_*`, `TASK_DYLD_INFO`) with a **single shared-cache slide**; Mach-O + dSYM via `atos`/CoreSymbolication (closed framework)                                                                                                                                                              | `[hw-verified: aarch64-darwin]`    |
+
+### Concern 5: event-space & tracing
+
+| Platform               | Mechanism                                                                                                                                                                                                  | Tag                                                          |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Linux                  | [tracepoints][c-eventspace] (`PERF_TYPE_TRACEPOINT`, tracefs `format` schemas, decode via [libtraceevent][libtraceevent] — which does **not** read tracefs itself); `id` files root-only on hardened hosts | `[hw-verified: x86_64-linux]` (gating) / `[source-verified]` |
+| Linux · branch records | x86 LBR; ARM [BRBE][arm] (≤64 records, type filters, `branch_stack`); RISC-V [CTR][riscv] ratified v1.0 (2024-11-22) but **no Linux consumer** at v7.1-rc6                                                 | `[source-verified]`                                          |
+| Windows                | [ETW][windows] providers + TDH schemas (krabsetw = the open consumption model; kernel-logger enable uses the undocumented `PERFINFO_GROUPMASK` path); LBR public since Win10 19H1                          | `[source-verified]`                                          |
+| macOS                  | kdebug/ktrace (kperf emits kdebug); DTrace exists but has **no `cpc` provider** (never ported from Solaris) and SIP blocks unprivileged use                                                                | `[hw-verified: aarch64-darwin]` + `[source-verified]`        |
+
+### Concern 6: NUMA & topology
+
+| Platform       | Mechanism                                                                                                                                                                                                                                                                               | Tag                                                    |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Linux          | sysfs `/sys/devices/system/node` (+ SLIT distances) wrapped by [libnuma][libnuma]; page→node oracles = raw `get_mempolicy(MPOL_F_NODE\|MPOL_F_ADDR)` / `move_pages` query (**no libnuma helper exists**); [uncore PMUs][c-uncore] are per-domain (`cpumask`), never thread-attributable | `[hw-verified: x86_64-linux]` (single-node round-trip) |
+| Linux · ARMv8+ | CMN (mesh, node-typed encodings) / DSU (cluster L3) / DMC-620 (DDR) uncore drivers, each cpumask-bound                                                                                                                                                                                  | `[source-verified]`                                    |
+| Linux · RISC-V | SBI `CACHE_NODE` **counter** only; no uncore driver framework at v7.1-rc6                                                                                                                                                                                                               | `[source-verified]`                                    |
+| Windows        | `GetLogicalProcessorInformationEx` (topology), `VirtualAllocExNuma` (placement), `QueryWorkingSetEx` → per-page `Node` (the `move_pages`-query analog); **no sampled-address→node path** (follows from concern 3)                                                                       | `[source-verified]`/`[literature]`                     |
+| macOS          | **Collapses** — Apple Silicon is UMA; the only topology axis is P/E `perflevels`                                                                                                                                                                                                        | `[hw-verified: aarch64-darwin]`                        |
+
+### Concern 7: event naming & encoding
+
+| Platform       | Mechanism                                                                                                                                                                                                                                                                                 | Tag                                                   |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Linux · x86_64 | [libpfm4][naming] (the engine under PAPI; CPUID detect + per-µarch tables; **auto-detect lags new silicon** — 4.13.0 misses Zen 4 model 0x61); Intel: public `intel/perfmon` self-generates the kernel's perf JSON; AMD: kernel-tree-only JSONs, different name space for the same events | `[hw-verified: x86_64-linux]`                         |
+| Linux · ARMv8+ | `ARM-software/data` JSON catalog (`architectural: true/false` — the split is **three-way**: architected ⊂ common `0x00-0x3F` ⊂ IMPDEF); kernel `pmu-events/arch/arm64` (no `apple/` directory)                                                                                            | `[source-verified]`                                   |
+| Linux · RISC-V | SBI standardizes the 20-bit `event_idx` **classes**; actual `mhpmevent` selectors implementation-defined (DT `riscv,event-to-mhpmevent`); vendor JSONs for 5 vendors                                                                                                                      | `[source-verified]`                                   |
+| Windows        | curated HAL profile-sources (`-pmcsources`); raw events registerable since Win10 1903 but only **system-globally** (WPRP/registry `Event`/`Unit`/`ExtendedBits`), not per-open; cross-ISA at the profile-source layer                                                                     | `[literature]`                                        |
+| macOS          | kpep plist DBs per cpufamily (world-readable); kernel `RESTRICT_TO_KNOWN` allowlist (102 events on T6041) — **even root cannot program unlisted selectors**; **M4 remapped the common subset onto PMUv3 architected numbers** (M1–M3 use Apple numbers)                                   | `[hw-verified: aarch64-darwin]` + `[source-verified]` |
+
+> [!NOTE]
+> No naming layer spans operating systems. libpfm4/PAPI are Linux-perf only;
+> LIKWID reaches furthest across _vendors_ (it ships an Apple-M1 table) but is
+> Linux-only too; Windows and macOS each curate their own vocabulary. A
+> cross-OS harness must own its event vocabulary — the finding the
+> [backend proposal][proposal] (§M1/M2) is built on.
+
+---
+
+## The consensus standard
+
+The field's de-facto reference model is Linux `perf_events` — the
+**hub-and-decoders architecture** ([linux-perf-events.md][linux]):
+
+- **One acquisition hub.** A single syscall + one `perf_event_attr` ABI covers
+  counting _and_ sampling on every ISA; hardware diversity is absorbed by
+  per-PMU drivers below the ABI, not by per-vendor userspace APIs above it.
+  Even the three mutually-alien precise engines (PEBS, IBS, SPE) surface
+  through **one** `perf_mem_data_src` union.
+- **Independent decoders.** Code-space (elfutils), event-space
+  (libtraceevent), topology (libnuma) are libraries that never touch the PMU;
+  the hub never interprets. Each side is replaceable without the other.
+- **Capability by probe.** `PMCEID*` bitmaps, sysfs `caps/`, open-time errno —
+  a consumer discovers, per host, what exists.
+
+Everything else surveyed is either a **subset** of this model (Windows: three
+disjoint surfaces — curated HCP, ETW, closed ring-0 drivers; macOS: a capable
+CPMU fenced behind root/entitlements/allowlist with Instruments as the
+sanctioned broker) or the same model behind an **indirection** (RISC-V: the
+identical perf ABI with firmware owning the counters via SBI).
+
+## Architectural trade-offs
+
+| Axis                    | Poles                                                                | Where each lands                                                                                                                                                     |
+| ----------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Event access policy     | open selectors ↔ [curated lists][c-curation]                         | Linux open (any `config`, `paranoid`-gated) · Windows curated + global registration escape · macOS allowlist even for root                                           |
+| Precise-sampling engine | counter-extension (PEBS) ↔ op-tagging (IBS) ↔ buffer-streaming (SPE) | PEBS: precise _per event_, DS-area; IBS: skid-0 by construction, event-agnostic, coarse NUMA bit; SPE: highest bandwidth, userspace decode, impl-defined data-source |
+| Decode inputs           | in-band (records carry identity) ↔ out-of-band (separate artifacts)  | Linux MMAP2 + in-ELF DWARF (+ optional in-record build-id) · Windows PDB by GUID+Age via symbol servers · macOS dSYM + shared-cache slide                            |
+| Counter ownership       | kernel-arbitrated per-event ↔ global single-tenant                   | Linux per-fd scheduling/multiplex · Windows driver config is system-global, one profiler at a time · macOS single-owner CPMU arbitration (`EBUSY`)                   |
+| Control plane           | direct MSR/sysreg in kernel ↔ firmware indirection                   | x86/ARM: kernel programs hardware · RISC-V: M-mode firmware programs `mhpmevent`, kernel asks via SBI                                                                |
+| Naming ownership        | vendor-published ↔ kernel-tree ↔ OS-curated                          | Intel publishes (`intel/perfmon`) · AMD contributes in-kernel only · ARM publishes JSON · Apple ships kpep plists · Windows HAL curates                              |
+
+---
+
+## The delta table: the survey vs. the sparkles baseline
+
+Each survey capability against [today's layer][baseline], with the
+[proposal][proposal] milestone that closes the gap.
+
+| Capability (best practice found)                                           | sparkles today                                                  | Gap                                                                   | Closes in                                             |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------- |
+| Grouped counting, exact (all-or-nothing groups)                            | ✅ 7-event group, calibration-drop of LLC pair                  | none — matches the survey's exact-counts stance                       | —                                                     |
+| Labeled multiplex estimates (`enabled/running` scaling, ~1% at 10-on-6)    | ❌ avoided entirely (columns dropped instead)                   | estimates never offered, coverage silently narrows                    | M2 (`countingScaled`)                                 |
+| Raw / per-µarch event selectors + naming tables                            | ❌ 7 hardcoded generics                                         | no vocabulary beyond `PERF_COUNT_*`; nothing µarch-specific reachable | M2 (`countingRaw`, `eventNaming`)                     |
+| [Self-monitoring][c-rdpmc] reads (rdpmc seqlock, ~10× cheaper bracket)     | ❌ `read(2)`/`ioctl(2)` per pass                                | syscall-priced brackets on very short bodies                          | M2 (`selfMonitoring`)                                 |
+| Overflow/IP sampling + flat profiles                                       | ❌ absent                                                       | "what regressed" but never "where"                                    | M6 (`ipSampling`)                                     |
+| Precise memory sampling (IBS skid-0 on this hardware; `perf_mem_data_src`) | ❌ absent                                                       | no latency distributions, no data addresses                           | M5 (`preciseMemory`)                                  |
+| Symbolization + build-id validation (libdwfl; stale-binary hazard)         | ❌ absent                                                       | nothing to attribute samples to                                       | M6 (`symbolization`)                                  |
+| Event-space gating (tracepoints beyond syscalls; PSI, sched)               | ⚠️ syscall counting only, root-gated tracefs correctly detected | no scheduling/fault/pressure context                                  | later (M11 of the [metric-catalog roadmap][baseline]) |
+| NUMA topology + page→node oracles                                          | ❌ absent                                                       | single-node today, but zero awareness even of that                    | M5 (`numaAttribution`)                                |
+| macOS floor (`proc_pid_rusage` unprivileged instructions/cycles)           | ❌ stub                                                         | loses _all_ counters on a platform that offers a real floor           | M3                                                    |
+| Windows floor (`CycleTime` driver-free; ETW when elevated)                 | ❌ stub                                                         | same cliff                                                            | M4                                                    |
+| Capability reporting ("unavailable because X")                             | ⚠️ per-tier `status()` strings                                  | absences not enumerated per capability                                | M1                                                    |
+
+---
+
+## Open questions & gaps
+
+What stayed `[literature]`/`[source-verified]` for lack of hardware, plus
+known hazards the harness must carry forward:
+
+1. **ARM-Linux is entirely source-verified.** SPE sampling, PMUv3 counter
+   behavior, BRBE, CMN/DSU/DMC uncore, big.LITTLE per-PMU opening, and the
+   `perf_user_access` userpage path have **no hardware verification** — no
+   `aarch64-linux` box existed. First target when one appears: re-run the
+   [counting probe][ex-counting] and an SPE capture on a Neoverse or
+   big.LITTLE part.
+2. **RISC-V has never been executed.** Sscofpmf sampling, SBI counter
+   behavior, and CTR are spec + kernel + firmware reading. CTR additionally
+   has **no Linux consumer** to even read yet; vendor `mhpmevent` tables
+   (5 vendors in-tree) are unexercised. QEMU was deliberately not used for
+   counts (it does not model PMUs faithfully).
+3. **Intel PEBS is unverified locally** — the test bed is AMD (no PEBS;
+   `max_precise = 0`). PEBS claims trace to `ds.c` + docs; a PDIR/`precise_ip
+= 3` experiment needs Intel silicon.
+4. **Cross-node NUMA classification is undemonstrated** — the box has one
+   node; the oracles round-trip but never disagree with anything. Multi-socket
+   verification (and IBS's remote-bit behavior across real hops) is open.
+5. **SNC/NPS uncore-topology caveats** `[literature]`: Intel Sub-NUMA
+   Clustering and AMD NPS BIOS modes multiply visible nodes and re-scope
+   uncore counters; a NUMA-aware backend must re-probe topology per boot and
+   never cache node counts across configuration changes. Undemonstrable on
+   this laptop-class part (which exposes no L3/DF uncore PMUs at all —
+   itself worth re-checking on desktop/server Zen).
+6. **The Apple third fixed counter.** kpep advertises `fixed_counters: 3` on
+   every generation; xnu's `kpc` FIXED class and Linux's driver model 2
+   (cycles, instructions). What the third is remains unresolved — carried as
+   an open discrepancy in the survey's internal QA ledger.
+7. **Apple M4 on Linux.** The M4 encoding remap is hw-confirmed from macOS,
+   but Linux's `apple_m1_cpu_pmu.c` has no M4 table and its 8-bit event field
+   cannot express the wider kpep selectors — whether/when upstream grows a
+   per-cpu-type table is open.
+8. **Windows PEBS-class ETW** exists in the undocumented internal enum only.
+   Whether it ever becomes public API is unknowable from outside; the survey
+   records the boundary as of Server 23H2 docs.
+9. **Build-id / stale-binary hazard** (for the harness, on every OS): Linux
+   MMAP2 arrives only for live mappings (synthesize + validate build-ids);
+   Windows needs GUID+Age matching; macOS needs dSYM discipline (`dsymutil`
+   on a one-shot build yields an _empty_ dSYM). Encoded as M6 acceptance
+   criteria in the [proposal][proposal].
+10. **libpfm4's silicon lag** is structural: any naming layer bundled today
+    will meet unrecognized CPUs tomorrow — the backend must force PMU tables
+    from CPUID and fail _loudly_ into `unavailableBecause`, never silently
+    misencode. `[hw-verified: x86_64-linux]` (4.13.0 vs model 0x61).
+11. **Gated primaries.** Arm ARM DDI 0487 (issue K.a) and the SPE whitepaper
+    could not be acquired (CDN-gated; Wayback holds only HTML shells) — ARM
+    architectural claims rest on the in-kernel headers + `arm-data`, cited by
+    chapter name. Intel SDM and the Zen 4 PPR are cited by section for the
+    same reason.
+
+## Sources
+
+Aggregated from the deep-dives; every cell's locator lives in its page's
+Sources section (repos pinned by SHA in the survey's internal QA ledger).
+Direct experiment evidence: the five [runnable probes][ex-counting] and the
+mac-bsn transcripts quoted in [macos.md][macos]/[arm.md][arm].
+
+<!-- References -->
+
+[spine]: ./#the-seven-concerns
+[baseline]: ./sparkles-baseline.md
+[proposal]: ./backend-proposal.md
+[linux]: ./linux-perf-events.md
+[elfutils]: ./elfutils.md
+[libtraceevent]: ./libtraceevent.md
+[libnuma]: ./libnuma.md
+[precise]: ./precise-sampling.md
+[arm]: ./arm.md
+[riscv]: ./riscv.md
+[windows]: ./windows.md
+[macos]: ./macos.md
+[naming]: ./event-naming.md
+[ex-counting]: ./examples/counting-group.d
+[c-group]: ./concepts.md#event-group
+[c-multiplex]: ./concepts.md#multiplexing-and-scaling
+[c-datasrc]: ./concepts.md#data-source-attribution
+[c-aux]: ./concepts.md#aux-buffer
+[c-buildid]: ./concepts.md#build-id
+[c-unwind]: ./concepts.md#unwinding
+[c-eventspace]: ./concepts.md#event-space-and-tracepoints
+[c-uncore]: ./concepts.md#uncore-pmu
+[c-curation]: ./concepts.md#capability-curation
+[c-rdpmc]: ./concepts.md#self-monitoring-and-user-space-counter-reads

--- a/docs/research/cpu-pmu/concepts.md
+++ b/docs/research/cpu-pmu/concepts.md
@@ -1,0 +1,280 @@
+# CPU-PMU Concepts
+
+The shared vocabulary of the CPU-PMU survey. Every term is defined **once**, here;
+the [deep-dives][index] link back to these definitions instead of re-explaining
+them. Definitions are grounded in the Linux `perf_events` implementation (the
+survey's reference model, [linux-perf-events.md][linux]) with per-ISA and per-OS
+variations noted where they exist.
+
+**Last reviewed:** July 11, 2026
+
+---
+
+## The two acquisition modes
+
+### Counting
+
+Reading the _aggregate value_ of a hardware event counter over a time window:
+enable, run the workload, read one number (e.g. "60,049,109 instructions
+retired"). Counting is cheap (no interrupts, no buffers — one register read per
+counter), perturbs the workload near-zero, and is the natural mode for a
+benchmarking harness that reports per-iteration averages. On Linux it is
+`perf_event_open(2)` + `read(2)`; on Windows the [curated][capability-curation]
+`ReadThreadProfilingData` path; on macOS `kpc_get_thread_counters` (root) or
+`proc_pid_rusage` (unprivileged). Contrast [sampling](#sampling).
+
+### Sampling
+
+Recording a _snapshot per event occurrence_ — canonically every N-th occurrence
+([overflow sampling](#overflow-sampling)) — containing at minimum the
+interrupted instruction pointer, and optionally registers, stack, data address,
+or [branch records](#branch-records). Sampling answers _where_ (which code, which
+data), not just _how much_, at the cost of interrupt overhead and a consumer-side
+decode pipeline ([symbolization](#symbolization)). A profile is a statistical
+estimate: sample counts approximate the true distribution only if samples are
+unbiased — the motivation for [precise sampling](#precise-sampling-and-skid).
+
+---
+
+## Counting machinery
+
+### Fixed and configurable counters
+
+PMUs split counters into a few **fixed-function** counters hard-wired to one
+event each (cycles, instructions — Intel's fixed counters, Apple's `PMC0`/`PMC1`)
+and N **configurable** (general-purpose) counters programmed via a per-counter
+event-select register (x86 `PERFEVTSELx`, ARM `PMEVTYPER<n>_EL0`, RISC-V
+`mhpmevent3..31`). The configurable count bounds how many events can be measured
+simultaneously without [multiplexing](#multiplexing-and-scaling) — 6 core PMCs on
+AMD Zen 4, typically 6 + 3 fixed on modern Intel, 5 + 2 fixed exposed by macOS
+`kpc` on Apple M-series.
+
+### Event group
+
+A set of events scheduled onto the PMU **as one atomic unit** so their values are
+mutually comparable (a valid IPC needs cycles and instructions counted over the
+_same_ window). In Linux a group is built by opening sibling events with
+`group_fd` = the leader's fd, and the kernel guarantees all-or-nothing
+scheduling: _"Groups can be scheduled in as one unit only"_
+(`kernel/events/core.c`). A group that exceeds the free counters is simply not
+scheduled — it does not partially count. `PERF_FORMAT_GROUP` reads the whole
+group atomically in one `read(2)`. Windows/macOS have no user-visible grouping
+seam; their counting APIs read whatever the (globally configured) counters hold.
+
+### Multiplexing and scaling
+
+When more events are enabled than counters exist, the kernel time-slices
+("rotates") them and reports, per event, how long it was **enabled** vs actually
+**running** on the PMU. The consumer scales the raw value by
+`enabled / running` to estimate the full-window count — the formula is spelled
+out in the uAPI header: `count = quot * enabled + (rem * enabled) / running`.
+Scaled counts are _estimates_: sub-millisecond running slices produce visible
+error, and an event may get zero PMU time (`running == 0`, perf's
+`<not counted>`). A harness avoids multiplexing by keeping its
+[group](#event-group) within the physical counter budget — the reason the
+sparkles [baseline][baseline] drops its LLC pair when calibration detects
+rotation.
+
+### Self-monitoring and user-space counter reads
+
+Reading a counter from the measured thread itself without a syscall: x86 `rdpmc`,
+ARMv8 `PMEVCNTR<n>_EL0` reads (gated by `PMUSERENR_EL0`), RISC-V `rdcycle`/
+`rdinstret` (gated by `scounteren`). Linux exposes this through the mmap'd
+`perf_event_mmap_page`: a seqlock-protected page publishing the counter index,
+offset, and width when `cap_user_rdpmc` is set. This is the lowest-overhead
+acquisition path (tens of cycles) and the natural fit for per-iteration bracketing
+inside a benchmark loop; its availability is arch- and OS-policy-dependent.
+
+---
+
+## Sampling machinery
+
+### PMI: performance monitoring interrupt
+
+The interrupt a PMU raises when a counter overflows: x86 uses an NMI (which is
+why the NMI watchdog permanently occupies one counter), ARM a normal PPI per
+core, RISC-V the Sscofpmf **LCOFI** local interrupt (bit 13). The PMI handler
+captures the sample context and writes it to the output buffer. Everything about
+sampling quality — [skid](#precise-sampling-and-skid), blind spots in
+interrupt-disabled regions — follows from PMI delivery mechanics.
+
+### Overflow sampling
+
+Program a counter to `-N`, let it overflow every N events, and record a sample
+per [PMI](#pmi-performance-monitoring-interrupt) — the canonical IP-profiling
+mode (`sample_period`/`sample_freq` + `PERF_SAMPLE_IP` on Linux; ETW
+`TraceProfileSourceConfigInfo` → `PERF_PMC_PROFILE` on Windows; `kperf`
+timer/PMI actions on macOS). Frequency mode (`sample_freq`) lets the kernel
+auto-adjust the period to hit a target rate.
+
+### Precise sampling and skid
+
+**Skid** is the distance between the instruction that caused a counter overflow
+and the IP the [PMI](#pmi-performance-monitoring-interrupt) handler observes —
+on an out-of-order core the architectural interrupt point lands several to
+hundreds of instructions later, biasing profiles. **Precise sampling** removes
+skid by making the _hardware_ capture the sample: Intel **PEBS** (the counter
+arms a hardware assist that writes a record to a memory buffer), AMD **IBS**
+(hardware tags a random micro-op and reports its retirement facts — skid 0 by
+construction), ARM **SPE** (hardware writes sample packets to a
+[profiling buffer](#aux-buffer)). Linux models the request as
+`perf_event_attr.precise_ip` (0–3). RISC-V has no precise mechanism — its
+sampled IP is the trapped `xepc`. See [precise-sampling.md][precise].
+
+### Data-source attribution
+
+The star payload of [precise sampling](#precise-sampling-and-skid): for a sampled
+memory access, _which level of the memory hierarchy served it_ (L1/L2/L3/local
+DRAM/remote node/…), the access latency, and the data virtual/physical address.
+Linux normalizes all three vendor engines (PEBS, IBS, SPE) into one ABI union —
+`perf_mem_data_src` — plus `PERF_SAMPLE_{ADDR,PHYS_ADDR,WEIGHT}`. The
+NUMA-locality signal in the union is deliberately coarse (IBS reports only a
+"remote" bit); node-precise attribution needs the
+[page→node oracles](#numa-topology-and-page-node-oracles). No public equivalent
+exists on Windows or macOS.
+
+### AUX buffer
+
+A second, high-bandwidth mmap area attached to a perf event, into which
+_hardware_ (not the PMI handler) streams records: ARM SPE profiling packets,
+Intel PT instruction traces. The kernel manages ownership handoff; userspace
+decodes the vendor packet format after the fact. Contrast the ordinary perf ring
+buffer, which the _kernel_ writes one sample record at a time.
+
+### Branch records
+
+A hardware ring of the last N taken control-flow transfers (source, target,
+prediction outcome, optionally cycle count): Intel **LBR** (32 entries), ARM
+**BRBE** (up to 64), RISC-V **CTR** (16–256, ratified 2024 but without a Linux
+consumer yet). Frozen at sample time, branch records give the _path leading to_
+a sample — the input AutoFDO and bottleneck analyses need. Exposed on Linux via
+`PERF_SAMPLE_BRANCH_STACK`; on Windows via ETW `TraceLbrConfigurationInfo`
+(public since Win10 19H1).
+
+---
+
+## The decode side
+
+### Symbolization
+
+Turning sampled instruction pointers into human meaning:
+address → module → symbol → source line (+ inline expansion). Requires two
+inputs: an **address-space model** (which file is mapped where — Linux
+`PERF_RECORD_MMAP2` records plus `/proc/PID/maps` synthesis; macOS the dyld image
+list with a single shared-cache slide; Windows ETW image-load events) and a
+**debug-info decoder** (ELF/DWARF via [elfutils][elfutils]' `libdwfl`; PE/PDB via
+DbgHelp/DIA; Mach-O/dSYM via CoreSymbolication/`atos`).
+
+### Build-id
+
+A content-derived identity stamped into a binary (ELF `NT_GNU_BUILD_ID` note; the
+PE analog is the PDB **GUID+Age**; Mach-O the LC*UUID) that lets a consumer prove
+the on-disk file it symbolizes against is the \_same build* that was executing.
+Symbolizing against a since-rebuilt binary produces silently wrong results — the
+**stale-binary hazard**. Linux can embed the build-id directly in mmap records
+(`PERF_RECORD_MISC_MMAP_BUILD_ID`), removing the race entirely.
+
+### Unwinding
+
+Reconstructing the call stack at sample time. Two families: **frame-pointer**
+walking (cheap, in-kernel — `PERF_SAMPLE_CALLCHAIN` — but requires the code to
+keep a frame chain) and **DWARF-CFI** unwinding (copy the raw stack top +
+registers with `PERF_SAMPLE_STACK_USER`/`REGS_USER`, replay call-frame
+information offline via `libdwfl` — works on frame-pointer-less builds at the
+cost of per-sample stack copies).
+
+### Event-space and tracepoints
+
+Beyond hardware counters, kernels expose _software event schemas_: Linux
+**tracepoints** (declared under tracefs with a self-describing `format` file,
+countable and sampleable through `perf_event_open` with
+`PERF_TYPE_TRACEPOINT`, decoded by [libtraceevent][libtraceevent]); Windows
+**ETW** providers (TDH schemas); macOS **kdebug**/DTrace probes. This is the
+"event-space" concern: gating and enriching PMU data with OS-level events
+(syscalls, scheduling, faults).
+
+---
+
+## Topology
+
+### Uncore PMU
+
+A PMU attached to a shared resource _outside_ any core — L3/system-level cache,
+memory controller, interconnect mesh (Intel uncore boxes, AMD L3/DF PMUs, ARM
+CMN/DSU/DMC). Uncore events are per-_domain_, not per-thread: they cannot be
+attributed to one benchmarked thread, only to a socket/cluster-wide aggregate,
+and their drivers restrict reads to one servicing CPU (a sysfs `cpumask`).
+Big.LITTLE systems extend the same pattern to _core_ PMUs: one PMU device per
+microarchitecture cluster, and an event must be opened on the PMU owning the
+pinned core.
+
+### NUMA topology and page-node oracles
+
+The placement decoder: enumerate nodes and distances (Linux sysfs
+`/sys/devices/system/node`, wrapped by [libnuma][libnuma]), and answer _"which
+node backs this page?"_ for a sampled data address. Linux offers two oracles —
+`get_mempolicy(MPOL_F_NODE | MPOL_F_ADDR)` and `move_pages()` in query mode
+(pages = the addresses, nodes = NULL) — notably **not** wrapped by any libnuma
+helper. Windows' analog is `QueryWorkingSetEx` (a per-page `Node` field); Apple
+Silicon is UMA, so the entire axis collapses there.
+
+---
+
+## Naming, encoding, policy
+
+### Architected vs implementation-defined events
+
+Whether an event's number and meaning are fixed by the ISA specification or left
+to each implementation. ARM PMUv3 architects a **common** event space
+(`0x0000–0x003F`, discoverable per-core via the `PMCEID*` registers) and leaves
+`0x0040+` implementation-defined; RISC-V architects _no_ hardware event numbers
+at all (only the SBI _classes_; the `mhpmevent` selector values are per-vendor);
+x86 has vendor-architected subsets (Intel's architectural events) plus large
+model-specific tables. The practical consequence: portable event names exist
+only as far as somebody maintains per-microarchitecture
+[encoding tables](#event-naming-and-encoding).
+
+### Event naming and encoding
+
+The mapping from a human event name (`RETIRED_INSTRUCTIONS`,
+`ex_ret_instr`, `INST_RETIRED.ANY`) to the hardware programming value —
+on Linux, `perf_event_attr.{type, config}`. The maintained mappings are
+per-microarchitecture tables: [libpfm4][naming] (the engine under PAPI),
+LIKWID's event files, Intel's public `intel/perfmon` repo, AMD's kernel-tree
+JSONs, ARM's `ARM-software/data`, Apple's on-disk kpep plists. No two agree on
+names for the same event, and none spans Linux + Windows + macOS — see
+[event-naming.md][naming].
+
+### Capability curation
+
+The policy stance of an OS that exposes only a _vetted list_ of events rather
+than raw selectors: Windows' HAL profile-sources (a small architected set;
+custom events need a system-global registration) and macOS's kernel
+`RESTRICT_TO_KNOWN` allowlist (102 events on M4 Max — even root cannot program
+an unlisted selector). Linux is the outlier: any `config` value can be opened by
+an unprivileged process (subject to
+[privilege gating](#privilege-gating)). Curation is why a cross-OS backend must
+advertise _capabilities_, not assume them.
+
+### Privilege gating
+
+Every OS gates PMU access, each differently: Linux's `perf_event_paranoid`
+sysctl (per-level: raw kernel profiling → CPU-wide events → any unprivileged
+use) plus seccomp/LSM; tracefs file permissions (root-only tracepoint `id`s on
+hardened systems); ARM SPE's physical-address collection gated on
+`perf_allow_kernel()`; Windows' `SeSystemProfilePrivilege`/administrators for
+ETW kernel sessions; macOS's "root or the blessed pid" `ktrace` ownership for
+`kpc`, with SIP standing behind it. A portable harness treats _"counter opened"_
+as a runtime capability probe, never an assumption — degradation must be
+detected and reported, not silently absorbed.
+
+<!-- References -->
+
+[index]: ./
+[linux]: ./linux-perf-events.md
+[precise]: ./precise-sampling.md
+[elfutils]: ./elfutils.md
+[libtraceevent]: ./libtraceevent.md
+[libnuma]: ./libnuma.md
+[naming]: ./event-naming.md
+[baseline]: ./sparkles-baseline.md

--- a/docs/research/cpu-pmu/elfutils.md
+++ b/docs/research/cpu-pmu/elfutils.md
@@ -1,0 +1,315 @@
+# elfutils (`libelf` / `libdw` / `libdwfl`)
+
+The survey's **code-space decoder**: it turns a raw sampled instruction pointer
+into `module → symbol → source line → inline chain`, and replays DWARF Call Frame
+Information to unwind a stack — and it never touches the PMU.
+
+| Field            | Value                                                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Libraries        | `libelf` (ELF), `libdw` (DWARF), `libdwfl` (the "front-end" session layer that ties them to a live process)               |
+| Role             | [Symbolization][symbolization] (address → module → symbol → line + inline expansion) and DWARF-CFI [unwinding][unwinding] |
+| Public headers   | `libdwfl/libdwfl.h`, `libdw/libdw.h`                                                                                      |
+| Version          | **0.194** (runtime-tested, nixpkgs) / **0.195** (source read, [`elfutils@6f8f78c`][elfutils-src])                         |
+| Touches the PMU? | **No.** It is a pure decoder — one of the four the [Linux hub][linux] delegates to (concern 4)                            |
+| Verification     | `[hw-verified: x86_64-linux]` — symbolized live samples (Experiment B) and a frame-pointer-less unwind (Experiment C)     |
+
+> [!NOTE]
+> This page is a decoder, so six of the survey's seven concerns are **not
+> applicable** to it — and saying so is itself a finding: elfutils has no
+> acquisition surface, no counter, no topology. Concern 4 is its entire reason to
+> exist. The two hardware experiments referenced here were recorded on **Linux
+> 6.18.26**, an **AMD Ryzen 9 7940HX** (Zen 4), **LDC 1.41**, against elfutils
+> **0.194**.
+
+---
+
+## Overview
+
+### What it decodes
+
+A [`perf_event_open`][linux] sample gives you a bare number: an interrupted
+instruction pointer like `0x55c5…`. That is meaningless without two things elfutils
+supplies — an **address-space model** (which ELF file is mapped where, so a runtime
+VA can be rebased to a file offset) and a **debug-info decoder** (ELF symbol tables
+plus DWARF `.debug_line` / `.debug_info` / `.eh_frame`). `libdwfl` is the layer
+that combines both: it reports the modules of a live process, then answers
+`address → symbol`, `address → source line`, `address → inline chain`, and — via
+DWARF CFI — `registers + stack → call frames`. `libelf` and `libdw` are the ELF
+and DWARF readers underneath; `libdwfl` is what a profiler actually calls.
+
+### Design philosophy: the non-NULL, activation-aware contract
+
+elfutils' API is terse, C, and unforgiving about pointer contracts — which is a
+recurring source of segfaults for first-time callers. Two verbatim excerpts from
+the public header set the tone. The symbol lookup **requires** its output pointers
+([`libdwfl/libdwfl.h:499`][elfutils-src]):
+
+> `OFFSET will be filled in with the difference from the start of the symbol (or function entry), OFFSET cannot be NULL.  SYM is filled in with the symbol associated with the matched ADDRESS, SYM cannot be NULL.`
+
+And the unwinder's per-frame program-counter accessor encodes the subtle
+"call-site versus return-address" adjustment that every correct backtrace needs
+([`libdwfl/libdwfl.h:820`][elfutils-src]):
+
+> `/* Return *PC (program counter) for thread-specific frame STATE. Set *ISACTIVATION according to DWARF frame "activation" definition. Typically you need to subtract 1 from *PC if *ACTIVATION is false to safely find function of the caller. */`
+
+`[source-verified]` Both are load-bearing: the first is a real segfault hit in the
+first probe run; the second is why the unwind probe does `pc -= 1` for non-leaf
+frames.
+
+---
+
+## How it works
+
+`libdwfl` is session-oriented. A `Dwfl*` handle is opened with `dwfl_begin`, given
+a `Dwfl_Callbacks` struct of four function pointers, populated with a process's
+modules, and closed. The callback struct is
+`{find_elf, find_debuginfo, section_address, debuginfo_path}`
+([`libdwfl/libdwfl.h:72`][elfutils-src]); for the common cases elfutils ships the
+standard implementations `dwfl_linux_proc_find_elf`
+([`:393`][elfutils-src]) and `dwfl_standard_find_debuginfo` ([`:319`][elfutils-src])
+that a caller just takes the address of. `[source-verified]`
+
+Once modules are reported, every query is `address`-keyed and dispatched to the
+owning module. The whole surface the profiler uses is a dozen functions, all in
+`libdwfl.h` — the sections below walk them in the order a sample flows through
+them.
+
+> [!WARNING]
+> **Version skew, recorded honestly.** The source was read at elfutils **0.195**
+> (`elfutils@6f8f78c`); the probes linked against **0.194** (nixpkgs). Every API
+> cited here exists in both — record 0.194 as the _tested_ version. Separately,
+> `nix shell nixpkgs#elfutils` puts elfutils _binaries_ on `PATH` but **not** on
+> the linker search path, so a `libs "dw" "elf"` build needs elfutils added to the
+> `ci` devShell/`buildInputs`, or the two symbolizing probes cannot link.
+
+---
+
+## The seven concerns
+
+The concern order is fixed across the survey. For a pure decoder, only one applies.
+
+### Scalar counting
+
+**Concern 1 — not applicable.** elfutils reads no counters and issues no
+`perf_event_open`; grouping and [multiplexing][linux] are entirely the
+[acquisition hub][linux]'s.
+
+### Overflow sampling
+
+**Concern 2 — not applicable to acquisition.** elfutils does not sample. It is the
+_downstream_ of a sample: the [Linux ring buffer][linux-sampling] produces the IPs;
+elfutils names them (concern 4).
+
+### Precise sampling and data-source attribution
+
+**Concern 3 — not applicable.** The [precise-sampling][precise] engines (PEBS/IBS/SPE)
+and the `perf_mem_data_src` union are decoded by the kernel and
+[libnuma][libnuma], not elfutils. elfutils would only ever symbolize the _code_
+address of such a sample, never its data-source payload.
+
+### Code-space decode and symbolization
+
+**Concern 4 — the entire page.** Everything elfutils does for this survey lives
+here. A sample's IP flows through four stages, then an optional stack unwind.
+
+#### Session and the module model: `dwfl_begin` → `dwfl_linux_proc_report`
+
+For a live process, the model is built in three calls: `dwfl_begin(&callbacks)`
+([`libdwfl.h:104`][elfutils-src]), then `dwfl_linux_proc_report(dwfl, pid)`
+([`:384`][elfutils-src]) — which parses `/proc/PID/maps` and reports each mapped
+module — then `dwfl_report_end` ([`:190`][elfutils-src]) to finalize. Reading the
+_same_ `/proc/PID/maps` is precisely how elfutils recovers the mappings that
+[`PERF_RECORD_MMAP2` never emitted][linux-sampling] for pre-existing code — the two
+halves of the address-space model meet at that file. `[source-verified]`
+
+> [!NOTE]
+> **Discrepancy resolved — perf uses `dwfl_report_elf`, not `dwfl_report_module`.**
+> An early hypothesis was that perf's user-unwinder reports modules with
+> `dwfl_report_module`; the source says otherwise. `tools/perf/util/unwind-libdw.c`
+> leaves `.find_elf` unset and reports each map with `dwfl_report_elf()` instead
+> (`unwind-libdw.c:66`, `:114`). Both entry points are legitimate; the probes here
+> use `dwfl_linux_proc_report` (the whole-process convenience), perf reports maps
+> individually. `[source-verified]`
+
+#### Address → module → symbol → line
+
+The resolution pipeline is four calls, each keyed on the runtime address:
+
+1. `dwfl_addrmodule(dwfl, addr)` ([`libdwfl.h:231`][elfutils-src]) — find the
+   owning `Dwfl_Module`.
+2. `dwfl_module_addrinfo(mod, addr, &offset, &sym, …)` ([`:514`][elfutils-src]) —
+   return the symbol **name** and fill `offset` (distance into the symbol) and a
+   `GElf_Sym`. elfutils explicitly **recommends `addrinfo` over the older
+   `addrsym`** ([`:520`][elfutils-src]).
+3. `dwfl_module_getsrc(mod, addr)` ([`:590`][elfutils-src]) — map the address to a
+   `Dwfl_Line`.
+4. `dwfl_lineinfo(line, …, &lineno, …)` ([`:606`][elfutils-src]) — read the file,
+   line, and column.
+
+`[source-verified]` **Experiment B**
+([`sampling-symbolize.d`](./examples/sampling-symbolize.d)) drove exactly this
+sequence over ~2000 live IP samples:
+
+```text
+top self-symbols (dwfl: name — samples — file:line):
+  …sumSquares…   1852   sampling-symbolize.d:137
+  …mixHash…       130   sampling-symbolize.d:129
+```
+
+The hottest sampled symbol resolved to a name _and_ a source line, and a captured
+`MMAP2` named the same image — closing the loop between acquisition and decode.
+`[hw-verified: x86_64-linux]`
+
+> [!WARNING]
+> **The `addrinfo` non-NULL gotcha (a real segfault).** Per the header quote
+> above, `dwfl_module_addrinfo`'s `offset` (arg 3) and `sym` (arg 4) arguments
+> **cannot be NULL** — the prototype carries `__nonnull_attribute__ (3, 4)`. Passing
+> `NULL` for either does not error; it segfaults inside `search_table`
+> (`__libdwfl_addrsym`). This was hit on the first probe run on a _real_ hardware
+> IP. Always pass real `GElf_Off*` and `GElf_Sym*` storage even if you only want
+> the name. `[hw-verified: x86_64-linux]`
+
+#### Inline expansion: `dwarf_getscopes`
+
+A single address can belong to several _inlined_ frames. To recover them, drop from
+`libdwfl` to `libdw`: `dwfl_module_addrdie(mod, addr, …)`
+([`libdwfl.h:567`][elfutils-src]) gets the compilation-unit DIE, then
+`dwarf_getscopes(cudie, addr, &scopes)` ([`libdw/libdw.h:859`][elfutils-src])
+returns an **innermost-first** array of scope DIEs, walking the
+`inlined_subroutine` chain. For each inline, `dwarf_decl_file` and
+`dwarf_decl_line` ([`libdw.h:929`][elfutils-src]/[`:932`][elfutils-src]) give the
+declaration coordinates — so a profiler can attribute one hardware IP to the full
+`caller → inlined callee` source chain. `[source-verified]`
+
+#### DWARF-CFI stack unwinding
+
+For a [call-graph profile][unwinding] on a frame-pointer-less build, there is no
+`%rbp` chain to walk — the backtrace must be replayed from DWARF Call Frame
+Information. elfutils exposes a full offline unwinder:
+
+- `dwfl_attach_state(dwfl, elf, pid, &thread_callbacks, arg)`
+  ([`libdwfl.h:725`][elfutils-src]) attaches an unwind session whose
+  `Dwfl_Thread_Callbacks` are `{next_thread, get_thread, memory_read,
+set_initial_registers, detach, thread_detach}` ([`:661`][elfutils-src]). The
+  caller's `memory_read` serves bytes (from a captured stack slab, in the offline
+  case); `set_initial_registers` seeds the register file via
+  `dwfl_thread_state_register_pc` ([`:783`][elfutils-src]) +
+  `dwfl_thread_state_registers` ([`:775`][elfutils-src]).
+- `dwfl_getthread_frames(dwfl, tid, callback, arg)` ([`:815`][elfutils-src]) drives
+  the unwinder frame by frame; each callback reads the frame's program counter with
+  `dwfl_frame_pc(state, &pc, &isactivation)` ([`:825`][elfutils-src]) — and applies
+  the `pc -= 1` for non-activation frames the header quote mandates.
+- The CFI itself comes from `dwfl_module_dwarf_cfi` / `dwfl_module_eh_cfi`
+  ([`:657`][elfutils-src]/[`:658`][elfutils-src]) — `.debug_frame` and `.eh_frame`
+  respectively.
+
+`[source-verified]` **Experiment C**
+([`unwind-stack-user.d`](./examples/unwind-stack-user.d)) captured
+[`PERF_SAMPLE_STACK_USER` + `PERF_SAMPLE_REGS_USER`][linux-unwind] on a
+`--frame-pointer=none` build and reconstructed the stack **offline**:
+
+```text
+DWARF-CFI backtrace (5 frames, frame pointers OMITTED — so this came purely from .eh_frame/.debug_frame CFI):
+  #0 …level3…+0x50   #1 …level2…+0x12   #2 …level1…+0x12   #3 …workload…+0x71   #4 …run…+0x29A
+```
+
+A full five-frame in-process unwind succeeded with **no** frame pointers — driven
+by `dwfl_getthread_frames`, with `memory_read` serving the captured `STACK_USER`
+slab and `set_initial_registers` seeding the captured `REGS_USER` set. This is
+byte-for-byte the wiring `perf` uses in `tools/perf/util/unwind-libdw.c` (the
+`Dwfl_Thread_Callbacks` at `:307`, the `dwfl_attach_state` +
+`dwfl_getthread_frames` drive at `:403`). The one non-portable piece is the
+perf-capture → DWARF register-number permutation, which is x86-64-specific and
+lives in the probe; ARM and RISC-V need their own maps (see [arm.md][arm] /
+[riscv.md][riscv]). `[hw-verified: x86_64-linux]`
+
+### Event-space and tracing
+
+**Concern 5 — applies only to DWARF, not tracefs.** elfutils decodes DWARF debug
+information; it does **not** parse a tracepoint's tracefs `format` schema or a raw
+tracepoint record — that is [libtraceevent][libtraceevent]'s job. The only overlap
+is conceptual (both are "schema-driven decoders").
+
+### NUMA and topology
+
+**Concern 6 — not applicable.** elfutils has no notion of nodes, distances, or
+placement. Topology is [libnuma][libnuma].
+
+### Event naming and encoding
+
+**Concern 7 — not applicable.** elfutils maps _addresses_ to symbols, not _event
+selectors_ to names. The `type`/`config` naming problem is
+[event-naming.md][naming]'s (libpfm4 et al.).
+
+---
+
+## Strengths
+
+- **One library spans the whole code-space decode**: modules, symbols, source
+  lines, inline chains, and CFI unwinding — no separate unwinder to bolt on.
+- **The live-process module model reads `/proc/PID/maps`**, exactly recovering the
+  mappings `PERF_RECORD_MMAP2` omits — the two halves of the address-space model
+  join naturally.
+- **Frame-pointer-independent unwinding**: `.eh_frame`/`.debug_frame` CFI replay
+  works on `-fomit-frame-pointer` builds where a `%rbp` walk cannot (Experiment C).
+- **It is the reference implementation** `perf` itself links (`unwind-libdw.c`), so
+  a backend that mirrors its calls inherits perf's battle-tested behavior.
+- **Inline attribution** (`dwarf_getscopes`) recovers the full source chain from a
+  single IP — essential for optimized builds.
+
+## Weaknesses
+
+- **A segfault-prone C API**: `dwfl_module_addrinfo`'s non-NULL `offset`/`sym`
+  contract is enforced by an attribute, not a graceful error — a `NULL` crashes on
+  a real IP (the gotcha above).
+- **Debug info must be present and matching**: without DWARF line tables you get
+  symbol names but no `file:line`; without a matching [build-id][build-id] you risk
+  symbolizing the wrong binary (that validation is the _caller's_ discipline —
+  elfutils will happily decode a stale file).
+- **No PMU, no acquisition**: it is one of four decoders, useless on its own — a
+  backend still needs the [hub][linux] to produce the addresses.
+- **Register-map portability is the caller's problem**: the perf-capture → DWARF
+  register permutation is per-ISA; elfutils gives the unwinder but not the mapping.
+- **Version/link-path friction**: source vs runtime version skew, and the
+  `nix shell` linker-path gap, are real integration papercuts.
+
+## Key design decisions and trade-offs
+
+| Decision                                                | Rationale                                                                     | Trade-off                                                                             |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `libdwfl` session model over raw `libelf`/`libdw`       | One handle owns the module map, symbol tables, DWARF, and CFI for a process   | An extra layer to learn; the `Dwfl_Callbacks` struct must be populated correctly      |
+| Report modules from `/proc/PID/maps`                    | Recovers the mappings `PERF_RECORD_MMAP2` never emits for pre-existing code   | Ties live symbolization to `/proc` availability; a snapshot must be captured in time  |
+| `dwfl_module_addrinfo` requires non-NULL `offset`/`sym` | Lets the function return name + offset + symbol in one call, no allocation    | A `NULL` segfaults instead of erroring — an unforgiving contract for first-time users |
+| Offline unwind via `Dwfl_Thread_Callbacks`              | `memory_read`/`set_initial_registers` let a _captured_ stack+regs be replayed | The caller must supply a correct per-ISA register permutation and stack slab          |
+| `dwarf_getscopes` returns innermost-first inline scopes | One IP expands to its full inline chain for optimized code                    | Requires DWARF `.debug_info`; drops to a bare symbol name without it                  |
+
+---
+
+## Sources
+
+- [elfutils project home][elfutils-home] and its [source tree][elfutils-src] (`libdwfl/libdwfl.h`, `libdw/libdw.h`, read at `elfutils@6f8f78c`, 0.195)
+- `libdwfl/libdwfl.h` — the session model (`dwfl_begin`/`dwfl_linux_proc_report`/`dwfl_report_end`), `dwfl_addrmodule` → `dwfl_module_addrinfo` → `dwfl_module_getsrc` → `dwfl_lineinfo`, and the unwind API (`dwfl_attach_state` → `dwfl_getthread_frames` → `dwfl_frame_pc`) — all quoted/cited above
+- `libdw/libdw.h` — `dwarf_getscopes`, `dwarf_decl_file`/`dwarf_decl_line` (inline expansion)
+- [`tools/perf/util/unwind-libdw.c`][perf-unwind] — the reference wiring the probes mirror (`dwfl_report_elf`, not `dwfl_report_module`)
+- Runnable probes: [`sampling-symbolize.d`](./examples/sampling-symbolize.d) (Experiment B) · [`unwind-stack-user.d`](./examples/unwind-stack-user.d) (Experiment C)
+- The [acquisition hub][linux] this decoder serves, and the sibling decoders [libtraceevent][libtraceevent] · [libnuma][libnuma]
+- Shared vocabulary: [concepts.md][concepts] ([symbolization][symbolization], [unwinding][unwinding], [build-id][build-id])
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[symbolization]: ./concepts.md#symbolization
+[unwinding]: ./concepts.md#unwinding
+[build-id]: ./concepts.md#build-id
+[linux]: ./linux-perf-events.md
+[linux-sampling]: ./linux-perf-events.md#overflow-sampling-the-ring-buffer-perf-record-mmap2-and-ip-symbolization
+[linux-unwind]: ./linux-perf-events.md#stack-unwinding-stack-user-regs-user-and-dwarf-cfi
+[libtraceevent]: ./libtraceevent.md
+[libnuma]: ./libnuma.md
+[precise]: ./precise-sampling.md
+[naming]: ./event-naming.md
+[arm]: ./arm.md
+[riscv]: ./riscv.md
+[elfutils-home]: https://sourceware.org/elfutils/
+[elfutils-src]: https://sourceware.org/git/?p=elfutils.git;a=tree
+[perf-unwind]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/util/unwind-libdw.c

--- a/docs/research/cpu-pmu/event-naming.md
+++ b/docs/research/cpu-pmu/event-naming.md
@@ -1,0 +1,571 @@
+# Event naming & encoding (libpfm4 / PAPI / LIKWID / vendor tables)
+
+The [seventh concern][c-naming] of the survey: the layer that turns `RETIRED_OPS`
+into `{type=4, config=0xc1}` — and where it runs out. A human event name
+(`RETIRED_INSTRUCTIONS`, `ex_ret_instr`, `INST_RETIRED.ANY`) is meaningless to
+`perf_event_open(2)`; something has to map it onto the raw
+`perf_event_attr.{type, config, exclude_*}` bits the ABI programs. This page
+surveys the five layers that do the mapping — [libpfm4][pfmlib-h] (the shared
+engine), [PAPI][papi-repo], [LIKWID][likwid-repo], Intel's public
+[`intel/perfmon`][perfmon-repo], and the kernel's in-tree
+[`pmu-events`][amdzen4] — and charts the two boundaries every one of them hits:
+**ISA** (none covers RISC-V but the kernel) and **OS** (none reaches Windows or
+macOS).
+
+| Field           | Value                                                                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Subject         | Event naming & encoding — symbolic name → `perf_event_attr`                                                                         |
+| Naming layers   | **libpfm4** (engine) · [PAPI][papi-repo] · [LIKWID][likwid-repo] · [`intel/perfmon`][perfmon-repo] · kernel [`pmu-events`][amdzen4] |
+| Encoding target | Linux `perf_event_attr.{type, config, config1, exclude_*}` (see [linux-perf-events][linux])                                         |
+| Concern         | 7 of 7 — [event naming & encoding][c-naming]                                                                                        |
+| ISA reach       | x86 (AMD + Intel), ARMv6–v9, POWER4–10, SPARC, s390x, MIPS, Itanium, Cell — **∅ RISC-V** in libpfm4/PAPI/LIKWID (kernel-only)       |
+| OS reach        | Linux `perf_events` **only** — no Windows or macOS naming layer anywhere in the field                                               |
+| Verification    | `[hw-verified: x86_64-linux]` (probe E1/E2) + `[source-verified]` (five pinned repos)                                               |
+| Last reviewed   | July 11, 2026                                                                                                                       |
+
+> [!NOTE]
+> **Verification bed.** The live round trip (E1/E2 below) was run on `x86_64-linux`:
+> kernel **6.18.26**, AMD **Ryzen 9 7940HX** (Zen 4, family 25 / model `0x61`),
+> `perf_event_paranoid = -1`, **libpfm 4.13.0** (nixpkgs), LDC 1.41. Every ISA/OS
+> coverage claim for ARM, POWER, and RISC-V is `[source-verified]` reading of the
+> pinned tables — there is no non-x86 hardware, and (as this page shows) no
+> non-Linux naming layer to verify against in the first place.
+
+---
+
+## Overview
+
+### What it solves
+
+`perf_event_open` takes a `perf_event_attr` whose `type`/`config` fields _are_ the
+hardware programming value — for a raw x86 core event, `config` is literally the
+`PERFEVTSEL` bytes (`event | umask<<8 | …`). Nobody wants to hand-assemble those.
+The naming layer owns per-microarchitecture tables that translate a symbolic
+string into those bits, and libpfm4 is the one most of the ecosystem shares. Its
+own manual states the contract ([`pfm_get_os_event_encoding.3`][man-encode]):
+
+> _"This is the key function to retrieve the encoding of an event for a specific
+> operating system interface. … The event string, `str`, may contains sub-event
+> masks (umask) and any other supported modifiers."_
+
+Two things are load-bearing in that sentence. First, "for a specific operating
+system interface" — libpfm4 does not just emit raw MSR bits, it emits them
+_shaped for an OS's counter ABI_ (on Linux, `perf_events`). Second, the event
+string is a small grammar (`event:umask:modifier`), not just a name.
+
+### The field: one engine, several alternates
+
+| Layer                   | Names from                                    | Encodes to                      | Derived metrics            | MSR-direct? | Uses libpfm4?      |
+| ----------------------- | --------------------------------------------- | ------------------------------- | -------------------------- | ----------- | ------------------ |
+| **libpfm4**             | own per-µarch tables (`lib/events/`)          | `perf_event_attr` (or raw PMU)  | no                         | no          | —                  |
+| **PAPI**                | `papi_events.csv` presets → native names      | via **vendored** libpfm4        | yes (`DERIVED_*` RPN)      | no          | **yes** (vendored) |
+| **LIKWID**              | own `perfmon_*_events.txt`                    | `perf_event` **or** raw MSR/PCI | yes (`groups/*` formulas)  | **yes**     | **no**             |
+| **`intel/perfmon`**     | Intel JSON (`EventCode`/`UMask`)              | data only → perf JSON / VTune   | yes (TMA metrics)          | n/a         | no                 |
+| **kernel `pmu-events`** | in-tree JSON (`amdzen4/`, `arm64/`, `riscv/`) | perf-tool `//` event syntax     | `recommended.json` metrics | no          | no                 |
+
+libpfm4 is the hub: `perf` and PAPI both route encoding through it, and it is the
+only layer that turns a bare name into a filled `perf_event_attr` with a single
+C call. The others are either **independent** re-implementations (LIKWID) or
+**data-only** catalogs (`intel/perfmon`, kernel `pmu-events`) that a tool must
+compile itself. The rest of this page walks libpfm4 first (because everything
+compares against it), then each alternate, then the two coverage boundaries.
+
+---
+
+## libpfm4: the name→encoding pipeline
+
+### The entry point and its ABI-checked argument
+
+The perf encoding call is one function ([`pfmlib.h`][pfmlib-h], `:1050`):
+
+```c
+int pfm_get_os_event_encoding(const char *str, int dfl_plm,
+                              pfm_os_t os, void *args);
+```
+
+With `os == PFM_OS_PERF_EVENT`, `args` is a `pfm_perf_encode_arg_t` whose `attr`
+field points at a caller-supplied `perf_event_attr` — libpfm fills it in place
+([`pfmlib_perf_event.h`][pfm-perf-event-h], `:37-45`):
+
+```c
+typedef struct {
+    struct perf_event_attr *attr;  /* in/out: perf_event struct pointer */
+    char **fstr;                   /* out/in: fully qualified event string */
+    size_t size;                   /* sizeof struct */
+    int idx, cpu, flags, pad0;
+} pfm_perf_encode_arg_t;
+```
+
+`[source-verified]` The `size` field is **ABI-checked** against `PFM_PERF_ENCODE_ABI0`
+= **40** on LP64 (pointer, pointer, `size_t`, four `int`s including the explicit 4-byte
+`pad0`); a binding with the wrong layout — classically a missing trailing pad — fails
+the call. The [probe][probe] declares the D struct as exactly 40 bytes for this reason.
+
+### PMU detection is CPUID-based
+
+libpfm does not read `/proc/cpuinfo` to decide which table applies. `pfm_amd64_detect`
+runs `cpuid(0)` for the `"AuthenticAMD"` vendor string and `cpuid(1)` for
+family/model/stepping (extended family folded in when base family `== 0xf`), then
+`amd64_get_revision` maps family/model onto a `PFM_PMU_*` revision; each family
+PMU's `pfm_amd64_family_detect` activates only when `revision == pmu->cpu_family`.
+`[source-verified]` [`pfmlib_amd64.c`][amd64-c] `:322-367`. In git HEAD the family-25
+branch is:
+
+```c
+} else if (cfg->family == 25) { /* family 19h */
+    if ((cfg->model >= 0x60) || (cfg->model >= 0x10 && cfg->model <= 0x1f))
+        rev = PFM_PMU_AMD64_FAM19H_ZEN4;   /* covers model 0x61 */
+    else
+        rev = PFM_PMU_AMD64_FAM19H_ZEN3;
+```
+
+`[source-verified]` [`pfmlib_amd64.c:191-196`][amd64-c] — covering this box's model
+`0x61`. (Released **4.13.0** does _not_; that is [the auto-detect hazard](#the-auto-detect-hazard).)
+
+### The `event:umask:modifier` grammar
+
+The event string is split on `PFMLIB_ATTR_DELIM`, defined as `":."` — **both** `:`
+and `.` separate attributes ([`pfmlib_priv.h:36`][pfmlib-priv-h]). After the event
+name come unit masks (`umask`) and modifiers. The AMD modifier set (`amd64_mods`,
+[`pfmlib_amd64.c:37-44`][amd64-c]) is:
+
+| Modifier | Meaning                                  | Lands in          |
+| -------- | ---------------------------------------- | ----------------- |
+| `k`      | monitor at privilege level 0 (kernel)    | `exclude_kernel`  |
+| `u`      | monitor at privilege levels 1/2/3 (user) | `exclude_user`    |
+| `e`      | edge                                     | `config` MSR bits |
+| `i`      | invert                                   | `config` MSR bits |
+| `c=N`    | counter-mask, range `[0-255]`            | `config` MSR bits |
+| `h`      | monitor in hypervisor                    | `exclude_hv`      |
+| `g`      | measure in guest                         | `exclude_guest`   |
+
+The `e`/`i`/`c` modifiers stay in the raw `config`; `k`/`u`/`h`/`g` are lifted out
+of it — [the OS-layer split](#the-os-layer-split) below.
+
+### RAW vs HARDWARE encoding
+
+Two encoding targets fall out of the naming layers:
+
+- A **generic** name (`PERF_COUNT_HW_CPU_CYCLES`) resolves through the always-present
+  software `perf` PMU to `type = PERF_TYPE_HARDWARE` (`0`), `config = 0` — the
+  OS-abstracted event, portable across vendors, no per-µarch table needed.
+- A **µarch-specific** name (`RETIRED_INSTRUCTIONS` from the `amd64_fam19h_zen4`
+  table) resolves to `type = PERF_TYPE_RAW` (`4`), `config = 0xc0` — the raw AMD
+  PMC event-select, which is exactly the table entry's `.code` field
+  (`RETIRED_INSTRUCTIONS`, `.code = 0xc0`, [`amd64_events_fam19h_zen4.h:1603-1606`][amd64-events-h]).
+
+`pfm_amd64_get_perf_encoding` sets `attr->type = PERF_TYPE_RAW` by default and only
+reads a dynamic sysfs type (via `find_pmu_type_by_name`) when the PMU carries a
+`perf_name` — the case for the IBS PMUs. `[source-verified]`
+[`pfmlib_amd64_perf_event.c:59-116`][amd64-perf-c].
+
+---
+
+## The OS-layer split
+
+The reason `PFM_OS_PERF_EVENT` exists — rather than just `PFM_OS_NONE`, which emits
+raw PMU bits — is that perf*events owns some of the config bits itself, through
+`attr.exclude*\*`rather than the MSR. After computing the raw encoding,`pfm_amd64_get_perf_encoding`**zeroes** the`EN`/`INT`/`OS`/`USR`/`GUEST`/`HOST`selector bits of`config` ([`pfmlib_amd64_perf_event.c:98-114`][amd64-perf-c]):
+
+> _"suppress the bits which are under the control of perf_events / they will be
+> ignore by the perf tool and the kernel interface / the OS/USR bits are controlled
+> by the attr.exclude_\* fields / the EN/INT bits are controlled by the kernel"\_
+
+So a `:u` modifier does **not** change `config`; it flips `attr.exclude_kernel`.
+That is the whole point of naming to an _OS interface_ instead of raw silicon, and
+the [probe][probe] shows it live — same `config = 0xc0`, `exclude_kernel` moving
+`0 → 1`:
+
+```text
+libpfm interface version 4.0 (release: see nixpkgs libpfm)
+
+== generic perf name (PERF_TYPE_HARDWARE) ==
+  generic       PERF_COUNT_HW_CPU_CYCLES
+        type=0 config=0x0  exclude_user=0 exclude_kernel=0
+        fstr=perf::PERF_COUNT_HW_CPU_CYCLES:u=1:k=1:h=0:mg=0:mh=1
+        count over workload window: 45369527
+
+== µarch-specific names via the amd64_fam19h_zen4 table (PERF_TYPE_RAW) ==
+  zen4-native   amd64_fam19h_zen4::RETIRED_INSTRUCTIONS
+        type=4 config=0xc0  exclude_user=0 exclude_kernel=0
+        fstr=amd64_fam19h_zen4::RETIRED_INSTRUCTIONS:e=0:i=0:c=0:g=0:u=1:k=1:h=0:mg=0:mh=1
+        count over workload window: 75120278
+  with-umask    amd64_fam19h_zen4::RETIRED_SSE_AVX_FLOPS:ADD_SUB_FLOPS
+        type=4 config=0x103  exclude_user=0 exclude_kernel=0
+        fstr=…RETIRED_SSE_AVX_FLOPS:ADD_SUB_FLOPS:e=0:i=0:c=0:g=0:u=1:k=1:h=0:mg=0:mh=1
+        count over workload window: 3000001
+  with-modifier amd64_fam19h_zen4::RETIRED_INSTRUCTIONS:u
+        type=4 config=0xc0  exclude_user=0 exclude_kernel=1
+        fstr=…RETIRED_INSTRUCTIONS:e=0:i=0:c=0:g=0:u=1:k=0:h=0:mg=0:mh=1
+        count over workload window: 75000087
+```
+
+`[hw-verified: x86_64-linux]` Three things are self-verifying in that output. The
+generic name lands `type=0`; the native name lands `type=4 config=0xc0` (the table
+`.code`); the `:ADD_SUB_FLOPS` umask lands in `config[15:8]` → `0x103`; and its
+count — **3,000,001** — matches the probe's 3,000,000-iteration FP-add loop exactly,
+proving the encoding is live, not merely plausible. The `:u` case is the OS-layer
+split caught in the act.
+
+### There is no non-Linux OS layer
+
+`pfm_os_t` has exactly three values ([`pfmlib.h:901-905`][pfmlib-h]):
+
+```c
+typedef enum {
+    PFM_OS_NONE = 0,       /* only PMU */
+    PFM_OS_PERF_EVENT,     /* perf_events PMU attribute subset + PMU */
+    PFM_OS_PERF_EVENT_EXT, /* perf_events all attributes + PMU */
+    PFM_OS_MAX,
+} pfm_os_t;
+```
+
+`[source-verified]` `PFM_OS_NONE` is raw PMU bits; the other two are both
+**perf_events**, differing only in how many `perf_event_attr` fields they populate
+(`_EXT` adds the perf-only attributes — sampling `period`, `precise_ip`, etc.).
+There is no `PFM_OS_WINDOWS`, no `PFM_OS_DARWIN`, no anything else. The entire OS
+abstraction in libpfm4 _is_ Linux perf_events — the first half of why [no naming
+layer spans OSes](#coverage-boundaries).
+
+---
+
+## PAPI: presets over a vendored libpfm4
+
+PAPI does not re-implement encoding: it **vendors an in-tree copy** of libpfm4 at
+`src/libpfm4` (a plain directory, not a submodule) and calls it — the perf_event
+component invokes `pfm_get_os_event_encoding(name, …, PFM_OS_PERF_EVENT_EXT, …)`
+for the actual bits. `[source-verified]` [`papi@ec16e00f`][papi-bridge]
+`src/components/perf_event/pe_libpfm4_events.c:199-201`.
+
+What PAPI adds on top is a **preset** layer. `src/papi_events.csv` holds 179
+`CPU,<libpfm-pmu>` sections (keyed by libpfm4 PMU name — `amd64_k7`,
+`amd64_fam19h_zen4`, `arm_ac76`, …), each mapping a portable `PAPI_*` name onto
+native events plus optional arithmetic ([`papi_events.csv`][papi-csv]):
+
+```text
+CPU,amd64_fam19h_zen4
+PRESET,PAPI_TOT_INS,NOT_DERIVED,RETIRED_INSTRUCTIONS
+PRESET,PAPI_FP_OPS,DERIVED_SUB,RETIRED_MMX_AND_FP_INSTRUCTIONS:…,DISPATCHED_FPU:OPS_STORE
+```
+
+`[source-verified]` The derivations (`DERIVED_ADD`/`DERIVED_SUB`/`DERIVED_POSTFIX`,
+the last an RPN expression) make a preset a per-µarch _arithmetic combination_ of
+native events, not just an alias.
+
+> [!NOTE]
+> **Refuted hypothesis.** A prior guess held that PAPI's presets are unmapped on
+> modern microarchitectures. They are **not**: `papi_events.csv` carries explicit
+> `CPU,amd64_fam19h_zen4` **and** `CPU,amd64_fam1ah_zen5` sections (`:514-515`).
+> PAPI's boundary is the one it inherits from libpfm4 — `arm_*` sections but **no
+> RISC-V and no Apple** — a refuted prompt hypothesis, recorded in the survey's
+> internal QA ledger.
+
+---
+
+## LIKWID: an independent stack with a wider OS reach
+
+LIKWID is fully independent of libpfm4 (`grep -ril libpfm src/` → **empty**). It
+ships its own hand-maintained event lists (`src/includes/perfmon_zen4_events.txt`,
+authored "Thomas Gruber (tr)"), its own per-arch counter maps, and its own
+derived-metric groups. `[source-verified]` [`likwid@f23c6663`][likwid-events].
+
+Two things distinguish it from the libpfm4/PAPI stack:
+
+**A three-way access split.** LIKWID can reach counters three ways
+([`likwid.h:297-301`][likwid-h], [`access.c`][likwid-access]):
+
+| `ACCESSMODE` | Value | Path                    | Reaches                          |
+| ------------ | ----- | ----------------------- | -------------------------------- |
+| `PERF`       | `-1`  | `perf_event_open`       | core PMUs, unprivileged          |
+| `DIRECT`     | `0`   | raw MSR / PCI           | + uncore, frequency (root)       |
+| `DAEMON`     | `1`   | setuid `likwid-accessD` | + uncore via a privileged broker |
+
+The direct/daemon modes reach uncore and frequency that the perf naming path
+cannot — the source is explicit: _"Cannot manipulate Uncore frequency with
+ACCESSMODE=perf_event"_ ([`frequency_uncore.c:191`][likwid-access]). This is the
+[MSR-direct][c-uncore] alternative to going through `perf_event_attr` at all.
+
+**Performance groups.** A LIKWID group bundles an `EVENTSET` (named events → counter
+slots), a `METRICS` block (formulas over those slots), and a `LONG` prose
+description — e.g. [`groups/zen4/CPI.txt`][likwid-cpi]:
+
+```text
+EVENTSET
+PMC0  RETIRED_INSTRUCTIONS
+PMC1  CPU_CLOCKS_UNHALTED
+METRICS
+CPI PMC1/PMC0
+IPC PMC0/PMC1
+```
+
+Crucially, **LIKWID out-covers libpfm4 on the OS/vendor axis**: it is the only
+surveyed layer shipping an **Apple M1** event table (`perfmon_applem1_events.txt`),
+alongside **Graviton3** and **A64FX** (`perfmon_graviton3_events.txt`,
+`perfmon_a64fx_events.txt`) — and AMD L3/uncore events inside its Zen 4 list.
+`[source-verified]` [`src/includes/perfmon_*`][likwid-apple]. But the Apple M1 table
+is a LIKWID-internal event list, **not** a macOS OS API — it still narrows to the
+[macOS `kpep`][macos] database at acquisition time.
+
+---
+
+## `intel/perfmon` and the kernel's tables: data, not engines
+
+Intel publishes its event catalog as JSON in the public [`intel/perfmon`][perfmon-repo]
+repo. Each event carries `EventCode`, `UMask`, `EventName`, `BriefDescription`,
+`Counter`, `PublicDescription`, `PEBS`, `Deprecated` (uncore events add `Unit`,
+`PortMask`, `FCMask`, `UMaskExt`, `Filter`); files are keyed to silicon by
+`mapfile.csv` (`GenuineIntel-6-XX` → `Filename`, `EventType`, `Core Type`).
+`[source-verified]` [`intel-perfmon@683a4d0b`][perfmon-mapfile] `mapfile.csv`,
+[`SKX/events/*.json`][perfmon-skx]. Separately it ships **TMA metric** JSONs
+(`ICX/metrics/icelakex_metrics.json` — 282 metrics with `MetricName`, TMA `Level`,
+`Events[]`, `Formula`) plus a `metrics/perf/` variant already in perf-tool syntax.
+`[source-verified]` [`ICX/metrics/…`][perfmon-metrics].
+
+The provenance is the surprising part. `intel/perfmon` is not just a reference — its
+own `scripts/create_perf_json.py` (© Intel + Google) is documented to emit, verbatim:
+
+> _"OUTPUT: A perf json directory suitable for the tools/perf folder."_
+
+`[source-verified]` [`scripts/create_perf_json.py:12`][perfmon-genjson]. Intel
+**self-generates** the kernel's Intel `pmu-events` from this repo; it is the
+machine-readable upstream of what perf ships.
+
+---
+
+## The vendor-table asymmetry
+
+AMD has **no public analogue** of `intel/perfmon`. `ls intel-perfmon | grep -i amd`
+is empty and every `mapfile.csv` key is `GenuineIntel-*`. The AMD event tables live
+_only_ in the kernel tree, contributed directly by AMD:
+
+`tools/perf/pmu-events/arch/x86/amdzen4/{branch,cache,core,data-fabric,floating-point,memory,memory-controller,other,pipeline,recommended}.json`,
+keyed `AuthenticAMD-25-[[:xdigit:]]+,v1,amdzen4,core`, and authored by
+`Sandipan Das <sandipan.das@amd.com>` ("perf vendor events amd: Add Zen 4 core
+events"). `recommended.json` even carries perf-syntax metrics —
+`branch_misprediction_ratio` with `MetricExpr = d_ratio(ex_ret_brn_misp, ex_ret_brn)`.
+`[source-verified]` [`linux@e43ffb69e043`][amdzen4] `mapfile.csv`, `amdzen4/`,
+`git log`.
+
+So the provenance is asymmetric — Intel maintains a public generator, AMD pushes
+JSON straight into the kernel — and so are the **name spaces**. The same 0xc0
+event-select is `RETIRED_INSTRUCTIONS` in libpfm4 but `ex_ret_instr` in the kernel's
+`amdzen4/core.json` ([`core.json:34-36`][amdzen4-core]). There is **no single
+canonical AMD event vocabulary**; a backend that wants to accept both must carry a
+cross-walk.
+
+---
+
+## Coverage boundaries
+
+Two axes bound every layer: which **ISA** it has tables for, and which **OS** it can
+target. Cells give the covering table, `∅` for none, or a qualifier.
+
+| Layer                   | x86            | ARM                                 | POWER       | RISC-V                      | Windows                       | macOS |
+| ----------------------- | -------------- | ----------------------------------- | ----------- | --------------------------- | ----------------------------- | ----- |
+| **libpfm4**             | AMD + Intel    | armv6–v9, Cortex, uncore            | 4–10        | **∅**                       | ∅                             | ∅     |
+| **PAPI**                | via libpfm4    | via libpfm4                         | via libpfm4 | **∅**                       | ∅                             | ∅     |
+| **LIKWID**              | own + uncore   | A57, **Apple M1**, Graviton3, A64FX | ∅           | **∅**                       | ∅ (M1 table is not an OS API) | ∅     |
+| **`intel/perfmon`**     | **Intel only** | ∅                                   | ∅           | ∅                           | (data feeds VTune)            | ∅     |
+| **kernel `pmu-events`** | AMD + Intel    | arm64 (per-vendor)                  | powerpc     | **sifive, thead, andes, …** | ∅                             | ∅     |
+
+`[source-verified]` Two findings stand out. libpfm4/PAPI/LIKWID/`intel-perfmon`
+carry **zero** RISC-V tables — libpfm4 has no `lib/events/*riscv*` and no
+`lib/pfmlib_*riscv*` at all — yet the kernel `pmu-events` tree _does_
+(`arch/riscv/{sifive,thead,andes,openhwgroup,starfive}/`), the one surveyed layer
+with any RISC-V naming (see [riscv][riscv]). And **nothing spans operating systems**:
+every layer above targets Linux `perf_events` or is OS-agnostic _data_ that a Linux
+tool consumes.
+
+The two non-Linux OSes are covered by their own deep-dives, and neither offers a
+name→encoding layer resembling libpfm4:
+
+- **Windows** — the only curated name set is the small architected list behind
+  `EnableThreadProfiling`/`ReadThreadProfilingData`; arbitrary events go through raw
+  `ProfileSource` IDs or vendor drivers (VTune SEP, AMD uProf) with private tables.
+  This is [capability curation][c-curation], not open naming → [windows][windows].
+- **macOS** — naming is Apple's `kpep` `.plist` database consumed by `kpc`/Instruments;
+  M-series remap onto PMUv3-style numbers. LIKWID's `applem1` table is the closest
+  portable Apple name set, but it is LIKWID-internal, not an OS API → [macos][macos].
+
+**Implication for the sparkles backend:** it must own its event-name vocabulary. No
+existing layer spans Linux + Windows + macOS, so a portable harness cannot delegate
+naming to one library the way it can delegate Linux _acquisition_ to `perf_event_open`.
+
+---
+
+## The auto-detect hazard
+
+> [!WARNING]
+> **A shipped libpfm can be too old for the silicon in the machine.** Stock
+> **libpfm 4.13.0** (the current nixpkgs build) **fails to auto-detect** this Ryzen 9
+> 7940HX's core PMU. Its released family-25 detect maps only decimal-17 (`model == 0x11`)
+> to Zen 4 (`if (model <= 0x0f || (model >= 0x20 && model <= 0x5f)) ZEN3; else if
+(model == 17) ZEN4;`), so model `0x61` matches nothing, `revision` stays
+> `PFM_PMU_NONE`, and a bare `pfm_get_os_event_encoding("RETIRED_INSTRUCTIONS", …)`
+> returns `PFM_ERR_NOTFOUND (-4)`. Only the software `perf`/`perf_raw` PMUs activate.
+> `[hw-verified: x86_64-linux]` (probe E2) + `[source-verified]` (nixpkgs 4.13.0 src).
+> **git HEAD fixes it** (`model >= 0x60`, [`pfmlib_amd64.c:191-196`][amd64-c]).
+
+The table is _compiled in_ — `strings libpfm.so.4.13.0 | grep amd64_fam19h_zen4`
+shows every symbol present — it is only **inert** because detection never selected it.
+Two workarounds are proven live (E2): `LIBPFM_FORCE_PMU=amd64_fam19h_zen4` (bare
+native names resolve, but generic `cycles`/`instructions` then fail — forcing is
+exclusive), **or** `LIBPFM_ENCODE_INACTIVE=1` plus an explicit `amd64_fam19h_zen4::`
+prefix (which is what the [probe][probe] does). `[hw-verified: x86_64-linux]`.
+
+**Design lesson.** Do not trust libpfm auto-detect on very recent silicon. A robust
+backend derives the correct table name from CPUID itself — exactly what a fixed
+`detect()` would pick — and forces the PMU, or requires a libpfm new enough for the
+part. The probe mirrors the _fixed_ `amd64_get_revision` in D from `/proc/cpuinfo` for
+precisely this reason.
+
+---
+
+## The seven concerns
+
+Naming is concern 7, but it is the connective tissue for the others: every counting
+or sampling request is a _named event_ before it is a `config` value. The
+interactions worth flagging:
+
+| #   | Concern                             | How naming touches it                                                                                                       | Owner                       |
+| --- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| 1   | [Scalar counting][c-counting]       | Naming produces the `config` counting reads; the [OS-layer split](#the-os-layer-split) routes `u`/`k` into `exclude_*`      | [linux][linux] · this page  |
+| 2   | Overflow / IP sampling              | Same name→`config`; sampling-only attrs (`period`, `precise_ip`) are added at `PFM_OS_PERF_EVENT_EXT`, not in the name      | [linux][linux]              |
+| 3   | [Precise data-source][c-datasrc]    | **"No precise mode on AMD"**: libpfm compacts the `precise` attr out for AMD; IBS is modeled as flagged events, no selector | [precise-sampling][precise] |
+| 4   | Code-space decode                   | Orthogonal — naming stops at the encoding; symbolization is downstream                                                      | [elfutils][linux]           |
+| 5   | Event-space & tracing               | Tracepoints/branch records are named through perf's own schemas, not libpfm4                                                | [linux][linux]              |
+| 6   | [NUMA & topology][c-uncore]         | Uncore event names diverge per layer; LIKWID's `ACCESSMODE_DIRECT` reaches uncore the perf naming path cannot               | [arm][arm] · this page      |
+| 7   | [Event naming & encoding][c-naming] | **This page** — five layers, two boundaries (∅ RISC-V but kernel; ∅ non-Linux)                                              | this page                   |
+
+On concern 3, the naming layer is where the vendors' precise engines show their
+seams. libpfm's perf validator **compacts the `precise` (`PERF_ATTR_PR`) attribute
+out for AMD** — the source comment reads _"No precise mode on AMD"_
+([`pfmlib_amd64_perf_event.c:144`][amd64-perf-c]) — and models **IBS** instead as
+ordinary events flagged `AMD64_FL_IBSFE`/`AMD64_FL_IBSOP`, whose encoding merely sets
+`reg.ibsfetch.en` / `reg.ibsop.en` with **no per-event selector**
+([`pfmlib_amd64.c:76-84,452-455`][amd64-c]). On Intel, by contrast, PEBS is surfaced
+as a first-class **`PEBS` field in the `intel/perfmon` JSON**, not as a name modifier.
+Same concept, three different naming representations — the reason the
+[precise-sampling][precise] page owns the cross-vendor semantics.
+
+---
+
+## Strengths
+
+- **One call, one filled `perf_event_attr`.** libpfm4 turns a symbolic string into
+  the exact ABI struct `perf_event_open` consumes — no hand-assembled `config`.
+- **The OS-layer split is principled.** Privilege/hypervisor/guest filtering lives in
+  `attr.exclude_*`, not the raw MSR, so a name is portable across the same event's
+  different privilege framings.
+- **Mature, wide ISA coverage.** x86 (AMD + Intel), ARMv6–v9, POWER4–10, SPARC,
+  s390x, MIPS, Itanium, Cell — the broadest single table set in the field.
+- **PAPI adds portable presets with arithmetic** (`DERIVED_*`), and its modern-AMD
+  presets are present, not stale.
+- **LIKWID reaches where perf can't** — raw MSR/PCI for uncore and frequency, plus the
+  only Apple-Silicon / Graviton3 / A64FX tables in the survey.
+- **Vendor catalogs are machine-readable and (Intel) self-generating** — `intel/perfmon`
+  emits the kernel's own perf JSON.
+
+## Weaknesses
+
+- **Zero RISC-V** in libpfm4/PAPI/LIKWID/`intel-perfmon`; only the kernel `pmu-events`
+  tree has (nascent, per-vendor) RISC-V event JSON.
+- **No non-Linux OS layer anywhere.** `pfm_os_t` is Linux perf_events only; Windows and
+  macOS have curated/private naming, not an open libpfm-style engine.
+- **Auto-detect lags new silicon** — a shipped libpfm (4.13.0) misses a family-25/model-`0x61`
+  Zen 4; the naming layer's usefulness is gated on the library being new enough.
+- **No single AMD name space** — `RETIRED_INSTRUCTIONS` (libpfm) vs `ex_ret_instr`
+  (kernel) for the same 0xc0; a consumer must cross-walk.
+- **AMD provenance is kernel-only** — no public `intel/perfmon` analogue, so AMD names
+  are harder to consume outside the kernel tree.
+- **Precise sampling is unevenly named** — AMD has no `precise` attribute (IBS is a
+  flagged event with no selector); Intel PEBS is a JSON flag; the abstraction leaks.
+
+## Key design decisions and trade-offs
+
+| Decision                                                         | Rationale                                                               | Trade-off                                                                          |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Reuse libpfm4 for Linux x86/ARM naming                           | Mature, matches `perf`, one call fills `perf_event_attr`                | ∅ RISC-V / Windows / macOS; auto-detect lag on new silicon                         |
+| Encode to `PFM_OS_PERF_EVENT` (not raw `PFM_OS_NONE`)            | Privilege/HV/guest filters land in `attr.exclude_*`, kernel owns EN/INT | Ties the encoding to Linux perf_events — no other OS layer exists                  |
+| Force the PMU from CPUID, don't trust auto-detect                | Survives a libpfm too old for the part (the 4.13.0 / model-`0x61` gap)  | Backend must carry its own family/model → table map, kept in sync with libpfm HEAD |
+| Own a cross-OS event vocabulary in the backend                   | No layer spans Linux + Windows + macOS; naming can't be delegated       | Must maintain name↔`{type,config}` walks per ISA/OS, and an AMD libpfm↔kernel walk |
+| Keep LIKWID/`intel-perfmon` as data references, not runtime deps | Avoids a second encoding engine; harvest their tables/metrics offline   | Manual harvest; TMA/derived-metric formulas must be re-expressed for the harness   |
+
+---
+
+## Sources
+
+- [`pfm_get_os_event_encoding.3`][man-encode] — the encoding call's contract (the
+  Overview quote).
+- [`include/perfmon/pfmlib.h`][pfmlib-h] — `pfm_get_os_event_encoding` signature,
+  `pfm_os_t` enum (no non-Linux OS layer).
+- [`include/perfmon/pfmlib_perf_event.h`][pfm-perf-event-h] — `pfm_perf_encode_arg_t`
+  (40-byte LP64 ABI).
+- [`lib/pfmlib_amd64.c`][amd64-c] — CPUID detection, the family-25 branch (HEAD fix),
+  the modifier set, IBS-as-flagged-events.
+- [`lib/pfmlib_amd64_perf_event.c`][amd64-perf-c] — RAW default, the bit-suppression
+  quote (OS-layer split), "No precise mode on AMD".
+- [`lib/pfmlib_priv.h`][pfmlib-priv-h] — `PFMLIB_ATTR_DELIM ":."` grammar delimiter.
+- [`lib/events/amd64_events_fam19h_zen4.h`][amd64-events-h] — `RETIRED_INSTRUCTIONS`
+  `.code = 0xc0`.
+- [PAPI `papi_events.csv`][papi-csv] · [`pe_libpfm4_events.c`][papi-bridge] — preset CSV
+  (zen4/zen5 sections) + the vendored-libpfm4 bridge.
+- [LIKWID `perfmon_zen4_events.txt`][likwid-events] · [`likwid.h`][likwid-h] ·
+  [`access.c`/`frequency_uncore.c`][likwid-access] · [`groups/zen4/CPI.txt`][likwid-cpi] ·
+  [`perfmon_applem1_events.txt` (+graviton3/a64fx)][likwid-apple] — independent stack,
+  ACCESSMODE split, groups, Apple/ARM tables.
+- [`intel/perfmon` `mapfile.csv`][perfmon-mapfile] · [`SKX/events/*.json`][perfmon-skx] ·
+  [`ICX/metrics/…`][perfmon-metrics] · [`scripts/create_perf_json.py`][perfmon-genjson]
+  — Intel JSON schema, TMA metrics, the self-generation provenance quote.
+- [kernel `amdzen4/`][amdzen4] · [`amdzen4/core.json`][amdzen4-core] ·
+  [`recommended.json`][amdzen4-recommended] — AMD's kernel-only tables (`ex_ret_instr`,
+  `branch_misprediction_ratio`).
+- The [`pfm4-name-roundtrip.d`][probe] probe — the E1/E2 evidence on this box.
+
+> [!NOTE]
+> **The runnable CI example for this page is [`pfm4-name-roundtrip.d`][probe]** — it
+> encodes the four names above, opens each on this thread, and counts a fixed workload,
+> `SKIP:`-ing cleanly on any host without libpfm or with `perf_event_paranoid` too high.
+> Its self-verifying case (the `0x103` umask counting exactly 3,000,001) is the primary
+> evidence the encodings are live. libpfm4 was cloned from the canonical
+> `git.code.sf.net` perfmon2 repository; the SourceForge links below resolve to the
+> pinned `6870a9f` commit.
+
+<!-- References -->
+
+[c-counting]: ./concepts.md#counting
+[c-datasrc]: ./concepts.md#data-source-attribution
+[c-uncore]: ./concepts.md#uncore-pmu
+[c-naming]: ./concepts.md#event-naming-and-encoding
+[c-curation]: ./concepts.md#capability-curation
+[linux]: ./linux-perf-events.md
+[precise]: ./precise-sampling.md
+[arm]: ./arm.md
+[riscv]: ./riscv.md
+[windows]: ./windows.md
+[macos]: ./macos.md
+[probe]: ./examples/pfm4-name-roundtrip.d
+[pfmlib-h]: https://sourceforge.net/p/perfmon2/libpfm4/ci/6870a9f00412/tree/include/perfmon/pfmlib.h
+[pfm-perf-event-h]: https://sourceforge.net/p/perfmon2/libpfm4/ci/6870a9f00412/tree/include/perfmon/pfmlib_perf_event.h
+[amd64-c]: https://sourceforge.net/p/perfmon2/libpfm4/ci/6870a9f00412/tree/lib/pfmlib_amd64.c
+[amd64-perf-c]: https://sourceforge.net/p/perfmon2/libpfm4/ci/6870a9f00412/tree/lib/pfmlib_amd64_perf_event.c
+[pfmlib-priv-h]: https://sourceforge.net/p/perfmon2/libpfm4/ci/6870a9f00412/tree/lib/pfmlib_priv.h
+[amd64-events-h]: https://sourceforge.net/p/perfmon2/libpfm4/ci/6870a9f00412/tree/lib/events/amd64_events_fam19h_zen4.h
+[man-encode]: https://sourceforge.net/p/perfmon2/libpfm4/ci/6870a9f00412/tree/docs/man3/pfm_get_os_event_encoding.3
+[papi-repo]: https://github.com/icl-utk-edu/papi
+[papi-csv]: https://github.com/icl-utk-edu/papi/blob/ec16e00f/src/papi_events.csv
+[papi-bridge]: https://github.com/icl-utk-edu/papi/blob/ec16e00f/src/components/perf_event/pe_libpfm4_events.c
+[likwid-repo]: https://github.com/RRZE-HPC/likwid
+[likwid-events]: https://github.com/RRZE-HPC/likwid/blob/f23c6663/src/includes/perfmon_zen4_events.txt
+[likwid-h]: https://github.com/RRZE-HPC/likwid/blob/f23c6663/src/includes/likwid.h
+[likwid-access]: https://github.com/RRZE-HPC/likwid/blob/f23c6663/src/access.c
+[likwid-cpi]: https://github.com/RRZE-HPC/likwid/blob/f23c6663/groups/zen4/CPI.txt
+[likwid-apple]: https://github.com/RRZE-HPC/likwid/blob/f23c6663/src/includes/perfmon_applem1_events.txt
+[perfmon-repo]: https://github.com/intel/perfmon
+[perfmon-mapfile]: https://github.com/intel/perfmon/blob/683a4d0b/mapfile.csv
+[perfmon-skx]: https://github.com/intel/perfmon/tree/683a4d0b/SKX/events
+[perfmon-metrics]: https://github.com/intel/perfmon/blob/683a4d0b/ICX/metrics/icelakex_metrics.json
+[perfmon-genjson]: https://github.com/intel/perfmon/blob/683a4d0b/scripts/create_perf_json.py
+[amdzen4]: https://github.com/torvalds/linux/tree/e43ffb69e043/tools/perf/pmu-events/arch/x86/amdzen4
+[amdzen4-core]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/pmu-events/arch/x86/amdzen4/core.json
+[amdzen4-recommended]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/pmu-events/arch/x86/amdzen4/recommended.json

--- a/docs/research/cpu-pmu/examples/counting-group.d
+++ b/docs/research/cpu-pmu/examples/counting-group.d
@@ -1,0 +1,222 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "cpu_pmu_counting_group"
+    platforms "linux"
+    targetPath "build"
++/
+/**
+ * Grouped scalar counting via `perf_event_open(2)` and PMC multiplexing, pure D.
+ *
+ * Two demonstrations of the Linux *counting* path, both over druntime's
+ * `core.sys.linux.perf_event` (the attr layout + syscall wrapper) — no C shim:
+ *
+ *   1. A `PERF_FORMAT_GROUP` group — a `cycles` leader plus `instructions` —
+ *      read in one `read(2)` as `{nr, time_enabled, time_running, value[nr]}`.
+ *      The two values give IPC. Because the events share one group the kernel
+ *      schedules them as a unit, so `time_running == time_enabled` and the
+ *      counts are exact (`scale == 1.0`).
+ *   2. Deliberate oversubscription: N independent single-event groups (N greater
+ *      than the PMU's general-purpose counters — 6 on Zen 4) opened over one
+ *      workload window so the kernel round-robin-*multiplexes* them. Each event
+ *      then reports `time_running < time_enabled`; perf recovers an estimate by
+ *      scaling `raw * time_enabled / time_running`. This is the accuracy cost
+ *      the grouped path in (1) is designed to avoid.
+ *
+ * Companion to docs/research/cpu-pmu/linux-perf-events.md
+ *   § "Scalar counting: groups, `PERF_FORMAT_GROUP`, and multiplexing".
+ *
+ * Run with: dub run --single counting-group.d
+ *
+ * Environment recorded: Linux 6.18.26, AMD Ryzen 9 7940HX (Zen 4; 6 core PMCs),
+ * `/proc/sys/kernel/perf_event_paranoid` = -1, LDC 1.41 druntime
+ * `core.sys.linux.perf_event`.
+ *
+ * Portability: any `perf_event_open` failure (`perf_event_paranoid`, seccomp,
+ * no PMU, non-Linux) prints a `SKIP:` line and exits 0 so CI stays green on any
+ * host.
+ */
+module cpu_pmu_counting_group;
+
+version (linux)
+{
+    import core.sys.linux.perf_event;
+    import core.sys.posix.unistd : read, close;
+    import core.sys.posix.sys.ioctl : ioctl;
+    import core.stdc.config : c_ulong;
+    import std.stdio : writefln, writeln;
+
+    /// A hardware event to count, named for the report.
+    struct Ev
+    {
+        string name;
+        ulong config; // a `perf_hw_id`
+    }
+
+    /// Opens one `PERF_TYPE_HARDWARE` event on the calling thread (`pid == 0`),
+    /// any CPU (`cpu == -1`). `groupFd == -1` makes it a group leader; a leader
+    /// carries the read format (`PERF_FORMAT_GROUP` when `grouped`, plus the two
+    /// time fields) and starts `disabled`. Returns the fd, or -1 on failure.
+    int openEvent(ulong config, int groupFd, bool grouped, bool excludeKernel) @trusted
+    {
+        perf_event_attr attr;
+        attr.size = perf_event_attr.sizeof;
+        attr.type = perf_type_id.PERF_TYPE_HARDWARE;
+        attr.config = config;
+        attr.exclude_hv = 1;
+        attr.exclude_kernel = excludeKernel ? 1 : 0;
+        const isLeader = groupFd < 0;
+        attr.disabled = isLeader ? 1 : 0; // enabling the leader enables the group
+        if (isLeader)
+        {
+            attr.read_format = perf_event_read_format.PERF_FORMAT_TOTAL_TIME_ENABLED
+                | perf_event_read_format.PERF_FORMAT_TOTAL_TIME_RUNNING;
+            if (grouped)
+                attr.read_format |= perf_event_read_format.PERF_FORMAT_GROUP;
+        }
+        return cast(int) perf_event_open(&attr, 0, -1, groupFd, 0);
+    }
+
+    void ctl(int fd, uint request, bool wholeGroup) @trusted
+    {
+        ioctl(fd, cast(c_ulong) request,
+            wholeGroup ? perf_event_ioc_flags.PERF_IOC_FLAG_GROUP : 0);
+    }
+
+    long readN(int fd, ulong[] buf) @trusted => read(fd, buf.ptr, buf.length * ulong.sizeof);
+
+    /// A fixed amount of work: multiply-shift-xor mixing, enough retired
+    /// instructions that counter noise is negligible. `__gshared` sink defeats
+    /// dead-code elimination.
+    __gshared ulong sink;
+    void workload()
+    {
+        ulong acc = 0x9E3779B97F4A7C15UL;
+        foreach (i; 0 .. 3_000_000UL)
+            acc = (acc + i) * 2654435761UL ^ (acc >> 13);
+        sink += acc;
+    }
+
+    int run()
+    {
+        // ---- Demo 1: a fitting group → exact IPC, scale == 1 --------------
+        // Probe permission once: prefer kernel+user, fall back to user-only.
+        bool excludeKernel = false;
+        int leader = openEvent(perf_hw_id.PERF_COUNT_HW_CPU_CYCLES, -1, true, false);
+        if (leader < 0)
+        {
+            excludeKernel = true;
+            leader = openEvent(perf_hw_id.PERF_COUNT_HW_CPU_CYCLES, -1, true, true);
+        }
+        if (leader < 0)
+        {
+            writefln("SKIP: perf_event_open failed — perf_event_paranoid too high, "
+                ~ "seccomp, or no PMU on this host");
+            return 0;
+        }
+        const insns = openEvent(perf_hw_id.PERF_COUNT_HW_INSTRUCTIONS, leader, true, excludeKernel);
+        if (insns < 0)
+        {
+            writefln("SKIP: could not add instructions to the group (errno on member open)");
+            close(leader);
+            return 0;
+        }
+
+        ctl(leader, PERF_EVENT_IOC_RESET, true);
+        ctl(leader, PERF_EVENT_IOC_ENABLE, true);
+        workload();
+        ctl(leader, PERF_EVENT_IOC_DISABLE, true);
+
+        // Group read: nr, time_enabled, time_running, value[cycles], value[insns].
+        ulong[5] g;
+        const got = readN(leader, g[]);
+        close(insns);
+        close(leader);
+        if (got < cast(long)(5 * ulong.sizeof))
+        {
+            writefln("SKIP: short group read (%d bytes) — counters unavailable", got);
+            return 0;
+        }
+        const nr = g[0], enabled = g[1], running = g[2], cyc = g[3], ins = g[4];
+        const groupScale = running > 0 ? cast(double) enabled / running : double.nan;
+        writefln("== Demo 1: fitting group (%s) ==", excludeKernel ? "user-only" : "kernel+user");
+        writefln("  nr=%d  time_enabled=%d ns  time_running=%d ns  scale=%.4f",
+            nr, enabled, running, groupScale);
+        writefln("  cycles=%d  instructions=%d  IPC=%.3f", cyc, ins,
+            cyc > 0 ? cast(double) ins / cyc : double.nan);
+        writeln("  (grouped events co-schedule → time_running == time_enabled → exact)");
+
+        // ---- Demo 2: oversubscribe the PMCs → multiplexing scaling --------
+        // N separate single-event groups counting the SAME event over ONE
+        // workload window. With N > general-purpose counters the kernel rotates
+        // them, so each sees only part of the window (running < enabled).
+        enum N = 10;
+        int[N] fds = -1;
+        int opened = 0;
+        foreach (ref fd; fds)
+        {
+            fd = openEvent(perf_hw_id.PERF_COUNT_HW_INSTRUCTIONS, -1, false, excludeKernel);
+            if (fd >= 0)
+                opened++;
+        }
+        if (opened == 0)
+        {
+            writefln("SKIP: oversubscription demo could not open any event");
+            return 0;
+        }
+
+        foreach (fd; fds)
+            if (fd >= 0)
+                ctl(fd, PERF_EVENT_IOC_RESET, false);
+        foreach (fd; fds)
+            if (fd >= 0)
+                ctl(fd, PERF_EVENT_IOC_ENABLE, false);
+        workload();
+        foreach (fd; fds)
+            if (fd >= 0)
+                ctl(fd, PERF_EVENT_IOC_DISABLE, false);
+
+        writefln("\n== Demo 2: %d instruction counters, %d general-purpose PMCs ==", opened, 6);
+        writeln("  ev   raw_running_count      enabled_ns    running_ns   scale   estimate");
+        bool sawMux = false;
+        foreach (i, fd; fds)
+        {
+            if (fd < 0)
+                continue;
+            ulong[3] s; // value, time_enabled, time_running
+            if (readN(fd, s[]) >= cast(long)(3 * ulong.sizeof))
+            {
+                if (s[2] < s[1])
+                    sawMux = true;
+                if (s[2] == 0)
+                    // Enabled but never got a counter this window: the kernel's
+                    // `<not counted>` state — a zero read is not a measurement.
+                    writefln("  %2d   %18d   %12d  %12d       —   <not scheduled>",
+                        i, s[0], s[1], s[2]);
+                else
+                {
+                    const sc = cast(double) s[1] / s[2];
+                    writefln("  %2d   %18d   %12d  %12d   %5.2f   %d",
+                        i, s[0], s[1], s[2], sc, cast(ulong)(s[0] * sc));
+                }
+            }
+            close(fd);
+        }
+        writefln("  multiplexing observed: %s", sawMux ? "yes (time_running < time_enabled — "
+            ~ "raw counts are partial; the scaled estimate recovers the whole-window value)"
+            : "no (this PMU has enough counters to co-schedule all events)");
+        return 0;
+    }
+}
+
+int main()
+{
+    version (linux)
+        return run();
+    else
+    {
+        import std.stdio : writefln;
+
+        writefln("SKIP: perf_event_open is Linux-only");
+        return 0;
+    }
+}

--- a/docs/research/cpu-pmu/examples/mem-latency-numa.d
+++ b/docs/research/cpu-pmu/examples/mem-latency-numa.d
@@ -1,0 +1,535 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "cpu_pmu_mem_latency_numa"
+    platforms "linux"
+    targetPath "build"
++/
+/**
+ * Precise memory-access sampling with data-source + NUMA-node attribution, pure D.
+ *
+ * The *precise data-source* concern of the analysis spine, exercised end to end
+ * on the one engine that implements it on this host — AMD **IBS** (Instruction-
+ * Based Sampling). It:
+ *
+ *   1. Opens the `ibs_op` PMU (its dynamic `type` read from
+ *      `/sys/bus/event_source/devices/ibs_op/type`) with
+ *      `PERF_SAMPLE_IP | ADDR | DATA_SRC | WEIGHT` (+ `PHYS_ADDR` when the host
+ *      permits it), then strides a buffer larger than L3 to provoke DRAM loads.
+ *      The kernel forwards a core-PMU `precise_ip` request to exactly this PMU
+ *      (`forward_event_to_ibs`, `arch/x86/events/amd/ibs.c`); AMD has **no**
+ *      PEBS, so the `cpu` PMU reports `max_precise == 0` and IBS is the *only*
+ *      precise engine — the `cpu`/`precise_ip` fallback below is Intel-only and
+ *      stays unexercised here.
+ *   2. Decodes each sample's `perf_mem_data_src` union (the same bitfields the
+ *      IBS driver fills from `IBS_OP_DATA2`/`DATA3`) into human level/op/snoop/
+ *      TLB strings, matching `tools/perf/util/mem-events.c`.
+ *   3. Classifies each sampled *data* address to a NUMA node two ways —
+ *      `get_mempolicy(MPOL_F_NODE | MPOL_F_ADDR)` and `move_pages()` query mode
+ *      (raw syscalls; see the note on libnuma below) — and compares them against
+ *      the workload buffer's home node. This box is single-node, so every
+ *      address resolves to node 0: the API round-trip is demonstrated, the
+ *      cross-node *classification* is not (recorded as a host limit).
+ *
+ * `get_mempolicy`/`move_pages` are NOT in glibc (they live in libnuma, whose
+ * functions are themselves thin syscall wrappers) and numactl ships no
+ * `numa.pc`, so a `libs "numa"` link would be a hard build-time dependency that
+ * a host without libnuma cannot satisfy — defeating "green on any host". We call
+ * the two syscalls directly through the libc `syscall(2)` wrapper instead: no
+ * external C library, identical kernel path.
+ *
+ * Companion to docs/research/cpu-pmu/precise-sampling.md
+ *   § "Data-source & data-address sampling: AMD IBS" and
+ *   § "From data address to NUMA node".
+ *
+ * Run with: dub run --single mem-latency-numa.d
+ *
+ * Environment recorded: Linux 6.18.26, AMD Ryzen 9 7940HX (Zen 4, family 0x19
+ * model 0x61; `ibs_op` type 11, `zen4_ibs_extensions=1`), single NUMA node,
+ * `/proc/sys/kernel/perf_event_paranoid` = -1, numactl 2.0.19 (headers only —
+ * not linked), LDC 1.41 druntime `core.sys.linux.perf_event`.
+ *
+ * Portability: no precise PMU (no IBS and `cpu` `max_precise == 0`), a refused
+ * `perf_event_open` (`perf_event_paranoid`, seccomp), no data-address samples,
+ * or a non-Linux/non-NUMA host each print a `SKIP:` or reduced line and exit 0,
+ * so CI stays green on any host.
+ */
+module cpu_pmu_mem_latency_numa;
+
+version (linux)
+{
+    import core.sys.linux.perf_event;
+    import core.sys.posix.unistd : close, sysconf, _SC_PAGESIZE;
+    import core.sys.posix.sys.mman : mmap, munmap, PROT_READ, PROT_WRITE,
+        MAP_SHARED, MAP_PRIVATE, MAP_FAILED;
+    import core.atomic : atomicLoad, atomicStore, MemoryOrder;
+    import std.stdio : writefln, writeln;
+    import std.algorithm : sort, min;
+
+    // ---- libc / kernel seams -------------------------------------------------
+
+    // Anonymous mapping for the workload buffer (Linux value; the druntime posix
+    // binding does not export MAP_ANON uniformly).
+    enum MAP_ANON = 0x20;
+
+    // PERF_SAMPLE_* live in a named D enum, so hoist the few this probe uses to
+    // unqualified manifest constants for readable sample_type expressions.
+    enum PERF_SAMPLE_IP        = perf_event_sample_format.PERF_SAMPLE_IP;
+    enum PERF_SAMPLE_ADDR      = perf_event_sample_format.PERF_SAMPLE_ADDR;
+    enum PERF_SAMPLE_WEIGHT    = perf_event_sample_format.PERF_SAMPLE_WEIGHT;
+    enum PERF_SAMPLE_DATA_SRC  = perf_event_sample_format.PERF_SAMPLE_DATA_SRC;
+    enum PERF_SAMPLE_PHYS_ADDR = perf_event_sample_format.PERF_SAMPLE_PHYS_ADDR;
+
+    // get_mempolicy(2) / move_pages(2) via the libc syscall wrapper. Numbers are
+    // per-arch; verified against arch/x86/entry/syscalls/syscall_64.tbl (239 /
+    // 279) and include/uapi/asm-generic/unistd.h (236 / 239) in the 7.1-rc6 tree.
+    extern (C) long syscall(long number, ...) @nogc nothrow;
+
+    version (X86_64)      { enum SYS_get_mempolicy = 239; enum SYS_move_pages = 279; enum nodeSyscalls = true; }
+    else version (AArch64){ enum SYS_get_mempolicy = 236; enum SYS_move_pages = 239; enum nodeSyscalls = true; }
+    else version (RISCV64){ enum SYS_get_mempolicy = 236; enum SYS_move_pages = 239; enum nodeSyscalls = true; }
+    else                  { enum SYS_get_mempolicy = 0;   enum SYS_move_pages = 0;   enum nodeSyscalls = false; }
+
+    // set_mempolicy(2)/get_mempolicy(2) flags — include/uapi/linux/mempolicy.h.
+    enum MPOL_F_NODE = 1 << 0; // return the node of `addr` (with MPOL_F_ADDR)
+    enum MPOL_F_ADDR = 1 << 1; // look the vma up by address
+
+    // Pin to one CPU so IBS per-thread sampling and the "home node" are stable.
+    extern (C) int sched_setaffinity(int pid, size_t cpusetsize, const(void)* mask) @nogc nothrow;
+
+    // ---- perf_mem_data_src decode (include/uapi/linux/perf_event.h) ----------
+    //
+    // The union is one u64 of contiguous bitfields; the shifts below are the
+    // documented field positions. Constant names/values are the PERF_MEM_*
+    // macros; the strings mirror tools/perf/util/mem-events.c so the decode
+    // reads the same as `perf report -D`.
+
+    ulong bits(ulong v, uint shift, uint width) @safe pure nothrow @nogc
+        => (v >> shift) & ((1UL << width) - 1);
+
+    string memOpStr(ulong ds) @safe pure nothrow @nogc
+    {
+        const op = bits(ds, 0, 5);
+        if (op & 0x02) return "LOAD";
+        if (op & 0x04) return "STORE";
+        if (op & 0x08) return "PFETCH";
+        if (op & 0x10) return "EXEC";
+        return "N/A";
+    }
+
+    // Composite level via mem_lvl_num (shift 33) + remote (37) + hops (43),
+    // the path perf_mem__lvl_scnprintf takes when lvl_num is set.
+    string memLvlStr(ulong ds) @safe nothrow
+    {
+        static immutable string[16] lvlnum = [
+            0x1: "L1", 0x2: "L2", 0x3: "L3", 0x4: "L4", 0x5: "L2 MHB",
+            0x6: "Memory-side Cache", 0x7: "L0", 0x8: "Uncached", 0x9: "CXL",
+            0xa: "I/O", 0xb: "Any cache", 0xc: "LFB/MAB", 0xd: "RAM",
+            0xe: "PMEM", 0xf: "N/A",
+        ];
+        static immutable string[5] hops = [
+            "N/A", "core, same node", "node, same socket",
+            "socket, same board", "board",
+        ];
+        const lvl = bits(ds, 5, 14);
+        const hit = (lvl & 0x02) ? "hit" : (lvl & 0x04) ? "miss" : "";
+        const num = cast(uint) bits(ds, 33, 4);
+        if (num != 0 && num != 0xf)
+        {
+            string s;
+            if (bits(ds, 37, 1)) s ~= "Remote ";
+            const h = cast(uint) bits(ds, 43, 3);
+            if (h != 0) s ~= hops[h] ~ " ";
+            s ~= lvlnum[num];
+            if (hit.length) s ~= " " ~ hit;
+            return s;
+        }
+        return "N/A";
+    }
+
+    string snoopStr(ulong ds) @safe pure nothrow @nogc
+    {
+        const s = bits(ds, 19, 5);
+        if (s & 0x10) return "HitM";
+        if (s & 0x08) return "Miss";
+        if (s & 0x04) return "Hit";
+        if (s & 0x02) return "None";
+        if (bits(ds, 38, 2) & 0x02) return "Peer";
+        if (bits(ds, 38, 2) & 0x01) return "Fwd";
+        return "N/A";
+    }
+
+    string tlbStr(ulong ds) @safe pure nothrow
+    {
+        const t = bits(ds, 26, 7);
+        const where = (t & 0x08) ? "L1" : (t & 0x10) ? "L2" : (t & 0x20) ? "walker" : "";
+        const hm = (t & 0x02) ? " hit" : (t & 0x04) ? " miss" : "";
+        if (where.length) return where ~ hm;
+        return "N/A";
+    }
+
+    // ---- NUMA node oracles ---------------------------------------------------
+
+    /// Node of the page containing `addr`, or a negative -errno, via
+    /// get_mempolicy(MPOL_F_NODE | MPOL_F_ADDR). numaif.h:
+    ///   long get_mempolicy(int *mode, ulong *nmask, ulong maxnode,
+    ///                      void *addr, ulong flags);
+    /// with these flags, `mode` receives the node number.
+    int nodeViaGetMempolicy(void* addr) @trusted @nogc nothrow
+    {
+        static if (!nodeSyscalls) return -1;
+        else
+        {
+            int node = -1;
+            const r = syscall(SYS_get_mempolicy, &node, null, 0UL, addr,
+                cast(ulong)(MPOL_F_NODE | MPOL_F_ADDR));
+            return r == 0 ? node : cast(int) r;
+        }
+    }
+
+    /// Node of the page containing `addr` via move_pages() query mode (nodes ==
+    /// NULL). numaif.h:
+    ///   long move_pages(int pid, ulong count, void **pages,
+    ///                   const int *nodes, int *status, int flags);
+    /// `status[0]` receives the node number (or a negative -errno).
+    int nodeViaMovePages(void* addr, size_t pageSize) @trusted @nogc nothrow
+    {
+        static if (!nodeSyscalls) return -1;
+        else
+        {
+            void* page = cast(void*)(cast(size_t) addr & ~(pageSize - 1));
+            int status = int.min;
+            const r = syscall(SYS_move_pages, 0, 1UL, &page, null, &status, 0UL);
+            return r == 0 ? status : cast(int) r;
+        }
+    }
+
+    // ---- sysfs helper --------------------------------------------------------
+
+    /// Reads a small unsigned integer from a sysfs file, or -1 on any failure.
+    long readSysLong(string path) @trusted
+    {
+        import std.file : readText;
+        import std.string : strip;
+        import std.conv : to;
+
+        try
+            return readText(path).strip.to!long;
+        catch (Exception)
+            return -1;
+    }
+
+    // ---- the workload --------------------------------------------------------
+
+    __gshared ulong sink;
+
+    /// Lay out `words` as one random permutation cycle of its own indices
+    /// (Sattolo's algorithm → a single cycle). Chasing `i = words[i]` is then a
+    /// dependent load per step whose target is unpredictable, so on a working set
+    /// wider than L3 nearly every step misses to DRAM — the classic pointer-chase
+    /// memory-latency pattern. Also faults every page in before classification.
+    void buildChase(size_t[] words) @safe
+    {
+        foreach (i; 0 .. words.length)
+            words[i] = i;
+        ulong rng = 0x9E3779B97F4A7C15UL;
+        for (size_t i = words.length - 1; i > 0; i--)
+        {
+            rng = rng * 6364136223846793005UL + 1442695040888963407UL;
+            const j = cast(size_t)(rng % i); // 0 <= j < i keeps it a single cycle
+            const t = words[i];
+            words[i] = words[j];
+            words[j] = t;
+        }
+    }
+
+    /// `steps` dependent chases from `start`; returns the landing index (folded
+    /// into a __gshared sink by the caller so the loads survive DCE).
+    size_t chase(const size_t[] words, size_t start, size_t steps) @safe
+    {
+        size_t i = start;
+        foreach (_; 0 .. steps)
+            i = words[i];
+        return i;
+    }
+
+    // ---- perf ring-buffer reader ---------------------------------------------
+
+    /// Copies `n` bytes out of the perf data area at logical offset `logicalTail`
+    /// (which may straddle the ring's wrap point) into `dst`.
+    void ringCopy(void* dst, const(ubyte)* dataStart, ulong dataSize, ulong logicalTail, size_t n) @system
+    {
+        auto d = cast(ubyte*) dst;
+        const off = cast(size_t)(logicalTail % dataSize);
+        foreach (i; 0 .. n)
+            d[i] = dataStart[(off + i) % dataSize];
+    }
+
+    /// One decoded PERF_RECORD_SAMPLE (only the fields this probe requests).
+    struct Sample
+    {
+        ulong ip, addr, weight, dataSrc, physAddr;
+    }
+
+    int run()
+    {
+        const pageSize = cast(size_t) sysconf(_SC_PAGESIZE);
+
+        // ---- locate a precise-sampling PMU ----------------------------------
+        bool viaIbs = true;
+        long pmuType = readSysLong("/sys/bus/event_source/devices/ibs_op/type");
+        int maxPrecise = 0;
+        if (pmuType < 0)
+        {
+            viaIbs = false;
+            maxPrecise = cast(int) readSysLong("/sys/bus/event_source/devices/cpu/caps/max_precise");
+            if (maxPrecise <= 0)
+            {
+                writefln("SKIP: no precise-sampling PMU — no AMD IBS (`ibs_op`) and "
+                    ~ "`cpu` max_precise == %d (Intel needs PEBS/precise_ip>0)", maxPrecise);
+                return 0;
+            }
+            pmuType = perf_type_id.PERF_TYPE_HARDWARE; // cpu-PMU precise fallback
+        }
+        const zen4 = readSysLong("/sys/bus/event_source/devices/ibs_op/caps/zen4_ibs_extensions") == 1;
+
+        // ---- NUMA topology --------------------------------------------------
+        int nodesOnline = 1;
+        {
+            import std.file : dirEntries, SpanMode, exists;
+            import std.algorithm : startsWith;
+            import std.path : baseName;
+
+            if (exists("/sys/devices/system/node"))
+            {
+                int c = 0;
+                foreach (e; dirEntries("/sys/devices/system/node", SpanMode.shallow))
+                    if (e.baseName.startsWith("node"))
+                        c++;
+                if (c > 0)
+                    nodesOnline = c;
+            }
+        }
+
+        // Pin to CPU 0 for a stable per-thread IBS context and home node.
+        ulong[16] cpuMask;
+        cpuMask[0] = 1;
+        sched_setaffinity(0, cpuMask.sizeof, cpuMask.ptr);
+
+        // ---- workload buffer + its home node --------------------------------
+        enum bufBytes = 64 * 1024 * 1024; // > per-CCX L3, so misses reach DRAM
+        void* raw = mmap(null, bufBytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+        if (raw == MAP_FAILED)
+        {
+            writefln("SKIP: could not mmap a %d MiB workload buffer", bufBytes >> 20);
+            return 0;
+        }
+        auto words = (cast(size_t*) raw)[0 .. bufBytes / size_t.sizeof];
+        buildChase(words); // also faults every page in before classifying
+        const homeNode = nodeViaGetMempolicy(raw);
+
+        // ---- open the sampling event ----------------------------------------
+        // Try richest sample set first (with PHYS_ADDR), then drop PHYS_ADDR;
+        // and prefer kernel exclusion, then fall back to unfiltered — so a
+        // stricter host still yields a working event.
+        //
+        // IBS filtering surprise: this Zen 4 lacks IBS_CAPS_BIT63_FILTER, so a
+        // bare `exclude_kernel`/`exclude_hv` is EINVAL (perf_ibs_init,
+        // arch/x86/events/amd/ibs.c). Kernel/user filtering must instead engage
+        // the software filter — the `swfilt` bit (config2:0, IBS_SW_FILTER_MASK).
+        // `exclude_hv` is never set: IBS rejects it outright.
+        enum swfilt = 1UL; // config2:0
+        enum baseType = PERF_SAMPLE_IP | PERF_SAMPLE_ADDR | PERF_SAMPLE_DATA_SRC | PERF_SAMPLE_WEIGHT;
+        int fd = -1;
+        ulong sampleType;
+        foreach (withPhys; [true, false])
+            foreach (exclKernel; [1, 0])
+            {
+                perf_event_attr attr;
+                attr.size = perf_event_attr.sizeof;
+                attr.type = cast(uint) pmuType;
+                attr.config = 0; // ibs_op: cnt_ctl=0 (cycles), no ldlat filter
+                attr.config2 = (viaIbs && exclKernel) ? swfilt : 0;
+                attr.sample_period = 20_000; // ibs_op min_period is 0x90
+                sampleType = baseType | (withPhys ? PERF_SAMPLE_PHYS_ADDR : 0);
+                attr.sample_type = sampleType;
+                attr.disabled = 1;
+                attr.exclude_kernel = exclKernel;
+                if (!viaIbs)
+                    attr.precise_ip = maxPrecise; // cpu-PMU (Intel) fallback path
+                fd = cast(int) perf_event_open(&attr, 0, -1, -1, 0);
+                if (fd >= 0)
+                    goto opened;
+            }
+    opened:
+        if (fd < 0)
+        {
+            writefln("SKIP: perf_event_open on %s failed — perf_event_paranoid, "
+                ~ "seccomp, or unsupported sample type", viaIbs ? "ibs_op" : "cpu");
+            munmap(raw, bufBytes);
+            return 0;
+        }
+
+        // ---- mmap the sample ring -------------------------------------------
+        enum dataPages = 128; // power of two
+        const mmapBytes = (1 + dataPages) * pageSize;
+        void* ring = mmap(null, mmapBytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        if (ring == MAP_FAILED)
+        {
+            writefln("SKIP: could not mmap the perf ring buffer");
+            close(fd);
+            munmap(raw, bufBytes);
+            return 0;
+        }
+        auto meta = cast(perf_event_mmap_page*) ring;
+        const dataStart = cast(const(ubyte)*) ring + meta.data_offset;
+        const dataSize = meta.data_size;
+
+        // ---- sample: enable, stride, drain ----------------------------------
+        import core.sys.posix.sys.ioctl : ioctl;
+        import core.stdc.config : c_ulong;
+
+        Sample[] samples;
+        ulong totalRecords, lostRecords;
+
+        void drain() @trusted
+        {
+            auto head = atomicLoad!(MemoryOrder.acq)(*cast(shared(ulong)*)&meta.data_head);
+            auto tail = meta.data_tail;
+            while (tail < head)
+            {
+                perf_event_header hdr;
+                ringCopy(&hdr, dataStart, dataSize, tail, hdr.sizeof);
+                if (hdr.type == perf_event_type.PERF_RECORD_SAMPLE)
+                {
+                    ubyte[256] rec;
+                    ringCopy(rec.ptr, dataStart, dataSize, tail, min(hdr.size, rec.length));
+                    size_t cur = hdr.sizeof;
+                    ulong take() { const v = *cast(ulong*)(rec.ptr + cur); cur += 8; return v; }
+                    Sample s;
+                    if (sampleType & PERF_SAMPLE_IP)        s.ip = take();
+                    if (sampleType & PERF_SAMPLE_ADDR)      s.addr = take();
+                    if (sampleType & PERF_SAMPLE_WEIGHT)    s.weight = take();
+                    if (sampleType & PERF_SAMPLE_DATA_SRC)  s.dataSrc = take();
+                    if (sampleType & PERF_SAMPLE_PHYS_ADDR) s.physAddr = take();
+                    samples ~= s;
+                    totalRecords++;
+                }
+                else if (hdr.type == perf_event_type.PERF_RECORD_LOST)
+                    lostRecords++;
+                tail += hdr.size;
+            }
+            atomicStore!(MemoryOrder.rel)(*cast(shared(ulong)*)&meta.data_tail, head);
+        }
+
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_RESET, 0);
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_ENABLE, 0);
+        size_t pos;
+        foreach (pass; 0 .. 200)
+        {
+            pos = chase(words, pos, 100_000);
+            sink += pos;
+            drain();
+            if (samples.length >= 4000)
+                break;
+        }
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_DISABLE, 0);
+        drain();
+
+        munmap(ring, mmapBytes);
+        close(fd);
+
+        // ---- report ---------------------------------------------------------
+        writefln("== precise memory-access sampling: %s ==", viaIbs
+            ? (zen4 ? "AMD IBS (ibs_op, zen4_ibs_extensions)" : "AMD IBS (ibs_op)")
+            : "cpu PMU precise_ip (Intel PEBS path — UNVERIFIED on this host)");
+        writefln("  PMU type=%d  period=20000  sample_type=IP|ADDR|DATA_SRC|WEIGHT%s",
+            pmuType, (sampleType & PERF_SAMPLE_PHYS_ADDR) ? "|PHYS_ADDR" : "");
+        writefln("  workload=%d MiB  home node(get_mempolicy)=%d  NUMA nodes online=%d",
+            bufBytes >> 20, homeNode, nodesOnline);
+        if (nodesOnline <= 1)
+            writeln("  (single-node host: node round-trip is demonstrated; cross-node "
+                ~ "classification is not — that needs a multi-socket box)");
+
+        // Keep only samples with a resolved data address (IBS sets ADDR only when
+        // DcLinAddrValid). Classify each such address to a node, both ways.
+        struct Row { Sample s; int nGmp, nMvp; }
+        Row[] rows;
+        foreach (s; samples)
+            if (s.addr != 0 && memOpStr(s.dataSrc) != "N/A")
+                rows ~= Row(s, nodeViaGetMempolicy(cast(void*) s.addr),
+                    nodeViaMovePages(cast(void*) s.addr, pageSize));
+
+        if (rows.length == 0)
+        {
+            writefln("  collected %d raw samples, %d with a usable data address — "
+                ~ "reduced output (no per-address rows to show)", samples.length, rows.length);
+            munmap(raw, bufBytes);
+            return 0;
+        }
+
+        // Lead with samples that missed the L1 — those exercise the whole
+        // data-source/latency path; pad with L1 hits if there are few.
+        Row[] show;
+        foreach (r; rows)
+            if (memLvlStr(r.s.dataSrc) != "L1 hit" && show.length < 8)
+                show ~= r;
+        foreach (r; rows)
+            if (show.length < 8)
+                show ~= r;
+        writefln("\n  sampled data accesses (%d of %d; cache-miss samples first):",
+            show.length, rows.length);
+        writeln("    ip                 addr               op     level              "
+            ~ "snoop  tlb      lat  node[gmp/mvp]");
+        foreach (r; show)
+            writefln("    0x%016x 0x%016x %-6s %-18s %-6s %-8s %4d  %d/%d",
+                r.s.ip, r.s.addr, memOpStr(r.s.dataSrc), memLvlStr(r.s.dataSrc),
+                snoopStr(r.s.dataSrc), tlbStr(r.s.dataSrc), r.s.weight, r.nGmp, r.nMvp);
+
+        // Level histogram + node-agreement summary.
+        ulong[string] lvlHist;
+        int agreeHome, disagree, gmpErr, mvpErr;
+        ulong[] lats;
+        foreach (r; rows)
+        {
+            lvlHist[memLvlStr(r.s.dataSrc)]++;
+            if (r.nGmp < 0) gmpErr++;
+            if (r.nMvp < 0) mvpErr++;
+            if (r.nGmp >= 0 && r.nMvp >= 0)
+            {
+                if (r.nGmp == homeNode && r.nMvp == homeNode) agreeHome++;
+                else disagree++;
+            }
+            if (r.s.weight > 0) lats ~= r.s.weight;
+        }
+        writefln("\n  data-source levels across %d resolved samples:", rows.length);
+        foreach (k, v; lvlHist)
+            writefln("    %-24s %d", k, v);
+        writefln("  node classification: %d on home node %d (get_mempolicy == move_pages), "
+            ~ "%d elsewhere; gmp errors=%d, mvp errors=%d",
+            agreeHome, homeNode, disagree, gmpErr, mvpErr);
+        if (lats.length)
+        {
+            lats.sort();
+            writefln("  DC-miss latency (WEIGHT) on %d load samples: min=%d median=%d max=%d cycles",
+                lats.length, lats[0], lats[$ / 2], lats[$ - 1]);
+        }
+        else
+            writeln("  DC-miss latency (WEIGHT): none — no sampled load missed the data cache");
+
+        munmap(raw, bufBytes);
+        return 0;
+    }
+}
+
+int main()
+{
+    version (linux)
+        return run();
+    else
+    {
+        import std.stdio : writefln;
+
+        writefln("SKIP: perf_event_open / IBS is Linux-only");
+        return 0;
+    }
+}

--- a/docs/research/cpu-pmu/examples/pfm4-name-roundtrip.d
+++ b/docs/research/cpu-pmu/examples/pfm4-name-roundtrip.d
@@ -1,0 +1,327 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "cpu_pmu_pfm4_name_roundtrip"
+    platforms "linux"
+    libs "pfm"
+    targetPath "build"
++/
+/**
+ * libpfm4 human-name → `perf_event_attr.{type,config}` round trip, then live count.
+ *
+ * The *event-naming & encoding* concern of the analysis spine, exercised end to
+ * end on this host. libpfm4 is the name-resolution layer under `perf`, PAPI, and
+ * many profilers: it owns per-microarchitecture event tables and turns a symbolic
+ * string into the `type`/`config`/`exclude_*` fields the `perf_event_open(2)` ABI
+ * expects. This probe:
+ *
+ *   1. `pfm_get_os_event_encoding(str, …, PFM_OS_PERF_EVENT, &arg)` with `arg.attr`
+ *      pointing at druntime's `perf_event_attr` — the same struct `perf_event_open`
+ *      consumes — so libpfm fills it directly (no hand-built encodings).
+ *   2. Encodes four names spanning the naming layers and prints the resulting
+ *      `type`/`config` hex plus the fully-qualified string libpfm echoes back:
+ *        - `PERF_COUNT_HW_CPU_CYCLES` — a *generic* perf name → `PERF_TYPE_HARDWARE`
+ *          (type 0), config 0: the OS-abstracted event, portable across vendors.
+ *        - `RETIRED_INSTRUCTIONS` — a *Zen 4-specific* name from libpfm's
+ *          `amd64_fam19h_zen4` table → `PERF_TYPE_RAW` (type 4), config `0xc0`
+ *          (the raw AMD PMC event-select), proving the per-µarch table is what
+ *          supplies the bits.
+ *        - `RETIRED_SSE_AVX_FLOPS:ADD_SUB_FLOPS` — a name carrying a *unit mask* →
+ *          the umask lands in config bits [15:8] (`0x103`), showing libpfm's
+ *          `event:umask` grammar.
+ *        - `RETIRED_INSTRUCTIONS:u` — a name carrying a *modifier* → config is
+ *          unchanged (`0xc0`) but `attr.exclude_kernel` is set: user/kernel/hv
+ *          filtering is lifted OUT of the raw config into the perf_event ABI's
+ *          `exclude_*` fields (`pfm_amd64_get_perf_encoding` zeroes the OS/USR
+ *          MSR bits; the common perf layer sets the attr fields). This split is
+ *          the whole reason `PFM_OS_PERF_EVENT` exists.
+ *   3. `perf_event_open`s each encoding on the calling thread and counts a fixed
+ *      workload window (integer mixing + scalar SSE FP), proving the encodings
+ *      are *live*, not just plausible.
+ *
+ * Auto-detect caveat (source-verified, load-bearing): stock **libpfm 4.13.0**
+ * (the current nixpkgs build) does NOT auto-detect this CPU's core PMU. Its
+ * family-19h detect (`lib/pfmlib_amd64.c`) maps only `model == 0x11` to Zen 4, so
+ * the Ryzen 9 7940HX (family 25/`0x19`, model **0x61**, Dragon Range) matches no
+ * branch, `revision` stays `PFM_PMU_NONE`, and only the software `perf`/`perf_raw`
+ * PMUs activate — a bare `pfm_get_os_event_encoding("RETIRED_INSTRUCTIONS", …)`
+ * then returns `PFM_ERR_NOTFOUND` (-4). libpfm git HEAD fixes this (`model >= 0x60`).
+ * To stay robust we (a) derive the correct table name from `/proc/cpuinfo`
+ * ourselves — exactly what a fixed `detect()` would pick — and address events with
+ * the explicit `amd64_fam19h_zen4::` prefix, and (b) set `LIBPFM_ENCODE_INACTIVE=1`
+ * before `pfm_initialize`, which places even un-detected tables on the searchable
+ * list. The lesson for a backend: do not trust libpfm auto-detect on very recent
+ * silicon — force the PMU by a name you resolve from CPUID, or require a new libpfm.
+ *
+ * Companion to docs/research/cpu-pmu/event-naming.md
+ *   § "libpfm4: the name→encoding pipeline" and § "The OS-layer split".
+ *
+ * Run with (nixpkgs libpfm has no pkg-config .pc, and `nix shell` does not run
+ * setup hooks, so feed its lib dir through LIBRARY_PATH/LD_LIBRARY_PATH):
+ *
+ *   P=$(nix eval --raw nixpkgs#libpfm)/lib; \
+ *   env LIBRARY_PATH="$P:$LIBRARY_PATH" LD_LIBRARY_PATH="$P:$LD_LIBRARY_PATH" \
+ *       dub run --single pfm4-name-roundtrip.d
+ *
+ * (Adding `libpfm` to the flake devShell's buildInputs would let a plain
+ * `dub run --single` resolve `libs "pfm"` via NIX_LDFLAGS — the intended CI path.)
+ *
+ * Environment recorded: Linux 6.18.26, AMD Ryzen 9 7940HX (Zen 4, family 25 /
+ * model 0x61), `/proc/sys/kernel/perf_event_paranoid` = -1, libpfm 4.13.0
+ * (nixpkgs), LDC 1.41 druntime `core.sys.linux.perf_event`.
+ *
+ * Portability: on a host without libpfm the build fails to link (libpfm is a
+ * link-time dependency, like `libdw` in the sibling probes). At runtime, a raised
+ * `perf_event_paranoid`, a non-AMD CPU, or any `perf_event_open` failure prints a
+ * `SKIP:` line and exits 0 so CI stays green on any host.
+ */
+module cpu_pmu_pfm4_name_roundtrip;
+
+version (linux)
+{
+    import core.sys.linux.perf_event : perf_event_attr, perf_event_open,
+        perf_type_id, perf_event_read_format, PERF_EVENT_IOC_RESET,
+        PERF_EVENT_IOC_ENABLE, PERF_EVENT_IOC_DISABLE;
+    import core.sys.posix.unistd : read, close;
+    import core.sys.posix.sys.ioctl : ioctl;
+    import core.sys.posix.stdlib : setenv;
+    import core.stdc.config : c_ulong;
+    import core.stdc.string : strlen;
+    import std.stdio : writefln, writeln;
+    import std.string : lineSplitter, startsWith, strip;
+
+    // ---- libpfm4 (extern(C), verified against $REPOS/c/libpfm4@6870a9f0
+    //      include/perfmon/pfmlib.h + pfmlib_perf_event.h) --------------------
+    enum PFM_OS_PERF_EVENT = 1; // pfm_os_t: perf_events attribute subset + PMU
+    enum PFM_PLM0 = 0x01;       // priv level 0 (kernel)
+    enum PFM_PLM3 = 0x08;       // priv level 3/2/1 (user)
+    enum PFM_SUCCESS = 0;
+
+    /// `pfm_perf_encode_arg_t` (pfmlib_perf_event.h): 40 bytes on LP64.
+    struct pfm_perf_encode_arg_t
+    {
+        perf_event_attr* attr; // in/out: the struct libpfm fills
+        char** fstr;           // out: fully-qualified event string
+        size_t size;           // sizeof(*this) — libpfm ABI-checks this
+        int idx;               // out: opaque event id
+        int cpu;               // out: cpu to program, -1 = unset
+        int flags;             // out: perf_event_open flags
+        int pad0;
+    }
+
+    extern (C) int pfm_initialize();
+    extern (C) int pfm_get_version();
+    extern (C) const(char)* pfm_strerror(int);
+    extern (C) int pfm_get_os_event_encoding(const(char)*, int, int, void*);
+
+    string cstr(const(char)* p) @trusted =>
+        p is null ? "(null)" : cast(string) p[0 .. strlen(p)];
+
+    /// Result of one encode.
+    struct Encoded
+    {
+        bool ok;
+        int err;            // pfm_err_t when !ok
+        perf_event_attr attr;
+        string fstr;
+    }
+
+    /// Name → `perf_event_attr` via libpfm. Counting at both priv levels
+    /// (PLM0|PLM3) is the default; per-name `:u`/`:k` modifiers override it.
+    Encoded encode(string name) @trusted
+    {
+        Encoded e;
+        e.attr.size = perf_event_attr.sizeof;
+        char* fstr;
+        pfm_perf_encode_arg_t arg;
+        arg.attr = &e.attr;
+        arg.fstr = &fstr;
+        arg.size = pfm_perf_encode_arg_t.sizeof;
+        const r = pfm_get_os_event_encoding(
+            (name ~ '\0').ptr, PFM_PLM0 | PFM_PLM3, PFM_OS_PERF_EVENT, &arg);
+        e.err = r;
+        e.ok = r == PFM_SUCCESS;
+        if (e.ok)
+            e.fstr = cstr(fstr).idup;
+        return e;
+    }
+
+    // ---- perf_event_open counting (mirrors counting-group.d) ----------------
+    void ctl(int fd, uint request) @trusted => cast(void) ioctl(fd, cast(c_ulong) request, 0);
+    long readN(int fd, ulong[] buf) @trusted => read(fd, buf.ptr, buf.length * ulong.sizeof);
+
+    /// A fixed workload: integer mixing (retired instructions) plus scalar SSE
+    /// double arithmetic (SSE/AVX FLOPS — one multiply and one add per iter).
+    /// `__gshared` sinks defeat dead-code elimination.
+    __gshared ulong iSink;
+    __gshared double fSink;
+    void workload()
+    {
+        ulong acc = 0x9E3779B97F4A7C15UL;
+        double f = 1.0;
+        foreach (i; 0 .. 3_000_000UL)
+        {
+            acc = (acc + i) * 2654435761UL ^ (acc >> 13);
+            f = f * 1.0000000001 + 0.5; // 1 MULT + 1 ADD_SUB FLOP
+        }
+        iSink += acc;
+        fSink += f;
+    }
+
+    /// Open the already-encoded `attr` on this thread (pid 0, any cpu), run the
+    /// workload, and return the multiplexing-scaled count, or `ulong.max` on
+    /// failure. Adds the two time fields so a rotated counter still scales.
+    ulong countWith(ref perf_event_attr attr) @trusted
+    {
+        attr.read_format = perf_event_read_format.PERF_FORMAT_TOTAL_TIME_ENABLED
+            | perf_event_read_format.PERF_FORMAT_TOTAL_TIME_RUNNING;
+        attr.disabled = 1;
+        attr.exclude_hv = 1;
+        const fd = cast(int) perf_event_open(&attr, 0, -1, -1, 0);
+        if (fd < 0)
+            return ulong.max;
+        ctl(fd, PERF_EVENT_IOC_RESET);
+        ctl(fd, PERF_EVENT_IOC_ENABLE);
+        workload();
+        ctl(fd, PERF_EVENT_IOC_DISABLE);
+        ulong[3] s; // value, time_enabled, time_running
+        const got = readN(fd, s[]);
+        close(fd);
+        if (got < cast(long)(3 * ulong.sizeof) || s[2] == 0)
+            return ulong.max;
+        return s[2] < s[1] ? cast(ulong)(s[0] * (cast(double) s[1] / s[2])) : s[0];
+    }
+
+    /// Report one name: encode, print type/config/exclude, then count.
+    void report(string label, string name) @trusted
+    {
+        auto e = encode(name);
+        if (!e.ok)
+        {
+            writefln("  %-13s %-42s ENCODE FAILED: %s (%d)",
+                label, name, cstr(pfm_strerror(e.err)), e.err);
+            return;
+        }
+        auto attr = e.attr; // copy: countWith mutates read_format/flags
+        const cnt = countWith(attr);
+        writefln("  %-13s %s", label, name);
+        writefln("        type=%d config=0x%x  exclude_user=%d exclude_kernel=%d",
+            e.attr.type, e.attr.config, e.attr.exclude_user, e.attr.exclude_kernel);
+        writefln("        fstr=%s", e.fstr);
+        if (cnt == ulong.max)
+            writefln("        count: <perf_event_open/read failed on this host>");
+        else
+            writefln("        count over workload window: %d", cnt);
+    }
+
+    /// Map /proc/cpuinfo (vendor + family + model) to the libpfm core-PMU table
+    /// name — mirroring the *fixed* `amd64_get_revision` (libpfm HEAD). Returns
+    /// null for anything this probe does not have a hand table for (non-AMD, or
+    /// an AMD family we don't enumerate) → the µarch-specific section is skipped.
+    string amdPmuName() @trusted
+    {
+        import std.conv : to;
+
+        string vendor;
+        int family = -1, model = -1;
+        try
+        {
+            import std.file : readText;
+
+            foreach (line; readText("/proc/cpuinfo").lineSplitter)
+            {
+                if (line.startsWith("vendor_id") && vendor is null)
+                    vendor = line["vendor_id".length .. $].strip(" \t:").idup;
+                else if (line.startsWith("cpu family") && family < 0)
+                    family = line["cpu family".length .. $].strip(" \t:").to!int;
+                else if (line.startsWith("model") && !line.startsWith("model name") && model < 0)
+                    model = line["model".length .. $].strip(" \t:").to!int;
+            }
+        }
+        catch (Exception)
+            return null;
+        if (vendor != "AuthenticAMD")
+            return null;
+        switch (family)
+        {
+        case 23: // 17h
+            return model >= 0x30 ? "amd64_fam17h_zen2" : "amd64_fam17h_zen1";
+        case 25: // 19h
+            return (model >= 0x60 || (model >= 0x10 && model <= 0x1f))
+                ? "amd64_fam19h_zen4" : "amd64_fam19h_zen3";
+        case 26: // 1ah
+            return (model <= 0x4f || (model >= 0x60 && model <= 0x7f))
+                ? "amd64_fam1ah_zen5" : "amd64_fam1ah_zen6";
+        default:
+            return null;
+        }
+    }
+
+    int run()
+    {
+        // Work around libpfm 4.13.0's auto-detect gap (see the header): place
+        // un-detected per-µarch tables on the searchable list so an explicit
+        // `pmu::event` prefix resolves. Must precede pfm_initialize.
+        setenv("LIBPFM_ENCODE_INACTIVE", "1", 1);
+
+        const initRc = pfm_initialize();
+        if (initRc != PFM_SUCCESS)
+        {
+            writefln("SKIP: pfm_initialize failed (%s) — libpfm unusable on this host",
+                cstr(pfm_strerror(initRc)));
+            return 0;
+        }
+        const v = pfm_get_version();
+        writefln("libpfm interface version %d.%d (release: see nixpkgs libpfm)",
+            v >> 16, v & 0xffff);
+
+        // --- Generic (OS-abstracted) name: resolves via the always-present
+        //     `perf` PMU regardless of hardware. ---
+        writeln("\n== generic perf name (PERF_TYPE_HARDWARE) ==");
+        report("generic", "PERF_COUNT_HW_CPU_CYCLES");
+
+        // Probe whether we can count at all; if the generic open failed for
+        // permission reasons, everything else will too.
+        {
+            auto probe = encode("PERF_COUNT_HW_CPU_CYCLES");
+            if (probe.ok)
+            {
+                auto a = probe.attr;
+                if (countWith(a) == ulong.max)
+                {
+                    writefln("SKIP: perf_event_open failed — perf_event_paranoid too high, "
+                        ~ "seccomp, or no PMU on this host");
+                    return 0;
+                }
+            }
+        }
+
+        // --- Microarchitecture-specific names via the host's libpfm table. ---
+        const pmu = amdPmuName();
+        if (pmu is null)
+        {
+            writeln("\n== µarch-specific names: SKIPPED (no hand table for this CPU; "
+                ~ "generic path above still demonstrates the round trip) ==");
+            return 0;
+        }
+        writefln("\n== µarch-specific names via the %s table (PERF_TYPE_RAW) ==", pmu);
+        report("zen4-native", pmu ~ "::RETIRED_INSTRUCTIONS");
+        report("with-umask", pmu ~ "::RETIRED_SSE_AVX_FLOPS:ADD_SUB_FLOPS");
+        report("with-modifier", pmu ~ "::RETIRED_INSTRUCTIONS:u");
+        writeln("\n  (config unchanged between native and :u — user/kernel filtering "
+            ~ "moved into attr.exclude_*, the PFM_OS_PERF_EVENT split.)");
+        return 0;
+    }
+}
+
+int main()
+{
+    version (linux)
+        return run();
+    else
+    {
+        import std.stdio : writefln;
+
+        writefln("SKIP: libpfm4 / perf_event_open is Linux-only");
+        return 0;
+    }
+}

--- a/docs/research/cpu-pmu/examples/sampling-symbolize.d
+++ b/docs/research/cpu-pmu/examples/sampling-symbolize.d
@@ -1,0 +1,415 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "cpu_pmu_sampling_symbolize"
+    platforms "linux"
+    libs "dw" "elf"
+    dflags "-g"
+    targetPath "build"
++/
+/**
+ * Overflow/IP sampling through the `perf_event` mmap ring buffer, then
+ * symbolization of the sampled instruction pointers via elfutils `libdwfl`.
+ *
+ * This is the end-to-end "profiler core": a hardware event (`cycles`) is armed
+ * with a target sample *frequency*; on each overflow the kernel writes a
+ * `PERF_RECORD_SAMPLE` (carrying the interrupted IP) into a memory-mapped ring
+ * buffer. We drain the ring, then hand the *live* process to `libdwfl`
+ * (`dwfl_linux_proc_report`, the library's own `/proc/PID/maps` reader) and
+ * resolve each IP to module → symbol (`dwfl_module_addrinfo`) → source line
+ * (`dwfl_module_getsrc` + `dwfl_lineinfo`).
+ *
+ * A key, verified subtlety about `PERF_RECORD_MMAP2` (`attr.mmap2 = 1`): the
+ * kernel emits it only for executable mappings **created while the event is
+ * enabled** — it does NOT re-emit pre-existing code (our own binary, libc).
+ * That is why the `perf` tool *synthesizes* `MMAP2` for the already-mapped
+ * regions from `/proc/PID/maps` at start, and why `libdwfl`'s
+ * `dwfl_linux_proc_report` reads the same file. To make a real captured
+ * `MMAP2` visible, we deliberately map `/proc/self/exe` `PROT_EXEC` mid-window;
+ * its record's `filename` matches the binary `libdwfl` symbolizes against —
+ * tying the two halves of the address-space model together.
+ *
+ * Companion to docs/research/cpu-pmu/linux-perf-events.md
+ *   § "Overflow sampling: the ring buffer, `PERF_RECORD_MMAP2`, and IP
+ *      symbolization" and docs/research/cpu-pmu/elfutils.md § "Address →
+ *      module → symbol → line".
+ *
+ * Run with: nix shell nixpkgs#elfutils nixpkgs#pkg-config -c dub run --single sampling-symbolize.d
+ *
+ * Environment recorded: Linux 6.18.26, AMD Ryzen 9 7940HX (Zen 4),
+ * `/proc/sys/kernel/perf_event_paranoid` = -1, elfutils 0.195 (libdw/libdwfl),
+ * LDC 1.41 druntime `core.sys.linux.perf_event`.
+ *
+ * Portability: any missing capability (`perf_event_open`/`mmap` refused by
+ * `perf_event_paranoid`/seccomp, no PMU, non-Linux) prints a `SKIP:` line and
+ * exits 0 so CI stays green on any host. A binary with no DWARF line table just
+ * prints symbol names without `file:line` — also a success.
+ */
+module cpu_pmu_sampling_symbolize;
+
+version (linux)
+{
+    import core.sys.linux.perf_event;
+    import core.sys.posix.unistd : close, getpid, sysconf, _SC_PAGESIZE;
+    import core.sys.posix.fcntl : open, O_RDONLY;
+    import core.sys.posix.sys.ioctl : ioctl;
+    import core.sys.posix.sys.mman : mmap, munmap, PROT_READ, PROT_WRITE, PROT_EXEC,
+        MAP_SHARED, MAP_PRIVATE, MAP_FAILED;
+    import core.stdc.config : c_ulong;
+    import core.stdc.string : memcpy, strlen;
+    import core.atomic : atomicLoad, atomicStore, MemoryOrder;
+    import core.time : MonoTime, msecs;
+    import std.stdio : writefln, writeln;
+    import std.string : fromStringz;
+
+    // ---- elfutils libdwfl: extern(C) prototypes declared in-file --------
+    // (a single-file dub program cannot compile a C shim; we link -ldw -lelf).
+    alias Dwarf_Addr = ulong;
+    alias Dwarf_Word = ulong;
+    alias GElf_Addr = ulong;
+    alias GElf_Off = ulong;
+    alias GElf_Word = uint;
+
+    /// `Elf64_Sym` (== `GElf_Sym` on LP64) — dwfl fills this; we read `st_value`.
+    struct GElf_Sym
+    {
+        uint st_name;
+        ubyte st_info;
+        ubyte st_other;
+        ushort st_shndx;
+        ulong st_value;
+        ulong st_size;
+    }
+
+    struct Dwfl; // opaque
+    struct Dwfl_Module; // opaque
+    struct Dwfl_Line; // opaque
+    struct Elf; // opaque
+
+    /// `Dwfl_Callbacks` (elfutils@6f8f78c libdwfl/libdwfl.h:72) as four pointers:
+    /// `find_elf`, `find_debuginfo`, `section_address`, `debuginfo_path`.
+    struct DwflCallbacks
+    {
+        void* find_elf;
+        void* find_debuginfo;
+        void* section_address;
+        char** debuginfo_path;
+    }
+
+    extern (C) @nogc nothrow
+    {
+        Dwfl* dwfl_begin(const(DwflCallbacks)*);
+        void dwfl_end(Dwfl*);
+        int dwfl_linux_proc_report(Dwfl*, int pid);
+        int dwfl_report_end(Dwfl*, void* removed, void* arg);
+        Dwfl_Module* dwfl_addrmodule(Dwfl*, Dwarf_Addr);
+        const(char)* dwfl_module_addrinfo(Dwfl_Module*, GElf_Addr, GElf_Off*,
+            GElf_Sym*, GElf_Word*, Elf**, Dwarf_Addr*);
+        Dwfl_Line* dwfl_module_getsrc(Dwfl_Module*, Dwarf_Addr);
+        const(char)* dwfl_lineinfo(Dwfl_Line*, Dwarf_Addr*, int*, int*, Dwarf_Word*, Dwarf_Word*);
+        // The two standard callbacks we take the address of for DwflCallbacks:
+        int dwfl_linux_proc_find_elf();
+        int dwfl_standard_find_debuginfo();
+    }
+
+    // ---- captured records -----------------------------------------------
+    struct Mapping
+    {
+        ulong addr, len, pgoff;
+        uint prot;
+        string filename;
+    }
+
+    __gshared ulong sink;
+
+    /// Two deliberately non-inlined hot functions, so sampled IPs land in
+    /// named symbols we can point at.
+    pragma(inline, false) ulong mixHash(ulong x)
+    {
+        foreach (_; 0 .. 96)
+            x = (x * 6364136223846793005UL + 1442695040888963407UL) ^ (x >> 29);
+        return x;
+    }
+
+    pragma(inline, false) ulong sumSquares(ulong n)
+    {
+        ulong s = 0;
+        foreach (i; 0 .. n)
+            s += i * i;
+        return s;
+    }
+
+    void workload()
+    {
+        auto deadline = MonoTime.currTime + 500.msecs;
+        ulong acc = 0x1234_5678_9ABC_DEF0UL;
+        while (MonoTime.currTime < deadline)
+        {
+            acc += mixHash(acc);
+            acc += sumSquares(2048);
+        }
+        sink += acc;
+    }
+
+    int run()
+    {
+        const pageSize = cast(size_t) sysconf(_SC_PAGESIZE);
+        enum dataPages = 256; // power of two
+        const dataSize = dataPages * pageSize;
+        const mmapSize = (1 + dataPages) * pageSize;
+
+        // Sampling event: cycles at ~4 kHz, user-space only so every IP is
+        // symbolizable against the process image. IP+TID+TIME per sample; the
+        // kernel also emits MMAP2 for executable mappings (attr.mmap2 = 1).
+        perf_event_attr attr;
+        attr.size = perf_event_attr.sizeof;
+        attr.type = perf_type_id.PERF_TYPE_HARDWARE;
+        attr.config = perf_hw_id.PERF_COUNT_HW_CPU_CYCLES;
+        attr.sample_type = perf_event_sample_format.PERF_SAMPLE_IP
+            | perf_event_sample_format.PERF_SAMPLE_TID
+            | perf_event_sample_format.PERF_SAMPLE_TIME;
+        attr.freq = 1;
+        attr.sample_freq = 4000;
+        attr.disabled = 1;
+        attr.exclude_kernel = 1;
+        attr.exclude_hv = 1;
+        attr.mmap = 1;
+        attr.mmap2 = 1;
+
+        int fd = (() @trusted => cast(int) perf_event_open(&attr, 0, -1, -1, 0))();
+        if (fd < 0)
+        {
+            writefln("SKIP: perf_event_open (sampling) failed — perf_event_paranoid, "
+                ~ "seccomp, or no PMU on this host");
+            return 0;
+        }
+
+        void* base = (() @trusted => mmap(null, mmapSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0))();
+        if (base is MAP_FAILED)
+        {
+            writefln("SKIP: mmap of the perf ring buffer failed "
+                ~ "(perf_event_mlock_kb too small?)");
+            close(fd);
+            return 0;
+        }
+        auto meta = cast(perf_event_mmap_page*) base;
+        auto dataArea = cast(ubyte*) base + pageSize;
+
+        // A fresh PROT_EXEC mapping of our own binary, created *inside* the
+        // enabled window, so the kernel emits a real PERF_RECORD_MMAP2 we can
+        // capture (pre-existing code is never re-emitted — see the header note).
+        int exeFd = (() @trusted => open("/proc/self/exe", O_RDONLY))();
+
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_RESET, 0);
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_ENABLE, 0);
+        void* exeMap = MAP_FAILED;
+        if (exeFd >= 0)
+            exeMap = (() @trusted => mmap(null, pageSize, PROT_READ | PROT_EXEC, MAP_PRIVATE, exeFd, 0))();
+        workload();
+        if (exeMap !is MAP_FAILED)
+            (() @trusted => munmap(exeMap, pageSize))();
+        if (exeFd >= 0)
+            close(exeFd);
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_DISABLE, 0);
+
+        // ---- drain the ring: data_tail .. data_head, wrapping mod dataSize
+        // (the reader-side seqcount contract: acquire-load head, process, then
+        //  release-store the new tail).
+        const head = atomicLoad!(MemoryOrder.acq)(meta.data_head);
+        ulong tail = meta.data_tail;
+
+        Mapping[] maps;
+        ulong[] ips;
+        ulong lost = 0;
+        ubyte[8192] rec;
+
+        void ringCopy(ulong pos, ubyte* dst, size_t n) @trusted
+        {
+            const o = pos % dataSize;
+            if (o + n <= dataSize)
+                memcpy(dst, dataArea + o, n);
+            else
+            {
+                const first = cast(size_t)(dataSize - o);
+                memcpy(dst, dataArea + o, first);
+                memcpy(dst + first, dataArea, n - first);
+            }
+        }
+
+        while (tail < head)
+        {
+            perf_event_header h;
+            ringCopy(tail, cast(ubyte*)&h, h.sizeof);
+            if (h.size == 0)
+                break;
+            size_t sz = h.size;
+            if (sz > rec.length)
+                sz = rec.length;
+            ringCopy(tail, rec.ptr, sz);
+            tail += h.size;
+
+            if (h.type == perf_event_type.PERF_RECORD_SAMPLE)
+            {
+                // body: ip(u64), pid(u32), tid(u32), time(u64)
+                ips ~= *(() @trusted => cast(ulong*)(rec.ptr + 8))();
+            }
+            else if (h.type == perf_event_type.PERF_RECORD_MMAP2)
+            {
+                // body offsets (after 8-byte header): addr@16 len@24 pgoff@32
+                // maj@40 min@44 ino@48 ino_gen@56 prot@64 flags@68 filename@72
+                Mapping m;
+                (() @trusted {
+                    m.addr = *cast(ulong*)(rec.ptr + 16);
+                    m.len = *cast(ulong*)(rec.ptr + 24);
+                    m.pgoff = *cast(ulong*)(rec.ptr + 32);
+                    m.prot = *cast(uint*)(rec.ptr + 64);
+                    auto fn = cast(char*)(rec.ptr + 72);
+                    m.filename = fromStringz(fn).idup;
+                })();
+                maps ~= m;
+            }
+            else if (h.type == perf_event_type.PERF_RECORD_LOST)
+                lost += *(() @trusted => cast(ulong*)(rec.ptr + 8 + 8))(); // id(u64), lost(u64)
+        }
+        atomicStore!(MemoryOrder.rel)(meta.data_tail, head);
+
+        (() @trusted => munmap(base, mmapSize))();
+        close(fd);
+
+        writefln("captured: %d PERF_RECORD_MMAP2 mappings, %d IP samples%s",
+            maps.length, ips.length, lost ? " (" ~ "some LOST — ring overflow" ~ ")" : "");
+        if (ips.length == 0)
+        {
+            writeln("note: no samples captured (workload too short, or overflow "
+                ~ "interrupts denied) — nothing to symbolize, but the ring path ran");
+            return 0;
+        }
+
+        // ---- symbolize via libdwfl: build the module model from the live
+        //      process, then addr -> symbol -> line for each IP ------------
+        __gshared DwflCallbacks cb;
+        cb.find_elf = (() @trusted => cast(void*)&dwfl_linux_proc_find_elf)();
+        cb.find_debuginfo = (() @trusted => cast(void*)&dwfl_standard_find_debuginfo)();
+        cb.section_address = null;
+        cb.debuginfo_path = null;
+
+        Dwfl* dwfl = (() @trusted => dwfl_begin(&cb))();
+        bool symbolized = false;
+        int[string] symCount;
+        string[string] symLine; // representative file:line per symbol
+        ulong[string] symIp; // representative IP per symbol
+        if (dwfl !is null)
+        {
+            const rc1 = (() @trusted => dwfl_linux_proc_report(dwfl, getpid()))();
+            const rc2 = (() @trusted => dwfl_report_end(dwfl, null, null))();
+            if (rc1 == 0 && rc2 == 0)
+            {
+                symbolized = true;
+                foreach (ip; ips)
+                {
+                    auto mod = (() @trusted => dwfl_addrmodule(dwfl, ip))();
+                    if (mod is null)
+                    {
+                        symCount["<no module>"]++;
+                        continue;
+                    }
+                    GElf_Off off;
+                    GElf_Sym sym;
+                    const namez = (() @trusted => dwfl_module_addrinfo(
+                        mod, ip, &off, &sym, null, null, null))();
+                    string name = namez ? fromStringz(namez).idup : "<unknown>";
+                    symCount[name]++;
+                    if (name !in symIp)
+                        symIp[name] = ip;
+                    if (name !in symLine)
+                    {
+                        auto line = (() @trusted => dwfl_module_getsrc(mod, ip))();
+                        if (line !is null)
+                        {
+                            int lineno;
+                            auto srcz = (() @trusted => dwfl_lineinfo(
+                                line, null, &lineno, null, null, null))();
+                            if (srcz)
+                            {
+                                import std.path : baseName;
+                                import std.conv : to;
+
+                                symLine[name] = baseName(fromStringz(srcz).idup) ~ ":" ~ lineno.to!string;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!symbolized)
+        {
+            writeln("note: libdwfl unavailable/failed to report modules — "
+                ~ "capture succeeded; symbolization skipped");
+            (() @trusted { if (dwfl) dwfl_end(dwfl); })();
+            return 0;
+        }
+
+        // Top symbols by sample count.
+        import std.algorithm : sort;
+        import std.array : array;
+
+        auto rows = symCount.byKeyValue.array;
+        rows.sort!((a, b) => a.value > b.value);
+        writeln("top self-symbols (dwfl: name — samples — file:line):");
+        size_t shown = 0;
+        foreach (r; rows)
+        {
+            writefln("  %-28s %6d   %s", r.key, r.value,
+                r.key in symLine ? symLine[r.key] : "(no DWARF line info)");
+            if (++shown >= 8)
+                break;
+        }
+
+        // ---- the captured PERF_RECORD_MMAP2 stream -----------------------
+        import std.path : baseName;
+
+        writefln("\nPERF_RECORD_MMAP2 captured during the window: %d record(s)", maps.length);
+        foreach (ref m; maps)
+            writefln("  [0x%x, 0x%x) pgoff=0x%x prot=0x%x %s",
+                m.addr, m.addr + m.len, m.pgoff, m.prot, m.filename);
+        writeln("  (the kernel re-emits MMAP2 only for mappings made while enabled; "
+            ~ "pre-existing code is recovered from /proc/PID/maps — what dwfl reads.)");
+
+        // Tie the two halves together: the deliberate exe mapping's filename is
+        // the same binary libdwfl symbolized our functions against.
+        string hot = rows[0].key;
+        enum exeName = "cpu_pmu_sampling_symbolize"; // matches dub's `name`
+        bool exeSeen = false;
+        foreach (ref m; maps)
+            if (m.filename.baseName == exeName)
+            {
+                exeSeen = true;
+                break;
+            }
+        if (exeSeen && hot in symIp)
+            writefln("model check: hottest symbol %s (IP 0x%x) was symbolized by libdwfl, "
+                ~ "and a captured MMAP2 names the same image (%s).", hot, symIp[hot], exeName);
+        else if (maps.length)
+            writefln("model check: captured MMAP2 for %s; symbolization via /proc/self/maps.",
+                maps[0].filename.baseName);
+        else
+            writeln("model check: no MMAP2 captured this window — symbolization still "
+                ~ "succeeded via /proc/self/maps (the pre-existing-mapping path).");
+
+        (() @trusted => dwfl_end(dwfl))();
+        return 0;
+    }
+}
+
+int main()
+{
+    version (linux)
+        return run();
+    else
+    {
+        import std.stdio : writefln;
+
+        writefln("SKIP: perf_event sampling is Linux-only");
+        return 0;
+    }
+}

--- a/docs/research/cpu-pmu/examples/unwind-stack-user.d
+++ b/docs/research/cpu-pmu/examples/unwind-stack-user.d
@@ -1,0 +1,455 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "cpu_pmu_unwind_stack_user"
+    platforms "linux"
+    libs "dw" "elf"
+    dflags "-g" "--frame-pointer=none"
+    targetPath "build"
++/
+/**
+ * DWARF-CFI stack unwinding from `PERF_SAMPLE_STACK_USER` + `PERF_SAMPLE_REGS_USER`
+ * on a frame-pointer-less build — the "call-graph profiler" acquisition path.
+ *
+ * Frame-pointer omission (`--frame-pointer=none`) makes the classic `%rbp`
+ * chain-walk impossible, so a backtrace must come from DWARF Call Frame
+ * Information. We arm `cycles` sampling that, on each overflow, additionally
+ * copies the interrupted thread's **register file** (`REGS_USER`) and a slab of
+ * its **user stack** (`STACK_USER`) into the ring buffer. Offline, we feed those
+ * to elfutils `libdwfl`'s frame API — `dwfl_attach_state` with a
+ * `Dwfl_Thread_Callbacks` whose `memory_read` serves bytes from the captured
+ * stack slab and whose `set_initial_registers` seeds the captured registers,
+ * then `dwfl_getthread_frames` drives the CFI unwinder frame by frame
+ * (`dwfl_frame_pc`) — exactly the wiring `perf`'s `unwind-libdw.c` uses.
+ *
+ * The probe has two guaranteed stages: (1) it demonstrably *captures* the
+ * registers + stack (printing the register ABI, key registers, and stack
+ * `dyn_size`); (2) it attempts the full in-process CFI unwind and prints the
+ * recovered backtrace. If the unwind cannot complete in-process it degrades to
+ * stage 1 and notes that the unwind API path is grounded by source-reading —
+ * either way it exits 0.
+ *
+ * Companion to docs/research/cpu-pmu/linux-perf-events.md
+ *   § "Stack unwinding: `STACK_USER` + `REGS_USER` and DWARF CFI" and
+ *   docs/research/cpu-pmu/elfutils.md § "DWARF-CFI stack unwinding".
+ *
+ * Run with: nix shell nixpkgs#elfutils nixpkgs#pkg-config -c dub run --single unwind-stack-user.d
+ *
+ * Environment recorded: Linux 6.18.26, AMD Ryzen 9 7940HX (Zen 4, x86-64),
+ * `/proc/sys/kernel/perf_event_paranoid` = -1, elfutils 0.195 (libdw/libdwfl),
+ * LDC 1.41 druntime `core.sys.linux.perf_event`. The perf→DWARF register
+ * mapping below is x86-64-specific.
+ *
+ * Portability: any missing capability prints a `SKIP:` line and exits 0.
+ */
+module cpu_pmu_unwind_stack_user;
+
+version (linux)
+{
+    version (X86_64) {}
+    else
+        version = NotX86_64;
+}
+
+version (linux)
+version (X86_64)
+{
+    import core.sys.linux.perf_event;
+    import core.sys.posix.unistd : close, getpid, sysconf, _SC_PAGESIZE;
+    import core.sys.posix.sys.ioctl : ioctl;
+    import core.sys.posix.sys.mman : mmap, munmap, PROT_READ, PROT_WRITE, MAP_SHARED, MAP_FAILED;
+    import core.stdc.config : c_ulong;
+    import core.stdc.string : memcpy;
+    import core.atomic : atomicLoad, atomicStore, MemoryOrder;
+    import core.time : MonoTime, msecs;
+    import std.stdio : writefln, writeln;
+    import std.string : fromStringz;
+
+    // ---- elfutils libdwfl: extern(C) prototypes ------------------------
+    alias Dwarf_Addr = ulong;
+    alias Dwarf_Word = ulong;
+    alias GElf_Addr = ulong;
+    alias GElf_Off = ulong;
+    alias GElf_Word = uint;
+
+    struct GElf_Sym
+    {
+        uint st_name;
+        ubyte st_info;
+        ubyte st_other;
+        ushort st_shndx;
+        ulong st_value;
+        ulong st_size;
+    }
+
+    struct Dwfl;
+    struct Dwfl_Module;
+    struct Dwfl_Frame;
+    struct Dwfl_Thread;
+    struct Elf;
+
+    /// `Dwfl_Callbacks` (find_elf, find_debuginfo, section_address, debuginfo_path).
+    struct DwflCallbacks
+    {
+        void* find_elf;
+        void* find_debuginfo;
+        void* section_address;
+        char** debuginfo_path;
+    }
+
+    /// `Dwfl_Thread_Callbacks` (elfutils@6f8f78c libdwfl/libdwfl.h:661): field
+    /// order next_thread, get_thread, memory_read, set_initial_registers,
+    /// detach, thread_detach.
+    struct DwflThreadCallbacks
+    {
+        void* next_thread;
+        void* get_thread;
+        void* memory_read;
+        void* set_initial_registers;
+        void* detach;
+        void* thread_detach;
+    }
+
+    extern (C) @nogc nothrow
+    {
+        Dwfl* dwfl_begin(const(DwflCallbacks)*);
+        void dwfl_end(Dwfl*);
+        int dwfl_linux_proc_report(Dwfl*, int pid);
+        int dwfl_report_end(Dwfl*, void* removed, void* arg);
+        Dwfl_Module* dwfl_addrmodule(Dwfl*, Dwarf_Addr);
+        const(char)* dwfl_module_addrinfo(Dwfl_Module*, GElf_Addr, GElf_Off*,
+            GElf_Sym*, GElf_Word*, Elf**, Dwarf_Addr*);
+        bool dwfl_attach_state(Dwfl*, Elf*, int pid, const(DwflThreadCallbacks)*, void* arg);
+        int dwfl_getthread_frames(Dwfl*, int tid, void* callback, void* arg);
+        bool dwfl_frame_pc(Dwfl_Frame*, Dwarf_Addr* pc, bool* isactivation);
+        void dwfl_thread_state_register_pc(Dwfl_Thread*, Dwarf_Word pc);
+        bool dwfl_thread_state_registers(Dwfl_Thread*, int firstreg, uint nregs, const(Dwarf_Word)* regs);
+        int dwfl_linux_proc_find_elf();
+        int dwfl_standard_find_debuginfo();
+    }
+
+    // ---- perf x86-64 register order (arch/x86/include/uapi/asm/perf_regs.h)
+    // The sample_regs_user mask we set selects, in ascending bit order:
+    //   AX BX CX DX SI DI BP SP IP  (bits 0..8), then R8..R15 (bits 16..23).
+    enum ulong regsMask = 0x1FFUL | (0xFFUL << 16); // 17 registers
+    enum CapIdx { AX, BX, CX, DX, SI, DI, BP, SP, IP, R8, R9, R10, R11, R12, R13, R14, R15 }
+
+    /// One captured sample: leaf IP, the 17 selected registers (perf order), and
+    /// a copy of the user-stack slab (valid `dyn_size` bytes from `sp` upward).
+    struct Sample
+    {
+        ulong ip;
+        int tid;
+        ulong regsAbi;
+        ulong[17] regs;
+        ubyte[] stack;
+        ulong sp;
+    }
+
+    // The unwind callbacks are C function pointers; a single-threaded probe can
+    // route their context through one global.
+    __gshared Sample* gSample;
+    __gshared Dwarf_Addr[64] gFrames;
+    __gshared size_t gNFrames;
+
+    extern (C) int uwNextThread(Dwfl* dwfl, void* arg, void** threadArgp) @nogc nothrow
+    {
+        if (*threadArgp !is null)
+            return 0;
+        *threadArgp = arg;
+        return gSample.tid;
+    }
+
+    extern (C) bool uwMemoryRead(Dwfl* dwfl, Dwarf_Addr addr, Dwarf_Word* result, void* arg) @nogc nothrow
+    {
+        auto s = gSample;
+        if (addr >= s.sp && addr + 8 <= s.sp + s.stack.length)
+        {
+            *result = *cast(ulong*)(s.stack.ptr + (addr - s.sp));
+            return true;
+        }
+        return false; // outside the captured slab → unwinder stops here
+    }
+
+    extern (C) bool uwSetInitialRegisters(Dwfl_Thread* thread, void* arg) @nogc nothrow
+    {
+        auto s = gSample;
+        // Map perf capture order → DWARF x86-64 register numbers 0..16.
+        with (CapIdx)
+        {
+            Dwarf_Word[17] dw = [
+                s.regs[AX], s.regs[DX], s.regs[CX], s.regs[BX], // dw 0..3
+                s.regs[SI], s.regs[DI], s.regs[BP], s.regs[SP], // dw 4..7
+                s.regs[R8], s.regs[R9], s.regs[R10], s.regs[R11], // dw 8..11
+                s.regs[R12], s.regs[R13], s.regs[R14], s.regs[R15], // dw 12..15
+                s.regs[IP], // dw 16 = RIP
+            ];
+            dwfl_thread_state_register_pc(thread, s.regs[IP]);
+            return dwfl_thread_state_registers(thread, 0, 17, dw.ptr);
+        }
+    }
+
+    extern (C) int uwFrameCb(Dwfl_Frame* state, void* arg) @nogc nothrow
+    {
+        Dwarf_Addr pc;
+        bool isActivation;
+        if (!dwfl_frame_pc(state, &pc, &isActivation))
+            return 1; // DWARF_CB_ABORT
+        if (!isActivation && pc)
+            pc -= 1; // step back into the call instruction for the caller frames
+        if (gNFrames < gFrames.length)
+            gFrames[gNFrames++] = pc;
+        return gNFrames >= 32 ? 1 : 0; // cap depth; DWARF_CB_OK = 0
+    }
+
+    // ---- a deliberately deep, frame-pointer-less call chain ------------
+    __gshared ulong sink;
+
+    pragma(inline, false) ulong level3(ulong x)
+    {
+        ulong s = 0;
+        foreach (i; 0 .. 6000)
+            s += (x ^ i) * (i + 1);
+        return s;
+    }
+
+    pragma(inline, false) ulong level2(ulong x) => level3(x) + level3(x >> 1);
+    pragma(inline, false) ulong level1(ulong x) => level2(x) ^ level2(x + 1);
+
+    void workload()
+    {
+        auto deadline = MonoTime.currTime + 400.msecs;
+        ulong acc = 0xABCD_1234_5678_9EF0UL;
+        while (MonoTime.currTime < deadline)
+            acc += level1(acc);
+        sink += acc;
+    }
+
+    /// Resolve a PC to `name+off` for the backtrace print.
+    string symbolize(Dwfl* dwfl, ulong pc)
+    {
+        auto mod = (() @trusted => dwfl_addrmodule(dwfl, pc))();
+        if (mod is null)
+            return "<no module>";
+        GElf_Off off;
+        GElf_Sym sym;
+        const namez = (() @trusted => dwfl_module_addrinfo(mod, pc, &off, &sym, null, null, null))();
+        if (namez is null)
+            return "<unknown>";
+        import std.conv : to;
+
+        return fromStringz(namez).idup ~ "+0x" ~ off.to!string(16);
+    }
+
+    int run()
+    {
+        const pageSize = cast(size_t) sysconf(_SC_PAGESIZE);
+        enum dataPages = 256;
+        const dataSize = dataPages * pageSize;
+        const mmapSize = (1 + dataPages) * pageSize;
+        enum stackBytes = 8192u;
+
+        perf_event_attr attr;
+        attr.size = perf_event_attr.sizeof;
+        attr.type = perf_type_id.PERF_TYPE_HARDWARE;
+        attr.config = perf_hw_id.PERF_COUNT_HW_CPU_CYCLES;
+        attr.sample_type = perf_event_sample_format.PERF_SAMPLE_IP
+            | perf_event_sample_format.PERF_SAMPLE_TID
+            | perf_event_sample_format.PERF_SAMPLE_TIME
+            | perf_event_sample_format.PERF_SAMPLE_REGS_USER
+            | perf_event_sample_format.PERF_SAMPLE_STACK_USER;
+        attr.sample_regs_user = regsMask;
+        attr.sample_stack_user = stackBytes;
+        attr.freq = 1;
+        attr.sample_freq = 1500;
+        attr.disabled = 1;
+        attr.exclude_kernel = 1;
+        attr.exclude_hv = 1;
+
+        int fd = (() @trusted => cast(int) perf_event_open(&attr, 0, -1, -1, 0))();
+        if (fd < 0)
+        {
+            writefln("SKIP: perf_event_open (stack sampling) failed — "
+                ~ "perf_event_paranoid, seccomp, or no PMU");
+            return 0;
+        }
+
+        void* base = (() @trusted => mmap(null, mmapSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0))();
+        if (base is MAP_FAILED)
+        {
+            writefln("SKIP: mmap of perf ring buffer failed");
+            close(fd);
+            return 0;
+        }
+        auto meta = cast(perf_event_mmap_page*) base;
+        auto dataArea = cast(ubyte*) base + pageSize;
+
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_RESET, 0);
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_ENABLE, 0);
+        workload();
+        ioctl(fd, cast(c_ulong) PERF_EVENT_IOC_DISABLE, 0);
+
+        const head = atomicLoad!(MemoryOrder.acq)(meta.data_head);
+        ulong tail = meta.data_tail;
+        ubyte[32768] rec;
+
+        void ringCopy(ulong pos, ubyte* dst, size_t n) @trusted
+        {
+            const o = pos % dataSize;
+            if (o + n <= dataSize)
+                memcpy(dst, dataArea + o, n);
+            else
+            {
+                const first = cast(size_t)(dataSize - o);
+                memcpy(dst, dataArea + o, first);
+                memcpy(dst + first, dataArea, n - first);
+            }
+        }
+
+        Sample[] samples;
+        size_t nRegsAbiNone = 0;
+        while (tail < head)
+        {
+            perf_event_header h;
+            ringCopy(tail, cast(ubyte*)&h, h.sizeof);
+            if (h.size == 0)
+                break;
+            size_t sz = h.size;
+            if (sz > rec.length)
+                sz = rec.length;
+            ringCopy(tail, rec.ptr, sz);
+            tail += h.size;
+            if (h.type != perf_event_type.PERF_RECORD_SAMPLE)
+                continue;
+
+            // body: ip(8) pid(4) tid(4) time(8) regsAbi(8) regs[17*8]
+            //       stackSize(8) stackData[stackSize] dynSize(8)
+            (() @trusted {
+                size_t o = 8;
+                Sample s;
+                s.ip = *cast(ulong*)(rec.ptr + o); o += 8;
+                o += 4; // pid
+                s.tid = *cast(int*)(rec.ptr + o); o += 4;
+                o += 8; // time
+                s.regsAbi = *cast(ulong*)(rec.ptr + o); o += 8;
+                if (s.regsAbi == 0)
+                {
+                    nRegsAbiNone++;
+                    return;
+                }
+                memcpy(s.regs.ptr, rec.ptr + o, 17 * 8); o += 17 * 8;
+                const stackSize = *cast(ulong*)(rec.ptr + o); o += 8;
+                const dynSize = *cast(ulong*)(rec.ptr + o + stackSize);
+                s.sp = s.regs[CapIdx.SP];
+                const valid = dynSize < stackSize ? dynSize : stackSize;
+                s.stack = (rec.ptr + o)[0 .. cast(size_t) valid].dup;
+                samples ~= s;
+            })();
+        }
+        atomicStore!(MemoryOrder.rel)(meta.data_tail, head);
+        (() @trusted => munmap(base, mmapSize))();
+        close(fd);
+
+        writefln("captured: %d samples with REGS_USER+STACK_USER "
+            ~ "(%d had ABI_NONE, no user regs)", samples.length, nRegsAbiNone);
+        if (samples.length == 0)
+        {
+            writeln("note: no register/stack samples captured — the ring path ran; "
+                ~ "nothing to unwind");
+            return 0;
+        }
+
+        // ---- set up libdwfl module model ---------------------------------
+        __gshared DwflCallbacks cb;
+        cb.find_elf = (() @trusted => cast(void*)&dwfl_linux_proc_find_elf)();
+        cb.find_debuginfo = (() @trusted => cast(void*)&dwfl_standard_find_debuginfo)();
+        Dwfl* dwfl = (() @trusted => dwfl_begin(&cb))();
+        if (dwfl is null
+            || (() @trusted => dwfl_linux_proc_report(dwfl, getpid()))() != 0
+            || (() @trusted => dwfl_report_end(dwfl, null, null))() != 0)
+        {
+            writeln("note: libdwfl module reporting failed — capture verified; "
+                ~ "unwind skipped");
+            return 0;
+        }
+
+        // Pick a sample whose leaf IP lands in level3 (the deepest frame) so the
+        // backtrace is a stable demonstration; fall back to the first sample.
+        Sample* chosen = &samples[0];
+        foreach (ref s; samples)
+        {
+            auto nm = symbolize(dwfl, s.ip);
+            import std.algorithm : canFind;
+
+            if (nm.canFind("level3"))
+            {
+                chosen = &s;
+                break;
+            }
+        }
+
+        // ---- Stage 1: prove the capture (registers + stack) ---------------
+        with (CapIdx)
+            writefln("\nchosen sample: leaf IP 0x%x (%s)\n"
+                ~ "  regs ABI=%d  RIP=0x%x  RSP=0x%x  RBP=0x%x  captured stack=%d bytes",
+                chosen.ip, symbolize(dwfl, chosen.ip), chosen.regsAbi,
+                chosen.regs[IP], chosen.regs[SP], chosen.regs[BP], chosen.stack.length);
+
+        // ---- Stage 2: attempt the full in-process CFI unwind --------------
+        gSample = chosen;
+        gNFrames = 0;
+        __gshared DwflThreadCallbacks tcb;
+        tcb.next_thread = (() @trusted => cast(void*)&uwNextThread)();
+        tcb.memory_read = (() @trusted => cast(void*)&uwMemoryRead)();
+        tcb.set_initial_registers = (() @trusted => cast(void*)&uwSetInitialRegisters)();
+
+        const attached = (() @trusted => dwfl_attach_state(dwfl, null, chosen.tid, &tcb, null))();
+        int rc = -1;
+        if (attached)
+            rc = (() @trusted => dwfl_getthread_frames(dwfl, gSample.tid,
+                (() @trusted => cast(void*)&uwFrameCb)(), null))();
+
+        if (attached && gNFrames > 0)
+        {
+            writefln("\nDWARF-CFI backtrace (%d frames, frame pointers OMITTED — "
+                ~ "so this came purely from .eh_frame/.debug_frame CFI):", gNFrames);
+            foreach (i, pc; gFrames[0 .. gNFrames])
+                writefln("  #%-2d 0x%x  %s", i, pc, symbolize(dwfl, pc));
+            writeln("  (dwfl_getthread_frames drove the unwind; memory_read served "
+                ~ "the captured STACK_USER slab, set_initial_registers the REGS_USER set.)");
+        }
+        else
+        {
+            writefln("\nnote: in-process dwfl unwind did not complete "
+                ~ "(attach=%s, rc=%d) — the CAPTURE is verified above; the unwind API "
+                ~ "path (dwfl_attach_state → Dwfl_Thread_Callbacks → "
+                ~ "dwfl_getthread_frames → dwfl_frame_pc) is grounded in "
+                ~ "docs/research/cpu-pmu/elfutils.md by source-reading.", attached, rc);
+        }
+
+        (() @trusted => dwfl_end(dwfl))();
+        return 0;
+    }
+}
+
+int main()
+{
+    version (linux)
+    {
+        version (X86_64)
+            return run();
+        else
+        {
+            import std.stdio : writefln;
+
+            writefln("SKIP: this unwind probe's perf→DWARF register map is x86-64-only");
+            return 0;
+        }
+    }
+    else
+    {
+        import std.stdio : writefln;
+
+        writefln("SKIP: perf_event sampling is Linux-only");
+        return 0;
+    }
+}

--- a/docs/research/cpu-pmu/examples/unwind-stack-user.d
+++ b/docs/research/cpu-pmu/examples/unwind-stack-user.d
@@ -3,14 +3,17 @@
     name "cpu_pmu_unwind_stack_user"
     platforms "linux"
     libs "dw" "elf"
-    dflags "-g" "--frame-pointer=none"
+    dflags "-g"
+    dflags "--frame-pointer=none" platform="ldc"
     targetPath "build"
 +/
 /**
  * DWARF-CFI stack unwinding from `PERF_SAMPLE_STACK_USER` + `PERF_SAMPLE_REGS_USER`
  * on a frame-pointer-less build — the "call-graph profiler" acquisition path.
  *
- * Frame-pointer omission (`--frame-pointer=none`) makes the classic `%rbp`
+ * Frame-pointer omission (`--frame-pointer=none`; applied under LDC only —
+ * DMD has no such switch, so a DMD build keeps frame pointers while the CFI
+ * unwind path stays identical) makes the classic `%rbp`
  * chain-walk impossible, so a backtrace must come from DWARF Call Frame
  * Information. We arm `cycles` sampling that, on each overflow, additionally
  * copies the interrupted thread's **register file** (`REGS_USER`) and a slab of

--- a/docs/research/cpu-pmu/grounding/_sources.md
+++ b/docs/research/cpu-pmu/grounding/_sources.md
@@ -1,0 +1,70 @@
+# Grounding sources — local-artifact map
+
+Lookup table for the per-page verification pass. Every external citation in the
+CPU-PMU survey maps here to a **local** artifact: a repo cloned under `$REPOS`
+(pinned below), a PDF/HTML capture under `$REPOS/papers/cpu-pmu/`, or a recorded
+experiment transcript. Web is a fallback **only** for the artifacts marked
+_gated_. `$REPOS` = `/home/petar/code/repos`.
+
+> Not published research. Do not link to it from the survey pages.
+
+**Acquisition:** 2026-07-10/11, by seven research workstreams (W1–W7). All
+repos read at the pinned SHA; `$REPOS/linux` was a pre-existing clean checkout
+(detached, **not** modified) reused read-only by W1–W4 and W7.
+
+## Source repos (pinned to reviewed HEAD)
+
+| Repo                           | Path                              | Pinned SHA          | As of      |
+| ------------------------------ | --------------------------------- | ------------------- | ---------- |
+| linux (v7.1-rc6)               | `$REPOS/linux`                    | `e43ffb69e043`      | 2026-05-31 |
+| elfutils (0.195 src)           | `$REPOS/c/elfutils`               | `6f8f78c`           | 2026-07-09 |
+| libtraceevent (1.9.0)          | `$REPOS/c/libtraceevent`          | `51d47b0`           | 2026-05-29 |
+| numactl / libnuma (2.0.19)     | `$REPOS/c/numactl`                | `93c1fe5`           | 2026-06-30 |
+| ARM-software/data              | `$REPOS/cpu-pmu/arm-data`         | `0806afb1`          | 2026-05-01 |
+| applecpu (dougallj)            | `$REPOS/cpu-pmu/applecpu`         | `0e6bc3f6`          | 2023-07-13 |
+| riscv-isa-manual               | `$REPOS/cpu-pmu/riscv-isa-manual` | `fbae3b43`          | 2026-07-10 |
+| riscv-sbi-doc                  | `$REPOS/cpu-pmu/riscv-sbi-doc`    | `8a545eff`          | 2026-07-10 |
+| riscv-control-transfer-records | `$REPOS/cpu-pmu/riscv-ctr`        | `42e299ca`          | 2026-07-10 |
+| opensbi                        | `$REPOS/c/opensbi`                | `26257121`          | 2026-07-10 |
+| krabsetw (Microsoft)           | `$REPOS/cpp/krabsetw`             | `6900de05`          | 2026-04-14 |
+| windows-d (rumbu13)            | `$REPOS/dlang/windows-d`          | `f34527e`           | 2026-06-03 |
+| xnu (apple-oss)                | `$REPOS/c/xnu`                    | tag `xnu-12377.1.9` | 2026-07-10 |
+| dtrace (apple-oss)             | `$REPOS/c/apple-dtrace`           | tag `dtrace-413`    | 2026-07-10 |
+| libpfm4 (perfmon2 canonical)   | `$REPOS/c/libpfm4`                | `6870a9f00412`      | 2026-07-11 |
+| PAPI                           | `$REPOS/c/papi`                   | `ec16e00f8b48`      | 2026-07-11 |
+| LIKWID                         | `$REPOS/c/likwid`                 | `f23c66630d1d`      | 2026-07-11 |
+| intel/perfmon                  | `$REPOS/cpu-pmu/intel-perfmon`    | `683a4d0bdd08`      | 2026-07-11 |
+
+Reference (not cloned): LDC 1.41.0 druntime `core/sys/linux/perf_event.d` and
+`core/sys/windows/{dbghelp,psapi}.d`, read from the toolchain install resolved
+via `ldc2.conf`; nixpkgs **libpfm 4.13.0** realized source (auto-detect
+comparison against libpfm4 git HEAD); mac-bsn on-disk kpep plists
+`/usr/share/kpep/{as1,a14,as3,as4-1,as5}.plist` (world-readable, macOS 26.3.1).
+
+## Papers & captures — `$REPOS/papers/cpu-pmu/`
+
+| Artifact                                                         | File                                                                                                  | Provenance                                                                                       |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| AMD64 APM Vol 2 (24593), IBS §13.3, 806 pp                       | `amd64-apm-vol2-24593.pdf`                                                                            | via verified Wayback snapshot, 2026-07-10                                                        |
+| RISC-V CTR (Smctr/Ssctr) v1.0, **Ratified**, 23 pp               | `riscv-ctr-spec-v1.0.pdf`                                                                             | GitHub release `v1.0` asset (published 2024-11-23), 2026-07-10                                   |
+| "Dissecting RISC-V Performance…" (arXiv 2507.22451), 16 pp       | `riscv-roofline-pmu-2507.22451.pdf`                                                                   | arXiv, 2026-07-10                                                                                |
+| 28 Microsoft Learn pages (HCP, ETW, WPT/WPR, DbgHelp, NUMA, WDK) | `win-*.html`, `etw-*.html`, `wpt-*.html`, `wpr-*.html`, `dbghelp-*.html`, `numa-*.html`, `wdk-*.html` | `learn.microsoft.com`, retrieved 2026-07-10 (full URL map in the [windows ledger](./windows.md)) |
+
+## Gated primaries → cite-by-name + secondary grounding
+
+| Citation                                                 | Why gated                                                                                                                                                  | Ground instead against                                                                      |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Arm ARM **DDI 0487** (latest = issue **K.a**)            | developer.arm.com is a JS SPA; direct PDF = Akamai HTTP-403; Wayback holds only HTML shells (CDX sweep 2026-07-10, recorded in the [arm ledger](./arm.md)) | in-kernel `include/linux/perf/arm_pmuv3.h` + `arm-data` JSON; cite chapters by name + issue |
+| Arm **SPE whitepaper** / SPE "learn the architecture"    | same CDN gating, live 403/404                                                                                                                              | `drivers/perf/arm_spe_pmu.c` + Arm ARM SPE chapter by name                                  |
+| Intel **SDM Vol 3** (PEBS chapters)                      | licence-gated download                                                                                                                                     | `arch/x86/events/intel/ds.c` + intel/perfmon JSONs; cite by section                         |
+| AMD Zen 4 **PPR 55898** (extended IBS DataSrc encodings) | not openly downloadable at AMD docs URLs                                                                                                                   | APM Vol 2 §13.3 + `arch/x86/include/asm/amd/ibs.h` (which cites PPR 55898)                  |
+
+## Experiment environments (recorded per experiment in pages + ledgers)
+
+| Bed                        | Facts                                                                                                                                                                                                                                                                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `x86_64-linux` (primary)   | NixOS, kernel **6.18.26**, AMD **Ryzen 9 7940HX** (Zen 4, family 0x19 model 0x61, 6 core PMCs), `perf_event_paranoid = -1`, single NUMA node, tracefs `id` files root-only; LDC **1.41.0**; elfutils **0.194** (runtime) / 0.195 (source); libpfm **4.13.0** (nixpkgs); numactl 2.0.19                                       |
+| `aarch64-darwin` (mac-bsn) | Apple **M4 Max** (`Mac16,5`, die T6041, `hw.cpufamily 0x17d5b93a`), macOS **26.3.1** (25D771280a), **SIP enabled**, non-root (`sudo -n` unavailable); running kernel xnu-**12377.91.3** vs source drop xnu-**12377.1.9** (same 12377 base — version-skew note in the [macos ledger](./macos.md)); clang 21.0.0, xctrace 16.0 |
+| `aarch64-linux`            | **none** — all ARM-Linux claims are source-reading of `linux@e43ffb69e043`, never hardware-verified                                                                                                                                                                                                                          |
+| RISC-V                     | **none** — spec + kernel + firmware source only; QEMU deliberately not used for counts (does not model PMU counts faithfully)                                                                                                                                                                                                |
+| Windows                    | **none** — official docs (saved) + open-source consumers (krabsetw, windows-d) only                                                                                                                                                                                                                                          |

--- a/docs/research/cpu-pmu/grounding/arm.md
+++ b/docs/research/cpu-pmu/grounding/arm.md
@@ -1,0 +1,128 @@
+# Grounding ledger — `arm.md`
+
+Claim-by-claim source verification of [`docs/research/cpu-pmu/arm.md`](../arm.md).
+ARM-Linux claims are checked against the **local** pinned kernel tree
+`linux@e43ffb69e043` (v7.1-rc6, read-only) and the vendor catalog
+`arm-data@0806afb1` (`ARM-software/data`, commit 2026-05-01); the Apple
+reverse-engineering repo is `applecpu@0e6bc3f6` (dougallj, 2023-07-13). Apple
+observations are read off `mac-bsn` = Apple **M4 Max** (`Mac16,5`, SoC `T6041`,
+`hw.cpufamily 0x17d5b93a`), macOS **26.3.1** (build 25D771280a), SIP enabled,
+non-root. `$REPOS = /home/petar/code/repos` (`linux` at `$REPOS/linux`).
+
+> Not published research. Do not link to it from the survey pages.
+
+## Status legend
+
+| Mark | Meaning                                                                        |
+| ---- | ------------------------------------------------------------------------------ |
+| `✓`  | Verified against the cited local artifact (locator recorded)                   |
+| `≈`  | Faithful paraphrase / inference from absence (no single line to point at)      |
+| `⚠`  | Discrepancy — open contradiction, flagged in the page                          |
+| `◯`  | Not locally groundable — synthesis/consequence, or source unobtainable (gated) |
+
+**Types:** `quote` (verbatim) · `src` (kernel/repo source-read, `[source-verified]`) ·
+`hw` (`mac-bsn`, `[hw-verified: aarch64-darwin]`) · `lit` (`[literature]`, gated) ·
+`synth` (derived consequence).
+
+## Verification note
+
+**No `aarch64-linux` hardware exists for this survey** — every `src` row is
+source-reading of the kernel driver, never a hardware observation. There is
+therefore **no `[hw-verified: aarch64-linux]` tag anywhere** in `arm.md`; the only
+hardware rows (`hw`) are Apple/macOS. This is by design, stated in the page's
+opening scope alert.
+
+## Claim ledger
+
+| #   | Claim (short)                                                                                      | Type   | Source (local + locator)                                                                                                                                                                                                                                                                | Status |
+| --- | -------------------------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| SM  | **Self-monitoring check** — arm64 has an EL0 `rdpmc` analog, doubly gated                          | src    | `arm_pmuv3.c:309-339` (`rdpmc`=config1[1:1] opt-in), `:790-821,836-849` (`PMUSERENR ER\|CR\|UEN`), `:1249-1258` (task-bound/unchained), `:1396-1422` (`perf_user_access` sysctl, default 0), `:1605-1622` (`cap_user_rdpmc`+`pmc_width` userpage), `:1034-1045` (instr ctr not exposed) | ✓      |
+| SM′ | Feature landed in Linux **5.17** (2022)                                                            | lit    | Known kernel history; **not** re-derived from git in timebox (shallow `-S` surfaces only the v6.4 driver relocation)                                                                                                                                                                    | ◯      |
+| C1  | Event space `0x00-0x3F` common / `0x40+` IMPDEF / `0x4000+` extensions; 16-bit selector            | src    | `arm_pmu.h:125` (`MAX_COMMON_EVENTS 0x40`); `arm_pmuv3.h:16-206` (common+IMPDEF), `:239` (`GENMASK(15,0)`), `:82-119` (ext)                                                                                                                                                             | ✓      |
+| C2  | `PMCEID0/1_EL0` per-core capability bitmaps gate visibility + `map_event`                          | src    | `arm_pmuv3.c:1333-1343` (read), `:1261-1264` (expose gate), `:281-289` (sysfs gate)                                                                                                                                                                                                     | ✓      |
+| C3  | `PMCR.N` (15:11) counter count; cycle idx 31, instr idx 32                                         | src    | `arm_pmuv3.c:1322-1331`; `arm_pmuv3.h:9-11,219`                                                                                                                                                                                                                                         | ✓      |
+| C4  | Width: cycle 64-bit; p5 `PMCR.LP` long events; pre-p5 chaining; p9 `PMICNTR`                       | src    | `arm_pmuv3.c:489-492,504-513,545-553,555-583,1189-1190`; `arch/arm64/…/arm_pmuv3.h:57-62,92-97`; `arm_pmuv3.h:11`                                                                                                                                                                       | ✓      |
+| C5  | `armv8_pmuv3_perf_map` generic→PMUv3; branch special-case; per-uarch overrides                     | src    | `arm_pmuv3.c:45-160,1198-1214,1275-1300`                                                                                                                                                                                                                                                | ✓      |
+| C6  | Threshold counting `FEAT_PMUv3_TH` via `config1`, capped by `PMMIR.THWIDTH`                        | src    | `arm_pmuv3.c:311-360,416-441,1142-1152`                                                                                                                                                                                                                                                 | ✓      |
+| C7  | Overflow sampling + EL-exclusion filters; `exclude_idle` EOPNOTSUPP; IP from `pt_regs`             | src    | `arm_pmuv3.h:246-251`; `arm_pmuv3.c:1090-1160` (`:1099-1102`, `:1117-1136`)                                                                                                                                                                                                             | ✓      |
+| C8  | SPE = PEBS/IBS analog; hardware buffer → AUX ring; PC+VA+PA+latency+data-src+ts                    | src    | `arm_spe_pmu.c:64-108,497-620,880-923`                                                                                                                                                                                                                                                  | ✓      |
+| C9  | SPE config → `PMSCR`/`PMSIRR`/`PMSFCR`/`PMSEVFR`/`PMSLATFR`/`PMSDSFR`                              | src    | `arm_spe_pmu.c:200-260,367-386,388-421,421-481,893-922`                                                                                                                                                                                                                                 | ✓      |
+| C10 | Feature probe `PMSIDR_EL1`; buffer-ownership `PMBIDR_EL1.P` → bail                                 | src    | `arm_spe_pmu.c:1105-1223,1122-1128,1140-1169,1171-1201`                                                                                                                                                                                                                                 | ✓      |
+| Q3  | _"profiling buffer owned by higher exception level"_                                               | quote  | `arm_spe_pmu.c:1125-1126`                                                                                                                                                                                                                                                               | ✓      |
+| C11 | PA/PCT physical-address collection gated on `perf_allow_kernel()`; CX likewise                     | src    | `arm_spe_pmu.c:873-877,42-55`                                                                                                                                                                                                                                                           | ✓      |
+| Q4  | `if (reg & (PMSCR_EL1_PA \| PMSCR_EL1_PCT)) / return perf_allow_kernel();`                         | quote  | `arm_spe_pmu.c:874-875`                                                                                                                                                                                                                                                                 | ✓      |
+| C12 | Code-space decode is Linux-generic (`libdwfl`); AAPCS64 frame chain                                | src≈   | absence of ARM-specific decode in `drivers/perf/`; consumer side `tools/perf/util/*` (deferred to W1)                                                                                                                                                                                   | ≈      |
+| C13 | BRBE ≤64 records, 2 banks of 32; `BRBSRC/BRBTGT/BRBINF` fields                                     | src    | `arm_brbe.c:29-61,144-212`; `arm_brbe.h:14-24`                                                                                                                                                                                                                                          | ✓      |
+| C14 | BRBE `BRBFCR` class filters; `BRBCR` per-EL enable + CC/MPRED/FZP; rejects `exclude_host`          | src    | `arm_brbe.c:14-19,371-425,430-464`                                                                                                                                                                                                                                                      | ✓      |
+| C15 | BRBE driven by core PMU (`brbe_probe` in `__armv8pmu_probe_pmu`); via `branch_stack`               | src    | `arm_pmuv3.c:1104-1109,1351,1354-1368`; `arm_brbe.h:14-24`                                                                                                                                                                                                                              | ✓      |
+| C16 | One perf PMU per uarch cluster + sysfs `cpumask`; pinned harness must pick the right PMU           | src    | `arm_pmu.c:566-573,519-524,347,540-552`; `arm_pmu_platform.c:59-121`                                                                                                                                                                                                                    | ✓      |
+| C17 | `PERF_PMU_CAP_EXTENDED_HW_TYPE` names a specific PMU; `NO_EXCLUDE` when no EL-exclusion            | src    | `arm_pmu.c:891-896,935-940`                                                                                                                                                                                                                                                             | ✓      |
+| C18 | CMN uncore: DTC counter block; `config` node-type/eventid/occupid/bynodeid/nodeid packing          | src    | `arm-cmn.c:123-147,163-187,664-688`                                                                                                                                                                                                                                                     | ✓      |
+| Q5  | _"The DTC node is where the magic happens"_                                                        | quote  | `arm-cmn.c:123`                                                                                                                                                                                                                                                                         | ✓      |
+| C19 | DSU cluster PMU: `CLUSTERPMCR`, cycle idx 31 `0x11`, `config:0-31`; `associated_cpus`/`active_cpu` | src    | `arm_dsu_pmu.c:35-67,97-160,164`                                                                                                                                                                                                                                                        | ✓      |
+| C20 | DMC-620 DDR PMU: 8-bit `eventid`+`clkdiv2`; shared IRQ; per-instance PMU bound to a CPU            | src    | `arm_dmc620_pmu.c:70-91,110-128`                                                                                                                                                                                                                                                        | ✓      |
+| C21 | All uncore PMUs domain-scoped → not thread-attributable; collapse to "whole chip" on UMA           | synth  | consequence of C18–C20                                                                                                                                                                                                                                                                  | ◯      |
+| C22 | `arm-data` catalog per core; three-way `architectural` flag; **no `apple/`** in-tree               | src    | `arm-data@0806afb1 pmu/neoverse-n1.json` (`architectural`, `counters:6`), `pmu/c1-ultra.json`; `linux …/pmu-events/arch/arm64/`                                                                                                                                                         | ✓      |
+| C23 | Apple IMPDEF register model: `PMCR0-4`/`PMESR0/1`/`PMSR`/`PMC0-9`, 10 ctrs (2 fixed), 8-bit field  | src    | `apple_m1_cpu_pmu.c:22-168,227-270,379-419,546-566`; `apple_m1_pmu.h:10-50`; `applecpu …/PMCKext2.c:5-32`                                                                                                                                                                               | ✓      |
+| Q1  | _"…a grand total of two known counters, and the rest is anybody's guess."_                         | quote  | `apple_m1_cpu_pmu.c:31-40`                                                                                                                                                                                                                                                              | ✓      |
+| C24 | Linux Apple driver = 4-event PMUv3 shim (`m1_pmu_pmceid_map`); rest raw via `config:0-7`           | src    | `apple_m1_cpu_pmu.c:170-187,215-220,568-586`                                                                                                                                                                                                                                            | ✓      |
+| C25 | **Apple changed event encoding at M4** (E2 table): `as1/a14/as3` Apple #s vs `as4/as5` PMUv3 #s    | hw+src | `mac-bsn:/usr/share/kpep/{as1,a14,as3,as4-1,as5}.plist` (E2); driver TODO `apple_m1_cpu_pmu.c:44-48`                                                                                                                                                                                    | ✓      |
+| Q2  | _"…we'll have to introduce per cpu-type tables."_ (predicts the M4 break)                          | quote  | `apple_m1_cpu_pmu.c:44-48`                                                                                                                                                                                                                                                              | ✓      |
+| C26 | Linux 8-bit Apple field (`GENMASK(7,0)`, `config:0-7`) under-exposes kpep's wider selectors        | src+hw | `apple_m1_cpu_pmu.c:24,215`; kpep `L1D_CACHE_MISS_LD=0x5a3`, `FETCH_RESTART=0x1de`, up to `0x4006` (M4)                                                                                                                                                                                 | ✓      |
+| C27 | Apple advanced filtering (`OPMAT/OPMSK`, `PMTRHLD`, `PMCR2-4`) Linux never programs                | src    | `applecpu@0e6bc3f6 timer-hacks/PMCKext2.c:13-32`                                                                                                                                                                                                                                        | ✓      |
+| E1  | This box's kpep = `as4-1.plist` via `cpu_100000c_2_17d5b93a.plist` symlink                         | hw     | `mac-bsn ls -la /usr/share/kpep \| grep 17d5b93a`                                                                                                                                                                                                                                       | ✓      |
+| E3  | Full M4-Max catalog = 103 events; SME block; `INST_ALL => {counters_mask:252, number:8}`           | hw     | `mac-bsn:/usr/share/kpep/as4-1.plist` (`python3`/`plutil`)                                                                                                                                                                                                                              | ✓      |
+
+## Discrepancies
+
+- **D1 (major, documented).** Apple's **M4 event-encoding change** (C25). Upstream
+  `apple_m1_cpu_pmu.c` has no M4 table and would mis-decode M4 raw event numbers;
+  the driver's own TODO comment (Q2) predicts exactly this case. Confirmed by the
+  E2 kpep transcript (monotone break across the common subset). Documented in the
+  page's [Apple sidebar](../arm.md#the-m4-encoding-change-hw-verified-aarch64-darwin);
+  not an open contradiction — a hardware-verified finding. `hw`+`src`.
+- **D2 (documented).** Linux's **8-bit Apple event field** (C26) structurally cannot
+  express macOS's wider selectors (`0x5a3`, `0x1de`, `0x4006`), so Linux
+  under-exposes Apple's PMU even on supported silicon. Documented; `src`+`hw`.
+- **D3 (OPEN ⚠).** kpep reports **`fixed_counters: 3`** on _every_ Apple generation
+  (E2), but the Linux driver models only **2** fixed counters (idx 0 cycles, idx 1
+  instructions; `apple_m1_cpu_pmu.c:22`). The third fixed counter macOS advertises is
+  unmodeled by Linux (candidate: a fixed reference/uptime counter). **Flagged, not
+  resolved** — carried as an open item in the page's Apple sidebar. `hw` vs `src`. ⚠
+- **D4 (refinement, resolved).** The "architected vs implementation-defined" split is
+  **three-way** in ARM's own catalog (C22): architectural (mandatory) ⊂ common
+  (`0x00-0x3F`, presence via `PMCEID`) ⊂ all; `0x40+` IMPDEF. The naïve
+  "`0x0000–0x003F` vs `0x0040+`" boundary is the _common/IMPDEF_ line, correct as
+  stated, but "architectural" is a stricter subset inside it. Presented in the page as
+  an explicit refinement of the two-way split, not a contradiction. `src`.
+- **D5 (GATED ◯).** The **Arm ARM (DDI 0487, latest = issue K.a)** and the **SPE
+  whitepaper** could not be downloaded, live or archived. Live:
+  `developer.arm.com/documentation/ddi0487/latest/` serves only a JavaScript SPA
+  shell; a direct `curl` of the print URL returned HTTP 403 (Akamai CDN) even with a
+  browser UA; the SPE whitepaper URLs returned 403/404. **Wayback/CDX follow-up
+  (2026-07-10):** every `ddi0487` capture is a `text/html` landing page (~7–8 KB); the
+  one archived `.pdf` URL (`.../ddi0487/bb/DDI0487B_b_armv8_arm.pdf`, snapshot
+  `20220120090340`) fetched via `web/<ts>id_/` is 12 KB of HTML, **not** a PDF; no
+  `application/pdf` asset for the Arm ARM or SPE whitepaper exists on any Arm CDN host
+  in the archive. **GATED stands.** All ARM encodings in the page are grounded in the
+  **in-kernel header** (`arm_pmuv3.h`, which mirrors DDI 0487's _"Performance Monitors
+  Extension"_ chapter) and the **arm-data** JSON, not the PDF; SPE maps to the Arm
+  ARM's _"Statistical Profiling Extension"_ chapter. Cited by chapter name + issue K.a,
+  PDF not reproduced (permitted by the guardrails). `lit`. ◯
+
+## Claims dropped / weakened
+
+- **SM′ (Linux 5.17 date)** softened from a hard fact to `◯ lit`: the mechanism is
+  fully source-verified, but the introducing kernel _version_ was not re-derived from
+  git within the source-check timebox, so the page states it as known history and
+  flags it as such.
+- Nothing else was dropped; the page carries all 27 sub-report claims (C1–C27), the
+  five quote candidates (Q1–Q5), the three experiments (E1–E3), and the added
+  self-monitoring source-check (SM).
+
+**Net:** 0 fabrications. Every ARM-Linux encoding/mechanism is source-verified against
+`linux@e43ffb69e043`; the Apple sidebar is `[hw-verified: aarch64-darwin]` off
+`mac-bsn` plus the Linux driver. **One open discrepancy** (D3, Apple fixed-counter
+count 3-vs-2, ⚠ flagged not resolved); **one gated source** (D5, DDI 0487 / SPE
+whitepaper, grounded via the in-kernel header instead). The self-monitoring
+cross-check resolved **affirmatively** — arm64 does have the `rdpmc` userpage analog.

--- a/docs/research/cpu-pmu/grounding/elfutils.md
+++ b/docs/research/cpu-pmu/grounding/elfutils.md
@@ -1,0 +1,50 @@
+# Grounding ledger — `elfutils.md`
+
+Claim-by-claim verification of `docs/research/cpu-pmu/elfutils.md` against the
+pinned tree `elfutils@6f8f78c` (source 0.195; probes linked against 0.194,
+nixpkgs). Hardware experiments recorded on **Linux 6.18.26**, **AMD Ryzen 9
+7940HX** (Zen 4), **LDC 1.41**. `$REPOS = /home/petar/code/repos`.
+
+> Not published research. Do not link to it from the survey pages.
+
+Status key: ✓ verified · ≈ paraphrase-verified · ⚠ discrepancy · ◯ not locally groundable · 🌐 web-only.
+Types: quote · fact · figure · behavior · exposition · opinion.
+
+| #   | Claim                                                                                                                                             | Type     | Source (local + locator)                                                                                           | Status |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ | ------ |
+| L1  | `libdwfl` session: `dwfl_begin(&cb)` → `dwfl_linux_proc_report(dwfl, pid)` (parses `/proc/PID/maps`) → `dwfl_report_end`                          | fact     | `libdwfl/libdwfl.h:104`, `:384`, `:190`; callbacks `:72`                                                           | ✓      |
+| L2  | Standard callbacks `dwfl_linux_proc_find_elf` / `dwfl_standard_find_debuginfo` are taken by address                                               | fact     | `libdwfl.h:393` / `:319`                                                                                           | ✓      |
+| L3  | Resolution pipeline: `dwfl_addrmodule` → `dwfl_module_addrinfo` → `dwfl_module_getsrc` → `dwfl_lineinfo`                                          | fact     | `libdwfl.h:231`, `:514`, `:590`, `:606`                                                                            | ✓      |
+| L4  | elfutils recommends `addrinfo` over the older `addrsym`                                                                                           | fact     | `libdwfl.h:520`                                                                                                    | ✓      |
+| L5  | `dwfl_module_addrinfo`'s `offset` (arg 3) and `sym` (arg 4) **cannot be NULL** — a `NULL` segfaults                                               | quote    | `libdwfl.h:499` (_"OFFSET cannot be NULL … SYM cannot be NULL"_) + `__nonnull_attribute__ (3, 4)` on the prototype | ✓ (hw) |
+| L6  | Inline expansion: `dwfl_module_addrdie` → `dwarf_getscopes` (innermost-first) + `dwarf_decl_file`/`dwarf_decl_line`                               | fact     | `libdwfl.h:567`; `libdw/libdw.h:859`, `:929`/`:932`                                                                | ✓      |
+| L7  | DWARF-CFI unwind: `dwfl_attach_state` (callbacks `{next_thread, memory_read, set_initial_registers}`) → `dwfl_getthread_frames` → `dwfl_frame_pc` | fact     | `libdwfl.h:725`, `:661`, `:815`, `:825`; register seeding `:783`/`:775`                                            | ✓      |
+| L8  | Per-frame PC/activation contract: subtract 1 from `*PC` when `*ISACTIVATION` is false                                                             | quote    | `libdwfl.h:820` (*"Typically you need to subtract 1 from *PC if _ACTIVATION is false…"_, verbatim)                 | ✓      |
+| L9  | CFI comes from `dwfl_module_dwarf_cfi` (`.debug_frame`) / `dwfl_module_eh_cfi` (`.eh_frame`)                                                      | fact     | `libdwfl.h:657` / `:658`                                                                                           | ✓      |
+| L10 | `numa_alloc_onnode`-style module reporting reads the **same** `/proc/PID/maps` perf synthesizes MMAP2 from                                        | behavior | `dwfl_linux_proc_report` (`:384`); cross-check `linux-perf-events.md` L8                                           | ✓      |
+| L11 | Version skew recorded honestly: source 0.195 vs runtime 0.194; all cited APIs exist in both                                                       | fact     | `configure.ac`/`NEWS` at `6f8f78c`; nixpkgs runtime 0.194                                                          | ✓      |
+| E2  | Symbolized ~2000 live IPs → `sumSquares` (1852) / `mixHash` (130) with `file:line`                                                                | figure   | Experiment B (`sampling-symbolize.d`)                                                                              | ✓ (hw) |
+| E3  | Frame-pointer-less 5-frame DWARF-CFI unwind offline (`level3→…→run`)                                                                              | figure   | Experiment C (`unwind-stack-user.d`)                                                                               | ✓ (hw) |
+
+## Discrepancies
+
+- **⚠ D-EF1 — perf reports modules with `dwfl_report_elf`, not `dwfl_report_module`.**
+  An early hypothesis named `dwfl_report_module` for perf's user unwinder; the
+  source shows `tools/perf/util/unwind-libdw.c` leaves `.find_elf` unset and uses
+  `dwfl_report_elf()` (`unwind-libdw.c:66`, `:114`). Both entry points are valid;
+  the page states this explicitly and uses `dwfl_linux_proc_report` in the probes.
+  Corrected in the page (the "Discrepancy resolved" NOTE). `[source-verified]`
+- **⚠ D-EF2 — `dwfl_module_addrsym` vs `dwfl_module_addrinfo` + the non-NULL trap.**
+  The brief named `addrsym`; elfutils documents `addrinfo` as preferred, and
+  `addrinfo`'s `offset`/`sym` must be non-NULL — a real segfault hit on the first
+  probe run on a live IP. Corrected: the page uses `addrinfo` and carries the
+  WARNING. `[hw-verified: x86_64-linux]`
+- **Note — version skew (L11).** Source read 0.195, probes linked 0.194. Every API
+  cited exists in both; the page records **0.194 as the tested version** and
+  flags the skew in a WARNING.
+
+**Net:** 0 substantive discrepancies remaining. Both header quotes (the non-NULL
+`addrinfo` contract and the PC/activation rule) are verbatim from `libdwfl.h`; both
+hardware experiments reproduced. The two ⚠ items were brief-vs-source corrections
+(`dwfl_report_elf`, `addrinfo`) that the page now states correctly, and the version
+skew is disclosed.

--- a/docs/research/cpu-pmu/grounding/event-naming.md
+++ b/docs/research/cpu-pmu/grounding/event-naming.md
@@ -1,0 +1,129 @@
+# Grounding ledger — `event-naming.md`
+
+Claim-by-claim source verification of [`docs/research/cpu-pmu/event-naming.md`](../event-naming.md).
+Every naming-layer claim is checked against a **local** pinned repo; the live round
+trip (E1/E2) is `[hw-verified: x86_64-linux]` off the 7940HX box. `$REPOS = /home/petar/code/repos`.
+
+Pinned trees (read-only): **libpfm4** `$REPOS/c/libpfm4@6870a9f` (perfmon2, cloned
+from the canonical `git.code.sf.net/p/perfmon2/libpfm4`, **not** the `wcohen/libpfm4`
+GitHub mirror — see [Discrepancies](#discrepancies)); **PAPI** `$REPOS/c/papi@ec16e00f`;
+**LIKWID** `$REPOS/c/likwid@f23c6663`; **`intel/perfmon`** `$REPOS/cpu-pmu/intel-perfmon@683a4d0b`;
+**linux** `$REPOS/linux@e43ffb69e043` (v7.1-rc6). Hardware bed: kernel **6.18.26**, AMD
+**Ryzen 9 7940HX** (Zen 4, family 25 / model `0x61`), `perf_event_paranoid = -1`,
+**libpfm 4.13.0** (nixpkgs), LDC 1.41.
+
+> Not published research. Do not link to it from the survey pages.
+
+## Status legend
+
+| Mark | Meaning                                                                   |
+| ---- | ------------------------------------------------------------------------- |
+| `✓`  | Verified against the cited local artifact (locator recorded)              |
+| `≈`  | Faithful paraphrase / inference from absence (no single line to point at) |
+| `⚠`  | Discrepancy — hypothesis refuted, or a hazard the page must flag          |
+| `◯`  | Not locally groundable — synthesis/consequence, or cross-page dependency  |
+| `🌐` | Web / secondary only (not asserted as a tree fact)                        |
+
+**Types:** `quote` (verbatim) · `src` (repo source-read, `[source-verified]`) ·
+`hw` (7940HX, `[hw-verified: x86_64-linux]`) · `lit` (`[literature]`) · `synth` (derived).
+
+## Claim ledger
+
+| #   | Claim (short)                                                                                          | Type   | Source (local + locator)                                                                                           | Status |
+| --- | ------------------------------------------------------------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------ | ------ |
+| 1   | `pfm_get_os_event_encoding` signature; `pfm_perf_encode_arg_t` = 40 B on LP64 (ABI-checked)            | src    | `libpfm4 include/perfmon/pfmlib.h:1050`; `pfmlib_perf_event.h:37-45` (`PFM_PERF_ENCODE_ABI0 40`)                   | ✓      |
+| 2   | `pfm_os_t` = `{NONE, PERF_EVENT, PERF_EVENT_EXT}` — **no non-Linux OS layer**                          | src    | `pfmlib.h:901-905`                                                                                                 | ✓      |
+| 3   | PMU detection is CPUID-based (`cpuid(0)` vendor, `cpuid(1)` family/model), not `/proc/cpuinfo`         | src    | `lib/pfmlib_amd64.c:322-367` (`pfm_amd64_detect`, `amd64_get_revision`)                                            | ✓      |
+| 4   | **git HEAD**: family 25 `model>=0x60 \|\| 0x10..0x1f` → `FAM19H_ZEN4` (covers `0x61`)                  | src    | `lib/pfmlib_amd64.c:191-196`                                                                                       | ✓      |
+| 5   | **released 4.13.0**: only `model==17` (0x11) → ZEN4; `0x61` matches nothing → `PFM_ERR_NOTFOUND`       | src    | nixpkgs libpfm **4.13.0** realized `lib/pfmlib_amd64.c` family-25 branch                                           | ⚠ ✓    |
+| 6   | Grammar delimiter `PFMLIB_ATTR_DELIM ":."`; `amd64_mods` = `k/u/e/i/c/h/g`                             | src    | `lib/pfmlib_priv.h:36`; `lib/pfmlib_amd64.c:37-44`                                                                 | ✓      |
+| 7   | AMD encoding defaults `PERF_TYPE_RAW`; zeroes `EN/INT/OS/USR/GUEST/HOST` config bits → `exclude_*`     | src+hw | `lib/pfmlib_amd64_perf_event.c:59-116`; probe: `:u` keeps `config 0xc0`, sets `exclude_kernel=1`                   | ✓      |
+| 8   | **No precise mode on AMD**; IBS modeled as flagged events (`AMD64_FL_IBSFE/IBSOP`), no selector        | src    | `pfmlib_amd64_perf_event.c:144`; `pfmlib_amd64.c:76-84,452-455` (`reg.ibsfetch.en`/`reg.ibsop.en`)                 | ✓      |
+| 9   | ISA coverage: x86/ARMv6–v9/POWER4–10/SPARC/s390x/MIPS/Itanium/Cell; **∅ RISC-V**                       | src    | `lib/events/` (no `*riscv*`); `lib/` (no `pfmlib_*riscv*`)                                                         | ✓      |
+| 10  | On 7940HX only `perf`/`perf_raw` present; zen4 table compiled-but-inert; 2 workarounds live            | hw     | probe E2; `strings libpfm.so.4.13.0 \| grep amd64_fam19h_zen4`; `pfmlib_common.c:1361-1401` (activation)           | ✓      |
+| 11  | PAPI **vendors** libpfm4 (`src/libpfm4`, plain dir) and bridges it for encoding                        | src    | `papi src/libpfm4/`; `src/components/perf_event/pe_libpfm4_events.c:199-201`                                       | ✓      |
+| 12  | Presets in `papi_events.csv`: `CPU,<pmu>` sections, `PRESET,<name>,<deriv>,<events>`; `DERIVED_*`      | src    | `papi src/papi_events.csv:8,10,17,20,514`                                                                          | ✓      |
+| 13  | **PAPI zen4 + zen5 preset sections EXIST** (refutes "unmapped"); **∅ RISC-V / Apple**                  | src    | `papi_events.csv:514-515` (`amd64_fam19h_zen4`, `amd64_fam1ah_zen5`); only `arm_*` beyond x86                      | ⚠ ✓    |
+| 14  | LIKWID does **not** use libpfm4; own event lists (`perfmon_zen4_events.txt`, "Thomas Gruber")          | src    | `grep -ril libpfm src/` → empty; `likwid src/includes/perfmon_zen4_events.txt`                                     | ✓      |
+| 15  | `ACCESSMODE` = `PERF`(-1) / `DIRECT`(0) / `DAEMON`; direct/daemon reach uncore + frequency             | src    | `likwid.h:297-301`; `access.c`; `frequency_uncore.c:191` ("Cannot manipulate Uncore frequency with … perf")        | ✓      |
+| 16  | Groups carry `EVENTSET` + `METRICS` + `LONG`; `CPI = CPU_CLOCKS_UNHALTED/RETIRED_INSTRUCTIONS`         | src    | `likwid groups/zen4/CPI.txt`                                                                                       | ✓      |
+| 17  | LIKWID ships **Apple M1**, Graviton3, A64FX tables — wider OS/vendor axis than libpfm4/PAPI            | src    | `likwid src/includes/perfmon_{applem1,graviton3,a64fx,a57}_events.txt`                                             | ✓      |
+| 18  | `intel/perfmon` JSON schema (`EventCode/UMask/EventName/…/PEBS/Deprecated`); `mapfile.csv` keying      | src    | `intel-perfmon mapfile.csv`; `SKX/events/*.json` (`"PEBS": "0"`)                                                   | ✓      |
+| 19  | TMA/metric JSONs (`Level`, `Events[]`, `Formula`); `metrics/perf/` variant in perf syntax              | src    | `intel-perfmon ICX/metrics/icelakex_metrics.json`                                                                  | ✓      |
+| 20  | **Provenance surprise**: `create_perf_json.py` self-generates the kernel's perf JSON                   | quote  | `intel-perfmon scripts/create_perf_json.py:12` ("OUTPUT: A perf json directory suitable for the tools/perf …")     | ✓      |
+| 21  | **AMD asymmetry**: no public analogue; kernel `amdzen4/` AMD-authored, keyed `AuthenticAMD-25-…`       | src    | `linux tools/perf/pmu-events/arch/x86/{mapfile.csv,amdzen4/}`; `git log` (`Sandipan Das <sandipan.das@amd.com>`)   | ✓      |
+| 22  | **Name-space divergence**: `RETIRED_INSTRUCTIONS` (libpfm) vs `ex_ret_instr` (kernel) for 0xc0         | src    | `amd64_events_fam19h_zen4.h:1603-1606` (`.code 0xc0`) vs `amdzen4/core.json:34-36` (`ex_ret_instr`, `0xc0`)        | ✓      |
+| 23  | **No cross-OS naming layer**: Windows curated `ProfileSource`; macOS `kpep`; backend must own one      | lit≈   | claim 2 (libpfm Linux-only) + W5 [windows][w], W6 [macos][m]                                                       | ≈      |
+| Q1  | _"This is the key function … The event string … may contains sub-event masks (umask) …"_               | quote  | `libpfm4 docs/man3/pfm_get_os_event_encoding.3:11-18`                                                              | ✓      |
+| Q2  | _"suppress the bits which are under the control of perf_events … the OS/USR bits … exclude_\*"\_       | quote  | `lib/pfmlib_amd64_perf_event.c:98-114`                                                                             | ✓      |
+| Q3  | _"No precise mode on AMD"_                                                                             | quote  | `lib/pfmlib_amd64_perf_event.c:144`                                                                                | ✓      |
+| Q4  | _"OUTPUT: A perf json directory suitable for the tools/perf folder."_                                  | quote  | `intel-perfmon scripts/create_perf_json.py:12`                                                                     | ✓      |
+| A1  | **Addition**: kernel `pmu-events` **does** carry per-vendor RISC-V JSON (sifive/thead/andes/…)         | src    | `linux tools/perf/pmu-events/arch/riscv/{sifive,thead,andes,openhwgroup,starfive}/`                                | ✓      |
+| A2  | **Addition**: Intel event JSON carries a first-class `PEBS` field (vs AMD's flagged IBS)               | src    | `intel-perfmon SKX/events/*.json` (`"PEBS": "0"`)                                                                  | ✓      |
+| A3  | **Addition**: `recommended.json` uses field `MetricExpr` (not `Formula`) for AMD perf metrics          | src    | `amdzen4/recommended.json:3-5` (`branch_misprediction_ratio`, `MetricExpr = d_ratio(ex_ret_brn_misp, ex_ret_brn)`) | ✓      |
+| E1  | Round trip: generic→type0/0x0; native→type4/0xc0; umask→0x103 count **3,000,001**; `:u`→exclude_kernel | hw     | probe `pfm4-name-roundtrip.d` (verbatim block reproduced in-page)                                                  | ✓      |
+| E2  | Auto-detect failure root cause + workarounds (`LIBPFM_FORCE_PMU`, `LIBPFM_ENCODE_INACTIVE`)            | hw+src | probe; realized 4.13.0 `pfmlib_amd64.c` family-25 branch (claim 5)                                                 | ✓      |
+
+## Discrepancies
+
+- **⚠ Hypothesis REFUTED — "PAPI presets unmapped on modern µarchs"** (claim 13). The
+  prompt hypothesis is false for Zen 4/Zen 5: `papi_events.csv:514-515` has explicit
+  `CPU,amd64_fam19h_zen4` **and** `CPU,amd64_fam1ah_zen5` sections with real `PRESET`
+  rows. The page states the refutation directly (Overview note under PAPI) and cites the
+  lines. What _is_ true is the inherited boundary: PAPI has no RISC-V and no Apple
+  presets, because it vendors libpfm4.
+- **⚠ Hazard — libpfm 4.13.0 auto-detect failure on model `0x61`** (claims 5, 10). Not a
+  page error but a real design constraint the page must flag: the prompt-implied
+  "`pfm_get_os_event_encoding('RETIRED_OPS')` just works" is **false on this box** —
+  stock 4.13.0 fails to detect the family-25/model-`0x61` Zen 4 and returns
+  `PFM_ERR_NOTFOUND`. Surfaced as the page's `[!WARNING]` (**The auto-detect hazard**);
+  root cause confirmed against the realized 4.13.0 source, fix confirmed at HEAD
+  (`pfmlib_amd64.c:191-196`), both workarounds proven live in E2. `hw`+`src`.
+- **Provenance surprise — `intel/perfmon` self-generates the perf JSON** (claims 20–22).
+  `create_perf_json.py` emits "a perf json directory suitable for the tools/perf folder"
+  — Intel maintains the machine-readable upstream, whereas AMD contributes JSON straight
+  into the kernel (`sandipan.das@amd.com`). Asymmetric provenance → asymmetric name
+  spaces (`RETIRED_INSTRUCTIONS` vs `ex_ret_instr` for the same 0xc0). Documented in
+  **The vendor-table asymmetry**; not a contradiction, a finding.
+- **Enrichment — RISC-V is `∅` for four layers but present in the kernel** (addition A1).
+  libpfm4/PAPI/LIKWID/`intel-perfmon` carry zero RISC-V tables, but `linux`'s
+  `pmu-events/arch/riscv/` ships per-vendor JSON (sifive/thead/andes/openhwgroup/starfive).
+  The page's coverage table and the ∅-RISC-V finding are sharpened accordingly (kernel is
+  the sole exception), cross-linking [riscv][r]. Beyond the 23 sub-report claims but
+  locator-grounded.
+- **libpfm4 canonical-source note.** The pinned libpfm4 tree is the perfmon2 SourceForge
+  repository (`git.code.sf.net/p/perfmon2/libpfm4`), **not** the widely-linked
+  `wcohen/libpfm4` GitHub mirror. Chosen for canonicity: SourceForge is upstream, the
+  mirror lags. The page's external libpfm4 links therefore point at
+  `sourceforge.net/p/perfmon2/libpfm4/ci/6870a9f00412/tree/…` (line anchors unavailable
+  in the SourceForge tree view; locators are recorded in this ledger's `file:line` form
+  instead). Recorded so a future reader does not "correct" the links to the mirror.
+
+## Claims dropped / weakened
+
+- **Claim 23 (no cross-OS naming layer)** is `≈ lit`: the libpfm-side half is
+  source-verified (claim 2, Linux-only `pfm_os_t`); the Windows/macOS half is a
+  cross-page dependency on [windows][w] / [macos][m] (W5/W6), stated as synthesis, not
+  re-derived here.
+- **Minor correction applied (A3):** the sub-report rendered the AMD metric field as
+  `Formula`; the kernel's `recommended.json` field is actually `MetricExpr`. The page
+  uses `MetricExpr = d_ratio(ex_ret_brn_misp, ex_ret_brn)` verbatim.
+- **Released-4.13.0 detect (claim 5)** carries no browsable hyperlink — it is the nixpkgs
+  _realized_ source, not a commit in the pinned SourceForge tree; grounded as the hazard
+  and cited by version + branch shape, with the HEAD fix linked for contrast.
+- Nothing else dropped; the page carries all 23 sub-report claims, the four quote
+  candidates (Q1–Q4; the kernel-commit "Add Zen 4 core events" line is folded into
+  claim 21), both experiments (E1/E2), and three locator-grounded additions (A1–A3).
+
+**Net:** 0 fabrications. Every naming-layer mechanism is source-verified against the five
+pinned repos; the live round trip and the auto-detect failure are `[hw-verified: x86_64-linux]`
+on the 7940HX. **One refuted hypothesis** (PAPI presets — mapped, not missing, for
+zen4/zen5) and **one flagged hazard** (libpfm 4.13.0 vs model `0x61`), both surfaced in
+the page. The two prompt boundary questions are **both confirmed**: libpfm4 has ∅ RISC-V
+(kernel-only) and no non-Linux OS layer.
+
+<!-- References -->
+
+[w]: ../windows.md
+[m]: ../macos.md
+[r]: ../riscv.md

--- a/docs/research/cpu-pmu/grounding/index.md
+++ b/docs/research/cpu-pmu/grounding/index.md
@@ -1,0 +1,71 @@
+# Grounding ledger — cpu-pmu survey
+
+Internal QA evidence for `docs/research/cpu-pmu/`. One ledger per page, a
+master discrepancy register, and the [local-artifact map](./_sources.md).
+
+> Not published research. Do not link to it from the survey pages.
+
+**Status legend:** `✓` verified against a local artifact · `≈`
+paraphrase-verified · `⚠` discrepancy found (see register) · `◯` not locally
+groundable / open · `🌐` web-only fallback.
+**Claim types:** quote · fact · figure · behavior · exposition · opinion.
+
+## Per-page index
+
+| Page                                                                                | Ledger                                      | Status     |
+| ----------------------------------------------------------------------------------- | ------------------------------------------- | ---------- |
+| linux-perf-events.md                                                                | [linux-perf-events](./linux-perf-events.md) | see ledger |
+| elfutils.md                                                                         | [elfutils](./elfutils.md)                   | see ledger |
+| libtraceevent.md                                                                    | [libtraceevent](./libtraceevent.md)         | see ledger |
+| libnuma.md                                                                          | [libnuma](./libnuma.md)                     | see ledger |
+| precise-sampling.md                                                                 | [precise-sampling](./precise-sampling.md)   | see ledger |
+| arm.md                                                                              | [arm](./arm.md)                             | see ledger |
+| riscv.md                                                                            | [riscv](./riscv.md)                         | see ledger |
+| windows.md                                                                          | [windows](./windows.md)                     | see ledger |
+| macos.md                                                                            | [macos](./macos.md)                         | see ledger |
+| event-naming.md                                                                     | [event-naming](./event-naming.md)           | see ledger |
+| index.md · concepts.md · comparison.md · sparkles-baseline.md · backend-proposal.md | [synthesis-pages](./synthesis-pages.md)     | see ledger |
+
+## Master discrepancy register
+
+Corrections of the research brief's embedded hypotheses (`R1`–`R16`, `R21`,
+`R22`) and load-bearing surprises the survey itself established (`R17`–`R20`).
+"Fixed?" = the survey pages state the corrected fact.
+
+| #   | Page                        | Claim (as hypothesized / naively assumed)                                 | Correction                                                                                                                                                                                                                                    | Source                                                                         | Fixed? |
+| --- | --------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------ |
+| R1  | precise-sampling            | "Intel/AMD PEBS/IBS are all testable on the primary box"                  | AMD Zen 4 box has **no PEBS**; `cpu` PMU `caps/max_precise = 0`; IBS is the only precise engine — PEBS stays source/literature                                                                                                                | sysfs (this host); `arch/x86/events/amd/ibs.c`                                 | ✓      |
+| R2  | precise-sampling            | "fall back to `cpu` PMU `precise_ip>0` if IBS unavailable"                | no precise mode exists on the AMD core PMU; `precise_ip` 1–2 is forwarded to `ibs_op`, `>2` → `-EOPNOTSUPP`                                                                                                                                   | `ibs.c:240-258`                                                                | ✓      |
+| R3  | riscv                       | "`drivers/perf/riscv_ctr.c`" exists to read                               | file does not exist at `linux@e43ffb69e043` (v7.1-rc6); zero Smctr/Ssctr code tree-wide                                                                                                                                                       | tree grep (recorded)                                                           | ✓      |
+| R4  | riscv                       | "CTR, ratified 2025"                                                      | ratified **2024-11-22**, v1.0, extension names **Smctr/Ssctr**; corroborated by the GitHub v1.0 "Ratified release" (2024-11-23)                                                                                                               | `riscv-ctr@42e299ca header.adoc`; release asset                                | ✓      |
+| R5  | riscv                       | "AIA/`Ssaia` dependency for sampling (incl. guests)"                      | **host** sampling needs only Sscofpmf; AIA is required specifically for **guest** overflow delivery (`HVIEN` bit 13)                                                                                                                          | `arch/riscv/kvm/aia.c:565-567`                                                 | ✓      |
+| R6  | macos                       | "document the DTrace `cpc` provider; run a `cpc` one-liner"               | no `cpc` provider exists anywhere in Apple's stack (xnu provider set + dtrace-413); SIP additionally blocks unprivileged dtrace                                                                                                               | `xnu bsd/dev/dtrace/`; `apple-dtrace@dtrace-413`; mac-bsn transcript           | ✓      |
+| R7  | windows                     | "HCP's curated set = cycle-only"                                          | HCP surfaces up to 16 PMCs via `HwCounters[]` — but only under a WDK driver (`KeSetHardwareCounterConfiguration`, system-global, single-tenant); the _driver-free_ datum is `CycleTime` only                                                  | `win-enablethreadprofiling.html`, `wdk-kesethardwarecounterconfiguration.html` | ✓      |
+| R8  | windows                     | `EnableThreadProfiling` lives in `realtimeapiset.h`                       | lives in **winbase.h** (tech root `hcp`); the `nf-realtimeapiset-*` URLs 404                                                                                                                                                                  | saved doc URLs                                                                 | ✓      |
+| R9  | linux/elfutils              | perf reports unwind modules via `dwfl_report_module`                      | perf uses **`dwfl_report_elf`** ("`.find_elf` is not set as we use dwfl_report_elf() instead.")                                                                                                                                               | `tools/perf/util/unwind-libdw.c:66`                                            | ✓      |
+| R10 | elfutils                    | `dwfl_module_addrsym` is the symbol lookup                                | `dwfl_module_addrinfo` is documented-preferred, and its `offset`/`sym` args **must be non-NULL** — NULL segfaults (hardware-hit)                                                                                                              | `libdwfl.h:495-520`; probe crash log                                           | ✓      |
+| R11 | libnuma                     | libnuma wraps an address→node query                                       | **no such helper exists**; the query is raw `get_mempolicy(MPOL_F_NODE\|MPOL_F_ADDR)` / `move_pages` query mode; `numa_police_memory` only faults pages in                                                                                    | `numactl@93c1fe5 libnuma.c`, `shm.c:307`, `test/mynode.c:10`                   | ✓      |
+| R12 | libtraceevent               | libtraceevent reads tracefs `format` files                                | it parses **caller-supplied buffers** only (file I/O is libtracefs's job); public header is `include/traceevent/event-parse.h`                                                                                                                | `libtraceevent@51d47b0 src/event-parse.c:8462-8467`                            | ✓      |
+| R13 | precise-sampling / examples | link libnuma via `libs "numa"` (pkg-config)                               | numactl ships **no `numa.pc`**, and `get_mempolicy`/`move_pages` aren't in glibc — the probe calls the raw syscalls instead                                                                                                                   | `pkg-config --exists numa` (fails); numactl tree                               | ✓      |
+| R14 | event-naming                | "PAPI presets unmapped/derived on modern µarchs"                          | `papi_events.csv` has explicit `amd64_fam19h_zen4` and `_zen5` preset sections                                                                                                                                                                | `papi@ec16e00f src/papi_events.csv:483-550`                                    | ✓      |
+| R15 | event-naming                | libpfm4 name→encoding "just works" on current silicon                     | stock **libpfm 4.13.0 fails to auto-detect** family 25 model `0x61` (this Zen 4) — `PFM_ERR_NOTFOUND` for native names; fixed in git HEAD; backends must force the PMU from CPUID                                                             | 4.13.0 realized src vs `libpfm4@6870a9f`; probe E2                             | ✓      |
+| R16 | arm                         | "architected `0x00-0x3F` vs IMPDEF `0x40+`" (two-way split)               | the catalog is **three-way**: architected (e.g. `SW_INCR`) ⊂ common `0x00-0x3F` (presence via `PMCEID*`) ⊂ IMPDEF `0x40+`; plus arch-extension space `0x4000+`                                                                                | `arm-data@0806afb1 pmu/*.json` (`architectural` flag); `arm_pmuv3.h`           | ✓      |
+| R17 | arm/macos                   | (survey finding) Apple event numbering is stable across generations       | **M4/M5 remap the common subset onto PMUv3 architected numbers** (`INST_ALL` `0x8c`→`0x8`, `CORE_ACTIVE_CYCLE` `0x2`→`0x11`); M1–M3 use Apple numbers; Linux ships no M4 table and its 8-bit event field can't express kpep's wider selectors | kpep plists (mac-bsn) + `xnu cpc_arm64_events.c` + `apple_m1_cpu_pmu.c`        | ✓      |
+| R18 | arm/macos                   | kpep `fixed_counters: 3` vs kpc `KPC_CLASS_FIXED` = 2 vs Linux driver = 2 | **unresolved** — the identity of the third kpep fixed counter is unknown (candidate: a fixed reference/uptime counter)                                                                                                                        | kpep plists vs `kern_kpc.c` / `apple_m1_cpu_pmu.c:22`                          | ☐ OPEN |
+| R19 | linux-perf-events           | (naive assumption) MMAP2 records describe the whole address space         | `PERF_RECORD_MMAP2` is emitted **only for mappings created while the event is enabled**; pre-existing code must be synthesized from `/proc/PID/maps` — the build-id/stale-binary hazard for a self-profiling harness                          | probe (0 MMAP2 until forced); `tools/perf/util/machine.c`                      | ✓      |
+| R20 | precise-sampling            | (naive attr) IBS opens like a core-PMU event                              | bare `exclude_kernel`/`exclude_hv` → `-EINVAL` on Zen 4 (no `IBS_CAPS_BIT63_FILTER`); privilege filtering needs the `swfilt` bit (`config2:0`); `exclude_hv` never accepted                                                                   | `ibs.c:346-370`; E2 errno matrix                                               | ✓      |
+| R21 | arm                         | Arm ARM (DDI 0487) + SPE whitepaper fetchable to papers/                  | **GATED** — developer.arm.com is a JS SPA, direct PDFs 403 (Akamai), Wayback holds only HTML shells (CDX sweep recorded); cited by chapter name + issue **K.a**; grounded via in-kernel headers + arm-data                                    | CDX transcripts in [arm ledger](./arm.md)                                      | ✓      |
+| R22 | macos                       | kpc per-thread counting demonstrable with recorded entitlement/root needs | confirmed **root-only** ("root or the blessed pid"); the `com.apple.private.ktrace-allow` escape is compiled only into DEVELOPMENT/DEBUG kernels; unprivileged floor is `proc_pid_rusage` (hw-verified EPERM matrix)                          | `kern_kpc.c:405-408`, `kern_ktrace.c:273-297`; Exp. a                          | ✓      |
+
+## Environment / integrity notes
+
+- `$REPOS/linux` reused read-only at a pre-existing detached checkout
+  (`e43ffb69e043`, v7.1-rc6); never fetched or modified during the survey.
+- mac-bsn runs xnu-12377.**91.3** while the open-source drop read is
+  xnu-12377.**1.9** — same 12377 base for the T6041; line numbers cite the
+  public drop (noted in the [macos ledger](./macos.md)).
+- elfutils version skew: source read 0.195 (`6f8f78c`), runtime-linked/tested
+  0.194 (nixpkgs) — all cited APIs exist in both.
+- All experiments on the primary box ran unprivileged at
+  `perf_event_paranoid = -1`; all mac-bsn experiments ran unprivileged with
+  SIP enabled (`sudo -n` unavailable) — nothing was escalated or disabled.

--- a/docs/research/cpu-pmu/grounding/libnuma.md
+++ b/docs/research/cpu-pmu/grounding/libnuma.md
@@ -1,0 +1,47 @@
+# Grounding ledger — `libnuma.md`
+
+Claim-by-claim verification of `docs/research/cpu-pmu/libnuma.md` against the pinned
+tree `numactl@93c1fe5` (libnuma 2.0.19, read 2026-06-30). Source-only.
+`$REPOS = /home/petar/code/repos`.
+
+> Not published research. Do not link to it from the survey pages.
+
+Status key: ✓ verified · ≈ paraphrase-verified · ⚠ discrepancy · ◯ not locally groundable · 🌐 web-only.
+Types: quote · fact · figure · behavior · exposition · opinion.
+
+| #   | Claim                                                                                                                     | Type       | Source (local + locator)                                                                                         | Status |
+| --- | ------------------------------------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- | ------ |
+| L1  | Mempolicy syscalls exposed as thin `WEAK` shims: `get_mempolicy`, `set_mempolicy`, `mbind`, `migrate_pages`, `move_pages` | fact       | `syscall.c:223`/`:238`/`:231`/`:246`/`:257`                                                                      | ✓      |
+| L2  | `numa_alloc_onnode` = `mmap` + `dombind` → `mbind`                                                                        | quote      | `libnuma.c:1150`, `:324` (_"static int dombind(… mbind(…) …"_, verbatim)                                         | ✓      |
+| L3  | `numa_set_membind` = `set_mempolicy(MPOL_BIND)`; `numa_move_pages` = `move_pages`                                         | fact       | `libnuma.c:1206`, `:1913`                                                                                        | ✓      |
+| L4  | Node enumeration is `opendir("/sys/devices/system/node")`                                                                 | fact       | `libnuma.c:371`                                                                                                  | ✓      |
+| L5  | Per-node CPU mask read from `.../node<N>/cpumap` → `getdelim` → `numa_parse_bitmap`                                       | fact       | `libnuma.c:1571`                                                                                                 | ✓      |
+| L6  | Inter-node distance (ACPI SLIT) from `.../node<N>/distance` via `read_distance_table` → `numa_distance`                   | fact       | `distance.c:47`, `:105`; `struct bitmask {size; maskp}` `numa.h:44`                                              | ✓      |
+| L7  | **No VA→node helper** — the query exists only as a raw syscall in the numactl _tool_, not `libnuma.c`                     | quote      | `test/mynode.c:10` — _"get_mempolicy(&nd, NULL, 0, man, MPOL_F_NODE\|MPOL_F_ADDR)"_ (verbatim); also `shm.c:307` | ✓      |
+| L8  | Alternative VA→node path: `move_pages` **query mode** (`NULL` target-nodes → node in `status[]`)                          | behavior   | `numa_move_pages`→`move_pages` (`libnuma.c:1913`); query-mode semantics                                          | ✓      |
+| L9  | `numa_police_memory` only **faults pages in** — it does **not** query their node                                          | behavior   | `libnuma.c` (`numa_police_memory` touches pages, no node read)                                                   | ✓      |
+| L10 | No `numa.pc` ships → `pkg-config libnuma` fails                                                                           | fact       | pinned tree has no `.pc`; contrast elfutils                                                                      | ✓      |
+| L11 | UMA collapse: on Apple Silicon the entire node axis is moot                                                               | exposition | cross-ref `macos.md` (UMA)                                                                                       | ✓      |
+
+## Discrepancies
+
+- **⚠ D-LN1 — libnuma has no "which node backs this VA" helper.** The headline
+  finding. The brief hypothesized a library wrapper; there is none — the VA→node
+  query is the raw `get_mempolicy(MPOL_F_NODE | MPOL_F_ADDR)` (used by the numactl
+  _tool_, `test/mynode.c:10` / `shm.c:307`) or `move_pages` query mode. The page
+  makes this its central point and quotes the raw call. `[source-verified]` This is
+  the exact gap `precise-sampling.md` (W2) builds its node classifier on.
+- **⚠ D-LN2 — `numa_police_memory` faults, it does not query.** A tempting
+  near-miss: the brief hypothesized `numa_police_memory` queries the backing node;
+  it only faults pages in. Corrected in the page (WARNING/NOTE + the Weaknesses
+  "false friend" bullet). `[source-verified]`
+- **Note — no runnable probe on this page.** libnuma is source-only in this drop;
+  the VA→node path it documents is exercised by W2's precise-sampling probe
+  (`mem-latency-numa.d`), not here. The page is tagged `[source-verified]`
+  throughout.
+
+**Net:** 0 substantive discrepancies. The two verbatim quotes (`dombind`→`mbind`;
+the raw `get_mempolicy` VA→node call) are exact from the pinned tree. Both ⚠ items
+are brief-vs-source corrections about _absence_ (no VA→node helper;
+`numa_police_memory` does not query) — precisely the findings the page is built to
+surface, and the ones the precise-sampling classifier depends on.

--- a/docs/research/cpu-pmu/grounding/libtraceevent.md
+++ b/docs/research/cpu-pmu/grounding/libtraceevent.md
@@ -1,0 +1,45 @@
+# Grounding ledger — `libtraceevent.md`
+
+Claim-by-claim verification of `docs/research/cpu-pmu/libtraceevent.md` against the
+pinned tree `libtraceevent@51d47b0` (1.9.0, read 2026-05-29). The acquisition-side
+tracefs gate was observed on **Linux 6.18.26** (AMD Ryzen 9 7940HX). Source-only
+otherwise. `$REPOS = /home/petar/code/repos`.
+
+> Not published research. Do not link to it from the survey pages.
+
+Status key: ✓ verified · ≈ paraphrase-verified · ⚠ discrepancy · ◯ not locally groundable · 🌐 web-only.
+Types: quote · fact · figure · behavior · exposition · opinion.
+
+| #   | Claim                                                                                                                                              | Type     | Source (local + locator)                                                                                                   | Status |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- | ------ |
+| L1  | Parses a caller-supplied `format` **buffer**; documents (but does not fetch) the tracefs `format` path                                             | quote    | `src/event-parse.c:8462` — _"These files currently come from: /sys/kernel/debug/tracing/events/.../.../format"_ (verbatim) | ✓      |
+| L2  | Handle lifecycle `tep_alloc`/`tep_free`; schema parse `tep_parse_event` / `tep_parse_format` return `enum tep_errno`                               | fact     | `event-parse.h:584`, `:458`; producer `src/event-parse.c:8469`/`:8491`                                                     | ✓      |
+| L3  | Event lookup `tep_find_event_by_name` / `tep_find_event_by_record`                                                                                 | fact     | `event-parse.h:523` / `:525`                                                                                               | ✓      |
+| L4  | Field extraction by name: `tep_find_field` → `struct tep_format_field {name,type,offset,size,flags}`                                               | fact     | `event-parse.h:506`, `:105`                                                                                                | ✓      |
+| L5  | Value read by offset/size: `tep_read_number_field` (sizes 1/2/4/8 only) or `tep_get_field_val`; record blob `struct tep_record {data,size,ts,cpu}` | fact     | `event-parse.h:516` (`src/event-parse.c:4414`), `:29`                                                                      | ✓      |
+| L6  | libtraceevent does **not** read the tracefs file — no `tracefs` reader exists (3 grep hits, all comments); that is `libtracefs`'s job              | behavior | grep of the pinned tree; boundary comment at `event-parse.c:8462`                                                          | ✓      |
+| L7  | Public header is `include/traceevent/event-parse.h` (impl in `src/event-parse.c`)                                                                  | fact     | pinned tree layout                                                                                                         | ✓      |
+| L8  | Acquisition-side gate: a tracepoint `id` lives in `.../events/<sys>/<event>/id`, root-only (`0700`) on hardened boxes                              | behavior | sparkles `--syscalls` encounter on the test box (see `sparkles-baseline.md`)                                               | ✓ (hw) |
+
+## Discrepancies
+
+- **⚠ D-LT1 — public header path.** An early note placed the header at
+  `src/event-parse.h`; the installed public header is
+  `include/traceevent/event-parse.h`, with the implementation in
+  `src/event-parse.c`. Corrected in the page (metadata row + a "Discrepancy
+  resolved" NOTE). `[source-verified]`
+- **⚠ D-LT2 — the parser/reader boundary.** The library does **not** read tracefs
+  files (a plausible assumption for a "trace event" library); reading the `format`
+  file is `libtracefs`'s job. The page makes this its central design point and
+  quotes the boundary comment. `[source-verified]`
+- **Note — no hardware decode experiment.** libtraceevent has no runnable probe in
+  this drop; the acquisition-side gate (L8) is the only `[hw-verified]` item, and it
+  is _upstream_ of the library (the events cannot be opened unprivileged, so the
+  decoder is never reached on this box). The page frames the page itself as
+  `[source-verified]` and the gate as `[hw-verified]`.
+
+**Net:** 0 substantive discrepancies. The one verbatim quote (the tracefs-`format`
+provenance comment) is exact; the two ⚠ items are brief-vs-source corrections
+(header path, does-not-read-tracefs) that the page now states as its core boundary.
+The only soft spot — no decode probe — is honest: the library is unreachable on the
+test box because its input events are root-gated, which the page states plainly.

--- a/docs/research/cpu-pmu/grounding/linux-perf-events.md
+++ b/docs/research/cpu-pmu/grounding/linux-perf-events.md
@@ -1,0 +1,55 @@
+# Grounding ledger — `linux-perf-events.md`
+
+Claim-by-claim verification of `docs/research/cpu-pmu/linux-perf-events.md` against
+the pinned local trees: `linux` v7.1-rc6 (`e43ffb69e043`), and druntime (LDC
+1.41.0). Hardware experiments recorded on **Linux 6.18.26**, **AMD Ryzen 9 7940HX**
+(Zen 4, 6 core PMCs), `perf_event_paranoid = -1`. `$REPOS = /home/petar/code/repos`.
+
+> Not published research. Do not link to it from the survey pages.
+
+Status key: ✓ verified · ≈ paraphrase-verified · ⚠ discrepancy · ◯ not locally groundable · 🌐 web-only.
+Types: quote · fact · figure · behavior · exposition · opinion.
+
+| #   | Claim                                                                                                                                                          | Type       | Source (local + locator)                                                                   | Status |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------ | ------ |
+| L1  | `perf_event_open` takes `perf_event_attr` (`type`/`config`/bitfield block), returns an fd; fds group via `group_fd`                                            | fact       | `include/uapi/linux/perf_event.h:393` (struct), `:418` (bitfield), `:576` (`IOC_*`)        | ✓      |
+| L2  | A group is scheduled all-or-nothing; a partial group is rolled back                                                                                            | quote      | `kernel/events/core.c:2886` — _"Groups can be scheduled in as one unit only…"_ (verbatim)  | ✓      |
+| L3  | `PERF_FORMAT_GROUP` → one `read(2)` returns `{nr, time_enabled, time_running, value[nr]}`                                                                      | fact       | read-format enum `perf_event.h:365`; producer `core.c:6154`, `nr` at `:6168`               | ✓      |
+| L4  | Multiplexing: hrtimer rotation; scale by `enabled/running`; formula documented in the uAPI                                                                     | quote      | `core.c:4587`/`:744`; formula block `perf_event.h:685` (quoted verbatim in page)           | ✓      |
+| L5  | `rdpmc` self-monitoring: mmap-page seqlock loop; `cap_user_rdpmc`/`pmc_width` are **arch**-set                                                                 | quote      | `perf_event.h:596`/`:608`/`:646`/`:663`; `core.c:6825`/`:6815`; `arch/x86/events/core.c`   | ✓      |
+| L6  | Sampling arms `sample_period`/`sample_freq` + `sample_type`; overflow writes `RECORD_SAMPLE` to the mmap ring (page 0 control, `data_head`/`data_tail`)        | fact       | `perf_event.h:142`/`:1059`/`:749`/`:750`/`:1061`                                           | ✓      |
+| L7  | Ring drain is a seqcount: acquire `data_head`, process `[tail,head)` mod size, release `data_tail`                                                             | behavior   | Experiment B parses it directly                                                            | ✓ (hw) |
+| L8  | `PERF_RECORD_MMAP2` emitted **only** for mappings made while enabled; perf synthesizes the rest from `/proc/PID/maps`                                          | behavior   | `perf_event.h:1091`; Exp B captured **0** MMAP2 until a mid-window `mmap(PROT_EXEC)`       | ✓ (hw) |
+| L9  | perf consumer pipeline: MMAP2 → `dso_id` → `map__new` → `thread__find_map` → `map__map_ip` → `dso__find_symbol`                                                | fact       | `machine.c:1728`; `map.h:107`; `maps.c:1122`; `symbol.c:412`                               | ✓      |
+| L10 | Build-id disambiguates the on-disk binary; a mismatch is rejected                                                                                              | behavior   | `build-id.c:863` (`dso__build_id_mismatch`)                                                | ✓      |
+| L11 | `type`/`config` are opaque numbers here; human names are external (concern 7)                                                                                  | exposition | libpfm4 et al. — see `event-naming.md` grounding                                           | ✓      |
+| L12 | Tracepoints countable/sampleable via `PERF_TYPE_TRACEPOINT` + `PERF_SAMPLE_RAW`; `id` files root-gated                                                         | behavior   | concern-5 boundary; tracefs `id` root gate on this box (`--syscalls` encounter)            | ✓ (hw) |
+| L13 | druntime `core.sys.linux.perf_event` models the mmap page, records, and every `PERF_SAMPLE_*` → **pure-D sampler needs no C shim**                             | behavior   | druntime `core/sys/linux/perf_event.d` (LDC 1.41); all three probes compile without a shim | ✓      |
+| E1  | `counting-group.d`: fitting group `scale=1.0000`, IPC 3.977; 10 counters / 6 PMCs multiplex, scaled estimates cluster at ~60.05M, two events `<not scheduled>` | figure     | Experiment A output (reproduced verbatim in page)                                          | ✓ (hw) |
+| E2  | `sampling-symbolize.d`: 1996 IP samples → `sumSquares` (1852) / `mixHash` (130) with source lines; 1 captured MMAP2 names the same image                       | figure     | Experiment B output                                                                        | ✓ (hw) |
+| E3  | `unwind-stack-user.d`: 5-frame DWARF-CFI backtrace on `--frame-pointer=none` (`level3→…→run`)                                                                  | figure     | Experiment C output                                                                        | ✓ (hw) |
+
+## Discrepancies
+
+- **⚠ D-L1 — perf-tool symbol naming drift (v7.1-rc6).** The `tools/perf` consumer
+  API has churned: `build_id__sprintf` → `build_id__snprintf`; `dso__build_id`
+  accessor → `dso__bid()`; `sample__resolve` → `machine__resolve`; user-side
+  `maps__insert` → `thread__insert_map` → `maps__fixup_overlap_and_insert`; and
+  `struct map` is now a `DECLARE_RC_STRUCT` (ref-counted, accessor-only). **Not a
+  page error** — the page's L9 pipeline deliberately uses the _current_
+  `e43ffb69e043` names (`machine__process_mmap2_event`, `thread__find_map`,
+  `map__map_ip`, `dso__find_symbol`), not older tutorial names. Recorded so a
+  reader hitting an older/newer tree knows the names are version-pinned.
+- **Note — multiplexing formula locator.** The scaling formula is the comment block
+  at `perf_event.h:685` (`quot`/`rem`/`count = quot*enabled + (rem*enabled)/running`),
+  confirmed verbatim; the surrounding `enabled += delta` pseudocode runs `:681-687`.
+- **Note — `cap_user_rdpmc` is arch-set (L5).** The generic
+  `arch_perf_update_userpage` (`core.c:6815`) is a `__weak` no-op; x86 sets the
+  cap/width in `arch/x86/events/core.c`. The ARM `arm_pmuv3` userpage path is
+  W3's — the page hands it off explicitly (link to `arm.md`).
+
+**Net:** 0 substantive discrepancies. Every quote (groups all-or-nothing, the
+multiplexing formula, the `rdpmc` seqlock) is verbatim from the uAPI/kernel; all
+three hardware experiments reproduced their outputs on the recorded box. The one ⚠
+is version-naming drift in the `tools/perf` consumer, which the page sidesteps by
+using the pinned-tree names.

--- a/docs/research/cpu-pmu/grounding/macos.md
+++ b/docs/research/cpu-pmu/grounding/macos.md
@@ -1,0 +1,134 @@
+# Grounding ledger — `macos.md`
+
+Claim-by-claim source verification of [`docs/research/cpu-pmu/macos.md`](../macos.md).
+Kernel claims are checked against the **local** pinned XNU / DTrace source drops
+`$REPOS/c/xnu` (`xnu-12377.1.9`, read-only) and `$REPOS/c/apple-dtrace`
+(`dtrace-413`); the Apple reverse-engineering repo is `applecpu@0e6bc3f`
+(dougallj, cross-reference only). Hardware observations are read off `mac-bsn` =
+Apple **M4 Max** (`Mac16,5`, SoC **T6041**, `hw.cpufamily 0x17d5b93a`), macOS
+**26.3.1** (build 25D771280a), **SIP enabled**, uid 501 (non-root), Apple clang
+21.0.0, `xctrace` 16.0. `$REPOS = /home/petar/code/repos`.
+
+> Not published research. Do not link to it from the survey pages.
+
+## Status legend
+
+| Mark | Meaning                                                                                |
+| ---- | -------------------------------------------------------------------------------------- |
+| `✓`  | Verified against the cited local artifact / recorded transcript (locator recorded)     |
+| `≈`  | Faithful paraphrase / inference from absence (no single line to point at)              |
+| `⚠`  | Discrepancy — open contradiction or a refuted prompt hypothesis, flagged in the page   |
+| `◯`  | Not locally groundable — synthesis/consequence, or surface closed (reverse-engineered) |
+
+**Types:** `quote` (verbatim) · `src` (xnu/dtrace source-read, `[source-verified]`) ·
+`hw` (`mac-bsn`, `[hw-verified: aarch64-darwin]`) · `synth` (derived consequence).
+
+## Verification note
+
+**Every hardware row was run unprivileged (uid 501)** — `sudo -n` needs a password
+on `mac-bsn`, so nothing requiring root was attempted; the EPERM boundary is
+observed from _outside_ the wall, and the privileged side (what `kpc` returns to
+root) is `src` only. There is **no `[hw-verified: aarch64-darwin]` observation of
+a privileged `kpc` read** anywhere in the page, by design. The closed userspace
+frameworks (`kperf.framework`, `kperfdata.framework`, `CoreSymbolication`,
+`xctrace` internals) are observed from the outside (`dlopen`, transcripts), never
+read — those rows are `hw`/`◯`, not `src`.
+
+## Claim ledger
+
+| #    | Claim (short)                                                                                                                   | Type   | Source (local + locator)                                                                                                                                                                                           | Status |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |
+| C1   | Userspace counting surface = `kpc` via private `kperf.framework`, thin wrappers over `kpc.*` sysctls                            | src+hw | `kern_kpc.c:380-500` (`kpc_sysctl` dispatcher); `dlopen` of `kperf.framework/kperf` resolves `kpc_*` (Exp. a)                                                                                                      | ✓      |
+| C2   | Only 3 `kpc` sysctls public (`classes`/`config_count`/`counter_count`); rest need ktrace access                                 | src    | `kern_kpc.c:398-413` (`REQ_*` break out; `default:` → `ktrace_read_check()`)                                                                                                                                       | ✓      |
+| C3   | `ktrace_read_check()` = owns ktrace **or** superuser; entitlement path dev/debug-only                                           | src    | `kern_ktrace.c:288-297`, `:273-285` (`_current_task_can_own_ktrace`), `:279-282` (`#if DEVELOPMENT\|\|DEBUG`), `:73` (`com.apple.private.ktrace-allow`)                                                            | ✓      |
+| Q1   | _"Require kperf access to read or write anything else. / This is either root or the blessed pid."_                              | quote  | `kern_kpc.c:405-408`                                                                                                                                                                                               | ✓      |
+| C4   | Unpriv EPERM boundary matches source: enumerate ✓, every configure/read → EPERM (errno 1)                                       | hw     | Exp. a (`kpc_set_config`, `kpc_set_thread_counting`, `kpc_get_thread_counters`, `force_all_ctrs`, `kpc.counting`)                                                                                                  | ✓      |
+| C5   | Fixed counters = 2 = monotonic `MT_CORE_CYCLES`/`MT_CORE_INSTRS`, read from fixed PMC0 `S3_2_C15_C0_0`                          | src    | `kern_monotonic.c:154,167,182-199`                                                                                                                                                                                 | ✓      |
+| C6   | `proc_pid_rusage(RUSAGE_INFO_V4)` unpriv `ri_instructions`/`ri_cycles`; IPC 2.82 measured                                       | src+hw | `bsd/sys/resource.h:365-366` (v4 fields); Exp. b delta 300 055 815 inst / 106 386 622 cyc, IPC 2.820                                                                                                               | ✓      |
+| C7   | `kpc` single-owner arbitration → `EBUSY` when CPMU claimed                                                                      | src    | `kern_kpc.c:417-419` (`cpc_hw_in_use(CPC_HW_CPMU)`) → `cpc.c:44-70` (atomic `cmpxchg NULL→owner`); handoff `kpc_common.c:167-264`                                                                                  | ✓      |
+| C8   | Sampling = `kperf` timers/PMI → `kperf_sample` walks callstack; PET samples all threads on a timer                              | src    | `pet.c:30-46`; `kpc_common.c:556-579` (`kpc_sample_kperf` → `kperf_sample`)                                                                                                                                        | ✓      |
+| Q4   | _"Profile Every Thread (PET) provides a profile of all threads on the system when a timer fires."_                              | quote  | `pet.c:30-31`                                                                                                                                                                                                      | ✓      |
+| C9   | Hardware PC-capture on overflow (`S3_1_C15_C14_1`, `HAS_CPMU_PC_CAPTURE`, `PC_CAPTURE_PC`); else skid                           | src+hw | `osfmk/arm64/kpc.c:824-838` (`kpc_pmi_handler`); `kpc.pc_capture_supported = 1` (Exp. a)                                                                                                                           | ✓      |
+| C10  | **No PEBS/SPE-style data-source/data-address sampling exposed** — PC on overflow only                                           | src≈   | absence: `bsd/kern/kern_kpc.c` + `osfmk/kern/kpc*.c` expose only counters/configs/periods/actionids; `PMTRHLD*` in HW unexposed (applecpu `PMCKext2.c`)                                                            | ✓      |
+| C11  | Module map from **dyld** (`_dyld_image_count`/`_dyld_get_image_*`), not per-mmap records; 45 images                             | hw     | Exp. b (`<mach-o/dyld.h>` API; dyld open but **not cloned**)                                                                                                                                                       | ✓      |
+| C12  | System dylibs share **one** `vmaddr_slide` (dyld shared cache); main exe has its own                                            | hw     | Exp. b (`libSystem`…`libc++` slide `0x1b00000`; `/private/tmp/mt_probe` slide `0x4a08000`)                                                                                                                         | ✓      |
+| C13  | Symbolization = Mach-O + dSYM (DWARF) via `atos`/`symbols`; engine `CoreSymbolication` (closed)                                 | hw     | Exp. c (`atos … → square (in sym2) (sym2.c:2)`; `symbols … [Dwarf, FunctionStarts]`; `dladdr` = symbol-only)                                                                                                       | ✓      |
+| C13a | One-shot `clang -g src -o bin` → **empty dSYM** (temp `.o` deleted); two-step build fixes it                                    | hw     | Exp. c (`dsymutil … no debug symbols`; retained-`.o` build yields DWARF)                                                                                                                                           | ✓      |
+| C14  | macOS tracing = kdebug/ktrace + DTrace, but **no DTrace `cpc` provider**                                                        | src    | xnu `bsd/dev/dtrace/` ships fbt/sdt/systrace/profile/fasttrap/lockstat/lockprof — no `dcpc`/`cpc`; `apple-dtrace@dtrace-413` has no `*cpc*`                                                                        | ✓ ⚠    |
+| C15  | DTrace unusable unprivileged under SIP (`dtrace -l` fails at init)                                                              | hw     | Exp. d ("system integrity protection is on … DTrace requires additional privileges")                                                                                                                               | ✓      |
+| Q5   | _"dtrace: failed to initialize dtrace: DTrace requires additional privileges"_                                                  | quote  | Exp. d transcript                                                                                                                                                                                                  | ✓      |
+| C16  | Apple Silicon is **UMA** — no NUMA nodes; only topology axis is `hw.nperflevels=2` (P/E)                                        | hw     | Exp. e (`hw.memsize` single value, no `hw.*node*`; `hw.physicalcpu=14`, page 16384, cacheline 128)                                                                                                                 | ✓      |
+| C17  | Event names → PMESR via on-disk **kpep** DB plists (`/usr/share/kpep/`, world-readable, per-cpufamily)                          | hw     | Exp. e (`cpu_100000c_2_17d5b93a.plist -> as4-1.plist` symlink; consumed by closed `kperfdata.framework`)                                                                                                           | ✓      |
+| C18  | Kernel `RESTRICT_TO_KNOWN` allowlist by default — **even root** can't program arbitrary selectors; 102 events T6041 vs 59 T6000 | src    | `cpc_arm64_events.c:74` (`_cpc_event_policy = CPC_EVPOL_DEFAULT`), `:92-111` (`cpc_event_allowed`), `:379-485` (T6041); `cpc_arm64.h:34-43` (`= RESTRICT_TO_KNOWN` when `!CPC_INSECURE`)                           | ✓      |
+| Q3   | _"Change how event restrictions are applied."_ (event-policy setter doc)                                                        | quote  | `cpc_arm64.h:47-49`                                                                                                                                                                                                | ✓      |
+| C19  | T6041 (M4) uses **PMUv3-architected** selectors for the common subset; T6000 (M1) Apple-proprietary                             | src    | `cpc_arm64_events.c:382-484` (T6041: `INST_ALL=0x0008`, `CORE_ACTIVE_CYCLE=0x0011`, `ARM_BR_MIS_PRED=0x0010`, `STALL_FE/BE=0x23/0x24`, SME block) vs `:118-177` (T6000: `INST_ALL=0x8c`, `CORE_ACTIVE_CYCLE=0x02`) | ✓      |
+| A1   | xctrace `CPU Counters` template runs **unprivileged** and produces real counter data (Tier 2 broker)                            | hw     | Exp. e (`xctrace record --template 'CPU Counters' … Recording completed` exit 0, no root; export `--toc` shows metricLegend + `kernel.release.t6041`)                                                              | ✓      |
+| A2   | Seven-concern map + three-tier counting framing + capability advertisement for the sparkles backend                             | synth  | derived from C1–C19                                                                                                                                                                                                | ◯      |
+
+## Discrepancies
+
+- **D1 (⚠ prompt hypothesis refuted).** The prompt's **DTrace `cpc` one-liner
+  hypothesis (3b) is wrong for macOS** (C14). There is **no `cpc`/`dcpc`
+  provider** anywhere in Apple's stack — absent from both the xnu kernel provider
+  set (`bsd/dev/dtrace/`) and the `apple-dtrace@dtrace-413` userland; the Solaris
+  `dcpc` provider was never ported. So even _with_ root the provider is
+  unavailable. Documented in the page as a `> [!WARNING]` in the
+  [event-space section](../macos.md#event-space-and-tracing--kdebug-dtrace-no-cpc-provider).
+  `src`.
+- **D2 (version skew, provenance note).** `mac-bsn` **runs** kernel
+  **xnu-12377.91.3** (`RELEASE_ARM64_T6041`); the public open-source drop is
+  **xnu-12377.1.9**. Same `12377` base for the same T6041 die, so the code read is
+  representative, but every line number in the page is from `12377.1.9`. Flagged in
+  the page's opening `> [!IMPORTANT]` scope box. Not a contradiction — a source
+  provenance caveat. `src` vs `hw`.
+- **D3 (OPEN ⚠, cross-page).** kpep reports **`fixed_counters: 3`** on _every_
+  Apple generation (the ARM page's E2 kpep table), but the box's unprivileged
+  `kpc_get_counter_count(FIXED)` returns **2** (Exp. a), matching the XNU
+  monotonic model's two fixed PMCs (C5). The third fixed counter kpep advertises is
+  unmodeled by the counting path exercised here (candidate: a fixed
+  reference/uptime counter). **Flagged, not resolved.** This is the same open item
+  as [`arm.md`'s D3][arm-d3], which owns the surfaced discussion in its Apple
+  sidebar; `macos.md` does not re-assert it to avoid a duplicated unresolved claim.
+  `hw` vs `src`. ⚠
+- **D4 (versioning note, resolved).** `force_all_ctrs` is **no longer a userspace
+  sysctl.** Older reverse-engineered headers expose `kpc_force_all_ctrs_set`; on
+  `12377` the whole-machine arbitration moved inside the kernel (`cpc.c`
+  single-owner + `kpc_common.c:167-264` power-management handoff), and the
+  framework call returns `EPERM` unprivileged regardless (C4/C7). Documented in the
+  page's [Tier-1 prose](../macos.md#tier-1--kpc-and-the-eperm-boundary). Not a
+  contradiction — a version-drift note. `src`+`hw`.
+- **D5 (surprise, resolved).** The cheap path is **richer than Linux's.**
+  `proc_pid_rusage` delivers true retired-instructions and core-cycles
+  unprivileged; the Linux `/proc`/tier0 equivalent gives only
+  context-switch/fault-style counters, not instructions — so macOS's low-privilege
+  whole-process IPC story is genuinely _better_ than Linux's (C6). Surfaced as the
+  lead [Strength](../macos.md#strengths). Not a discrepancy — a documented finding.
+  `hw`.
+
+## Claims dropped / weakened
+
+- **Q2 (RAWPMU fence quote) not used verbatim.** The sub-report offered
+  `kern_kpc.c:471-473` (_"Client shouldn't ask for config words that aren't
+  available…"_) as a candidate; the page states the RAWPMU/`POWER` fence in prose
+  (`classes=11`, `POWER(4)` absent to userspace) rather than quoting it, to keep to
+  one quote per section. The fact is source-grounded; only the verbatim quote is
+  omitted. `src`.
+- **D3 (fixed-counter 3-vs-2) carried, not surfaced in-page.** Left as an OPEN
+  ledger item cross-referenced to `arm.md`'s D3 (which owns it) rather than
+  re-asserted in `macos.md`. Nothing else dropped: the page carries all 19
+  sub-report claims (C1–C19), the four used quote candidates (Q1, Q3, Q4, Q5), the
+  empty-dSYM gotcha (C13a), and the `xctrace` Tier-2 evidence (A1).
+
+**Net:** 0 fabrications. Every kernel mechanism is `[source-verified]` against
+`xnu-12377.1.9` / `dtrace-413`; every measurement is `[hw-verified: aarch64-darwin]`
+off `mac-bsn` (unprivileged). **One refuted prompt hypothesis** (D1, no DTrace
+`cpc` provider — recorded as a page WARNING), **one open discrepancy** (D3, kpep
+`fixed_counters` 3 vs `kpc` FIXED 2, ⚠ flagged not resolved, owned by `arm.md`),
+one source-version skew (D2, running `12377.91.3` vs drop `12377.1.9`, noted), and
+two documented findings (D4 `force_all_ctrs` internalized, D5 `rusage` richer than
+Linux). No privileged `kpc` read was hardware-observed — the EPERM wall is verified
+from outside and the privileged side is source-read only.
+
+<!-- References -->
+
+[arm-d3]: ./arm.md#discrepancies

--- a/docs/research/cpu-pmu/grounding/precise-sampling.md
+++ b/docs/research/cpu-pmu/grounding/precise-sampling.md
@@ -1,0 +1,72 @@
+# Grounding ledger — `precise-sampling.md`
+
+Claim-by-claim verification of `docs/research/cpu-pmu/precise-sampling.md`. Primary
+artifacts: the **local** Linux tree `$REPOS/linux` `e43ffb69e043` (v7.1-rc6,
+2026-07-10), `$REPOS/papers/cpu-pmu/amd64-apm-vol2-24593.pdf` (AMD64 APM Vol 2,
+§13.3), numactl `93c1fe5` (v2.0.19), and **host sysfs / `perf_event_open`** on the
+test box (Linux 6.18.26, AMD Ryzen 9 7940HX / Zen 4, `perf_event_paranoid = -1`,
+single NUMA node). `$REPOS = /home/petar/code/repos`. This tree is internal QA
+evidence — excluded from the VitePress build and lychee.
+
+> Not published research. Do not link to it from the survey pages.
+
+## Status legend
+
+| Mark | Meaning                                                             |
+| ---- | ------------------------------------------------------------------- |
+| `✓`  | Verified against the cited local artifact / host (locator recorded) |
+| `≈`  | Faithful paraphrase of the source                                   |
+| `⚠`  | Discrepancy — corrected + reflected in the page                     |
+| `◯`  | Not locally groundable — editorial / synthesis                      |
+| `🌐` | Web / secondary only                                                |
+
+**Types:** `quote` · `fact` · `behavior` (code does X) · `figure` (number/bound) · `synth`.
+
+## Claims
+
+| #   | Claim                                                                                                                                                                                     | Type           | Source (local + locator)                                                                                                                      | Status |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| 1   | AMD has no PEBS; `cpu/caps/max_precise = 0`; IBS is the only precise engine (`ibs_op` 11, `ibs_fetch` 10, `zen4_ibs_extensions = 1`)                                                      | fact           | host sysfs `/sys/bus/event_source/devices/{cpu/caps/max_precise, ibs_op/type, ibs_fetch/type, ibs_op/caps/zen4_ibs_extensions}` (E1)          | ✓      |
+| 2   | Core-PMU `precise_ip` forwarded to `ibs_op`; IBS skid 0, sets `PERF_EFLAGS_EXACT`; `precise_ip > 2` → `-EOPNOTSUPP`                                                                       | quote+behavior | `linux/arch/x86/events/amd/ibs.c:240-258` (`forward_event_to_ibs`)                                                                            | ✓      |
+| 3   | IBS tags a random retired µop at a programmable op/cycle interval (27-bit counter, `IbsOpCntCtl`, `IbsOpMaxCnt`) — instruction-based, PMC-independent                                     | behavior       | `papers/cpu-pmu/amd64-apm-vol2-24593.pdf` §13.3                                                                                               | ✓      |
+| 4   | IBS fills `perf_mem_data_src` from `IBS_OP_DATA2.DataSrc` + `IBS_OP_DATA3` (`mem_op`/`mem_lvl`/`mem_lvl_num`/`mem_snoop`/`mem_dtlb`/`mem_lock`)                                           | behavior       | `linux/arch/x86/events/amd/ibs.c:1016-1253` (dispatcher `perf_ibs_get_data_src` `:1242`)                                                      | ✓      |
+| 5   | Zen 4 widens `DataSrc` to 5 bits (`data_src_hi<<3 \| data_src_lo`) → `g_zen4_data_src[32]` vs legacy `g_data_src[8]`; gated on `IBS_CAPS_ZEN4` (`1U<<11`), host advertises it             | behavior+fact  | `linux/arch/x86/events/amd/ibs.c:1033-1069`; `arch/x86/include/asm/amd/ibs.h:12-26`; `arch/x86/include/asm/perf_event.h:644`; host sysfs      | ✓      |
+| 6   | IBS remote signal is coarse — `REM \| HOPS(1)` (or `REM_RAM1`) unconditionally, never a node; quote "HOPS_1 because IBS doesn't provide remote socket detail"                             | quote+behavior | `linux/arch/x86/events/amd/ibs.c:1113-1119, 1128-1134`                                                                                        | ✓      |
+| 7   | `WEIGHT` = `dc_miss_lat` (load-miss only); `ADDR` = `IBSDCLINAD`/`dc_lin_addr_valid`; `PHYS_ADDR` = `IBSDCPHYSAD`/`dc_phy_addr_valid`                                                     | behavior       | `linux/arch/x86/events/amd/ibs.c:1296-1317`; host: median 412-cyc, max ~1.8k-cyc pointer-chase latencies (E3)                                 | ✓      |
+| 8   | Zen 4 hardware load-latency filter `IBS_CAPS_OPLDLAT`: `config1` threshold `[128, 2048]` cyc; sub-threshold ops dropped in IRQ handler                                                    | behavior       | `linux/arch/x86/events/amd/ibs.c:281-287, 407-419, 1464-1478`                                                                                 | ✓      |
+| 9   | No `IBS_CAPS_BIT63_FILTER` on this Zen 4 → bare `exclude_kernel`/`exclude_user`/`exclude_hv` = `-EINVAL`; kernel/user filtering needs `swfilt` (`config2:0`); `exclude_hv` never accepted | behavior       | `linux/arch/x86/events/amd/ibs.c:346-370`; host `perf_event_open` matrix (E2)                                                                 | ✓      |
+| 10  | `perf mem` on AMD = single `mem-ldst` on `ibs_op` (not Intel's `mem-loads,ldlat=%u` + `mem-stores`)                                                                                       | behavior       | `linux/tools/perf/arch/x86/util/mem-events.c:24-34`; host `perf mem report` → `event 'ibs_op//'` (E4)                                         | ✓      |
+| 11  | PEBS precise levels 1/2/3; level 3 = zero-skid (PDIR/PDist, needs a specific counter); kernel special-cases `precise_ip == 3`                                                             | behavior       | `linux/arch/x86/events/intel/core.c:5239, 5260, 5278, 5298, 5358, 5398, 5511`                                                                 | ✓      |
+| 12  | PEBS data-source from DS-area record `dse` field → per-µarch `pebs_data_source[]` (`load_latency_data`/`__grt_latency_data`); latency `pebs->lat`, addr `pebs->dla`                       | behavior       | `linux/arch/x86/events/intel/ds.c:125-260, 455-708, 2131-2202`                                                                                | ✓      |
+| 13  | Both PEBS and IBS target the identical `perf_mem_data_src` ABI union                                                                                                                      | fact           | `linux/include/uapi/linux/perf_event.h:1319-1459`                                                                                             | ✓      |
+| 14  | Union layout (one LE `u64`: `mem_op:5`…`mem_rsvd:13`) + `PERF_MEM_LVLNUM_*` / `PERF_MEM_HOPS_*` constants                                                                                 | fact           | `linux/include/uapi/linux/perf_event.h:1319-1459`                                                                                             | ✓      |
+| 15  | Canonical decode strings (`mem_lvlnum[]`/`mem_hops[]`/`snoop_access[]`/`tlb_access[]`) from perf; probe output matches `perf mem report`                                                  | quote+behavior | `linux/tools/perf/util/mem-events.c:370-559`; host cross-check (E4)                                                                           | ✓      |
+| 16  | `get_mempolicy(…MPOL_F_NODE\|MPOL_F_ADDR)` / `move_pages(…query…)` return the page's node; raw syscalls (239/279 x86_64; 236/239 asm-generic), not glibc                                  | fact+behavior  | `linux/arch/x86/entry/syscalls/syscall_64.tbl:237-239, 279`; `include/uapi/asm-generic/unistd.h:601-608`; numactl `numaif.h:11-46`; host (E3) | ✓      |
+| 17  | Single-node host: only `node0`, every address → node 0, oracles trivially agree; round-trip shown, cross-node classification not                                                          | fact           | host sysfs `/sys/devices/system/node`; probe (E3)                                                                                             | ✓      |
+| 18  | numactl ships no `numa.pc` (`pkg-config numa` fails); libnuma is a plain `-lnuma` whose `get_mempolicy`/`move_pages` are thin syscall wrappers                                            | fact           | host `pkg-config --exists numa` → "No package 'numa' found"; numactl `93c1fe5` (v2.0.19)                                                      | ✓      |
+| 19  | SPE is an AUX-buffer PMU; format attrs `pa_enable` (`PMSCR_EL1.PA`), `load_filter`/`store_filter` (`PMSFCR_EL1`), `min_latency` (`PMSLATFR_EL1.MINLAT`), event filter (`PMSEVFR_EL1`)     | behavior       | `linux/drivers/perf/arm_spe_pmu.c:81-91, 203-324`                                                                                             | ✓      |
+| 20  | Each SPE record carries `virt_addr` + `phys_addr` + `context_id` + `latency`                                                                                                              | fact           | `linux/tools/perf/util/arm-spe-decoder/arm-spe-decoder.h:112-125`                                                                             | ✓      |
+| 21  | SPE data-source is implementation-defined (MIDR-dispatched: Neoverse common + AmpereOne + HiSilicon HIP tables), framing architected; Neoverse 3-level quote                              | quote+behavior | `linux/tools/perf/util/arm-spe.c:585-705` (`arm_spe__synth_data_source_common` `:651`, quote `:654-660`); enums `arm-spe-decoder.h:77-108`    | ✓      |
+| S1  | APM Overview quote ("For a load or store op: …")                                                                                                                                          | quote          | `papers/cpu-pmu/amd64-apm-vol2-24593.pdf` §13.3                                                                                               | ✓      |
+| S2  | Legacy `PERF_MEM_LVL_*` deprecation quote                                                                                                                                                 | quote          | `linux/include/uapi/linux/perf_event.h:1368-1370`                                                                                             | ✓      |
+| S3  | IBS-vs-PEBS contrast table; seven-concern mapping; Strengths/Weaknesses/decision tables                                                                                                   | synth          | derived from claims 1–21                                                                                                                      | ◯      |
+
+## Discrepancies
+
+All five are **prompt-vs-hardware** corrections surfaced during W2 research; each is
+reflected in the page rather than left as a page error.
+
+| #   | Prompt assumption                                                  | Reality (this host)                                                                                          | Reflected in page                                                              |
+| --- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| D1  | "Intel PEBS + AMD IBS both testable here"                          | AMD Zen 4 box has **no PEBS** (`cpu/caps/max_precise = 0`); IBS is the sole precise engine                   | PEBS section tagged `[source-verified]`/`[literature]`, never `[hw-verified]`  |
+| D2  | "Fall back to `cpu` PMU with `precise_ip > 0` if IBS unavailable"  | The AMD `cpu` PMU has **no precise mode at all**; the fallback is Intel-only and unreachable here            | Stated in the IBS section; probe's `cpu` branch labelled Intel-only/UNVERIFIED |
+| D3  | Bare `exclude_kernel`/`exclude_hv` opens an IBS mem-sampling event | `-EINVAL` without `IBS_CAPS_BIT63_FILTER`; needs the `swfilt` bit; `exclude_hv` never accepted (E2)          | `swfilt`/`exclude_*` WARNING alert + E2 errno matrix                           |
+| D4  | `DATA_SRC` gives a NUMA **node** for remote accesses               | IBS gives only a coarse **remote bit** (`HOPS(1)`); node needs the address→node oracle (complementary)       | Coarse-remote quote + "From data address to NUMA node" section                 |
+| D5  | Link `libs "numa"` (pkg-config name) for the oracles               | numactl ships **no `numa.pc`**; `get_mempolicy`/`move_pages` aren't in glibc — probe calls syscalls directly | "No `numa.pc`" paragraph + single-node WARNING                                 |
+
+**Net:** 0 page discrepancies. All 21 research claims + both added quote rows (S1/S2)
+are grounded in the local Linux tree / AMD APM PDF / host sysfs+`perf_event_open`;
+S3 is flagged synthesis (◯). The five prompt-vs-hardware corrections (D1–D5) are all
+reflected honestly in the page. PEBS (D1) and ARM SPE are `[source-verified]`/`[literature]`
+only — no local hardware — and the page marks them so; the sole `[hw-verified: x86_64-linux]`
+claims are the AMD IBS + NUMA-round-trip ones actually exercised on the test box.

--- a/docs/research/cpu-pmu/grounding/riscv.md
+++ b/docs/research/cpu-pmu/grounding/riscv.md
@@ -1,0 +1,115 @@
+# Grounding ledger — `riscv.md`
+
+Claim-by-claim verification of [`docs/research/cpu-pmu/riscv.md`](../riscv.md) against the
+**local** pinned trees. `$REPOS = /home/petar/code/repos`. Every load-bearing assertion is a
+primary-source spec or kernel/firmware line at a pinned SHA; no RISC-V hardware was measured
+(`[source-verified]` + `[literature]` only). This tree is internal QA evidence — excluded from
+the VitePress build (`srcExclude`) and from lychee (`exclude_path`).
+
+> Not published research. Do not link to it from the survey pages.
+
+## Pinned sources
+
+| Repo / artifact                                    | Pinned SHA / id                            | As of      |
+| -------------------------------------------------- | ------------------------------------------ | ---------- |
+| `linux` (v7.1-rc6)                                 | `e43ffb69e0438cddd72aaa30898b4dc446f664f8` | 2026-07-10 |
+| `cpu-pmu/riscv-isa-manual`                         | `fbae3b43b3feefefe88a8576596d0f06425c2697` | 2026-07-10 |
+| `cpu-pmu/riscv-sbi-doc`                            | `8a545effe9b50484ff897d9815d7d9015cdef203` | 2026-07-10 |
+| `c/opensbi`                                        | `262571217c75c649115633d8075cb6a40d940733` | 2026-07-10 |
+| `cpu-pmu/riscv-ctr` (Smctr/Ssctr v1.0, Ratified)   | `42e299ca4f72df6931589068a34956685825c247` | 2026-07-10 |
+| `papers/cpu-pmu/riscv-roofline-pmu-2507.22451.pdf` | arXiv 2507.22451 (16 pp)                   | 2026-07-10 |
+| `papers/cpu-pmu/riscv-ctr-spec-v1.0.pdf`           | CTR v1.0 release asset (23 pp, byte-exact) | 2026-07-10 |
+
+## Status key
+
+| Mark | Meaning                                                        |
+| ---- | -------------------------------------------------------------- |
+| `✓`  | Verified verbatim / exactly against the cited local artifact   |
+| `≈`  | Faithful paraphrase of the cited source                        |
+| `⚠`  | Discrepancy — correction recorded + applied to the page        |
+| `◯`  | Not source-groundable — editorial synthesis / opinion          |
+| `🌐` | Web / secondary (release metadata not in the pinned spec text) |
+
+**Types:** `quote` · `fact` · `behavior` (source does X) · `absence` (verified-not-present) ·
+`literature` · `opinion`.
+
+## Claim table
+
+| Claim | Assertion (short)                                                                                                                         | Type       | Source (local + locator)                                                                                                   | Status |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- | ------ |
+| C1.1  | S-mode reads but cannot control counters; only M-mode configures; firmware may refuse SBI PMU if `mcountinhibit` unimplemented            | behavior   | `riscv-sbi-doc src/ext-pmu.adoc:3-12`                                                                                      | ✓      |
+| C1.2  | SBI PMU EID `0x504D55`; discover/configure per-hart counters + "full access to … raw event encodings"                                     | quote      | `riscv-sbi-doc src/ext-pmu.adoc:1,22-29`; cross-checked `linux arch/riscv/include/asm/sbi.h:34`                            | ✓      |
+| C1.3  | Counter FIDs 0–5 (base) + 6/7/8 (`fw_read_hi`/`snapshot_set_shmem`/`event_get_info`, SBI 2.0/2.0/3.0)                                     | fact       | `riscv-sbi-doc src/ext-pmu.adoc:699-715`                                                                                   | ✓      |
+| C1.4  | `counter_get_info` packs `CSR[11:0]`, `Width[17:12]` (−1), `Type[XLEN-1]` (0=HW,1=FW)                                                     | fact       | `riscv-sbi-doc src/ext-pmu.adoc:285-296`                                                                                   | ✓      |
+| C1.5  | Linux allocates via `SBI_EXT_PMU_COUNTER_CFG_MATCH` then start/stop/read                                                                  | behavior   | `linux drivers/perf/riscv_pmu_sbi.c:538-594,799-856,739-779`                                                               | ✓      |
+| C1.6  | HW read = direct CSR read; FW read = `SBI_EXT_PMU_COUNTER_FW_READ`                                                                        | behavior   | `linux drivers/perf/riscv_pmu_sbi.c:756-776`                                                                               | ✓      |
+| C1.7  | `scounteren` gates unprivileged reads; per-event toggled on `mmap`; `perf_event_mmap_page` user-read                                      | behavior   | `linux drivers/perf/riscv_pmu_sbi.c:781-797,1157-1160,1322-1355` (`0x7` confirmed at `:1158`)                              | ✓      |
+| C1.8  | Legacy fallback: only `cycle`/`instret`, 63-bit, no start/stop/interrupt/exclude                                                          | fact       | `linux drivers/perf/riscv_pmu_legacy.c:15-32,40-44,110-130`                                                                | ✓      |
+| C1.9  | OpenSBI requires DT `riscv,event-to-mhpm*` maps (or platform hooks) or SBI PMU is not enabled                                             | behavior   | `opensbi docs/pmu_support.md:1-45`, `opensbi lib/utils/fdt/fdt_pmu.c:49,75,121`                                            | ✓      |
+| C1.10 | Firmware writes selector via `sbi_platform_pmu_xlate_to_mhpmevent` → `csr_write_num(CSR_MHPMEVENT3+…)`                                    | behavior   | `opensbi lib/sbi/sbi_pmu.c:516-557`                                                                                        | ✓      |
+| C2.1  | Sscofpmf adds `mhpmevent[63:58]` = `OF,MINH,SINH,UINH,VSINH,VUINH`                                                                        | fact       | `riscv-isa-manual src/priv/sscofpmf.adoc:29-64`                                                                            | ✓      |
+| C2.2  | LCOFI on overflow (`OF==0`) = local IRQ bit 13 of `mip/mie/sip/sie`; `mideleg` delegates; `IRQ_PMU_OVF=13`                                | quote      | `riscv-isa-manual src/priv/sscofpmf.adoc:69-91`; `linux arch/riscv/include/asm/csr.h:101,537`                              | ✓      |
+| C2.3  | `scountovf` (CSR `0xda0`) read-only shadow of `OF` bits, per-bit gated by `mcounteren`/`hcounteren`                                       | fact       | `riscv-isa-manual src/priv/sscofpmf.adoc:111-129`; `linux arch/riscv/include/asm/csr.h:317`                                | ✓      |
+| C2.4  | Sampling enabled only under Sscofpmf (or vendor errata IRQ); else `NO_INTERRUPT\|NO_EXCLUDE` + message                                    | quote      | `linux drivers/perf/riscv_pmu_sbi.c:1192-1218,1449-1454` (message verbatim at `:1451`)                                     | ✓      |
+| C2.5  | Overflow handler reads `scountovf`/snapshot, calls `perf_event_overflow` with `xepc` regs → skidded IP                                    | behavior   | `linux drivers/perf/riscv_pmu_sbi.c:1041-1146` (`:1091` `get_irq_regs`, `:1136`)                                           | ✓      |
+| C2.6  | `exclude_kernel→SINH` etc. via SBI `config_flags`, applied by firmware only under Sscofpmf                                                | behavior   | `linux …riscv_pmu_sbi.c:517-536`; `riscv-sbi-doc src/ext-pmu.adoc:332-354`; `opensbi lib/sbi/sbi_pmu.c:504-514,534-543`    | ✓      |
+| C2.7  | SBI snapshot (FID 7): `counter_overflow_bitmap` (valid only under Sscofpmf) + 64-bit `counter_values[]`                                   | fact       | `riscv-sbi-doc src/ext-pmu.adoc:549-609`; `linux …riscv_pmu_sbi.c:1076-1078,919-946`                                       | ✓      |
+| C2b.1 | KVM builds host `perf_event` per guest counter; handler calls `kvm_riscv_vcpu_set_interrupt(IRQ_PMU_OVF)`                                 | behavior   | `linux arch/riscv/kvm/vcpu_pmu.c:293-331,334-361`                                                                          | ✓      |
+| C2b.2 | `IRQ_PMU_OVF` is one of four IRQs KVM may inject into a VS-mode guest                                                                     | fact       | `linux arch/riscv/kvm/vcpu.c:405-426`                                                                                      | ✓      |
+| C2b.3 | Guest LCOFI delivery via AIA `HVIEN` bit 13, guarded by Sscofpmf-avail **and** `kvm_riscv_aia_available()`                                | behavior   | `linux arch/riscv/kvm/aia.c:565-567,581-582`; `arch/riscv/kvm/vcpu.c:391-396`                                              | ✓      |
+| C2b.4 | Absent Sscofpmf, guest falls back to legacy `cycle`/`instret` (KVM returns 0 / illegal-traps others)                                      | behavior   | `linux arch/riscv/kvm/vcpu_pmu.c:388-402`                                                                                  | ✓      |
+| C3.1  | **No PEBS/SPE analog**; no `PERF_SAMPLE_{ADDR,PHYS_ADDR,DATA_SRC}` producer — full-tree manual search                                     | absence    | search over `riscv-isa-manual src/**` (only unrelated RVWMO/PMA hits)                                                      | ✓      |
+| C3.2  | Closest construct is the SBI HW-cache `NODE` event (a counter, not a per-sample tag)                                                      | fact       | `riscv-sbi-doc src/ext-pmu.adoc:140`                                                                                       | ✓      |
+| C3.3  | Roofline paper: "workaround to circumvent hardware bugs … enabling robust event sampling"; PMU-independent roofline                       | literature | `papers/cpu-pmu/riscv-roofline-pmu-2507.22451.pdf` abstract (arXiv 2507.22451)                                             | ✓      |
+| C4.1  | RISC-V perf PMU = ordinary `perf_pmu` ("cpu", `PERF_TYPE_RAW`) → ISA-neutral ELF/DWARF decode                                             | behavior   | `linux drivers/perf/riscv_pmu_sbi.c:1475`                                                                                  | ✓      |
+| C4.2  | No HW call/branch-stack producer at v7.1-rc6; callchains via FP / DWARF-CFI; CTR would supply it                                          | absence    | CTR intent `riscv-ctr intro.adoc:4-6`; cf. C5.2                                                                            | ✓      |
+| C5.1  | CTR = Smctr/Ssctr, v1.0 **ratified 2024-11-22**; `ctrsource`/`ctrtarget`/`ctrdata`; depth `2^(DEPTH+4)`=16–256; `siselect 0x200–0x2FF`    | quote      | `riscv-ctr header.adoc:4-6,39-47`, `intro.adoc:4-8`, `body.adoc:161-208,285-296`; `riscv-isa-manual src/priv/smctr.adoc:3` | ✓      |
+| C5.2  | **`drivers/perf/riscv_ctr.c` does not exist**; grep for `s[ms]ctr\|control_transfer\|…S[MS]CTR` = no CTR consumer                         | absence    | `linux@e43ffb69` full-tree grep (`arch/riscv/`, `drivers/perf/`, `include/`)                                               | ⚠      |
+| C5.3  | `ctrdata.TYPE[3:0]` = 16 transfer types + optional cycle-count `CC`                                                                       | fact       | `riscv-ctr body.adoc:340-373,574-595`                                                                                      | ✓      |
+| C5.4  | Filtering: `mctrctl`/`sctrctl` privilege bits + per-transfer-type inhibits + RASEMU                                                       | fact       | `riscv-ctr body.adoc:10-99`                                                                                                | ✓      |
+| C5.5  | Freeze-on-LCOFI (`LCOFIFRZ` → `sctrstatus.FROZEN`) preserves path to `xepc`                                                               | quote      | `riscv-ctr body.adoc:55,734`                                                                                               | ✓      |
+| C5.6  | CTR depends on S-mode and `Sscsrind` (indirect-CSR)                                                                                       | fact       | `riscv-ctr intro.adoc:28`; `riscv-isa-manual src/priv/smctr.adoc`                                                          | ✓      |
+| C5.7  | No Intel-PT/ETM full-trace standard; SBI firmware events (type 15) are counts, not traces                                                 | fact       | `riscv-sbi-doc src/ext-pmu.adoc:203-259`                                                                                   | ✓      |
+| C6.1  | No architected NUMA-source classification; only SBI `CACHE_NODE`; topology is OS/ACPI/DT (ISA-neutral)                                    | absence    | `riscv-sbi-doc src/ext-pmu.adoc:140`; `linux …riscv_pmu_sbi.c:281-300`                                                     | ✓      |
+| C6.2  | No standardized uncore / system-PMU framework for RISC-V at this SHA                                                                      | absence    | `ls linux drivers/perf/riscv*` (only `riscv_pmu{,_sbi,_legacy}.c`)                                                         | ✓      |
+| C7.1  | SBI `event_idx` 20-bit: `type[19:16]`, `code[15:0]`; types 0/1/2/3/15                                                                     | fact       | `riscv-sbi-doc src/ext-pmu.adoc:37-59`                                                                                     | ✓      |
+| C7.2  | HW-general codes 1–10; HW-cache = `cache_id[15:3]`,`op_id[2:1]`,`result_id[0]` with `NODE` cache id                                       | fact       | `riscv-sbi-doc src/ext-pmu.adoc:62-160`                                                                                    | ✓      |
+| C7.3  | Raw selectors implementation-defined (raw-v2 `event_data` 56-bit); Linux distinguishes via `config[63:62]`                                | behavior   | `riscv-sbi-doc src/ext-pmu.adoc:165-201`; `linux …riscv_pmu_sbi.c:416-478`                                                 | ✓      |
+| C7.4  | Perf vendor JSON: sifive/thead/openhwgroup/starfive/andes, keyed by `mvendorid-marchid-mimpid`                                            | fact       | `linux tools/perf/pmu-events/arch/riscv/mapfile.csv` + per-vendor `*.json`                                                 | ✓      |
+| A1    | Three-level privilege-indirection table (U/S read · S-mode via SBI · M-mode firmware writes)                                              | synthesis  | derived from C1.1–C1.10                                                                                                    | ◯      |
+| A2    | Strengths / Weaknesses / Decision·Rationale·Trade-off tables                                                                              | opinion    | derived                                                                                                                    | ◯      |
+| A3    | "Model RISC-V as a capability subset" decision row (counting always / sampling under Sscofpmf / branch-records never yet / precise never) | opinion    | sub-report suggested row; derived from C1–C7                                                                               | ◯      |
+
+## Discrepancies
+
+Three rows carried from the W4 sub-report; the first two were prompt hypotheses this survey
+overturned, applied to the page as the `⚠` warnings in [Concern 5](../riscv.md#concern-5-event-space-branch-records-ctr).
+
+| #   | Prompt / prior claim                                           | Finding (applied to page)                                                                                                                                                                                                                                                                                                    | Source                                                   | Status |
+| --- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ------ |
+| 1   | Prompt asserted a `drivers/perf/riscv_ctr.c` in `$REPOS/linux` | **Refuted.** `drivers/perf/riscv_ctr.c` **does not exist** at `linux@e43ffb69e043` (v7.1-rc6); a full-tree grep for `ssctr\|smctr\|control_transfer\|RISCV_ISA_EXT_S[MS]CTR` returns only unrelated hits. CTR has **no upstream Linux consumer**. Page flags this as the headline gap.                                       | `linux@e43ffb69` (verified by absence)                   | ⚠      |
+| 2   | Prompt said "CTR, ratified 2025"                               | **Corrected.** CTR was ratified **2024-11-22** (not 2025) and the extensions are named **Smctr / Ssctr**. Independently corroborated by the GitHub **v1.0 "Ratified release"** (published 2024-11-23), whose PDF asset is saved at `$REPOS/papers/cpu-pmu/riscv-ctr-spec-v1.0.pdf` (23 pp, byte-exact to the release asset). | `riscv-ctr@42e299ca header.adoc:39-47`; CTR v1.0 release | ⚠      |
+| 3   | Easy to overstate as "sampling needs AIA"                      | **Nuance.** _Host_ sampling needs only **Sscofpmf**; _guest_ (VS-mode) LCOFI **delivery** additionally needs **AIA** (Ssaia/Smaia) because `hvip` injects only the three standard VS interrupts — bit 13 goes through `HVIEN`. Page states the precise split and adds a `[!NOTE]` against overstatement.                     | `linux arch/riscv/kvm/aia.c:565-567,581-582`             | ⚠      |
+
+**Resolved note (`◯`→ok):** CTR is folded into **both** the standalone `riscv-ctr` repo **and**
+the unified ISA manual (`riscv-isa-manual src/priv/smctr.adoc`, "`ext:smctr[]` … Version 1.0") —
+two concurring primary sources, not a conflict. The page cites the standalone repo for line
+precision and the manual for the ratified-in-manual fact.
+
+## Web / secondary (🌐)
+
+- **CTR v1.0 release metadata** (tag `v1.0`, "Ratified release" published 2024-11-23, asset
+  `riscv-ctr-v1.0.pdf`) is GitHub release data, not spec text; the _ratified-state_ and
+  _revdate 11/22/2024_ facts themselves are in-tree (`header.adoc:39-47`), so the page's date
+  claim is `[source-verified]`, with the release as corroboration only.
+- **Sibling-page links** (`./linux-perf-events.md`, `./precise-sampling.md`, `./elfutils.md`,
+  `./event-naming.md`, `./arm.md`, `./comparison.md`, `./sparkles-baseline.md`) resolve within
+  the cpu-pmu tree once its companion pages land; they carry no RISC-V claim of their own.
+
+**Net:** 45 claims mapped (C1.1–C7.4 + 3 page-level synthesis rows). **0 fabrications**; every
+quote is byte-verbatim from the pinned tree (SBI-PMU purpose, Sscofpmf `OF`/LCOFI, CTR
+ratified-state, CTR freeze-on-LCOFI, roofline abstract — all re-checked this session). Three `⚠`
+rows are **prompt corrections applied to the page**, not page errors: two overturned prompt
+hypotheses (no `riscv_ctr.c`; CTR ratified 2024 not 2025) and the host-vs-guest AIA nuance. The
+only `◯` rows are the strengths/weaknesses/decision synthesis and the "capability subset"
+recommendation, both flagged as editorial in-page.

--- a/docs/research/cpu-pmu/grounding/synthesis-pages.md
+++ b/docs/research/cpu-pmu/grounding/synthesis-pages.md
@@ -1,0 +1,84 @@
+# Ledger — synthesis pages (index · concepts · comparison · sparkles-baseline · backend-proposal)
+
+> Not published research. Do not link to it from the survey pages.
+
+Key: `✓` verified · `≈` paraphrase-verified · `⚠` discrepancy (see
+[master register](./index.md)) · `◯` open / not locally groundable · `🌐` web.
+Synthesis pages aggregate the deep-dives; rows below verify the claims these
+pages _originate_ (aggregations, timeline entries, baseline observations) —
+cell-level facts re-stated from a deep-dive are checked in that page's ledger.
+
+## index.md
+
+| #   | Claim                                                                                                                                   | Type     | Source                                                                                                               | Status |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- | ------ |
+| I1  | Master-catalog verification beds per row (which pages carry hw tags)                                                                    | fact     | per-page ledgers                                                                                                     | ✓      |
+| I2  | Timeline: PEBS ~2000 (NetBurst); IBS 2007 (Fam 10h); perf_event_open Linux 2.6.31 (2009); SPE Armv8.2 (2016); Sscofpmf + SBI 0.3 (2021) | fact     | `[literature]` — coarse, marked as such in-page                                                                      | 🌐     |
+| I3  | Timeline: HCP min Windows 7; LBR public 19H1; raw ProfileSource 1903                                                                    | fact     | saved MS docs (`win-enablethreadprofiling.html`, `etw-trace-query-info-class.html`, `wpt-recording-pmu-events.html`) | ✓      |
+| I4  | Timeline: PMUv3p5 64-bit event counters (Armv8.5); BRBE (Armv9.2)                                                                       | fact     | `arm_pmuv3.c:489-492`, `arm_brbe.c`                                                                                  | ✓      |
+| I5  | Timeline: CTR ratified 2024-11-22; no Linux consumer at v7.1-rc6                                                                        | fact     | `riscv-ctr@42e299ca header.adoc`; tree grep                                                                          | ✓      |
+| I6  | Timeline: M4 PMUv3-number remap (2024 silicon)                                                                                          | fact     | kpep plists + `cpc_arm64_events.c`                                                                                   | ✓      |
+| I7  | Probe table (what each demonstrates, env: 6.18.26 / 7940HX / LDC 1.41)                                                                  | behavior | probe outputs in sub-reports; probes in `examples/`                                                                  | ✓      |
+
+## concepts.md
+
+| #   | Claim                                                                                       | Type        | Source                                                                            | Status     |
+| --- | ------------------------------------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------- | ---------- |
+| C1  | Group all-or-nothing quote ("scheduled in as one unit only")                                | quote       | `kernel/events/core.c:2886`                                                       | ✓          |
+| C2  | Scaling formula quote (`count = quot * enabled + …`)                                        | quote       | `include/uapi/linux/perf_event.h:685`                                             | ✓          |
+| C3  | Counter budgets: 6 PMCs Zen 4; 5+2 exposed by kpc on M-series                               | figure      | sysfs (this host); mac-bsn Exp. a                                                 | ✓          |
+| C4  | NMI watchdog occupies a counter (x86)                                                       | fact        | bench-baseline.md observation + perf.d calibration behavior; widely documented    | ≈          |
+| C5  | Sscofpmf LCOFI = interrupt bit 13                                                           | fact        | `sscofpmf.adoc:69-91`; `csr.h:101`                                                | ✓          |
+| C6  | IBS skid-0; PEBS assist; SPE buffer — engine one-liners                                     | fact        | `ibs.c:240-243`; `ds.c`; `arm_spe_pmu.c`                                          | ✓          |
+| C7  | LBR 32 / BRBE ≤64 / CTR 16–256 depths                                                       | figure      | `[literature]` (LBR) / `arm_brbe.c:29-61` / `riscv-ctr body.adoc:161-208`         | ✓ (LBR 🌐) |
+| C8  | MMAP2-while-enabled; `MISC_MMAP_BUILD_ID`; GUID+Age; LC_UUID                                | fact        | probe + `machine.c`; PE/Mach-O `[literature]`                                     | ✓/≈        |
+| C9  | No libnuma VA→node helper; the two oracles; `QueryWorkingSetEx.Node`; Apple UMA             | fact        | R11; windows/macos ledgers                                                        | ✓          |
+| C10 | Curation: HAL profile-sources; `RESTRICT_TO_KNOWN` 102 events on M4 Max                     | fact/figure | `wpt-recording-pmu-events.html`; `cpc_arm64_events.c:379-485`                     | ✓          |
+| C11 | Gating: paranoid levels; SPE PA gate; `SeSystemProfilePrivilege`; "root or the blessed pid" | fact        | uAPI header; `arm_spe_pmu.c:873-877`; `etw-starttrace.html`; `kern_kpc.c:405-408` | ✓          |
+
+## comparison.md
+
+| #   | Claim                                                        | Type       | Source                                                                                     | Status           |
+| --- | ------------------------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------ | ---------------- |
+| M1  | Capability-matrix cells                                      | fact       | each cell restates a deep-dive claim; verified in the owning page's ledger                 | ✓ (by reference) |
+| M2  | "No naming layer spans OSes"                                 | fact       | event-naming ledger (libpfm4 `pfm_os_t`; LIKWID Linux-only; kpep/profile-sources OS-local) | ✓                |
+| M3  | Consensus/trade-off tables (aggregation, no new facts)       | exposition | deep-dives                                                                                 | ✓                |
+| M4  | Delta-table "sparkles today" column                          | behavior   | sparkles-baseline ledger rows B1–B14                                                       | ✓                |
+| M5  | Open questions 1–4 (no ARM-Linux/RISC-V/Intel/multi-node hw) | fact       | `_sources.md` environment table                                                            | ✓                |
+| M6  | SNC/NPS re-scope nodes/uncore; must re-probe per boot        | fact       | `[literature]` — flagged as such in-page                                                   | 🌐               |
+| M7  | Third Apple fixed counter unresolved                         | ◯          | R18                                                                                        | ◯                |
+| M8  | rdpmc bracket "~10× cheaper" figure in delta table           | figure     | `[literature]` order-of-magnitude (uAPI design intent); not measured here                  | 🌐               |
+
+## sparkles-baseline.md
+
+Observed-behavior rows; line numbers are the in-repo tree at survey date.
+
+| #   | Claim                                                                                                                     | Type     | Source                                                              | Status |
+| --- | ------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------- | ------ |
+| B1  | 7-event group layout, leader cycles, `pid:0,cpu:-1`                                                                       | behavior | `perf.d:74-88,199-201`                                              | ✓      |
+| B2  | `read_format = GROUP\|TOTAL_TIME_ENABLED\|TOTAL_TIME_RUNNING`; plain `read(2)`; no rdpmc/mmap                             | behavior | `perf.d:194-197`; `perf_group.d`                                    | ✓      |
+| B3  | Calibration handshake: ~2 ms spin; `< 0.98` → drop LLC pair; zero-time → unavailable                                      | behavior | `perf.d:129-154,214-227`                                            | ✓      |
+| B4  | Kernel+user → user-only fallback (`exclude_kernel`)                                                                       | behavior | `perf.d:158-168`                                                    | ✓      |
+| B5  | Off-Linux stub, identical surface, `available == false`                                                                   | behavior | `perf.d:293-311`                                                    | ✓      |
+| B6  | Bracket: RESET once; ENABLE→timed→DISABLE per iter; `between` untimed; per-pass time base (RESET zeroes values not times) | behavior | `perf_group.d:61-121`                                               | ✓      |
+| B7  | tier0 = getrusage + `/proc/self/io` raw-read (`std.file` size-0 trap); self-cost median-of-9 subtracted                   | behavior | `tier0.d:218-248,335-369`                                           | ✓      |
+| B8  | syscalls tier: `raw_syscalls:sys_enter` leader + ≤62 named; tracefs ids; `inherit=1`; root-only gate detected             | behavior | `syscalls.d:77-168`                                                 | ✓      |
+| B9  | `MetricClass`/`MetricCell`/`MetricDescriptor` shapes as quoted                                                            | fact     | `metrics.d:29-63`                                                   | ✓      |
+| B10 | `rowCells`/`catalog`/`visibleMetrics`/`selectsSource` render path; `--metrics` opens tiers transitively                   | behavior | `metrics.d:250-260,514-539,645-692`                                 | ✓      |
+| B11 | Bencher protocol: double-until-5ms, 32 samples, median/MAD; MonoTime ticks; counting pass separate, capped 100k iters     | behavior | `bench.d:82-98,294-331,434-440`                                     | ✓      |
+| B12 | "One field + one line in each of open/close/countInto" extension contract                                                 | quote    | `bench.d:377-419` module doc                                        | ✓      |
+| B13 | wired bench reuses runner `--perf`; no private backend; per-byte derivation; LLC drop on this host (NMI watchdog)         | behavior | `runner.d:8-9`; `bench-baseline.md:22-24,63-99`                     | ✓      |
+| B14 | Seven-concern absence table (concerns 2,3,4,6 absent; 5,7 partial)                                                        | behavior | absence of any sampling/symbolization/NUMA code in the five modules | ✓      |
+
+## backend-proposal.md
+
+| #   | Claim                                                                                                                                                       | Type       | Source                                                               | Status           |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------- | ---------------- |
+| P1  | Design constraints imported (libpfm force-PMU; swfilt; rusage floor; CycleTime floor; oracles; MMAP2 hazard; addrinfo non-NULL; PMUSERENR/scounteren gates) | fact       | the owning deep-dive ledgers (R2, R10, R11, R13, R15, R19, R20, R22) | ✓ (by reference) |
+| P2  | `isCounterBackend`/`Capability` D sketches compile-shaped against `metrics.d` seam                                                                          | exposition | design sketch — not compiled; marked as sketch                       | ◯                |
+| P3  | Milestone dependency/effort ordering                                                                                                                        | opinion    | design judgment                                                      | ◯                |
+
+**Net:** synthesis pages originate few facts; the load-bearing ones are ✓
+against pinned artifacts. Deliberate `[literature]`/🌐 rows: coarse timeline
+dates (I2), SNC/NPS caveat (M6), rdpmc cost figure (M8). Open: R18 (M7), and
+the D sketches are design artifacts, not compiled code (P2).

--- a/docs/research/cpu-pmu/grounding/windows.md
+++ b/docs/research/cpu-pmu/grounding/windows.md
@@ -1,0 +1,218 @@
+# Grounding ledger — `windows.md`
+
+Claim-by-claim source verification of [`docs/research/cpu-pmu/windows.md`](../windows.md).
+**No Windows hardware exists for this survey** — every row is either `[literature]`
+(read from an official Microsoft Learn page saved to `$REPOS/papers/cpu-pmu/<file>.html`,
+retrieved 2026-07-10, all HTTP 200) or `[source-verified]` (read from a pinned
+open-source tree or ldc-1.41.0 druntime). **No `[hw-verified]` tag appears anywhere.**
+
+Locators: `krabsetw` = `$REPOS/cpp/krabsetw @ 6900de05` (cloned this session,
+`6900de05d8ad7a38867719974f0406d5fd57af02`, 2026-04-14); `windows-d` =
+`$REPOS/dlang/windows-d @ f34527e` (`f34527ed18958ca94749c3934167ff66ec0156cc`,
+2026-06-03); `druntime` = ldc-1.41.0 `.../include/d/core/sys/windows` (resolved via
+`ldc2.conf`); `docs` = `$REPOS/papers/cpu-pmu/<file>.html` (base URL
+`https://learn.microsoft.com`). `$REPOS = /home/petar/code/repos`.
+
+> Not published research. Do not link to it from the survey pages.
+
+## Status legend
+
+| Mark | Meaning                                                                         |
+| ---- | ------------------------------------------------------------------------------- |
+| `✓`  | Verified against the cited local artifact (saved doc or repo, locator recorded) |
+| `≈`  | Faithful paraphrase / inference from absence (no single line to point at)       |
+| `⚠`  | Discrepancy vs the prompt's hypothesis — corrected + reflected in the page      |
+| `◯`  | Not locally groundable — synthesis/consequence, or standard PE/PDB knowledge    |
+| `🌐` | Web/secondary (none load-bearing on this page)                                  |
+
+**Types:** `lit` (`[literature]`, saved Microsoft Learn doc) · `src`
+(`[source-verified]`, krabsetw / windows-d / druntime read) · `quote` (verbatim) ·
+`synth` (derived consequence / inference from absence).
+
+## Claim ledger
+
+Numbering follows the W5 sub-report (claims 1–36 + quote candidates Q1–Q6).
+
+### Concern 1 — Scalar counting
+
+| #   | Claim (short)                                                                                                                           | Type      | Source (local + locator)                                                                     | Status |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------- | ------ |
+| 1   | HCP counting path: `EnableThreadProfiling`/`ReadThreadProfilingData`/`Disable`/`Query`, `winbase.h`, Kernel32, min Win7/Server 2008 R2  | lit       | `win-enablethreadprofiling.html`, `win-hcp-overview.html`                                    | ✓      |
+| 2   | `HardwareCounters` bitmask selects up to 16 counters **by zero-based index**, not by event                                              | lit/quote | `win-enablethreadprofiling.html` (Q2)                                                        | ✓      |
+| 3   | `EnableThreadProfiling` handle **"must be the current thread"**                                                                         | lit       | `win-enablethreadprofiling.html`                                                             | ✓      |
+| 4   | Counters **configured globally by a kernel driver** before profiling                                                                    | lit/quote | `win-enablethreadprofiling.html` (Q1)                                                        | ✓      |
+| 5   | `PERFORMANCE_DATA` fields; **only driver-free hardware datum is `CycleTime`**; PMCs via `HwCounters[]`                                  | lit       | `win-performance-data.html`                                                                  | ✓      |
+| 6   | `HARDWARE_COUNTER_DATA = {Type; Reserved; Value}`                                                                                       | lit/src   | `win-hardware-counter-data.html`; `windows-d …/performance/hardwarecounterprofiling.d:26-32` | ✓      |
+| 7   | `KeSetHardwareCounterConfiguration` (ntddk.h, WDK): global, single-tenant; `HalAllocate/FreeHardwareCounters`                           | lit/quote | `wdk-kesethardwarecounterconfiguration.html` (Q3)                                            | ✓      |
+| 8   | ETW counting: PMCs logged on ETW events (`CSwitch`); `xperf -pmc InstructionRetired,TotalCycles CSWITCH strict`; WPRP `HardwareCounter` | lit       | `wpt-recording-pmu-events.html`                                                              | ✓      |
+
+### Concern 2 — Overflow / IP sampling
+
+| #   | Claim (short)                                                                                                                                                                                       | Type      | Source (local + locator)                                           | Status |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------ | ------ |
+| 9   | ETW PMC-overflow sampling; `xperf -on …+pmc_profile -pmcprofile … -stackwalk pmcinterrupt`; WPRP `SampledCounter Interval` (events)                                                                 | lit       | `wpt-recording-pmu-events.html`                                    | ✓      |
+| 10  | Config classes in `TRACE_QUERY_INFO_CLASS`: `TraceSampledProfileIntervalInfo=5`, `TraceProfileSourceConfigInfo=6`, `…List=7`, `TracePmcEventListInfo=8`, `TracePmcCounterListInfo=9`; min Win7/Win8 | lit/quote | `etw-trace-query-info-class.html` (Q4 for 6)                       | ✓      |
+| 11  | `TraceMaxPmcCounterQuery=22` (19H1), `TracePmcCounterOwners=25` (21H2); budget = 3 PMCs (4 w/ ctx-switch)                                                                                           | lit       | `etw-trace-query-info-class.html`; `wpt-recording-pmu-events.html` | ✓      |
+
+### Concern 3 — Precise data-source / address sampling
+
+| #   | Claim (short)                                                                                                                                              | Type             | Source (local + locator)                                           | Status |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------ | ------ |
+| 12  | **No public data-address/PEBS class** in `TRACE_QUERY_INFO_CLASS` (full 0–28 read); docs describe only IP+stack                                            | src/lit (ABSENT) | `etw-trace-query-info-class.html`, `wpt-recording-pmu-events.html` | ✓      |
+| 13  | Kernel PEBS plumbing exists but **walled off**: undocumented internal `EVENT_TRACE_INFORMATION_CLASS` lists `EventTracePebsTracingInformation`             | src              | `krabsetw krabs/krabs/perfinfo_groupmask.hpp:155-176`              | ✓      |
+| 14  | Public analogs: **LBR** `TraceLbrConfigurationInfo=20`/`…EventListInfo=21` (Win10 19H1), branch-only; `TraceContextRegisterInfo=28` (Server 23H2), GP regs | lit              | `etw-trace-query-info-class.html`                                  | ✓      |
+| 15  | Arbitrary events need a **ring-0 driver** (VTune SEP, AMD uProf, closed); supported enum = `wpr/xperf -pmcsources`                                         | lit              | `wpt-recording-pmu-events.html` (+ claims 4/7)                     | ✓      |
+
+### Concern 4 — Code-space decode & symbolization
+
+| #   | Claim (short)                                                                                                                                             | Type  | Source (local + locator)                                                            | Status |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------- | ------ |
+| 16  | DbgHelp present in druntime as lazy fn-ptrs: `SymInitialize`/`StackWalk64`/`SymSetOptions`/`SymGetLineFromAddr64`/`SymGetSymFromAddr64`/`SymLoadModule64` | src   | `druntime dbghelp.d:27-92`                                                          | ✓      |
+| 17  | windows-d has modern DbgHelp `extern(Windows)` decls: `SymInitialize`/`SymFromAddr`/`SymGetLineFromAddr64`                                                | src   | `windows-d …/diagnostics/debug_/package.d:7046,7176,7252`                           | ✓      |
+| 18  | PDB **out-of-band**; build-id analog = **PDB GUID+Age** (CodeView `RSDS`); symbol servers via `_NT_SYMBOL_PATH`                                           | lit/◯ | `dbghelp-symfromaddr.html`, `dbghelp-symgetlinefromaddr64.html` (+ standard PE/PDB) | ✓      |
+| 19  | `MMAP2`→symbolization analog = ETW image-load events + `TraceProviderBinaryTracking=18` (Win10 1709)                                                      | lit   | `etw-trace-query-info-class.html`                                                   | ✓      |
+| 20  | psapi module-enum in druntime: `EnumProcessModules`/`GetModuleInformation`/`GetMappedFileNameW`                                                           | src   | `druntime psapi.d:102,108,133`                                                      | ✓      |
+
+### Concern 5 — Event-space & tracing
+
+| #   | Claim (short)                                                                                                                                                          | Type      | Source (local + locator)                                                            | Status |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------- | ------ |
+| 21  | krabsetw = open ETW consumption model: `trace<T>` (`ut`/`kt`), `open()`→`register/enable/open_trace`→`process_trace()`; provider/parser split by `ProviderId` via TDH  | src       | `krabsetw etw.hpp:180-211`, `kt.hpp:174-186`, `kernel_providers.hpp`                | ✓      |
+| 22  | Kernel-logger enablement via **undocumented** extended group-mask (`Nt[Query/Set]SystemInformation(SystemPerformanceTraceInformation)`); `PERF_PMC_PROFILE=0x20000400` | src/quote | `krabsetw kt.hpp:120-146,63-66` (Q6), `perfinfo_groupmask.hpp:61`                   | ✓      |
+| 23  | Documented per-session seam = `set_trace_information` → `TraceSetInformation(handle, class, …)`                                                                        | src       | `krabsetw etw.hpp:199-211`                                                          | ✓      |
+| 24  | ETW control APIs: `StartTrace`/`StopTrace` + `EVENT_TRACE_PROPERTIES(_V2)`, `EnableTraceEx2`, `ProcessTrace`, `TdhGetProperty`                                         | lit       | `etw-starttrace.html`, `etw-event-trace-properties.html`, `etw-enabletraceex2.html` | ✓      |
+| 25  | Session control gated: admins / Performance Log Users / LocalSystem; PMC sessions need `SeSystemProfilePrivilege`                                                      | lit/quote | `etw-starttrace.html`                                                               | ✓      |
+
+### Concern 6 — NUMA & topology
+
+| #   | Claim (short)                                                                                                                                      | Type           | Source (local + locator)                                                                                       | Status |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------- | ------ |
+| 26  | druntime `core.sys.windows` has **zero** NUMA/`*InformationEx` topology APIs (grep)                                                                | src (ABSENT)   | `druntime` (grep: no `GetLogicalProcessorInformation(Ex)`/`GetNuma*`/`VirtualAllocExNuma`/`QueryWorkingSetEx`) | ✓      |
+| 27  | windows-d has `GetLogicalProcessorInformationEx` + `SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX`, `GetNumaHighestNodeNumber`, `GetNumaProcessorNodeEx` | src            | `windows-d …/system/systeminformation.d:769,1009`                                                              | ✓      |
+| 28  | `VirtualAllocExNuma` node-targeted allocation                                                                                                      | src            | `windows-d …/system/memory/package.d:743`; `numa-virtualallocexnuma.html`                                      | ✓      |
+| 29  | `move_pages`-query analog = `QueryWorkingSetEx` → `PSAPI_WORKING_SET_EX_BLOCK.Node` per-page                                                       | src            | `windows-d …/system/processstatus.d:80,99,102`; `numa-queryworkingsetex.html`                                  | ✓      |
+| 30  | **No sampled-data-address → node** path (follows from concern-3 absence); page→node only for a known VA                                            | synth (ABSENT) | derived from claims 12, 29                                                                                     | ✓      |
+
+### Concern 7 — Event naming & encoding
+
+| #   | Claim (short)                                                                                                                                                                                                           | Type      | Source (local + locator)                                              | Status |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------- | ------ |
+| 31  | `HARDWARE_COUNTER_TYPE = {PMCCounter, MaxHardwareCounterType}` — a single real value; no generic encoding type at HCP                                                                                                   | lit       | `win-hardware-counter-type.html`                                      | ✓      |
+| 32  | Named surface = curated architectural profile-sources (`Timer`, `TotalCycles`, `InstructionRetired`, `LLCMisses`, … + `*Fixed`) via `-pmcsources`                                                                       | lit/quote | `wpt-recording-pmu-events.html`, `wpt-using-xperf-profiles.html` (Q5) | ✓      |
+| 33  | Raw/non-arch events registerable **since Win10 1903**, but only **system-global** (WPRP `ProfileSource Event/Unit/ExtendedBits` or registry), not inline; Intel `ExtendedBits` = CMask/CMaskInvert/AnyThread/EdgeDetect | lit       | `wpt-recording-pmu-events.html`                                       | ✓      |
+| 34  | Naming surface is CPU-vendor-neutral, **cross-ISA** (Intel/AMD/ARM64; doc registers a Snapdragon counter) — abstracts above `perf_event_attr.config`                                                                    | lit       | `wpt-recording-pmu-events.html`                                       | ✓      |
+
+### D-bindings reality check (feeds the backend proposal)
+
+| #   | Claim (short)                                                                                                                                                                                                                      | Type | Source (local + locator)                | Status |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | --------------------------------------- | ------ |
+| 35  | druntime present = `dbghelp.d`, `psapi.d`; missing = all ETW (`evntrace/evntcons/tdh`), all HCP, all NUMA/topology `*Ex`                                                                                                           | src  | `druntime` (grep)                       | ✓      |
+| 36  | windows-d `@ f34527e` has every gap with exact signatures — HCP (`hardwarecounterprofiling.d:51,44`), ETW (`etw.d:143,1539,2279`), NUMA (`systeminformation.d`/`memory/package.d`/`processstatus.d`), DbgHelp (`debug_/package.d`) | src  | `windows-d` (module:line refs as cited) | ✓      |
+
+### Quote candidates (verbatim)
+
+| #   | Quote (subject)                                                                                                                                               | Source (local + locator)                                           | Status |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------ |
+| Q1  | _"To profile hardware performance counters, you need a driver … see the KeSetHardwareCounterConfiguration function in the Windows Driver Kit (WDK)."_         | `win-enablethreadprofiling.html` (Remarks)                         | ✓      |
+| Q2  | _"You can specify up to 16 performance counters. Each bit relates directly to the zero-based hardware counter index …"_                                       | `win-enablethreadprofiling.html` (`HardwareCounters`)              | ✓      |
+| Q3  | _"The operating system supports only one profiling application at a time. … A thread can enable thread profiling for itself but not for other threads."_      | `wdk-kesethardwarecounterconfiguration.html`                       | ✓      |
+| Q4  | _"Configures the list of profiling sources … collected counters will be emitted as part of the `PERF_PMC_PROFILE` event."_                                    | `etw-trace-query-info-class.html` (`TraceProfileSourceConfigInfo`) | ✓      |
+| Q5  | _"Only a small subset of PMU events in CPU vendor's documents are implemented in Windows HAL by default. However, WPR provides a way to extend PMU events …"_ | `wpt-recording-pmu-events.html`                                    | ✓      |
+| Q6  | _"Enables the configured kernel rundown flags. This ETW feature is undocumented and should be used with caution."_                                            | `krabsetw krabs/krabs/kt.hpp:63-66`                                | ✓      |
+
+## Saved-docs URL map
+
+Local artifacts for this page: `$REPOS/papers/cpu-pmu/*.html`, all retrieved
+2026-07-10 (HTTP 200) via `curl -A Mozilla/5.0`, base URL `https://learn.microsoft.com`.
+This is the local-artifact map — each `[literature]` row above cites one of these files.
+
+| File                                         | URL path                                                                             |
+| -------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `win-enablethreadprofiling.html`             | `/windows/win32/api/winbase/nf-winbase-enablethreadprofiling`                        |
+| `win-readthreadprofilingdata.html`           | `/windows/win32/api/winbase/nf-winbase-readthreadprofilingdata`                      |
+| `win-disablethreadprofiling.html`            | `/windows/win32/api/winbase/nf-winbase-disablethreadprofiling`                       |
+| `win-querythreadprofiling.html`              | `/windows/win32/api/winbase/nf-winbase-querythreadprofiling`                         |
+| `win-performance-data.html`                  | `/windows/win32/api/winnt/ns-winnt-performance_data`                                 |
+| `win-hardware-counter-data.html`             | `/windows/win32/api/winnt/ns-winnt-hardware_counter_data`                            |
+| `win-hardware-counter-type.html`             | `/windows/win32/api/winnt/ne-winnt-hardware_counter_type`                            |
+| `win-hcp-overview.html`                      | `/windows/win32/api/_hcp/`                                                           |
+| `wdk-kesethardwarecounterconfiguration.html` | `/windows-hardware/drivers/ddi/ntddk/nf-ntddk-kesethardwarecounterconfiguration`     |
+| `etw-tracesetinformation.html`               | `/windows/win32/api/evntrace/nf-evntrace-tracesetinformation`                        |
+| `etw-trace-query-info-class.html`            | `/windows/win32/api/evntrace/ne-evntrace-trace_query_info_class`                     |
+| `etw-event-trace-properties.html`            | `/windows/win32/api/evntrace/ns-evntrace-event_trace_properties`                     |
+| `etw-event-trace-properties-v2.html`         | `/windows/win32/api/evntrace/ns-evntrace-event_trace_properties_v2`                  |
+| `etw-starttrace.html`                        | `/windows/win32/api/evntrace/nf-evntrace-starttracew`                                |
+| `etw-enabletraceex2.html`                    | `/windows/win32/api/evntrace/nf-evntrace-enabletraceex2`                             |
+| `etw-nt-kernel-logger-privilege.html`        | `/windows/win32/etw/configuring-and-starting-the-nt-kernel-logger-session`           |
+| `wpt-recording-pmu-events.html`              | `/windows-hardware/test/wpt/recording-pmu-events`                                    |
+| `wpt-using-xperf-profiles.html`              | `/windows-hardware/test/wpt/using-xperf-profiles`                                    |
+| `wpt-xperf-profiles.html`                    | `/windows-hardware/test/wpt/xperf-profiles`                                          |
+| `wpr-reference.html`                         | `/windows-hardware/test/wpt/wpr-reference`                                           |
+| `wpr-recorder.html`                          | `/windows-hardware/test/wpt/windows-performance-recorder`                            |
+| `dbghelp-symfromaddr.html`                   | `/windows/win32/api/dbghelp/nf-dbghelp-symfromaddr`                                  |
+| `dbghelp-symgetlinefromaddr64.html`          | `/windows/win32/api/dbghelp/nf-dbghelp-symgetlinefromaddr64`                         |
+| `dbghelp-syminitialize.html`                 | `/windows/win32/api/dbghelp/nf-dbghelp-syminitialize`                                |
+| `numa-getlogicalprocessorinformationex.html` | `/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex`       |
+| `numa-getnumahighestnodenumber.html`         | `/windows/win32/api/systemtopologyapi/nf-systemtopologyapi-getnumahighestnodenumber` |
+| `numa-virtualallocexnuma.html`               | `/windows/win32/api/memoryapi/nf-memoryapi-virtualallocexnuma`                       |
+| `numa-queryworkingsetex.html`                | `/windows/win32/api/psapi/nf-psapi-queryworkingsetex`                                |
+
+Repo reads (no saved HTML — read in place): `krabsetw @ 6900de05` (`etw.hpp`,
+`kt.hpp`, `perfinfo_groupmask.hpp`, `kernel_providers.hpp`), `windows-d @ f34527e`
+(the four generated modules), druntime via `ldc2.conf` import path (`dbghelp.d`,
+`psapi.d`, grep for absences).
+
+## Discrepancies
+
+These are corrections/refinements against the **prompt's** hypotheses, each reflected
+in the page — not open contradictions in the source material.
+
+- **⚠ "Curated set = cycle-only + `HARDWARE_COUNTER_DATA`": partially refuted.** HCP is
+  **not** cycle-only — it can surface up to 16 PMCs via `HwCounters[]` (claim 5). But
+  those require a WDK driver; the only _driver-free_ hardware datum is `CycleTime`. So
+  "cycle-only" is true for the pure-usermode subset and false in general. The page
+  states this precisely (metadata "driver-free = `CycleTime` only";
+  [How it works (a)](../windows.md#a-hardware-counter-profiling--per-thread-counting)).
+- **⚠ HCP lives in `winbase.h`, not `realtimeapiset.h`.** The sub-report's initial URL
+  guesses `nf-realtimeapiset-*` 404'd; the correct pages are `nf-winbase-*` (the HCP
+  `tech.root` is `hcp`). The page and every claim-1/2/3/4 citation use `winbase.h`.
+- **The `TRACE_INFO_CLASS` ≡ `TRACE_QUERY_INFO_CLASS` surprise.** They are the **same
+  typedef**; `TraceSetInformation`'s documented `InformationClass` parameter says "see
+  `TRACE_QUERY_INFO_CLASS`". The page uses `TRACE_QUERY_INFO_CLASS` throughout (the
+  name that carries the enumeration) to avoid the ambiguity.
+- **1903 raw-registration refinement (sharpens concern 7).** Contrary to a naïve
+  "Windows only exposes a fixed curated set", raw non-architectural events **are**
+  configurable since Win10 1903 (claim 33) — but via **system-global registration**
+  (WPRP/registry with `Event`/`Unit`/`ExtendedBits`), a structurally different seam
+  than an inline `perf_event_attr.config` field. Presented in the page as an explicit
+  refinement, not a contradiction.
+- **PEBS-absent finding: CONFIRMED and sharpened.** The public `TRACE_QUERY_INFO_CLASS`
+  has no PEBS/data-address class (claim 12), yet the undocumented internal enum in
+  krabs (`EventTracePebsTracingInformation`, claim 13) shows the kernel _has_ the
+  capability, walled off from third parties. LBR is public but branch-only; context
+  registers are public on Server 23H2+ (GP regs only). Not a discrepancy — a confirmed
+  and sharpened absence.
+- **D-bindings gap larger than expected.** druntime has _no NUMA APIs whatsoever_ (not
+  even `GetNumaHighestNodeNumber`) and no ETW/HCP — three of the four Windows surfaces
+  have zero druntime coverage (claims 26, 35); windows-d covers all (claims 27–29, 36).
+  Reflected in the page's [D-bindings callout](../windows.md#d-bindings).
+
+## Claims dropped / weakened
+
+- **Nothing dropped.** The page carries all 36 sub-report claims (1–36) and all six
+  quote candidates (Q1–Q6).
+- **Row 18 (PDB GUID+Age build-id analog)** rests partly on standard PE/PDB knowledge
+  (the CodeView `RSDS` directory layout) beyond the two saved DbgHelp pages; the
+  saved docs ground the DbgHelp API surface, the GUID+Age identity is flagged `◯`
+  where it exceeds them (consistent with the sub-report's own `[literature]` marking).
+- **Row 30 (no sampled-address → node)** is an `≈`/`synth` inference from the joint
+  absence of claims 12 and 29, not a single cited line; labelled as derived in-page.
+
+**Net:** 0 fabrications. Every claim is `[literature]` (a saved Microsoft Learn page,
+named by file, retrieved 2026-07-10) or `[source-verified]` (`krabsetw @ 6900de05`,
+`windows-d @ f34527e`, or ldc-1.41.0 druntime); **no hardware, no `[hw-verified]`
+tags.** Two prompt-hypothesis corrections (HCP is not cycle-only; HCP is in
+`winbase.h`, not `realtimeapiset.h`) are folded into the page; the precise-sampling
+absence is **confirmed and sharpened** via the undocumented internal PEBS enum; the
+Win10-1903 raw-registration path refines — but does not overturn — the curated-event
+thesis.

--- a/docs/research/cpu-pmu/index.md
+++ b/docs/research/cpu-pmu/index.md
@@ -1,0 +1,192 @@
+# Native CPU-PMU Integration
+
+How to build a native CPU-performance-monitoring data layer for the sparkles
+benchmarking harness — [`sparkles:test-runner --bench`][bench-docs] and the
+[`wired` runtime bench][wired-bench]. The survey grounds the Linux stack
+(`perf_event_open` and its decoder libraries — elfutils, libtraceevent,
+libnuma), maps it onto **ARMv8+** and **RISC-V**, surveys the alternative
+acquisition APIs on **Windows** and **macOS**, and lands in a capability
+matrix, an audit baseline, and a milestoned backend proposal. Every page is
+grounded twice over: claims carry pinned `repo@commit path:line` locators or
+recorded experiments, and locally-demonstrable behavior is backed by
+[runnable probes](#the-runnable-probes) CI compiles and runs.
+
+**Last reviewed:** July 11, 2026
+
+This survey answers ten questions:
+
+1. What does `perf_event_open` actually provide — counting, sampling, and the
+   contracts underneath (groups, multiplexing, the ring buffer, rdpmc)? →
+   [linux-perf-events][linux]
+2. How do the four Linux decoder libraries divide the work, and where do they
+   stop? → [elfutils][elfutils], [libtraceevent][libtraceevent],
+   [libnuma][libnuma]
+3. How does precise memory sampling work on each vendor engine (IBS, PEBS,
+   SPE), and how does a sampled data address become a NUMA node? →
+   [precise-sampling][precise]
+4. How does the model map onto ARMv8+/ARMv9 — PMUv3's event space, SPE, BRBE,
+   big.LITTLE, uncore — and what is Apple Silicon really? → [arm][arm]
+5. How does it map onto RISC-V, and which capabilities simply do not exist
+   there yet? → [riscv][riscv]
+6. What can a Windows profiler use without a kernel driver, and what only
+   with one? → [windows][windows]
+7. What can a macOS process measure at each privilege level, and what is
+   fenced behind root, entitlements, and the event allowlist? →
+   [macos][macos]
+8. How do human event names become hardware encodings, and which naming layer
+   covers which ISA and OS? → [event-naming][naming]
+9. Where does the sparkles harness stand today against all of the above? →
+   [sparkles-baseline][baseline] + the [delta table][comparison-delta]
+10. What should sparkles build? → [backend-proposal][proposal]
+
+---
+
+## The seven concerns
+
+Every subject in the tree is analyzed against the same seven-concern spine —
+where a concern does not apply, the page says so, because the _absence_ of a
+capability is itself a finding:
+
+1. **Scalar [counting][c-counting]** — groups, exactness, multiplexing.
+2. **[Overflow/IP sampling][c-sampling]** — periods, PMIs, ring buffers.
+3. **[Precise data-source/address sampling][c-datasrc]** — skidless engines,
+   latency, data addresses.
+4. **[Code-space decode & symbolization][c-symbolization]** — address-space
+   models, debug info, unwinding.
+5. **[Event-space & tracing][c-eventspace]** — tracepoints/ETW/kdebug, branch
+   records.
+6. **[NUMA & topology][c-numa]** — nodes, uncore scoping, page→node oracles.
+7. **[Event naming & encoding][c-naming]** — name→selector tables and their
+   coverage boundaries.
+
+## Master catalog
+
+| Subject             | What it is                                      | Concern focus          | Verification bed                  | Link                              |
+| ------------------- | ----------------------------------------------- | ---------------------- | --------------------------------- | --------------------------------- |
+| Concepts            | the tree's shared vocabulary                    | all                    | —                                 | [concepts.md][concepts]           |
+| Linux `perf_events` | the acquisition hub (reference model)           | 1, 2                   | `x86_64-linux` hw                 | [linux-perf-events.md][linux]     |
+| elfutils            | code-space decoder (`libelf`/`libdw`/`libdwfl`) | 4                      | `x86_64-linux` hw                 | [elfutils.md][elfutils]           |
+| libtraceevent       | event-space decoder (tracefs `format`)          | 5                      | source                            | [libtraceevent.md][libtraceevent] |
+| libnuma             | topology/placement decoder                      | 6                      | `x86_64-linux` hw (single-node)   | [libnuma.md][libnuma]             |
+| Precise sampling    | IBS · PEBS · SPE → one ABI; address→node        | 3, 6                   | IBS hw; PEBS/SPE source           | [precise-sampling.md][precise]    |
+| ARMv8+              | PMUv3, SPE, BRBE, big.LITTLE, uncore, Apple     | 1–7 mapping            | source; Apple `aarch64-darwin` hw | [arm.md][arm]                     |
+| RISC-V              | SBI indirection, Sscofpmf, CTR                  | 1–7 mapping (absences) | source + spec                     | [riscv.md][riscv]                 |
+| Windows             | HCP, ETW, ring-0 drivers, PDB, Win32 NUMA       | 1–7 mapping            | docs + open consumers             | [windows.md][windows]             |
+| macOS               | kpc/kperf, rusage, Instruments, dyld/dSYM       | 1–7 mapping            | `aarch64-darwin` hw               | [macos.md][macos]                 |
+| Event naming        | libpfm4, PAPI, LIKWID, vendor tables            | 7                      | `x86_64-linux` hw                 | [event-naming.md][naming]         |
+| Comparison          | capability matrix · trade-offs · delta table    | synthesis              | —                                 | [comparison.md][comparison]       |
+| sparkles baseline   | today's counter layer, as observed              | audit target           | in-repo                           | [sparkles-baseline.md][baseline]  |
+| Backend proposal    | milestoned per-OS acquisition core, in D        | design                 | —                                 | [backend-proposal.md][proposal]   |
+
+## Taxonomies
+
+### By ISA
+
+| ISA            | Counting model                          | Precise engine          | Branch records              | Pages                                |
+| -------------- | --------------------------------------- | ----------------------- | --------------------------- | ------------------------------------ |
+| x86_64 (AMD)   | `perf_event_open`, 6 PMCs               | IBS (skid 0)            | LBR                         | [linux][linux], [precise][precise]   |
+| x86_64 (Intel) | `perf_event_open`, fixed+GP             | PEBS (`precise_ip` 1–3) | LBR                         | [precise][precise], [naming][naming] |
+| ARMv8+/v9      | PMUv3 (PMCEID-probed), per-cluster PMUs | SPE (AUX)               | BRBE                        | [arm][arm]                           |
+| RISC-V         | SBI-mediated `mhpmcounter`              | **none**                | CTR (ratified, no consumer) | [riscv][riscv]                       |
+| Apple Silicon  | proprietary CPMU, 2 fixed + 8           | **none exposed**        | none exposed                | [arm][arm] §Apple, [macos][macos]    |
+
+### By OS
+
+| OS      | Acquisition surface                              | Event policy                     | Decode stack                        | Page               |
+| ------- | ------------------------------------------------ | -------------------------------- | ----------------------------------- | ------------------ |
+| Linux   | one syscall, all modes                           | open selectors, `paranoid`-gated | MMAP2 + DWARF (elfutils)            | [linux][linux]     |
+| Windows | HCP + ETW + closed ring-0 drivers                | curated + global registration    | image-load events + PDB (DbgHelp)   | [windows][windows] |
+| macOS   | kpc/kperf (root) · rusage (unpriv) · Instruments | kernel allowlist, even for root  | dyld map + dSYM (CoreSymbolication) | [macos][macos]     |
+
+### By verification level
+
+| Level                           | What carries it                                                                                                         |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `[hw-verified: x86_64-linux]`   | Linux counting/sampling/unwinding, IBS, libpfm4 round trip, NUMA round trip — the five probes below                     |
+| `[hw-verified: aarch64-darwin]` | kpep catalogs, kpc EPERM matrix, rusage counting, xctrace, dyld/atos — mac-bsn transcripts in [macos][macos]/[arm][arm] |
+| `[source-verified]`             | ARM-Linux drivers, RISC-V kernel/SBI/firmware, PEBS, xnu/dtrace, krabsetw, all pinned repos                             |
+| `[literature]`                  | vendor docs (saved), gated specs cited by section                                                                       |
+
+## Milestones
+
+When the key capabilities landed. Coarse dates are `[literature]`; entries
+verified in this survey's sources are tagged.
+
+| When       | What                                                                                                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ~2000      | Intel **PEBS** ships with NetBurst (Pentium 4) `[literature]`                                                                                                                   |
+| 2007       | AMD **IBS** ships with Family 10h (Barcelona) `[literature]`                                                                                                                    |
+| 2009       | Linux 2.6.31 merges **`perf_event_open`** `[literature]`; Windows 7 ships **HCP** thread profiling (min-version per the API docs) `[source-verified]`                           |
+| 2016       | Armv8.2 defines **SPE** `[literature]`                                                                                                                                          |
+| 2019       | Win10 1903 allows **raw ProfileSource registration**; 19H1 makes **ETW LBR** public `[source-verified]` (docs); Armv8.5/PMUv3p5 makes event counters 64-bit `[source-verified]` |
+| 2021       | RISC-V **Sscofpmf** ratified; SBI 0.3 adds the **PMU extension** `[literature]`; Armv9.2 defines **BRBE** `[source-verified]`                                                   |
+| 2024-11-22 | RISC-V **CTR** (Smctr/Ssctr) v1.0 **ratified** `[source-verified]` — still no Linux consumer at v7.1-rc6                                                                        |
+| 2024       | Apple **M4** remaps its common PMU events onto PMUv3 architected numbers `[hw-verified: aarch64-darwin]`                                                                        |
+
+## The runnable probes
+
+Standalone `dub` single-file programs under [`examples/`](#quick-navigation);
+CI compiles and runs each (they `SKIP` cleanly on hosts lacking a capability).
+Environment: Linux 6.18.26, AMD Ryzen 9 7940HX, LDC 1.41.
+
+| Probe                               | Demonstrates                                         | Backs                               |
+| ----------------------------------- | ---------------------------------------------------- | ----------------------------------- |
+| [counting-group.d][ex-counting]     | grouped IPC (exact) + forced multiplex scaling       | [linux][linux] concern 1            |
+| [sampling-symbolize.d][ex-sampling] | ring-buffer IP sampling → libdwfl symbolization      | [linux][linux] concern 2/4          |
+| [unwind-stack-user.d][ex-unwind]    | DWARF-CFI unwind of a frame-pointer-less build       | [linux][linux]/[elfutils][elfutils] |
+| [mem-latency-numa.d][ex-mem]        | IBS data-source/latency sampling + page→node oracles | [precise][precise]                  |
+| [pfm4-name-roundtrip.d][ex-pfm4]    | libpfm4 name→`perf_event_attr`→open→count            | [naming][naming]                    |
+
+## Quick navigation
+
+- **"I'm designing the sparkles backend"** — [concepts][concepts] →
+  [sparkles-baseline][baseline] → [linux-perf-events][linux] →
+  [event-naming][naming] → [comparison][comparison] (matrix + delta) →
+  [backend-proposal][proposal]; add [precise-sampling][precise] before
+  milestone 5 and [macos][macos]/[windows][windows] before 3/4.
+- **"Why is my profile lying to me?"** — [concepts § skid][c-skid] →
+  [precise-sampling][precise] → [linux § build-id hazard][linux].
+- **"What breaks off x86-Linux?"** — [arm][arm] → [riscv][riscv] →
+  [windows][windows] → [macos][macos] → [comparison § open questions][comparison-open].
+- **Vocabulary lookup** — [concepts.md][concepts].
+
+## Sources
+
+Per-page Sources sections carry the primary references; repos are pinned by
+SHA and papers archived locally (see each deep-dive). The five probes and the
+mac-bsn transcripts are the survey's own experimental evidence; experiment
+environments are recorded alongside every quoted output.
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[linux]: ./linux-perf-events.md
+[elfutils]: ./elfutils.md
+[libtraceevent]: ./libtraceevent.md
+[libnuma]: ./libnuma.md
+[precise]: ./precise-sampling.md
+[arm]: ./arm.md
+[riscv]: ./riscv.md
+[windows]: ./windows.md
+[macos]: ./macos.md
+[naming]: ./event-naming.md
+[comparison]: ./comparison.md
+[comparison-delta]: ./comparison.md#the-delta-table-the-survey-vs-the-sparkles-baseline
+[comparison-open]: ./comparison.md#open-questions-gaps
+[baseline]: ./sparkles-baseline.md
+[proposal]: ./backend-proposal.md
+[bench-docs]: ../../libs/test-runner/how-to/benchmark.md
+[wired-bench]: ../../../libs/wired/bench/runtime/
+[ex-counting]: ./examples/counting-group.d
+[ex-sampling]: ./examples/sampling-symbolize.d
+[ex-unwind]: ./examples/unwind-stack-user.d
+[ex-mem]: ./examples/mem-latency-numa.d
+[ex-pfm4]: ./examples/pfm4-name-roundtrip.d
+[c-counting]: ./concepts.md#counting
+[c-sampling]: ./concepts.md#overflow-sampling
+[c-datasrc]: ./concepts.md#data-source-attribution
+[c-symbolization]: ./concepts.md#symbolization
+[c-eventspace]: ./concepts.md#event-space-and-tracepoints
+[c-numa]: ./concepts.md#numa-topology-and-page-node-oracles
+[c-naming]: ./concepts.md#event-naming-and-encoding
+[c-skid]: ./concepts.md#precise-sampling-and-skid

--- a/docs/research/cpu-pmu/libnuma.md
+++ b/docs/research/cpu-pmu/libnuma.md
@@ -1,0 +1,232 @@
+# libnuma
+
+The survey's **topology / placement decoder**: it enumerates NUMA nodes and their
+distances from sysfs and wraps the memory-policy syscalls — but it has **no helper
+for the one query a data-source profiler needs**: _which node backs this address?_
+
+| Field            | Value                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------- |
+| Library          | `libnuma` (shipped in the `numactl` package)                                                             |
+| Role             | Enumerate nodes + inter-node distances (sysfs) and wrap the mempolicy syscalls                           |
+| Version          | **2.0.19**, [`numactl@93c1fe5`][numactl-repo]                                                            |
+| Sysfs root       | `/sys/devices/system/node`                                                                               |
+| pkg-config       | **None ships** — there is no `numa.pc`, so `pkg-config --cflags libnuma` fails                           |
+| Touches the PMU? | **No.** Pure decoder — the [Linux hub][linux]'s concern-6 delegate, and the classifier half of concern 3 |
+| Verification     | `[source-verified]` — read against the pinned `numactl@93c1fe5` tree                                     |
+
+> [!NOTE]
+> libnuma covers one of the survey's seven concerns (topology, concern 6) and is
+> the _classifier_ half of a second (precise data-source attribution, concern 3) —
+> the other five are **not applicable**. The headline finding is an **absence**:
+> the VA→node query that concern 3 depends on is _not wrapped by any libnuma
+> helper_. On UMA platforms (Apple Silicon) the whole layer collapses — see
+> [macos.md][macos].
+
+---
+
+## Overview
+
+### What it decodes
+
+Where [elfutils][elfutils] decodes code space and [libtraceevent][libtraceevent]
+decodes event space, libnuma decodes **placement**: it answers _how many nodes are
+there, how far apart are they, and which CPUs belong to each_, and it wraps the
+kernel's memory-policy syscalls (`mbind`, `set_mempolicy`, `move_pages`, …) so a
+program can bind memory to a node. For the CPU-PMU survey it is the layer that
+_would_ turn a sampled data address into a NUMA node — the last mile of
+[data-source attribution][datasrc] — except that the crucial query is one it does
+not expose.
+
+### Design philosophy: thin syscall shims + a sysfs reader
+
+libnuma is deliberately thin. Its placement primitives are near-direct syscall
+shims, and its topology is read straight from sysfs. The convenience allocators
+are one syscall under the hood — `numa_alloc_onnode` is just `mmap` followed by an
+`mbind`, verbatim ([`libnuma.c:324`][libnuma-c]):
+
+> `static int dombind(void *mem, size_t size, int pol, struct bitmask *bmp) { if (mbind(mem, size, pol, bmp ? bmp->maskp : NULL, bmp ? bmp->size : 0, mbind_flags) < 0) {`
+
+And the one query a data-source profiler actually wants — _which node backs this
+virtual address?_ — appears **only in the numactl `test/` tool**, as a raw syscall,
+because there is no library wrapper for it ([`test/mynode.c:10`][mynode-c]):
+
+> `if (get_mempolicy(&nd, NULL, 0, man, MPOL_F_NODE|MPOL_F_ADDR) < 0)`
+
+`[source-verified]` Those two excerpts frame the whole page: libnuma wraps
+_placement_ generously and _introspection of an address_ not at all.
+
+---
+
+## How it works
+
+libnuma has two faces — a set of syscall wrappers and a sysfs topology reader —
+with a thin layer of placement convenience on top.
+
+**Syscall wrappers.** The mempolicy syscalls are exposed as thin `WEAK` shims:
+`get_mempolicy`, `set_mempolicy`, `mbind`, `migrate_pages`, and `move_pages`
+([`syscall.c:223`][syscall-c] / `:238` / `:231` / `:246` / `:257`). The public
+placement helpers build directly on these: `numa_alloc_onnode` = `mmap` + `dombind`
+→ `mbind` ([`libnuma.c:1150`][libnuma-c], `:324`); `numa_set_membind` =
+`set_mempolicy(MPOL_BIND)` ([`:1206`][libnuma-c]); `numa_move_pages` = `move_pages`
+([`:1913`][libnuma-c]). `[source-verified]`
+
+**Sysfs topology and distances.** Topology comes entirely from sysfs, not a
+syscall. Node enumeration is `opendir("/sys/devices/system/node")`
+([`libnuma.c:371`][libnuma-c]); each node's CPU set is read from
+`.../node<N>/cpumap` via `getdelim` → `numa_parse_bitmap` ([`:1571`][libnuma-c]);
+and the inter-node distance matrix (the ACPI SLIT) is read from
+`.../node<N>/distance` by `read_distance_table` ([`distance.c:47`][distance-c]) and
+exposed as `numa_distance` ([`distance.c:105`][distance-c]). A CPU/node set is
+carried in a `struct bitmask {size; maskp}` ([`numa.h:44`][numactl-repo]).
+`[source-verified]`
+
+> [!WARNING]
+> **No `numa.pc` ships.** `libnuma` provides no pkg-config file, so
+> `pkg-config --cflags --libs libnuma` fails — a build integrating it must add
+> `-lnuma` and the header path by hand (contrast elfutils, which ships `.pc`
+> files). One more integration papercut for a would-be backend.
+
+---
+
+## The seven concerns
+
+The concern order is fixed across the survey. libnuma owns concern 6, is the
+classifier half of concern 3, and is not applicable to the rest.
+
+### Scalar counting
+
+**Concern 1 — not applicable.** libnuma reads no counters and opens no
+[`perf_event`][linux].
+
+### Overflow sampling
+
+**Concern 2 — not applicable.** libnuma does not sample. It only ever receives a
+data _address_ that a sample already carried.
+
+### Precise sampling and data-source attribution
+
+**Concern 3 — the classifier half, and the finding [precise-sampling.md][precise]
+builds on.** A [precise sample][precise] can carry a data virtual/physical address
+(`PERF_SAMPLE_ADDR`/`PERF_SAMPLE_PHYS_ADDR`) and a coarse `perf_mem_data_src`
+locality hint, but turning that into a _node_ — "this L3 miss was served from
+remote node 1" — requires a VA→node lookup. libnuma is where that lookup would
+live, and **it does not exist as a helper** (see [the missing VA-to-node
+helper](#the-missing-va-to-node-helper) below). So concern 3's node-precise
+classifier is _open-coded on top of libnuma's syscall shims_, not called from it —
+the exact gap [precise-sampling.md][precise] depends on.
+
+### Code-space decode and symbolization
+
+**Concern 4 — not applicable.** Addresses become symbols via [elfutils][elfutils],
+not libnuma.
+
+### Event-space and tracing
+
+**Concern 5 — not applicable.** Tracepoint records are decoded by
+[libtraceevent][libtraceevent].
+
+### NUMA and topology
+
+**Concern 6 — the entire page.** Everything in [How it works](#how-it-works) is
+this concern: node/distance enumeration from sysfs, and the mempolicy syscall
+wrappers. Node enumeration + distances give a placement decoder everything it needs
+to _describe_ the machine; what it cannot do is introspect an address.
+
+#### The missing VA-to-node helper
+
+The single most important finding on this page: **libnuma exposes no "which node
+backs this virtual address?" helper.** The query exists only as a raw syscall,
+used by the numactl _tool_ (never by `libnuma.c` itself):
+
+- `get_mempolicy(&node, NULL, 0, addr, MPOL_F_NODE | MPOL_F_ADDR)` — returns, in
+  `node`, the node backing the page containing `addr` ([`test/mynode.c:10`][mynode-c];
+  also `shm.c:307`), or
+- `numa_move_pages(pid, n, pages, NULL, status, 0)` in **query mode** (a `NULL`
+  target-nodes array) — after which each `status[i]` holds the current node of
+  `pages[i]`.
+
+A tempting near-miss, `numa_police_memory`, does **not** do this — it only _faults
+pages in_ (touches them to force allocation); it never _queries_ their node. So a
+data-source profiler that wants node-precise attribution must open-code one of the
+two raw calls above; there is no `numa_addr_to_node(...)` to reach for.
+`[source-verified]`
+
+> [!NOTE]
+> **Discrepancy resolved.** An early hypothesis held that `numa_police_memory`
+> queries the backing node. It does not — it faults pages in. The VA→node query is
+> the raw `get_mempolicy(MPOL_F_NODE | MPOL_F_ADDR)` / `move_pages` query-mode path.
+> This correction is exactly what [precise-sampling.md][precise]'s node classifier
+> is built on. `[source-verified]`
+
+### Event naming and encoding
+
+**Concern 7 — not applicable.** Node numbers are not hardware-event selectors;
+event naming is [event-naming.md][naming]'s.
+
+---
+
+## Strengths
+
+- **Complete topology description**: node count, per-node CPU masks, and the full
+  ACPI SLIT distance matrix, all read straight from a stable sysfs layout.
+- **Thin, predictable syscall wrappers**: `numa_alloc_onnode`, `numa_set_membind`,
+  and `numa_move_pages` are one syscall each — easy to reason about and to
+  reimplement.
+- **Placement is well-served**: binding memory to a node, migrating pages, and
+  setting policy are all first-class.
+- **Stable, ubiquitous ABI**: `libnuma`/`numactl` is present on essentially every
+  Linux NUMA system.
+
+## Weaknesses
+
+- **No VA→node helper** — the one query a data-source profiler needs is absent from
+  the library and must be open-coded as a raw `get_mempolicy`/`move_pages` call
+  (the headline finding).
+- **`numa_police_memory` is a false friend**: it faults pages, it does not query
+  their node — an easy trap.
+- **No `numa.pc`**: no pkg-config integration, so build systems wire `-lnuma` by
+  hand.
+- **Coarse upstream signal**: the `perf_mem_data_src` locality hint libnuma would
+  refine is itself coarse (IBS reports only a "remote" bit), so even a correct
+  VA→node lookup only sharpens an already-lossy signal — see
+  [precise-sampling.md][precise].
+- **Linux-only and moot on UMA**: on Apple Silicon (UMA) the entire node axis
+  collapses ([macos.md][macos]).
+
+## Key design decisions and trade-offs
+
+| Decision                                                     | Rationale                                                              | Trade-off                                                                                    |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Topology from sysfs, not a syscall                           | `/sys/devices/system/node` is a stable, parseable, unprivileged source | Ties the reader to the sysfs layout; a container without it sees no topology                 |
+| Thin `WEAK` syscall shims for mempolicy                      | Near-zero overhead; the kernel policy is the source of truth           | The library is a thin veneer — anything the syscalls do not offer, it does not either        |
+| Placement helpers (`numa_alloc_onnode`) but no VA→node query | Optimizes the common _placement_ path (bind memory to a node)          | Leaves _introspection_ (which node backs an address) unwrapped — profilers must open-code it |
+| Ship no pkg-config file                                      | Historical; the ABI is stable enough to link by hand                   | Every consumer wires `-lnuma` and the include path manually                                  |
+
+---
+
+## Sources
+
+- [numactl / libnuma — GitHub repository][numactl-repo] (`libnuma.c`, `syscall.c`, `distance.c`, `numa.h`, `shm.c`, `test/mynode.c`, read at `numactl@93c1fe5`, 2.0.19)
+- [`libnuma.c`][libnuma-c] — node enumeration, `numa_parse_bitmap`, `dombind`→`mbind`, `numa_alloc_onnode`/`numa_set_membind`/`numa_move_pages`
+- [`syscall.c`][syscall-c] — the `WEAK` mempolicy shims (`get_mempolicy`/`set_mempolicy`/`mbind`/`migrate_pages`/`move_pages`)
+- [`distance.c`][distance-c] — `read_distance_table` / `numa_distance` (the ACPI SLIT)
+- [`test/mynode.c`][mynode-c] — the raw `get_mempolicy(MPOL_F_NODE | MPOL_F_ADDR)` VA→node query that libnuma itself never wraps
+- The classifier this decoder feeds: [precise-sampling.md][precise]; the [acquisition hub][linux] it serves; the sibling decoders [elfutils][elfutils] · [libtraceevent][libtraceevent]; and the UMA collapse on [macOS][macos]
+- Shared vocabulary: [concepts.md][concepts] ([NUMA topology and page→node oracles][numa-concept], [data-source attribution][datasrc])
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[numa-concept]: ./concepts.md#numa-topology-and-page-node-oracles
+[datasrc]: ./concepts.md#data-source-attribution
+[linux]: ./linux-perf-events.md
+[precise]: ./precise-sampling.md
+[elfutils]: ./elfutils.md
+[libtraceevent]: ./libtraceevent.md
+[macos]: ./macos.md
+[naming]: ./event-naming.md
+[numactl-repo]: https://github.com/numactl/numactl
+[libnuma-c]: https://github.com/numactl/numactl/blob/93c1fe5/libnuma.c
+[syscall-c]: https://github.com/numactl/numactl/blob/93c1fe5/syscall.c
+[distance-c]: https://github.com/numactl/numactl/blob/93c1fe5/distance.c
+[mynode-c]: https://github.com/numactl/numactl/blob/93c1fe5/test/mynode.c

--- a/docs/research/cpu-pmu/libtraceevent.md
+++ b/docs/research/cpu-pmu/libtraceevent.md
@@ -1,0 +1,214 @@
+# libtraceevent
+
+The survey's **event-space decoder**: given a tracepoint's tracefs `format` schema
+and a raw record blob, it extracts typed fields by name — and it neither counts,
+samples, nor reads a single file from disk.
+
+| Field            | Value                                                                                                 |
+| ---------------- | ----------------------------------------------------------------------------------------------------- |
+| Library          | `libtraceevent` (the trace-event parsing library split out of the kernel `tools/lib/traceevent`)      |
+| Role             | Parse a tracepoint `format` schema, then extract typed fields from a raw record blob by name          |
+| Public header    | `include/traceevent/event-parse.h`                                                                    |
+| Version          | **1.9.0**, [`libtraceevent@51d47b0`][lte-src]                                                         |
+| Boundary         | Pairs with **`libtracefs`**, which reads the tracefs files; libtraceevent parses buffers it is handed |
+| Touches the PMU? | **No.** Pure decoder — the [Linux hub][linux]'s concern-5 delegate                                    |
+| Verification     | `[source-verified]` — the acquisition-side tracepoint gate is `[hw-verified: x86_64-linux]` (below)   |
+
+> [!NOTE]
+> Like the other decoders in this survey, libtraceevent is scoped to exactly one
+> of the seven concerns — event-space (concern 5). The rest are **not applicable**,
+> and saying so is a finding: it has no counter, no sampler, no symbol table, no
+> topology. Source read at **1.9.0** (`libtraceevent@51d47b0`, 2026-05-29).
+
+---
+
+## Overview
+
+### What it decodes
+
+A [`perf_event_open`][linux] event opened with `PERF_TYPE_TRACEPOINT` and
+`PERF_SAMPLE_RAW` delivers a raw, opaque byte blob per sample — the tracepoint's
+argument record. That blob is _typed_ only by the tracepoint's tracefs `format`
+schema. libtraceevent is the parser that turns the pair `(format schema, record
+blob)` into named, typed field reads: given the `sched_switch` format and a raw
+record, it answers `prev_comm`, `next_pid`, and so on. This is the
+[event-space][eventspace] half of the survey — enriching and gating hardware PMU
+data with OS-level events (syscalls, scheduling, faults).
+
+### Design philosophy: a parser, not a reader
+
+The library's defining boundary is stated in its own source. `tep_parse_format`
+and `tep_parse_event` take the format text as a **buffer the caller supplies** —
+the library documents where those buffers _come from_ but does not fetch them
+([`src/event-parse.c:8462`][lte-src]):
+
+> `* This parses the event format and creates an event structure * to quickly parse raw data for a given event. * * These files currently come from: * * /sys/kernel/debug/tracing/events/.../.../format`
+
+`[source-verified]` That comment names the tracefs path — and then hands the file
+I/O to somebody else. Reading `.../events/<system>/<event>/format` off disk is
+**`libtracefs`**'s job (or the caller's); libtraceevent only ever sees a buffer.
+A grep of the tree for a `tracefs` file reader turns up three hits, all in
+comments — there is no such function. `[source-verified]`
+
+---
+
+## How it works
+
+The lifecycle is: allocate a parser context, feed it one or more `format`
+buffers to register event schemas, then repeatedly decode record blobs against
+those schemas by field name.
+
+**The `tep_handle` and the `format` parse.** A parser context is a
+`struct tep_handle`, created with `tep_alloc` and released with `tep_free`
+([`event-parse.h:584`][lte-src]). A schema is registered by parsing a `format`
+buffer: `tep_parse_event(tep, buf, size, sys)` or the lower-level
+`tep_parse_format(tep, &event, buf, size, sys)` ([`event-parse.h:458`][lte-src]),
+both returning an `enum tep_errno`. After registration, an event is looked up by
+name with `tep_find_event_by_name` ([`:523`][lte-src]) or, from a live record,
+with `tep_find_event_by_record` ([`:525`][lte-src]). The producers are
+`__parse_event` at [`src/event-parse.c:8469`][lte-src] / [`:8491`][lte-src].
+`[source-verified]`
+
+**Field extraction by name.** Once an event schema is parsed, a field is found by
+name with `tep_find_field(event, name)` ([`event-parse.h:506`][lte-src]), returning
+a `struct tep_format_field {name, type, offset, size, flags}`
+([`:105`][lte-src]). The value is then read out of the raw record by
+offset/size — `tep_read_number_field(field, data, &val)`
+([`:516`][lte-src], implemented at [`src/event-parse.c:4414`][lte-src], and only for
+field sizes 1/2/4/8) or the more general `tep_get_field_val`. The record blob
+itself is a `struct tep_record {data, size, ts, cpu}` ([`:29`][lte-src]) — the
+bytes plus a timestamp and originating CPU. `[source-verified]`
+
+So the whole decode is: parse a `format` string once → get a `tep_event` → for
+each raw record, `tep_find_field` + `tep_read_number_field` per field of interest.
+Nothing in that path opens a file or reads a counter.
+
+> [!NOTE]
+> **Discrepancy resolved — the public header is `include/traceevent/event-parse.h`.**
+> An early note placed the header at `src/event-parse.h`; the installed public
+> header is `include/traceevent/event-parse.h`. The implementation lives in
+> `src/event-parse.c`. `[source-verified]`
+
+---
+
+## The seven concerns
+
+The concern order is fixed across the survey. For an event-space decoder, one
+applies and six do not.
+
+### Scalar counting
+
+**Concern 1 — not applicable.** libtraceevent reads no counters; a tracepoint is
+_counted_ through [`perf_event_open`][linux], and the number never passes through
+this library.
+
+### Overflow sampling
+
+**Concern 2 — not applicable to acquisition.** The [ring buffer][linux] delivers
+the `PERF_SAMPLE_RAW` blob; libtraceevent is the _downstream_ that types it
+(concern 5).
+
+### Precise sampling and data-source attribution
+
+**Concern 3 — not applicable.** Precise-sampling payloads
+([precise-sampling.md][precise]) are hardware-defined records, not tracepoint
+schemas — a different decode path entirely.
+
+### Code-space decode and symbolization
+
+**Concern 4 — not applicable.** Turning an instruction pointer into a symbol is
+[elfutils][elfutils]' job. libtraceevent decodes _event arguments_, not addresses.
+
+### Event-space and tracing: `PERF_TYPE_TRACEPOINT` and `PERF_SAMPLE_RAW`
+
+**Concern 5 — the entire page.** This is libtraceevent's whole reason to exist, and
+everything in [How it works](#how-it-works) is this concern. It is the second half
+of a two-part pipeline: the [Linux hub][linux-trace] _acquires_ the tracepoint (open
+it with `PERF_TYPE_TRACEPOINT`, attach its record with `PERF_SAMPLE_RAW`);
+libtraceevent _types_ the resulting blob against the `format` schema.
+
+> [!IMPORTANT]
+> **The decoder is only reachable once the events are opened — and opening them is
+> gated.** A tracepoint's numeric `id` (the `config` value
+> `perf_event_open` needs) lives in `.../events/<system>/<event>/id` under tracefs,
+> whose files are **root-only** on hardened boxes. The sparkles `--syscalls` layer
+> hits exactly this gate on the test machine — the tracepoint `id` files are
+> `0700`, so an unprivileged process cannot even read the `id` to open the event,
+> let alone reach libtraceevent's decode. This is a [privilege-gating][privilege]
+> finding on the acquisition side; libtraceevent itself is blameless (it never
+> touches the file). See [sparkles-baseline.md][baseline]. `[hw-verified: x86_64-linux]`
+
+### NUMA and topology
+
+**Concern 6 — not applicable.** No nodes, no distances, no placement. Topology is
+[libnuma][libnuma].
+
+### Event naming and encoding
+
+**Concern 7 — not applicable in the hardware sense.** libtraceevent resolves a
+tracepoint _field_ name from a `format` schema, but the hardware-event
+`type`/`config` naming problem is [event-naming.md][naming]'s. The overlap is
+nominal only.
+
+---
+
+## Strengths
+
+- **A clean parser/reader split**: libtraceevent parses buffers; `libtracefs`
+  reads files. A consumer can supply a captured or synthesized `format` string and
+  decode without any tracefs mount at all.
+- **Schema-driven, name-based field access**: `tep_find_field` +
+  `tep_read_number_field` decode by field name, so a consumer is insulated from a
+  tracepoint's exact byte layout.
+- **Self-describing records**: the `format` schema fully types the blob — no
+  hand-written struct per tracepoint.
+- **Battle-tested provenance**: it is the kernel's own trace-event parser, split
+  out of `tools/lib/traceevent`.
+
+## Weaknesses
+
+- **It decodes, it does not acquire**: the tracepoint must first be opened through
+  [`perf_event_open`][linux], and that open is [privilege-gated][privilege] behind
+  root-only tracefs `id` files on hardened systems — the real blocker in practice.
+- **You must supply the schema**: without the `format` buffer (from `libtracefs`
+  or a capture) there is nothing to parse against.
+- **Numeric-field convenience only for 1/2/4/8-byte fields**:
+  `tep_read_number_field` handles the common integer sizes; arrays/strings/complex
+  fields need the more general `tep_get_field_val` path.
+- **Two libraries for one job**: a full tracepoint pipeline pulls in both
+  libtraceevent and libtracefs, each with its own ABI.
+
+## Key design decisions and trade-offs
+
+| Decision                                                    | Rationale                                                                  | Trade-off                                                                       |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Parse a caller-supplied `format` buffer, never read tracefs | Decouples parsing from file I/O; works on captured/synthesized schemas     | A consumer must also pull in `libtracefs` (or read the files itself) to feed it |
+| Name-based field lookup (`tep_find_field`)                  | Insulates consumers from a tracepoint's byte layout across kernel versions | A per-field lookup + read, rather than a fixed struct cast                      |
+| `tep_read_number_field` limited to 1/2/4/8-byte fields      | Covers the overwhelmingly common integer fields with a tight fast path     | Non-integer fields fall back to `tep_get_field_val`                             |
+| Split out of the kernel tree as a standalone library        | Reusable by `perf`, `trace-cmd`, and third parties without the kernel tree | Version skew between the standalone library and the kernel it decodes for       |
+
+---
+
+## Sources
+
+- [libtraceevent project page][lte-home] and its [source tree][lte-src] (`include/traceevent/event-parse.h`, `src/event-parse.c`, read at `libtraceevent@51d47b0`, 1.9.0)
+- `include/traceevent/event-parse.h` — `tep_alloc`/`tep_free`, `tep_parse_event`/`tep_parse_format`, `tep_find_event_by_name`/`_by_record`, `tep_find_field`, `tep_read_number_field`, `struct tep_format_field`, `struct tep_record`
+- `src/event-parse.c` — the `__parse_event` producer and the tracefs-`format` provenance comment quoted above
+- The [acquisition hub][linux-trace] that opens the tracepoint (concern 5, acquisition half), and the sibling decoders [elfutils][elfutils] · [libnuma][libnuma]
+- The acquisition-side [privilege gate][baseline] the sparkles `--syscalls` layer hits
+- Shared vocabulary: [concepts.md][concepts] ([event-space and tracepoints][eventspace], [privilege gating][privilege])
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[eventspace]: ./concepts.md#event-space-and-tracepoints
+[privilege]: ./concepts.md#privilege-gating
+[linux]: ./linux-perf-events.md
+[linux-trace]: ./linux-perf-events.md#event-space-and-tracing-perf-type-tracepoint-perf-sample-raw
+[elfutils]: ./elfutils.md
+[libnuma]: ./libnuma.md
+[precise]: ./precise-sampling.md
+[naming]: ./event-naming.md
+[baseline]: ./sparkles-baseline.md
+[lte-home]: https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/
+[lte-src]: https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tree/

--- a/docs/research/cpu-pmu/linux-perf-events.md
+++ b/docs/research/cpu-pmu/linux-perf-events.md
@@ -1,0 +1,468 @@
+# Linux `perf_events`
+
+The survey's reference model: one syscall — `perf_event_open(2)` — is the single
+acquisition hub for _both_ [counting][counting] and [sampling][sampling], and four
+independent libraries decode what it produces without ever touching the PMU.
+
+| Field        | Value                                                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------------------------------------- |
+| Subsystem    | `perf_events` (kernel `kernel/events/`) + the `tools/perf` userspace consumer                                         |
+| Entry point  | `perf_event_open(2)` — returns one fd per event; fds compose into [groups][group]                                     |
+| ABI          | `struct perf_event_attr` (uAPI `include/uapi/linux/perf_event.h`) in, records + counter reads out                     |
+| Kernel read  | v7.1-rc6, [`linux@e43ffb69e043`][uapi]                                                                                |
+| Role         | Hub-and-decoders: the syscall _acquires_; `libdwfl`/`libtraceevent`/`libnuma` _interpret_                             |
+| Decoders     | [code space][elfutils] (`libdwfl`) · [event space][libtraceevent] (`libtraceevent`) · [topology][libnuma] (`libnuma`) |
+| Verification | `[hw-verified: x86_64-linux]` — Linux 6.18.26, AMD Ryzen 9 7940HX (Zen 4), LDC 1.41                                   |
+
+> [!NOTE]
+> All three hardware experiments on this page were recorded on **Linux 6.18.26**,
+> an **AMD Ryzen 9 7940HX** (Zen 4, 6 general-purpose core PMCs), with
+> `/proc/sys/kernel/perf_event_paranoid = -1`, built with **LDC 1.41** over
+> druntime's `core.sys.linux.perf_event`. Each is a runnable probe under
+> [`examples/`](./examples/counting-group.d) that CI compiles and runs.
+
+---
+
+## Overview
+
+### What it acquires
+
+Every other page in this survey describes a _variation on_, or a _decoder for_,
+the machinery here. Linux is the survey's reference model for a reason: it is the
+one platform where a single, uniform, unprivileged-capable syscall covers the
+whole acquisition surface. `perf_event_open(2)` opens **one event** — described
+by a `struct perf_event_attr` — and returns a file descriptor. Whether that event
+_counts_ (accumulate one number, read it with `read(2)`) or _samples_ (write a
+record stream into an mmap'd ring on every counter overflow) is a property of the
+same `attr`, not a different API. Windows splits this across ETW, the HAL, and
+`ReadThreadProfilingData`; macOS across `kpc` and `kperf`; Linux unifies it.
+
+The `perf_event_attr` ABI is wide but flat: a major `type`
+(`PERF_TYPE_HARDWARE`, `PERF_TYPE_TRACEPOINT`, …), a `config` number selecting the
+event within that type, and a bitfield block of modifiers (`disabled`,
+`exclude_kernel`, `exclude_hv`, `precise_ip`, `sample_type`, …)
+([`perf_event.h:393`][uapi-attr] for the struct, [`:418`][uapi-bitfield] for the
+modifier block). `linux@e43ffb69e043 include/uapi/linux/perf_event.h`.
+`[source-verified]`
+
+### The hub-and-decoders model
+
+The load-bearing architectural fact — the one that shapes every other page — is
+that **none of the four decoder libraries is required to acquire data; each is
+required only to interpret it.** `perf_event_open` and `read`/`mmap` give you raw
+numbers, raw instruction pointers, and raw record blobs. Turning those into
+meaning is delegated:
+
+| Decoder                                | Decodes         | From                                                  | Owns concern |
+| -------------------------------------- | --------------- | ----------------------------------------------------- | ------------ |
+| [`libelf`/`libdw`/`libdwfl`][elfutils] | **code space**  | IP → module → symbol → line + DWARF-CFI unwind        | 4            |
+| [`libtraceevent`][libtraceevent]       | **event space** | a tracefs `format` schema → typed field extraction    | 5            |
+| [`libnuma`][libnuma]                   | **topology**    | sysfs `/sys/devices/system/node` + mempolicy syscalls | 6            |
+| [`libpfm4` etc.][naming]               | **naming**      | human event name → `attr.{type, config}`              | 7            |
+
+A [group][group] is scheduled onto the PMU **as one atomic unit** — the property
+that makes a valid IPC possible ([counting][counting] cycles and instructions over
+the _same_ window). If the whole group cannot fit on the hardware it is rolled
+back and not scheduled at all, verbatim from the kernel
+([`kernel/events/core.c:2886`][core-group]):
+
+> `/* Groups can be scheduled in as one unit only, so undo any partial group before returning: */`
+
+That all-or-nothing contract is why a benchmarking harness sizes its group to the
+physical counter budget rather than hoping the kernel partial-counts — it never
+will. `[source-verified]`
+
+---
+
+## How it works
+
+The lifecycle of an event is four phases: **open** (`perf_event_open` with a
+filled `attr`), **arm** (`PERF_EVENT_IOC_RESET` + `PERF_EVENT_IOC_ENABLE` via
+`ioctl`, [`:576`][uapi-attr]), **run** (the workload executes), **harvest**
+(`read(2)` for counting; drain the mmap ring for sampling). Grouping and
+enable/disable can address a whole group at once with the
+`PERF_IOC_FLAG_GROUP` ioctl flag: enabling the leader enables every sibling.
+
+The kernel side is a per-CPU/per-task context of scheduled events. When more
+events are enabled than there are counters, a per-CPU hrtimer
+([`perf_rotate_context`, core.c:4587][core-rotate]) time-slices them, and the
+kernel accounts, per event, how long it was **enabled** versus actually
+**running** on hardware ([`__perf_update_times`, core.c:744][core-times]). Those
+two timestamps are the entire basis of [multiplexing scaling][multiplexing],
+below. `[source-verified]`
+
+---
+
+## The seven concerns
+
+This survey scores every backend against the same seven concerns. Linux is where
+five of them are _acquired_ and two (3, then the decode halves of 4–7) are
+_deferred to a decoder_. The concern order is fixed across the tree.
+
+### Scalar counting: groups, `PERF_FORMAT_GROUP`, and multiplexing
+
+**Concern 1 — acquired here.** A counting event is opened with
+`attr.disabled = 1` on the leader; sibling events
+pass the leader's fd as `group_fd`, which joins the [group][group]
+([`perf_event.h:393`][uapi-attr]). The leader carries the read format. With
+`PERF_FORMAT_GROUP` set, a single `read(2)` on the leader returns the whole group
+atomically as `{nr, time_enabled, time_running, value[nr]}`
+([read-format enum `:365`][uapi-readfmt]; producer
+[`perf_read_group`, core.c:6154][core-readgroup], with
+`nr = 1 + leader->nr_siblings`). Counting is cheap: no interrupts, no buffers, one
+register read per counter, near-zero perturbation — the natural mode for a
+per-iteration benchmark harness. `[source-verified]`
+
+**Multiplexing.** When enabled events exceed the counter budget, the reader must
+scale each raw count by `time_enabled / time_running` to estimate the full-window
+value. The exact formula is documented in the uAPI header itself
+([`perf_event.h:685`][uapi-scale]):
+
+```text
+/* include/uapi/linux/perf_event.h:685 */
+ *   quot = count / running;
+ *   rem  = count % running;
+ *   count = quot * enabled + (rem * enabled) / running;
+```
+
+Scaled counts are _estimates_: a sub-millisecond running slice produces visible
+error, and an event that got zero PMU time (`running == 0`) reads as perf's
+`<not counted>` — a zero read is not a measurement. A harness avoids the whole
+problem by keeping its group inside the physical counter budget — the reason the
+sparkles [baseline][baseline] drops its LLC pair when calibration detects
+rotation. `[source-verified]`
+
+**Experiment A** — [`counting-group.d`](./examples/counting-group.d) — reads a
+fitting `cycles`+`instructions` group (exact IPC, `scale == 1`), then deliberately
+oversubscribes 10 instruction counters onto 6 Zen-4 PMCs to force multiplexing:
+
+```text
+== Demo 1: fitting group (kernel+user) ==
+  nr=2  time_enabled=3020595 ns  time_running=3020595 ns  scale=1.0000
+  cycles=15099126  instructions=60049109  IPC=3.977
+== Demo 2: 10 instruction counters, 6 general-purpose PMCs ==
+  ev   raw_running_count      enabled_ns    running_ns   scale   estimate
+   0             13444336        3337469        762700    4.38   58830542
+   3             60058404        3332911       3332911    1.00   60058404   ← fit, exact
+   7             10661419        3320297        582933    5.70   60725808
+   8                    0        3316961             0       —   <not scheduled>
+  multiplexing observed: yes
+```
+
+The scaled estimates cluster at the true ~60.05M retired instructions; two events
+got **zero** PMU time (perf's `<not counted>` state); the extreme 5.70× scale from
+a 0.58 ms slice is visibly the noisiest recovery — a caution for the harness's
+LLC-pair-drop heuristic and any pinned, oversubscribed group.
+`[hw-verified: x86_64-linux]`
+
+#### `rdpmc` self-monitoring and the mmap-page seqlock
+
+The lowest-overhead counter read skips the syscall entirely. The mmap'd
+`perf_event_mmap_page` (page 0 of the ring mapping, [`perf_event.h:596`][uapi-page])
+publishes the counter `index`, `offset`, `pmc_width`, and a `cap_user_rdpmc`
+capability bit ([`:646`][uapi-caps]/[`:663`][uapi-width]). The
+[self-monitoring][rdpmc] read is a userspace seqlock loop that reads the counter
+with the `rdpmc` instruction, verbatim from the uAPI
+([`perf_event.h:608`][uapi-rdpmc]):
+
+```text
+/* include/uapi/linux/perf_event.h:608 */
+ *   do {
+ *     seq = pc->lock;
+ *     barrier()
+ *     ...
+ *     index = pc->index;
+ *     count = pc->offset;
+ *     if (pc->cap_user_rdpmc && index) {
+ *       width = pc->pmc_width;
+ *       pmc = rdpmc(index - 1);
+ *     }
+ *     barrier();
+ *   } while (pc->lock != seq);
+```
+
+The kernel republishes the page under an incrementing `lock` seqcount in
+`perf_event_update_userpage` ([core.c:6825][core-userpage], `++userpg->lock` +
+`barrier()`). One caveat for the per-ISA pages that follow:
+**`cap_user_rdpmc` and `pmc_width` are set by _arch_ code, not the generic
+core** — the `__weak arch_perf_update_userpage` stub at
+[core.c:6815][core-weakstub] is a no-op, and x86 fills the fields in
+`arch/x86/events/core.c`. The ARM `arm_pmuv3` userpage path is its own story (see
+[arm.md][arm]). `[source-verified]`
+
+### Overflow sampling: the ring buffer, `PERF_RECORD_MMAP2`, and IP symbolization
+
+**Concern 2 — acquired here.** [Sampling][sampling] arms `attr.sample_period` (or `attr.sample_freq` with
+`attr.freq = 1`) plus a `sample_type` bitmask selecting which fields each record
+carries ([`PERF_SAMPLE_IP = 1<<0` … `STACK_USER = 1<<13` … `DATA_SRC = 1<<15`,
+`:142`][uapi-sample]). On each [overflow][overflow] the [PMI][pmi] handler writes
+a `PERF_RECORD_SAMPLE` (record type `9`, [`:1059`][uapi-rectype]) into the mmap
+ring: page 0 is the control `perf_event_mmap_page` (`data_head`/`data_tail`,
+[`:749`][uapi-head]/[`:750`][uapi-tail]); pages 1.. are the data area. The
+sample's field order (IP, TID, TIME, …, `REGS_USER`, `STACK_USER`, …) is fixed by
+the `sample_type` bit order and documented at the record comment
+[`:1061`][uapi-recsample]. `[source-verified]`
+
+**Consumer ordering.** The reader-side contract is a seqcount: acquire-load
+`data_head`, process `[data_tail, data_head)` wrapping modulo the data size, then
+release-store the new `data_tail` back. Experiment B parses this directly.
+`[hw-verified: x86_64-linux]`
+
+**The `MMAP2` / stale-binary hazard.** The single biggest surprise for anyone
+writing a self-profiler: **`PERF_RECORD_MMAP2` (record type `10`,
+[`:1091`][uapi-mmap2]) is emitted only for executable mappings created _while the
+event is enabled_.** The kernel does **not** re-emit already-mapped code — your
+own binary, libc, everything that was mapped before you enabled sampling produces
+_zero_ `MMAP2` records. This is why the `perf` tool _synthesizes_ `MMAP2` for
+pre-existing regions from `/proc/PID/maps` at start, and why
+[`libdwfl`][elfutils]'s `dwfl_linux_proc_report` reads that same file. For a
+harness this is a real [build-id][build-id]/[stale-binary][build-id] hazard:
+symbolization must lean on `/proc/self/maps` or synthesize `MMAP2`, and must
+validate [build-ids][build-id] or risk silently symbolizing against a rebuilt
+binary. Perf's build-id path validates and rejects on mismatch
+([`build-id.c:863`][perf-buildid], `dso__build_id_mismatch`).
+`[hw-verified: x86_64-linux]` — the probe captured **0** `MMAP2` records until a
+mid-window `mmap(PROT_EXEC)` of `/proc/self/exe` forced one.
+
+**Experiment B** — [`sampling-symbolize.d`](./examples/sampling-symbolize.d) —
+samples `cycles` at ~4 kHz, drains `SAMPLE` + `MMAP2` from the ring, and hands the
+IPs to `libdwfl`:
+
+```text
+captured: 1 PERF_RECORD_MMAP2 mappings, 1996 IP samples
+top self-symbols (dwfl: name — samples — file:line):
+  …sumSquares…   1852   sampling-symbolize.d:137
+  …mixHash…       130   sampling-symbolize.d:129
+PERF_RECORD_MMAP2 captured during the window: 1 record(s)
+  [0x798b80c68000, 0x798b80c69000) pgoff=0x0 prot=0x5 …/build/cpu_pmu_sampling_symbolize
+model check: hottest symbol …sumSquares… (IP 0x55c5…) was symbolized by libdwfl,
+and a captured MMAP2 names the same image.
+```
+
+The IPs land purely on the acquisition side here; the address → symbol → line
+decode is elfutils' job — see [elfutils.md § "Address → module → symbol →
+line"][elfutils-addr]. `[hw-verified: x86_64-linux]`
+
+### Precise sampling and data-source attribution
+
+**Concern 3 — deferred to [precise-sampling.md][precise].**
+`perf_event_open` _acquires_ the precise-sampling request and its payload — the
+attr carries `precise_ip` (0–3) and the `sample_type` bits
+`PERF_SAMPLE_ADDR`, `PERF_SAMPLE_DATA_SRC`, `PERF_SAMPLE_PHYS_ADDR`,
+`PERF_SAMPLE_WEIGHT` — but the _semantics_ (Intel PEBS, AMD IBS, ARM SPE, the
+`perf_mem_data_src` union, [skid][skid] removal, and node classification) are one
+whole page of their own. This concern is covered end-to-end in
+[precise-sampling.md][precise]; the [data-source attribution][datasrc] payload it
+decodes is captured through this same syscall.
+
+### Code-space decode: the record → address model and stack capture
+
+**Concern 4 — address model here, decode → [elfutils.md][elfutils].**
+The kernel hands you records; turning them into a symbol requires an
+**address-space model** (which file is mapped where) and a **debug-info decoder**.
+Linux acquires the first and _defers the second_ to [`libdwfl`][elfutils].
+
+**The perf consumer pipeline (the address model).** Perf's own record → symbol
+path is the reference wiring: `MMAP2` → `machine__process_mmap2_event` builds a
+`struct dso_id` (the [build-id][build-id] if
+`PERF_RECORD_MISC_MMAP_BUILD_ID` is present, else `maj/min/ino`) + `map__new` +
+`thread__insert_map` ([machine.c:1728][perf-machine]); then a sampled IP resolves
+via `thread__find_map` (a `maps__find` bsearch, [maps.c:1122][perf-maps]) →
+`map__map_ip` rebases the runtime VA to a file offset ([map.h:107][perf-map]) →
+`map__find_symbol` → `dso__find_symbol` (rbtree containment,
+[symbol.c:412][perf-symbol]). `[source-verified]`
+
+#### Stack unwinding: `STACK_USER` + `REGS_USER` and DWARF CFI
+
+For a [call-graph profile][unwinding] on a frame-pointer-less build, the
+frame-pointer chain-walk is impossible, so the sample additionally carries the
+interrupted
+thread's **register file** (`PERF_SAMPLE_REGS_USER`) and a copied slab of its
+**user stack** (`PERF_SAMPLE_STACK_USER`) — `attr.sample_regs_user` is the
+register mask, `attr.sample_stack_user` the slab size. The DWARF-CFI _replay_ that
+turns those into a backtrace is again elfutils' — see [elfutils.md § "DWARF-CFI
+stack unwinding"][elfutils-unwind]. This page owns only the capture.
+
+**Experiment C** — [`unwind-stack-user.d`](./examples/unwind-stack-user.d) —
+samples with `REGS_USER`+`STACK_USER` on a `--frame-pointer=none` build and
+reconstructs a 5-frame backtrace **offline** from `.eh_frame`/`.debug_frame` CFI:
+
+```text
+captured: 125 samples with REGS_USER+STACK_USER (0 had ABI_NONE)
+chosen sample: leaf IP 0x… (…level3…+0x50)  regs ABI=2  RIP=0x… RSP=0x… captured stack=2776 bytes
+DWARF-CFI backtrace (5 frames, frame pointers OMITTED …):
+  #0 …level3…+0x50   #1 …level2…+0x12   #2 …level1…+0x12   #3 …workload…+0x71   #4 …run…+0x29A
+```
+
+This is byte-for-byte the wiring perf uses in
+[`tools/perf/util/unwind-libdw.c`][perf-unwind]. The perf → DWARF x86-64 register
+permutation lives in the probe; ARM and RISC-V need their own maps (see
+[arm.md][arm] / [riscv.md][riscv]). `[hw-verified: x86_64-linux]`
+
+### Event-space and tracing: `PERF_TYPE_TRACEPOINT` + `PERF_SAMPLE_RAW`
+
+**Concern 5 — raw blob here, decode → [libtraceevent.md][libtraceevent].**
+Beyond hardware counters, `perf_event_open` counts and samples kernel
+[software-event schemas][eventspace]. Opening an event with
+`attr.type = PERF_TYPE_TRACEPOINT` and `attr.config` set to a tracepoint's numeric
+`id` makes that tracepoint countable; adding `PERF_SAMPLE_RAW` to `sample_type`
+attaches the tracepoint's raw record blob to each sample. The blob is _typed_ only
+by the tracepoint's tracefs `format` schema, which [`libtraceevent`][libtraceevent]
+parses — see [libtraceevent.md][libtraceevent]. Two boundaries matter here: the
+numeric `id` comes from reading `.../events/<sys>/<event>/id` under tracefs (whose
+files are **root-only** on hardened boxes — the gate the sparkles `--syscalls`
+layer hits on this machine), and `libtraceevent` decodes the blob but does _not_
+read the tracefs files (libtracefs does). `[source-verified]`
+
+### NUMA and topology
+
+**Concern 6 — n/a to the syscall → [libnuma.md][libnuma].**
+The `perf_event_open` syscall has **no** topology concern — it neither enumerates
+nodes nor attributes a sampled data address to a node. A sample can _carry_ the
+data virtual/physical address (`PERF_SAMPLE_ADDR`/`PERF_SAMPLE_PHYS_ADDR`, concern
+3), but answering _"which node backs this page?"_ is a separate decoder: sysfs
+`/sys/devices/system/node` topology plus the mempolicy syscalls, wrapped (mostly)
+by [`libnuma`][libnuma]. See [libnuma.md][libnuma] — including the
+[missing VA→node helper][libnuma] that [precise-sampling.md][precise] must
+open-code.
+
+### Event naming and encoding
+
+**Concern 7 — opaque numbers here → [event-naming.md][naming].**
+On this page `attr.type` and `attr.config` are **opaque numbers**. The syscall
+takes `PERF_COUNT_HW_INSTRUCTIONS` (an architected enum) or a raw
+`PERF_TYPE_RAW` `config` and asks no questions about what it means. The mapping
+from a human name (`ex_ret_instr`, `INST_RETIRED.ANY`) to those numbers is a
+per-microarchitecture table maintained _outside_ the kernel — [libpfm4][naming],
+LIKWID, `intel/perfmon` — and is [event-naming.md][naming]'s whole subject. The
+kernel exposes `config` freely to unprivileged processes (subject to
+[privilege gating][privilege]), which — unlike Windows/macOS
+[capability curation][curation] — is why Linux is the survey's _"any event"_
+outlier.
+
+---
+
+## Strengths
+
+- **One uniform acquisition hub.** Counting and sampling are the same syscall and
+  the same `attr` ABI; there is no second API to learn for profiling vs
+  benchmarking. Windows and macOS both split this across several subsystems.
+- **Atomic [group][group] scheduling** makes derived metrics (IPC, MPKI) honest —
+  the co-scheduled counts share one window or the group does not schedule at all.
+- **User-space counter reads** via `rdpmc` + the mmap page reach tens-of-cycles
+  overhead, the natural fit for per-iteration bracketing inside a benchmark loop.
+- **Self-describing sampling records.** The `sample_type` bitmask makes each
+  record's layout deterministic; druntime's `core.sys.linux.perf_event` already
+  models the mmap page, headers, and every `PERF_SAMPLE_*`, so a **pure-D**
+  sampler needs _no_ C shim for the ring buffer (only `libdwfl` needs
+  `extern(C)`).
+- **Unprivileged by default** (`perf_event_paranoid` permitting): any `config`
+  value is openable without a global registration step.
+- **A public, reference consumer** (`tools/perf`) whose record → symbol pipeline
+  is readable source, not a black box.
+
+## Weaknesses
+
+- **The `MMAP2`/stale-binary hazard** (concern 2): a naive self-profiler captures
+  _zero_ mmap records and must synthesize the address-space model from
+  `/proc/PID/maps` and validate [build-ids][build-id], or it symbolizes against
+  the wrong binary silently.
+- **[Multiplexing][multiplexing] error is real and unbounded** below a
+  millisecond of running time — a sub-ms slice can inflate the scale to 5×+
+  (Experiment A). The harness must detect rotation and shrink the group, not trust
+  the estimate.
+- **`rdpmc` capability is arch- and policy-dependent**: `cap_user_rdpmc` is set by
+  arch code and may be disabled by sysadmin policy; a portable path must probe it,
+  never assume it.
+- **The decode surface is four separate libraries**, each with its own ABI and
+  version skew — the acquisition is trivial, the _interpretation_ is where the
+  engineering lives.
+- **[Privilege gating][privilege] is multi-dimensional**: `perf_event_paranoid`
+  levels, tracefs file permissions (concern 5), and SPE physical-address gating
+  (concern 3) each fail differently and must be treated as runtime capability
+  probes.
+
+## Key design decisions and trade-offs
+
+| Decision                                                               | Rationale                                                                           | Trade-off                                                                                            |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| One syscall for counting _and_ sampling (`perf_event_open`)            | A single flat `attr` ABI covers the whole surface; nothing to unify at the consumer | The `attr` struct is wide and versioned; every capability is a bit or field to probe                 |
+| All-or-nothing [group][group] scheduling                               | Co-scheduled counts share one window → derived metrics are valid                    | A group larger than the counter budget silently does not schedule — sizing is the caller's job       |
+| `time_enabled`/`time_running` + a documented scaling formula           | The reader can recover a full-window estimate under [multiplexing][multiplexing]    | Estimates degrade sharply below a millisecond of running time; `running == 0` is unrecoverable       |
+| `rdpmc` + a seqlock'd mmap page for user-space reads                   | Tens-of-cycles counter reads, no syscall, ideal for per-iteration bracketing        | Capability is arch-set and policy-gated; needs a seqcount retry loop and a probe                     |
+| `MMAP2` only for mappings made _while enabled_                         | The kernel avoids re-dumping the entire (large, static) address space per event     | Self-profilers capture nothing pre-existing → must synthesize from `/proc/maps` + validate build-ids |
+| Decoders (`libdwfl`/`libtraceevent`/`libnuma`) live outside the kernel | The acquisition path stays minimal; decode complexity is opt-in and swappable       | Four ABIs, four version-skew surfaces, and none of them portable off Linux                           |
+| `config` openable by unprivileged processes (paranoia-gated)           | No global event registration; any raw selector is reachable                         | Shifts the [curation][curation] burden to userspace — a portable backend must advertise, not assume  |
+
+---
+
+## Sources
+
+- [`perf_event_open(2)` — man page][man] (the authoritative prose; the uAPI header is its source)
+- [`include/uapi/linux/perf_event.h`][uapi] — `perf_event_attr`, read/sample formats, the mmap page, the scaling formula, and the `rdpmc` seqlock (all quoted above)
+- [`kernel/events/core.c`][core] — group scheduling ([all-or-nothing][core-group]), group reads, multiplex rotation, the userpage seqcount
+- [`arch/x86/events/core.c`][x86core] — where `cap_user_rdpmc`/`pmc_width` are actually set
+- [`tools/perf/util/`][perf-util] — the reference consumer: `machine.c`, `map.h`, `maps.c`, `symbol.c`, `build-id.c`, `unwind-libdw.c`
+- druntime `core.sys.linux.perf_event` (LDC 1.41) — the pure-D `attr`/record/mmap-page layout the probes use
+- Runnable probes: [`counting-group.d`](./examples/counting-group.d) · [`sampling-symbolize.d`](./examples/sampling-symbolize.d) · [`unwind-stack-user.d`](./examples/unwind-stack-user.d)
+- The decoders this hub defers to: [elfutils][elfutils] · [libtraceevent][libtraceevent] · [libnuma][libnuma] · [event naming][naming]
+- Shared vocabulary: [concepts.md][concepts]
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[counting]: ./concepts.md#counting
+[sampling]: ./concepts.md#sampling
+[group]: ./concepts.md#event-group
+[multiplexing]: ./concepts.md#multiplexing-and-scaling
+[rdpmc]: ./concepts.md#self-monitoring-and-user-space-counter-reads
+[pmi]: ./concepts.md#pmi-performance-monitoring-interrupt
+[overflow]: ./concepts.md#overflow-sampling
+[skid]: ./concepts.md#precise-sampling-and-skid
+[datasrc]: ./concepts.md#data-source-attribution
+[build-id]: ./concepts.md#build-id
+[unwinding]: ./concepts.md#unwinding
+[eventspace]: ./concepts.md#event-space-and-tracepoints
+[curation]: ./concepts.md#capability-curation
+[privilege]: ./concepts.md#privilege-gating
+[elfutils]: ./elfutils.md
+[elfutils-addr]: ./elfutils.md#address-→-module-→-symbol-→-line
+[elfutils-unwind]: ./elfutils.md#dwarf-cfi-stack-unwinding
+[libtraceevent]: ./libtraceevent.md
+[libnuma]: ./libnuma.md
+[precise]: ./precise-sampling.md
+[naming]: ./event-naming.md
+[arm]: ./arm.md
+[riscv]: ./riscv.md
+[baseline]: ./sparkles-baseline.md
+[man]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+[uapi]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h
+[uapi-attr]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L393
+[uapi-bitfield]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L418
+[uapi-readfmt]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L365
+[uapi-scale]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L685
+[uapi-page]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L596
+[uapi-rdpmc]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L608
+[uapi-caps]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L646
+[uapi-width]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L663
+[uapi-sample]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L142
+[uapi-rectype]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L1059
+[uapi-recsample]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L1061
+[uapi-mmap2]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L1091
+[uapi-head]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L749
+[uapi-tail]: https://github.com/torvalds/linux/blob/e43ffb69e043/include/uapi/linux/perf_event.h#L750
+[core]: https://github.com/torvalds/linux/blob/e43ffb69e043/kernel/events/core.c
+[core-group]: https://github.com/torvalds/linux/blob/e43ffb69e043/kernel/events/core.c#L2886
+[core-readgroup]: https://github.com/torvalds/linux/blob/e43ffb69e043/kernel/events/core.c#L6154
+[core-rotate]: https://github.com/torvalds/linux/blob/e43ffb69e043/kernel/events/core.c#L4587
+[core-times]: https://github.com/torvalds/linux/blob/e43ffb69e043/kernel/events/core.c#L744
+[core-userpage]: https://github.com/torvalds/linux/blob/e43ffb69e043/kernel/events/core.c#L6825
+[core-weakstub]: https://github.com/torvalds/linux/blob/e43ffb69e043/kernel/events/core.c#L6815
+[x86core]: https://github.com/torvalds/linux/blob/e43ffb69e043/arch/x86/events/core.c
+[perf-util]: https://github.com/torvalds/linux/tree/e43ffb69e043/tools/perf/util
+[perf-machine]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/util/machine.c#L1728
+[perf-map]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/util/map.h#L107
+[perf-maps]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/util/maps.c#L1122
+[perf-symbol]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/util/symbol.c#L412
+[perf-buildid]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/util/build-id.c#L863
+[perf-unwind]: https://github.com/torvalds/linux/blob/e43ffb69e043/tools/perf/util/unwind-libdw.c

--- a/docs/research/cpu-pmu/macos.md
+++ b/docs/research/cpu-pmu/macos.md
@@ -1,0 +1,554 @@
+# macOS (kpc / kperf / DTrace / Instruments)
+
+The macOS mapping of the survey's [seven concerns][concepts]: a genuinely
+capable Apple-Silicon CPMU that is **fenced behind root-or-entitlement and a
+kernel event allowlist**, reached by third parties either through
+**Instruments/`xctrace`** (an entitled broker) or through the one unprivileged
+door — `proc_pid_rusage`, the fixed-counter [counting][counting] path that on
+this box turns out _richer_ than Linux `/proc`.
+
+| Field              | Value                                                                                                                            |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| OS                 | macOS **26.3.1** (build 25D771280a)                                                                                              |
+| ISA                | ARMv8 / Apple Silicon (not [PMUv3][arm]) — the CPMU                                                                              |
+| Hardware           | Apple **M4 Max** (`Mac16,5`, SoC **T6041**, `hw.cpufamily 0x17d5b93a`) `[hw-verified: aarch64-darwin]`                           |
+| Counting APIs      | `proc_pid_rusage(RUSAGE_INFO_V4)` (unprivileged) · `kpc` via `kperf.framework` (root) · `xctrace` (unprivileged, brokered)       |
+| Sampling           | `kperf` PET/PMI + hardware PC-capture (`S3_1_C15_C14_1`) — root/blessed or Instruments only                                      |
+| Symbolization      | Mach-O + dSYM (DWARF) via `atos`/`symbols`, engine `CoreSymbolication.framework` (closed)                                        |
+| Event catalog      | on-disk **kpep** DB plists (`/usr/share/kpep/`, world-readable) + the kernel `RESTRICT_TO_KNOWN` allowlist (102 events on T6041) |
+| Open-source anchor | **xnu-12377.1.9** + **dtrace-413** (source drops); **dyld** open, not cloned                                                     |
+| Verification       | `[hw-verified: aarch64-darwin]` for `mac-bsn` transcripts; `[source-verified]` for xnu/dtrace reads                              |
+
+> [!IMPORTANT]
+> **This page is grounded in recorded `mac-bsn` transcripts, not a CI probe.**
+> There is no `aarch64-darwin` machine in CI and CI cannot reach `mac-bsn`, so —
+> unlike the Linux deep-dives — no runnable example ships here; the five in-page
+> experiment transcripts (Exp. a–e) _are_ the hardware evidence, tagged
+> `[hw-verified: aarch64-darwin]`. Everything read from the kernel is tagged
+> `[source-verified]` against the open-source drop. **One version skew to keep in
+> mind:** `mac-bsn` _runs_ kernel **xnu-12377.91.3** (`RELEASE_ARM64_T6041`), but
+> the public source drop is **xnu-12377.1.9** — same `12377` base for the same
+> die, so the code read is representative, but every line number below is from
+> `12377.1.9`. All experiments ran **unprivileged (uid 501)**; `sudo -n` needs a
+> password on this box, so nothing requiring root was attempted — the EPERM
+> boundary is observed from the outside.
+
+---
+
+## Overview
+
+### What it acquires
+
+Apple Silicon has a full-featured core performance-monitoring unit (the **CPMU**):
+2 fixed counters, 5 configurable counters exposed to software, counter-overflow
+PMIs, and hardware PC-capture. The catch is entirely one of _policy_. The real
+configuration-and-read surface is the kernel's **`kpc`** subsystem, and almost
+every `kpc` operation is gated behind `ktrace_read_check()` — which the source
+states in one comment ([`kern_kpc.c:405-408`][kpc-c]):
+
+> _"Require kperf access to read or write anything else. / This is either root or
+> the blessed pid."_
+
+Only three `kpc` sysctls — `classes`, `config_count`, `counter_count` — answer
+before that check; everything that would actually _program_ or _read_ a counter
+returns `EPERM` to an unprivileged caller. On a stock release kernel there is
+**no entitlement escape**: the `com.apple.private.ktrace-allow` path is compiled
+in only under `DEVELOPMENT || DEBUG` ([`kern_ktrace.c:279-282`][ktrace-c]). And
+even root cannot program an _arbitrary_ raw selector — a kernel-baked allowlist
+(`RESTRICT_TO_KNOWN`, 102 events on T6041) stands behind the privilege gate.
+
+So a third party has exactly three ways in, and the whole page is the story of
+those three tiers:
+
+1. **`proc_pid_rusage`** — unprivileged, whole-process, the two fixed counters.
+2. **`kpc`** (via the private `kperf.framework`) — root/blessed, full 2+5 counting
+   and sampling.
+3. **`xctrace`/Instruments** — unprivileged but _brokered_ through an entitled
+   helper; the sanctioned UI.
+
+### Design philosophy: capable but curated
+
+macOS's bet is the opposite of Linux's. Linux lets any unprivileged process open
+almost any `config` value (subject to [`perf_event_paranoid`][gating]); macOS
+_curates_ — it exposes a vetted event list and a privilege wall, and points third
+parties at Instruments. This puts it in the same [capability-curation][curation]
+family as [Windows][windows] (whose HAL profile-sources are likewise a small
+architected set), and squarely against Linux's open-selector stance. The
+practical upshot for a portable harness is that "counter opened" must be a
+_runtime capability probe_, never an assumption — the survey's recurring theme,
+and nowhere more true than here.
+
+---
+
+## How it works
+
+Three layers sit between a consumer and the CPMU. The kernel core is open; the
+userspace frameworks and the symbolication engine are closed and only
+reverse-engineered.
+
+| Layer                 | Component                                               | Open?      | Role                                                                                                |
+| --------------------- | ------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------- |
+| **1 — kernel core**   | XNU `kpc` / `kperf` / `cpc` / `monotonic`               | open (xnu) | counter config/read, PMI sampling, single-owner CPMU arbitration, fixed-counter (`monotonic`) reads |
+| **2 — userspace**     | `kperf.framework` / `kperfdata.framework`               | **closed** | thin `kpc_*` / `kpep_*` wrappers over the `kpc.*` sysctls and the kpep DBs                          |
+| **3 — sanctioned UI** | Instruments / `xctrace` + `CoreSymbolication.framework` | **closed** | the entitled broker that reaches `kperf` for unprivileged users; symbolizes via dSYM                |
+
+```text
+  consumers   proc_pid_rusage(V4)      kpc.* sysctls          xctrace / Instruments
+              (unprivileged)           (root or blessed)      (unprivileged, brokered)
+                    │                        │                        │
+                    │                        ▼                        ▼
+                    │                  kperf.framework          entitled helper
+                    │                  kperfdata.framework            │
+                    ▼                        ▼                        ▼
+  XNU core     monotonic  ◄──────  kpc  ◄─────  kperf (PET/PMI, callstacks)  ──►  kdebug
+              (2 fixed PMCs)        │                                             (ktrace)
+                                    ▼
+                                   cpc   (single-owner CPMU arbitration; RESTRICT_TO_KNOWN)
+                                    │
+                                    ▼
+                          CPMU hardware — Apple M4 Max / T6041
+```
+
+The `kpc` sysctl dispatcher (`kpc_sysctl`, [`kern_kpc.c:380-500`][kpc-c]) is the
+gate: it breaks out early for the three public enumeration requests, then calls
+`ktrace_read_check()` for everything else. `ktrace_read_check()` resolves to
+_"current proc owns ktrace, **or** is superuser"_
+([`kern_ktrace.c:288-297`][ktrace-c] → `_current_task_can_own_ktrace`,
+[`:273-285`][ktrace-c]). The rest of this page walks the CPMU concern by concern.
+
+---
+
+## Scalar counting: three privilege tiers
+
+Counting is where macOS is most interesting, because the three tiers land at
+different privilege levels with different granularity. `[source-verified]` +
+`[hw-verified: aarch64-darwin]`.
+
+| Tier  | Path                                          | Privilege                   | Counters                                 | Granularity / notes                                          |
+| ----- | --------------------------------------------- | --------------------------- | ---------------------------------------- | ------------------------------------------------------------ |
+| **0** | `proc_pid_rusage(RUSAGE_INFO_V4)`             | **unprivileged**            | 2 fixed (`ri_instructions`, `ri_cycles`) | whole-process aggregate; true retired instructions           |
+| **1** | `kpc` via `kperf.framework` / `kpc.*` sysctls | **root or blessed pid**     | 2 fixed + 5 configurable                 | per-thread (`kpc_get_thread_counters`); single-owner `EBUSY` |
+| **2** | `xctrace record --template 'CPU Counters'`    | **unprivileged (brokered)** | via the entitled `kperf` helper          | Instruments-mediated; deferred trace                         |
+
+### Tier 0: `proc_pid_rusage`, the unprivileged fixed counters
+
+`proc_pid_rusage(pid, RUSAGE_INFO_V4, …)` returns per-process `ri_instructions`
+and `ri_cycles` with **no root and no entitlement**
+([field defs `bsd/sys/resource.h:365-366`][resource-h]). These are the XNU
+"monotonic" fixed counters — `MT_CORE_INSTRS` / `MT_CORE_CYCLES`, read directly
+from the fixed cycle PMC `S3_2_C15_C0_0` (= PMC0)
+([`kern_monotonic.c:154,167,182-199`][monotonic-c]). This is the macOS analog of
+the sparkles [`tier0`][baseline] cheap counters — and, unlike Linux `/proc`, it
+delivers _true retired-instruction and core-cycle_ counts. Measured over a spin
+loop (Exp. b): a delta of **300,055,815 instructions / 106,386,622 cycles**, an
+[IPC][counting] of **2.82** `[hw-verified: aarch64-darwin]`.
+
+### Tier 1: `kpc`, and the EPERM boundary
+
+Everything richer than the two fixed counters lives behind `kpc`. Only three
+`kpc` sysctls are public — `REQ_CLASSES`, `REQ_CONFIG_COUNT`, `REQ_COUNTER_COUNT`
+break out of the dispatcher _before_ the access check
+([`kern_kpc.c:398-413`][kpc-c]); the `default:` case calls `ktrace_read_check()`.
+Exp. a probes the boundary from an unprivileged process, and it matches the
+source exactly — enumeration succeeds, every configure/read is `EPERM`:
+
+```text
+== kpc unprivileged acquisition probe ==   (uid=501)
+-- public enumeration (no access check) --
+  sysctl kpc.classes              = 11        # FIXED(1) | CONFIGURABLE(2) | RAWPMU(8)
+  sysctl kpc.pc_capture_supported = 1
+  kpc_get_counter_count(FIXED)    = 2
+  kpc_get_counter_count(CONFIG)   = 5
+  kpc_get_config_count(CONFIG)    = 5
+-- gated configure / read (ktrace_read_check) --
+  sysctl kpc.thread_counters      -> EPERM (errno 1)
+  sysctl kpc.counting             -> EPERM (errno 1)
+  kpc_set_config(CONFIG)          -> EPERM (errno 1)
+  kpc_set_thread_counting(F|C)    -> EPERM (errno 1)
+  kpc_set_counting(F|C)           -> EPERM (errno 1)
+  kpc_get_thread_counters         -> EPERM (errno 1)
+  kpc_force_all_ctrs_get / _set   -> EPERM (errno 1)
+```
+
+`[hw-verified: aarch64-darwin]` (Exp. a). Two footnotes to the transcript.
+`kpc_get_classes` is **not** exported by the framework (resolves to `0x0`); the
+class mask is read via the `kpc.classes` sysctl, and `POWER(4)` is absent to
+userspace (`classes=11 = FIXED|CONFIGURABLE|RAWPMU`). And `force_all_ctrs` is
+**no longer a userspace lever** — older reverse-engineered headers expose
+`kpc_force_all_ctrs_set`, but on `12377` the whole-machine arbitration moved
+inside the kernel (see below) and the framework call just returns `EPERM`
+unprivileged regardless. The fixed counters here are the same
+`MT_CORE_CYCLES`/`MT_CORE_INSTRS` that Tier 0 reads without any of this.
+
+### Single-owner arbitration: `EBUSY`
+
+The CPMU is a **single-owner** resource. Even a privileged `kpc` caller is refused
+with `EBUSY` when the hardware is already claimed (e.g. by a running Instruments
+session): `kpc_sysctl` checks `cpc_hw_in_use(CPC_HW_CPMU)` and returns `EBUSY`
+before touching the hardware ([`kern_kpc.c:417-419`][kpc-c]). The arbitration is
+an atomic `cmpxchg NULL→owner` in `cpc_hw_acquire` / `cpc_hw_in_use`
+([`cpc.c:44-70`][cpc-c], with the power-management handoff in
+[`kpc_common.c:167-264`][kpc-common-c]). There is no Linux-style per-event
+[grouping][event-group] seam here — the CPMU is claimed whole, by one owner.
+
+> [!NOTE]
+> **Tier 2 (`xctrace`) is the third-party escape hatch.** `xctrace record
+--template 'CPU Counters'` ran **unprivileged** on `mac-bsn` and produced a
+> trace with real counter data (Exp. e, below): it brokers `kperf` through an
+> entitled helper rather than opening `kpc` directly. It is the sanctioned path
+> a non-root tool uses when it needs the configurable counters or sampling.
+
+---
+
+## Overflow and IP sampling: `kperf` and PC-capture
+
+[Sampling][sampling] on macOS is `kperf`. Two triggers drive `kperf_sample`,
+which walks the user/kernel callstack into the kperf buffer: **timers**
+(`kptimer.c`) and **counter PMIs**. **PET** ("Profile Every Thread") samples all
+threads on a timer tick ([`pet.c:30-46`][pet-c]):
+
+> _"Profile Every Thread (PET) provides a profile of all threads on the system
+> when a timer fires."_
+
+On a counter [overflow][overflow] PMI, `kpc_sample_kperf` routes into
+`kperf_sample` ([`kpc_common.c:556-579`][kpc-common-c]). Hardware **PC-capture on
+overflow** — the Apple-Silicon precise-IP analog — is present: the PMI handler
+reads special register `S3_1_C15_C14_1` and extracts the captured PC
+(`HAS_CPMU_PC_CAPTURE`, `PC_CAPTURE_PC`, [`arm64/kpc.c:824-838`][arm64-kpc-c]),
+with `kpc.pc_capture_supported = 1` confirmed on the box (Exp. a). When a counter
+lacks PC-capture it falls back to the interrupt-frame PC — i.e. ordinary
+[skid][precise]. Crucially, the whole sampling surface is reachable **only** via
+`kperf` (root/blessed) or Instruments; there is no unprivileged sampling door
+analogous to Tier 0's counting. `[source-verified]` + `[hw-verified: aarch64-darwin]`.
+
+---
+
+## Precise data-source sampling: absent
+
+**No PEBS/SPE-style data-source or data-address sampling is exposed to third
+parties.** The CPMU carries a PC on overflow (above), but the `kpc`/`kperf`
+interface surfaces **no data virtual/physical address, no access latency, and no
+memory-hierarchy source packet** — there is nothing analogous to Linux's
+`perf_mem_data_src` union or its [data-source attribution][datasrc]. The kernel
+sources bear this out: `bsd/kern/kern_kpc.c` and `osfmk/kern/kpc*.c` expose only
+counter values, configs, periods, and action-ids — no data-source union.
+`[source-verified]` (absence).
+
+The hardware _has_ the raw ingredients — Apple's latency-threshold registers
+`PMTRHLD*` exist (documented in the [ARM deep-dive's][arm] Apple sidebar via
+`applecpu`'s `PMCKext2.c`) — but they are not surfaced as a data-source sampling
+API. This is the concern that simply has no answer on macOS, the way it has no
+answer on [RISC-V][riscv]; the rich cross-vendor data-source story
+([`precise-sampling.md`][precise-page]) is a Linux-and-`perf` phenomenon.
+
+---
+
+## Code-space decode: dyld, Mach-O and dSYM
+
+macOS's [symbolization][symbolization] inputs differ structurally from Linux's,
+in two ways worth a harness's attention.
+
+### The address-space model comes from dyld, not per-mmap records
+
+The module map is read from **dyld**: `_dyld_image_count` /
+`_dyld_get_image_{header,name,vmaddr_slide}` in-process (or `task_info(…,
+TASK_DYLD_INFO)` → `dyld_all_image_infos` for another process). Exp. b enumerated
+**45 images** this way `[hw-verified: aarch64-darwin]`. The structural contrast
+with Linux is the **shared cache single slide**: all system dylibs live in the
+**dyld shared cache** (one mapped region), so they share **one** `vmaddr_slide`,
+whereas the main executable has its own:
+
+```text
+_dyld_image_count() = 45
+  [ 0] hdr=0x104a08000 slide=0x4a08000  /private/tmp/mt_probe        # main exe: own slide
+  [ 1] hdr=0x191aab000 slide=0x1b00000  /usr/lib/libSystem.B.dylib   # shared cache…
+  [ 2] hdr=0x191aa5000 slide=0x1b00000  /usr/lib/system/libcache.dylib
+  … [44] slide=0x1b00000  /usr/lib/libc++.1.dylib                     # …all one slide
+```
+
+Where Linux emits one `PERF_RECORD_MMAP2` per DSO segment, macOS gives one slide
+for the entire system-library set plus a per-executable slide. `dyld` is
+open-source (`apple-oss-distributions/dyld`) but was **not cloned** — the public
+`<mach-o/dyld.h>` API was exercised directly.
+
+### Debug info: Mach-O + dSYM via CoreSymbolication
+
+Symbolization to `file:line` needs Mach-O + a **dSYM** (DWARF) bundle, resolved by
+`atos` / `symbols`; the engine is the closed **`CoreSymbolication.framework`**.
+Exp. c: `atos -o <dSYM> 0x…460` → `square (in sym2) (sym2.c:2)`; `symbols` reports
+`[… Dwarf, FunctionStarts]` provenance. `dladdr` alone gives only symbol-table
+names — no `file:line`. `[hw-verified: aarch64-darwin]`.
+
+> [!WARNING]
+> **A one-shot `clang -g src.c -o bin` yields an _empty_ dSYM.** `dsymutil` needs
+> the intermediate `.o` retained to find the DWARF; a single-step build deletes
+> the temp object, and `dsymutil` then warns _"no debug symbols in executable"_
+> and `atos` degrades to symbol-only (no line). The fix is a two-step build that
+> keeps the object: `clang -g -O0 -c sym2.c -o sym2.o && clang -g -O0 sym2.o -o
+sym2 && dsymutil sym2`. This is the macOS analog of Linux's
+> [build-id / stale-binary hazard][build-id] — get the debug-info plumbing wrong
+> and symbolization silently degrades rather than failing loudly.
+
+The [unwinding][unwinding] and DWARF details themselves are the same story as
+Linux (deferred to [`elfutils.md`][elfutils]); only the container (Mach-O/dSYM)
+and the engine (CoreSymbolication) are macOS-specific.
+
+---
+
+## Event-space and tracing: kdebug, DTrace, no `cpc` provider
+
+macOS's [event-space][eventspace] is **kdebug/ktrace** (kperf emits kdebug events
+that Instruments consumes) plus **DTrace**. The survey opened with a hypothesis
+that macOS might offer a DTrace `cpc` (CPU-performance-counter) provider — the
+Solaris `dcpc` one-liner path. **It does not.**
+
+> [!WARNING]
+> **Refuted: there is no DTrace `cpc` provider on macOS.** xnu's `bsd/dev/dtrace/`
+> ships `fbt`, `sdt`, `systrace`, `profile_prvd`, `fasttrap`, `lockstat`, and
+> `lockprof` — but **no `dcpc`/`cpc`** — and `apple-dtrace@dtrace-413` contains no
+> `*cpc*` source at all. The Solaris `dcpc` provider was never ported. So even
+> _with_ root, the CPU-counter-via-DTrace path does not exist on macOS.
+> `[source-verified]` ([`bsd/dev/dtrace/`][dtrace-tree] provider set; the
+> [`dtrace`][dtrace-repo] tree). Recorded as a corrected hypothesis in the
+> survey's internal QA ledger.
+
+DTrace is unusable unprivileged under **SIP** anyway — `dtrace -l -P cpc` (and any
+`dtrace -l`) fails at init (Exp. d):
+
+```text
+$ dtrace -l -P cpc
+dtrace: system integrity protection is on, some features will not be available
+dtrace: failed to initialize dtrace: DTrace requires additional privileges
+```
+
+`[hw-verified: aarch64-darwin]`. SIP is the outer wall behind the "root or blessed
+pid" check — the macOS end of the survey's [privilege-gating][gating] concern.
+
+---
+
+## NUMA and topology: the axis collapses
+
+Apple Silicon is **UMA** — a single memory pool, no NUMA nodes — so the
+[NUMA/page→node][numa] concern that [`libnuma.md`][libnuma] models on Linux has
+**nothing to model** here. Exp. e: `hw.memsize` is a single value, there are no
+`hw.*node*` sysctls, and the only topology axis is the P/E core split
+(`hw.nperflevels = 2`):
+
+```text
+$ sysctl hw.physicalcpu hw.nperflevels hw.perflevel0.name hw.perflevel1.name hw.memsize hw.pagesize hw.cachelinesize
+hw.physicalcpu: 14   hw.nperflevels: 2
+hw.perflevel0.name: Performance   (10 cores)
+hw.perflevel1.name: Efficiency    (4 cores)
+hw.memsize: 38654705664   hw.pagesize: 16384   hw.cachelinesize: 128
+```
+
+`[hw-verified: aarch64-darwin]`. The page size is **16 KiB** and the cache line
+**128 B** — both larger than the x86 defaults a harness might assume. The
+heterogeneous-core wrinkle (P vs E) is the Apple echo of ARM's
+[big.LITTLE][arm] story, but without Linux's per-cluster PMU device model to
+express it.
+
+---
+
+## Event naming and the kernel allowlist
+
+Two layers stand between an event _name_ and the hardware selector, and the
+second one is unusual: the kernel itself curates the allowed events.
+
+### kpep DBs: the name→selector tables
+
+Event names map to PMESR selectors through on-disk **kpep** database plists in
+`/usr/share/kpep/`, one per `cpufamily`, **world-readable** (`-rw-r--r-- root
+wheel`, no root needed), consumed by the closed `kperfdata.framework` (`kpep_*`).
+This box's DB is reached by symlink: `cpu_100000c_2_17d5b93a.plist -> as4-1.plist`
+(the M4-Max P-core catalog). `[hw-verified: aarch64-darwin]` (Exp. e). This is
+macOS's entry in the [event-naming][naming] survey — the per-microarchitecture
+table analog of libpfm4 / `ARM-software/data`.
+
+### `RESTRICT_TO_KNOWN`: the allowlist even root cannot bypass
+
+The kernel enforces an event **allowlist** by default on release kernels:
+`_cpc_event_policy = CPC_EVPOL_DEFAULT` ([`cpc_arm64_events.c:74`][cpc-events-c]),
+and `CPC_EVPOL_DEFAULT` resolves to **`RESTRICT_TO_KNOWN`** when `!CPC_INSECURE`
+([`cpc_arm64.h:34-43`][cpc-h]). A configurable-counter event must be in a
+kernel-baked list (`cpc_event_allowed`, [`:92-111`][cpc-events-c]), so **even root
+cannot program an arbitrary raw PMESR selector** on a stock release kernel. The
+allowlist is per-die: **102 events for T6041** (M4 Max) versus **59 for T6000**
+(M1 Pro/Max) ([`cpc_arm64_events.c:379-485`][cpc-events-c]). The policy-setter's
+own doc comment frames it ([`cpc_arm64.h:47-49`][cpc-h]):
+
+> _"Change how event restrictions are applied."_
+
+This is the direct macOS parallel to [Windows'][windows] curated architected event
+set — both OSes curate the event space, and both contrast with Linux's open
+`config` — the essence of the [capability-curation][curation] concern.
+
+### T6041 uses PMUv3-architected selectors: the M4 remap, kernel-side
+
+T6041 (M4) uses **PMUv3-architected selectors** for the common subset —
+`INST_ALL=0x0008`, `CORE_ACTIVE_CYCLE=0x0011`, `ARM_BR_MIS_PRED=0x0010`,
+`ARM_STALL_FRONTEND/BACKEND=0x23/0x24` — where T6000 (M1) used Apple-proprietary
+numbers (`INST_ALL=0x8c`, `CORE_ACTIVE_CYCLE=0x02`). It also adds an `SME_ENGINE_*`
+block. `[source-verified]` ([`cpc_arm64_events.c:382-484`][cpc-events-c] for
+T6041 vs [`:118-177`][cpc-events-c] for T6000). This confirms — **from the kernel
+side** — the [ARM deep-dive's][arm] M4 encoding-change finding, which reached the
+same conclusion independently from the kpep DBs.
+
+---
+
+## The seven concerns
+
+A compact map from the survey's [seven concerns][concepts] to where each is
+answered above, and how macOS lands relative to the Linux reference model.
+
+| #   | Concern                      | macOS answer                                                                                             | Section                                                               |
+| --- | ---------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 1   | Scalar counting              | three tiers: `rusage` (unpriv, 2 fixed) · `kpc` (root, 2+5) · `xctrace` (brokered); `EBUSY` single-owner | [three tiers](#scalar-counting-three-privilege-tiers)                 |
+| 2   | Overflow / IP sampling       | `kperf` PET/PMI + hardware PC-capture (`S3_1_C15_C14_1`); root/blessed or Instruments only               | [sampling](#overflow-and-ip-sampling-kperf-and-pc-capture)            |
+| 3   | Precise data-source sampling | **absent** — PC-capture only; no data-VA/PA/latency packet interface exposed                             | [absent](#precise-data-source-sampling-absent)                        |
+| 4   | Code-space decode            | dyld image list (shared-cache single slide) + Mach-O/dSYM via `atos`/CoreSymbolication                   | [code-space](#code-space-decode-dyld-mach-o-and-dsym)                 |
+| 5   | Event space & tracing        | kdebug/ktrace + DTrace **minus a `cpc` provider**; SIP gate                                              | [event-space](#event-space-and-tracing-kdebug-dtrace-no-cpc-provider) |
+| 6   | NUMA & topology              | **collapses** — UMA; only P/E perflevels                                                                 | [NUMA](#numa-and-topology-the-axis-collapses)                         |
+| 7   | Event naming & encoding      | kpep DB plists + kernel `RESTRICT_TO_KNOWN` allowlist (102 events T6041); PMUv3-architected remap        | [naming](#event-naming-and-the-kernel-allowlist)                      |
+
+---
+
+## Strengths
+
+- **Free, unprivileged, per-process IPC — richer than Linux `/proc`.**
+  `proc_pid_rusage(V4)` gives true retired-instruction and core-cycle counts with
+  no privilege, no entitlement, no counter arbitration; the Linux `/proc`/tier0
+  equivalent gives context-switch/fault-style counters, not instructions. For
+  whole-process measurement macOS's low-privilege story is genuinely _better_.
+- **A capable CPMU** — 2 fixed + 5 configurable counters, counter-overflow PMIs,
+  and hardware PC-capture — when the privilege is there (root/blessed) or brokered
+  (Instruments).
+- **A sanctioned unprivileged path exists** — `xctrace record --template 'CPU
+Counters'` reaches the configurable counters and sampling without root.
+- **World-readable event catalog.** The kpep plists are readable with no
+  privilege, so a tool can build a name→selector map offline even where it cannot
+  program the counter.
+- **Open kernel core.** The entire XNU acquisition path (`kpc`, `kperf`, `cpc`,
+  `monotonic`) is open source, so the policy is fully auditable — this page's
+  boundary claims are source-verified, not reverse-engineered guesses.
+
+## Weaknesses
+
+- **No root-free per-region raw events.** The one thing a benchmarking harness
+  most wants — arbitrary configurable events bracketed around a code region —
+  needs root/blessed access; unprivileged tools get only the two fixed counters
+  (whole-process) or the Instruments broker.
+- **Even root is fenced by the allowlist.** `RESTRICT_TO_KNOWN` refuses raw PMESR
+  selectors outside `_known_cpmu_events`, so root is _not_ the escape hatch it is
+  on Linux.
+- **No entitlement escape on release kernels** — `com.apple.private.ktrace-allow`
+  is `DEVELOPMENT || DEBUG`-only.
+- **No precise data-source sampling** — no PEBS/SPE analog surfaced; concern 3 has
+  no answer.
+- **Single-owner CPMU** — `EBUSY` when Instruments (or any owner) holds it; no
+  concurrent independent sessions.
+- **Closed userspace + symbolication.** `kperf.framework`, `kperfdata.framework`,
+  `CoreSymbolication.framework`, and Instruments internals are all closed and
+  reverse-engineered; a native backend either links private frameworks or shells
+  out to `xctrace`/`atos`.
+- **dSYM plumbing is a silent foot-gun** — a one-shot build produces an empty
+  dSYM and degrades symbolization to symbol-only without erroring.
+
+## Key design decisions and trade-offs
+
+| Decision                                            | Rationale                                                                                                           | Trade-off                                                                                 |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `kpc` gated by "root or blessed pid"                | Keeps raw counter programming out of untrusted hands                                                                | No unprivileged configurable-event access; harness must broker or run as root             |
+| Unprivileged `proc_pid_rusage` fixed counters       | A safe, cheap, whole-process IPC number for any process                                                             | Only 2 fixed counters, no per-region granularity, no configurable events                  |
+| `xctrace`/Instruments as the entitled broker        | Third parties get sampling/counters without shipping a privileged helper                                            | Deferred-trace UX; opaque export format; single-owner `EBUSY` contention                  |
+| `RESTRICT_TO_KNOWN` event allowlist (even for root) | Curated, vetted events; matches Windows' curation stance                                                            | No raw selectors even with root; per-die allowlist must be kept current                   |
+| No entitlement escape on release kernels            | Hard privilege wall behind SIP                                                                                      | Dev/debug-only `com.apple.private.ktrace-allow`; no production side-door                  |
+| Single-owner CPMU arbitration (`cpc` cmpxchg)       | One coherent owner of the shared hardware                                                                           | `EBUSY` blocks concurrent sessions; whole-CPMU claim, no per-event grouping               |
+| dyld shared-cache single slide                      | One relocation for the whole system-library set                                                                     | Decode differs from Linux per-DSO `MMAP2`; needs the dyld image-list API                  |
+| PC-capture only (no data-source packets)            | Skid-free IP on capable counters, cheaply                                                                           | No data-VA/PA/latency; concern 3 unanswerable to third parties                            |
+| **Sparkles backend capabilities advertised**        | `{process-IPC: yes (rusage) · configurable-events: no (needs root) · sampling/symbolication: via-Instruments-only}` | a macOS backend ships Tier-0 counting universally; richer modes are opt-in and privileged |
+
+---
+
+## Sources
+
+**Open (read + verified).** The entire XNU acquisition path, the DTrace tree, and
+the on-disk kpep DBs are open and were read directly:
+
+- [`bsd/kern/kern_kpc.c`][kpc-c] — the `kpc_sysctl` dispatcher: public
+  enumeration vs `ktrace_read_check()` gate, the "root or blessed pid" comment,
+  the `EBUSY` single-owner check.
+- [`bsd/kern/kern_ktrace.c`][ktrace-c] — `ktrace_read_check` /
+  `_current_task_can_own_ktrace`; the `DEVELOPMENT || DEBUG`-only entitlement.
+- [`osfmk/kern/kpc_common.c`][kpc-common-c] — PMI → `kperf_sample`; power-management
+  arbitration handoff.
+- [`osfmk/kern/cpc.c`][cpc-c] — single-owner CPMU acquisition (`cmpxchg`).
+- [`osfmk/kern/kern_monotonic.c`][monotonic-c] — `MT_CORE_INSTRS`/`MT_CORE_CYCLES`
+  ← fixed PMC0 (`S3_2_C15_C0_0`).
+- [`osfmk/arm64/kpc.c`][arm64-kpc-c] — `kpc_pmi_handler`, PC-capture
+  (`S3_1_C15_C14_1`).
+- [`osfmk/arm64/cpc_arm64_events.c`][cpc-events-c] · [`cpc_arm64.h`][cpc-h] —
+  `RESTRICT_TO_KNOWN` policy + the 102-event T6041 allowlist + PMUv3 remap.
+- [`osfmk/kperf/pet.c`][pet-c] — PET ("Profile Every Thread").
+- [`bsd/sys/resource.h`][resource-h] — `rusage_info_v4`, `ri_instructions`/`ri_cycles`.
+- [`bsd/dev/dtrace/`][dtrace-tree] (xnu) + the [`apple-oss-distributions/dtrace`][dtrace-repo]
+  tree — the provider set, confirming **no `cpc`/`dcpc`** provider.
+- `apple-oss-distributions/dyld` — open, **not cloned**; the public
+  `<mach-o/dyld.h>` API was exercised directly (Exp. b).
+
+**Closed (reverse-engineered surfaces only).** `kperf.framework`,
+`kperfdata.framework`, `CoreSymbolication.framework`, and Instruments/`xctrace`
+internals are not open; their behavior here is observed from the outside
+(`dlopen` symbol resolution, `xctrace` transcripts, `atos` output), never read.
+
+- `mac-bsn:/usr/share/kpep/*.plist` — the world-readable kpep event catalog
+  (`cpu_100000c_2_17d5b93a.plist → as4-1.plist`). `[hw-verified: aarch64-darwin]`
+
+> [!NOTE]
+> **No runnable CI example ships with this page.** The survey's convention is a
+> [CI-compiled probe][linux] per deep-dive, but the acquisition surface here is
+> macOS-and-Apple-Silicon-only and CI has no `aarch64-darwin` host. The five
+> in-page transcripts (Exp. a — the `kpc` EPERM matrix; b — `rusage` IPC + dyld
+> map; c — `atos`/dSYM; d — DTrace/SIP; e — topology/kpep/`xctrace`) are the
+> primary evidence, tagged `[hw-verified: aarch64-darwin]`; the kernel mechanics
+> are `[source-verified]` against `xnu-12377.1.9` / `dtrace-413`. Probe sources
+> (`kpc_probe.c`, `mt_probe.c`, `symtest.sh`, `tools.sh`) are kept in the job
+> scratchpad and on `mac-bsn:/tmp`.
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[counting]: ./concepts.md#counting
+[event-group]: ./concepts.md#event-group
+[sampling]: ./concepts.md#sampling
+[overflow]: ./concepts.md#overflow-sampling
+[precise]: ./concepts.md#precise-sampling-and-skid
+[datasrc]: ./concepts.md#data-source-attribution
+[symbolization]: ./concepts.md#symbolization
+[build-id]: ./concepts.md#build-id
+[unwinding]: ./concepts.md#unwinding
+[eventspace]: ./concepts.md#event-space-and-tracepoints
+[numa]: ./concepts.md#numa-topology-and-page-node-oracles
+[naming]: ./concepts.md#event-naming-and-encoding
+[curation]: ./concepts.md#capability-curation
+[gating]: ./concepts.md#privilege-gating
+[linux]: ./linux-perf-events.md
+[arm]: ./arm.md
+[riscv]: ./riscv.md
+[precise-page]: ./precise-sampling.md
+[elfutils]: ./elfutils.md
+[libnuma]: ./libnuma.md
+[windows]: ./windows.md
+[baseline]: ./sparkles-baseline.md
+[kpc-c]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/bsd/kern/kern_kpc.c
+[ktrace-c]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/bsd/kern/kern_ktrace.c
+[kpc-common-c]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/osfmk/kern/kpc_common.c
+[cpc-c]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/osfmk/kern/cpc.c
+[monotonic-c]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/osfmk/kern/kern_monotonic.c
+[arm64-kpc-c]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/osfmk/arm64/kpc.c
+[cpc-events-c]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/osfmk/arm64/cpc_arm64_events.c
+[cpc-h]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/osfmk/arm64/cpc_arm64.h
+[pet-c]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/osfmk/kperf/pet.c
+[resource-h]: https://github.com/apple-oss-distributions/xnu/blob/xnu-12377.1.9/bsd/sys/resource.h
+[dtrace-tree]: https://github.com/apple-oss-distributions/xnu/tree/xnu-12377.1.9/bsd/dev/dtrace
+[dtrace-repo]: https://github.com/apple-oss-distributions/dtrace

--- a/docs/research/cpu-pmu/precise-sampling.md
+++ b/docs/research/cpu-pmu/precise-sampling.md
@@ -1,0 +1,464 @@
+# Precise sampling & NUMA data-source attribution
+
+Precise, low-skid sampling that attributes each memory access to a PC, a data
+address, a cache/DRAM source, and a latency — and the address→NUMA-node oracle
+that turns a coarse "remote" bit into a concrete node.
+
+| Dimension               | AMD IBS                                   | Intel PEBS                                        | ARM SPE                                     |
+| ----------------------- | ----------------------------------------- | ------------------------------------------------- | ------------------------------------------- |
+| Mechanism               | Micro-op tagging → per-op MSR reads       | Counter-overflow assist → DS-area memory buffer   | Statistical profiling → AUX-buffer packets  |
+| Verification bed        | `[hw-verified: x86_64-linux]` (Zen 4)     | `[source-verified]` / `[literature]`              | `[source-verified]` (no `aarch64` hardware) |
+| Precise levels          | `precise_ip` 1–2 (skid 0 by construction) | `precise_ip` 1–3 (level 3 = zero-skid PDIR/PDist) | AUX stream (no `precise_ip` scale)          |
+| Data-source granularity | 3-bit legacy / 5-bit Zen 4 `DataSrc`      | per-µarch `pebs_data_source[]` tables             | MIDR-dispatched, implementation-defined     |
+| NUMA signal             | coarse "remote" bit → `HOPS(1)`           | coarse (per-table)                                | implementation-defined                      |
+| Linux ABI target        | `perf_mem_data_src` union                 | `perf_mem_data_src` union                         | `perf_mem_data_src` union                   |
+
+> [!NOTE]
+> **Hardware bed.** Every `[hw-verified: x86_64-linux]` claim on this page was
+> checked on Linux **6.18.26**, an **AMD Ryzen 9 7940HX** (Zen 4, family `0x19`
+> model `0x61`), `perf_event_paranoid = -1`, **single NUMA node**, LDC 1.41.
+> Kernel source (`path:line`) is read at `linux@e43ffb69e043` (v7.1-rc6). This is
+> an **AMD** part, so the precise engine here is **IBS**, not PEBS — PEBS claims
+> are `[source-verified]` / `[literature]` only, and ARM SPE has no local
+> hardware. See [The seven concerns](#the-seven-concerns) for scope.
+
+---
+
+## Overview
+
+A profile is only ever a statistical estimate of the true event distribution,
+and it is unbiased only if the recorded [instruction pointer][sampling] is the
+one that actually caused the event. On an out-of-order core it usually is not:
+the [PMI][pmi] fires several to hundreds of instructions past the culprit, and
+that distance — [**skid**][skid] — smears samples onto whatever happened to
+retire when the interrupt was taken. **Precise sampling** removes skid by making
+the _hardware_ capture the sample at retirement instead of leaving it to the
+interrupt handler.
+
+Skid is only half the problem. A memory-analysis profile needs more than _where_
+the access came from in the code — it needs _which level of the memory hierarchy
+served it_ (L1/L2/L3/local DRAM/remote node), how long it took, and the data
+address touched. None of that survives to the interrupt handler: by the time the
+PMI is taken, the load's µop is long retired and its cache-lookup outcome is
+gone. Only the hardware, at the moment of retirement, still holds it. This is
+[data-source attribution][data-source], and it is the reason precise sampling
+exists at all. From the AMD64 Architecture Programmer's Manual, Vol. 2 (§13.3),
+describing what an IBS-tagged op reports `[literature]`:
+
+> "For a load or store op: – Whether the load or store missed in the data
+> cache. – Whether the load or store address hit or missed in the TLBs. – The
+> linear and physical address of the data operand associated with the load or
+> store operation. – Source information for cache, DRAM, MMIO, or I/O accesses."
+
+Three vendors implement this three different ways — AMD **IBS**, Intel **PEBS**,
+ARM **SPE** — but Linux funnels all three into a single ABI so a consumer decodes
+the payload once. This page is that story: the shared ABI, the three engines,
+and the address→node oracle that upgrades the ABI's deliberately coarse
+locality bit into a real NUMA node.
+
+---
+
+## How it works: three engines, one ABI
+
+The vendor-neutral seam is the `perf_mem_data_src` union plus four sample fields
+requested through `perf_event_attr.sample_type`:
+
+- `PERF_SAMPLE_ADDR` — the data **virtual** address of the sampled access.
+- `PERF_SAMPLE_PHYS_ADDR` — its **physical** address ([privilege][privilege]-gated).
+- `PERF_SAMPLE_DATA_SRC` — the `perf_mem_data_src` union (level/op/snoop/TLB/hops).
+- `PERF_SAMPLE_WEIGHT` — the access latency (cycles).
+
+The union is one little-endian `u64` of contiguous bitfields `[source-verified]`
+(`include/uapi/linux/perf_event.h:1319-1459`):
+
+```c
+union perf_mem_data_src {
+    __u64 val;
+    struct {
+        __u64 mem_op       : 5,   /* type of opcode: load/store/prefetch/exec */
+              mem_lvl      : 14,   /* legacy memory hierarchy level  */
+              mem_snoop     : 5,   /* snoop mode                     */
+              mem_lock      : 2,   /* lock instruction               */
+              mem_dtlb      : 7,   /* dTLB access                    */
+              mem_lvl_num   : 4,   /* memory hierarchy level number  */
+              mem_remote    : 1,   /* remote                         */
+              mem_snoopx    : 2,   /* snoop mode, ext                */
+              mem_blk       : 3,   /* access blocked                 */
+              mem_hops      : 3,   /* hop level                      */
+              mem_region    : 5,   /* access memory region          */
+              mem_rsvd     : 13;
+    };
+};
+```
+
+The composite fields are the modern truth: `mem_lvl_num` names the level
+(`PERF_MEM_LVLNUM_L1..L4`, `ANY_CACHE = 0xb`, `LFB = 0xc`, `RAM = 0xd`,
+`PMEM = 0xe`, `CXL = 9`, `IO = 0xa`, `NA = 0xf`), `mem_remote` flags off-node,
+and `mem_hops` (`PERF_MEM_HOPS_0..3`) counts the distance. The wide `mem_lvl`
+field it replaces is on the way out `[source-verified]`
+(`include/uapi/linux/perf_event.h:1368-1370`):
+
+> "The PERF*MEM_LVL*\* namespace is being deprecated to some extent in favour of
+> newer composite PERF*MEM*{LVLNUM*,REMOTE*,SNOOPX\_} fields."
+
+Because IBS, PEBS, and SPE all fill this same union `[source-verified]`
+(`include/uapi/linux/perf_event.h:1319-1459`), a backend writes _one_ decoder —
+the `memLvlStr`/`snoopStr`/`tlbStr` functions in the [probe][probe] are exactly
+that decoder — and it serves every engine. The engines differ only in _how_ the
+bits get filled, which is the next three sections.
+
+---
+
+## Data-source & data-address sampling: AMD IBS
+
+`[hw-verified: x86_64-linux]` — this is the engine that runs on the test box.
+
+**No PEBS; IBS is the only precise engine.** On this AMD part the core `cpu` PMU
+reports `caps/max_precise = 0`, i.e. it has _no_ precise mode at all; the two IBS
+PMUs (`ibs_op` type `11`, `ibs_fetch` type `10`) carry the whole burden, and
+`ibs_op/caps/zen4_ibs_extensions = 1` `[hw-verified: x86_64-linux]` (sysfs, E1).
+So the "fall back to the `cpu` PMU with `precise_ip > 0`" recipe from the Intel
+world **does not exist on AMD** — the [probe][probe] keeps a structurally-present
+`cpu`/`precise_ip` branch but labels it Intel-only and it is unreachable here.
+
+**Micro-op tagging, not counter overflow.** IBS increments an internal 27-bit
+counter either per core clock (`IbsOpCntCtl = 0`) or per dispatched op
+(`IbsOpCntCtl = 1`); when it reaches `IbsOpMaxCnt` the hardware tags one random
+retired micro-op and records its retirement facts `[literature]` (AMD64 APM Vol 2
+§13.3). This is _instruction-based_ and independent of any PMC event — the
+fundamental structural difference from PEBS, which extends a _counter_ overflow.
+
+**Skid 0, and the `precise_ip` forward.** A core-PMU `precise_ip` request is
+transparently rerouted to `ibs_op` by `forward_event_to_ibs`, which returns
+`-EOPNOTSUPP` for `!precise_ip || precise_ip > 2` `[source-verified]`
+(`arch/x86/events/amd/ibs.c:240-258`). The in-tree comment states the guarantee:
+
+> "The rip of IBS samples has skid 0. Thus, IBS supports precise levels 1 and 2
+> and the PERF_EFLAGS_EXACT is set."
+
+**Filling the union.** IBS populates `perf_mem_data_src` from `IBS_OP_DATA2.DataSrc`
+plus `IBS_OP_DATA3` bits: `mem_op` (from the `ld_op`/`st_op` flags), `mem_lvl` +
+`mem_lvl_num` (via lookup tables), `mem_snoop` (`HITM` for cache-to-cache),
+`mem_dtlb` (L1/L2 hit/miss) and `mem_lock`, dispatched through
+`perf_ibs_get_data_src` `[source-verified]` (`arch/x86/events/amd/ibs.c:1016-1253`,
+dispatcher at `:1242`). **Zen 4 widens `DataSrc` to 5 bits**
+(`data_src_hi<<3 | data_src_lo`), selecting `g_zen4_data_src[32]` instead of the
+legacy `g_data_src[8]` — so it distinguishes near-CCX from far-CCX cache, plus
+PMEM, CXL / extension memory, and peer-agent memory. It is gated on
+`IBS_CAPS_ZEN4` (`1U<<11`), which this host advertises
+`[source-verified + hw-verified: x86_64-linux]`
+(`arch/x86/events/amd/ibs.c:1033-1069`; enum `arch/x86/include/asm/amd/ibs.h:12-26`;
+`arch/x86/include/asm/perf_event.h:644`).
+
+**Latency and addresses are valid-bit gated.** `WEIGHT` carries the DC-miss
+latency `dc_miss_lat`, but only for a load that _missed_ the data cache
+(`dc_miss && mem_op == LOAD`); `ADDR` comes from `IBSDCLINAD` under
+`dc_lin_addr_valid`, and `PHYS_ADDR` from `IBSDCPHYSAD` under `dc_phy_addr_valid`
+`[source-verified + hw-verified: x86_64-linux]`
+(`arch/x86/events/amd/ibs.c:1296-1317`). A sample with a cache _hit_ therefore
+has no meaningful weight — which is why the probe leads with cache-miss samples.
+
+**A hardware load-latency filter.** Zen 4 exposes `IBS_CAPS_OPLDLAT`: `config1`
+sets a latency threshold in `[128, 2048]` cycles and the IRQ handler drops ops
+below it — the AMD analog of Intel PEBS `ldlat` `[source-verified]`
+(`arch/x86/events/amd/ibs.c:281-287, 407-419, 1464-1478`).
+
+### The `swfilt` / `exclude_*` gotcha
+
+> [!WARNING]
+> A backend that carries the usual perf-attr habits into IBS will fail to open a
+> memory-sampling event. This Zen 4 lacks `IBS_CAPS_BIT63_FILTER`, so a bare
+> `exclude_kernel`, `exclude_user`, or `exclude_hv` returns `-EINVAL`. Kernel/user
+> filtering must instead engage the **software filter** — the `swfilt` bit
+> (`config2:0`, `IBS_SW_FILTER_MASK`) — and `exclude_hv` is _never_ accepted by
+> IBS `[hw-verified: x86_64-linux + source-verified]`
+> (`arch/x86/events/amd/ibs.c:346-370`).
+
+The errno matrix from E2 (opening `ibs_op` with
+`sample_type = IP|ADDR|DATA_SRC|WEIGHT|PHYS_ADDR`, varying the filters):
+
+```text
+full, exclude_kernel=1, exclude_hv=1                : -22 (EINVAL)
+full, exclude_kernel=1, exclude_hv=0                : -22 (EINVAL)
+full, exclude_kernel=0, exclude_hv=0                :   3 (ok)
+full, exclude_kernel=0, exclude_hv=1                : -22 (EINVAL)
+full, exclude_kernel=1, config2=1 (swfilt)          :   3 (ok)   ← the recipe
+```
+
+`PHYS_ADDR` opened cleanly at `perf_event_paranoid = -1`; on a stricter host it
+is the first field to drop (see [privilege gating][privilege]). Relatedly,
+`perf mem` on AMD is a single `mem-ldst` event on `ibs_op`, not the Intel split
+of `mem-loads,ldlat=%u` + `mem-stores` `[source-verified + hw-verified: x86_64-linux]`
+(`tools/perf/arch/x86/util/mem-events.c:24-34`; `perf mem report` shows
+`event 'ibs_op//'`).
+
+### End to end
+
+The [probe][probe] `./examples/mem-latency-numa.d` pointer-chases a 64 MiB buffer
+(wider than the per-CCX L3, so dependent loads miss to DRAM) and decodes every
+IBS sample. Its output on the test box:
+
+```text
+== precise memory-access sampling: AMD IBS (ibs_op, zen4_ibs_extensions) ==
+  PMU type=11  period=20000  sample_type=IP|ADDR|DATA_SRC|WEIGHT|PHYS_ADDR
+  workload=64 MiB  home node(get_mempolicy)=0  NUMA nodes online=1
+  sampled data accesses (8 of 3390; cache-miss samples first):
+    ip                 addr               op     level      snoop  tlb      lat  node[gmp/mvp]
+    0x..3c4f 0x000078b2b8e08c10 LOAD   RAM hit    N/A    L2 miss   415  0/0
+    0x..3c4f 0x000078b2b9c32980 LOAD   L2 hit     N/A    L2 hit     11  0/0
+    0x..3c4f 0x000078b2b8739b38 LOAD   L3 hit     HitM   L2 miss    45  0/0
+    ...
+  data-source levels across 3390 resolved samples: RAM hit 143  L1 hit 3204  L2 hit 17  L3 hit 26
+  node classification: 3389 on home node 0 (get_mempolicy == move_pages), 0 elsewhere; gmp errors=1, mvp errors=1
+  DC-miss latency (WEIGHT) on 180 load samples: min=11 median=412 max=1845 cycles
+```
+
+Every pointer-chase load attributes to one zero-skid IP (`…3c4f`, the
+`i = words[i]` load) — demonstrating IBS's skid-0 IP, the full data-source decode,
+and the valid-bit-gated latency in one run. The decode vocabulary
+(`L1 hit`, `L2 hit`, `N/A`, TLB `L1 hit`) was byte-checked against
+`perf mem report` (E4), whose decoder is `tools/perf/util/mem-events.c:370-559`
+`[source-verified + hw-verified: x86_64-linux]`. The probe exits `0` and degrades
+to a `SKIP:` line on any host without IBS, a refused `perf_event_open`, or no
+data-address samples.
+
+---
+
+## Intel PEBS: the counter-overflow analog
+
+`[source-verified]` / `[literature]` — **not testable on this AMD host** (no PEBS;
+`cpu/caps/max_precise = 0`).
+
+Where IBS tags a random op, **Precise Event-Based Sampling** arms a hardware
+assist off a _counter overflow_: the tagged event's PMC crosses zero, the assist
+writes a record into the Debug-Store (DS) area of memory, and the kernel converts
+that record after the fact. Its precise levels are 1/2/3, and **level 3 is the
+zero-skid tier** (PDIR / PDist), which requires a specific counter — the kernel
+special-cases `precise_ip == 3` throughout counter scheduling `[source-verified]`
+(`arch/x86/events/intel/core.c`, `precise_ip == 3` at
+`:5239, 5260, 5278, 5298, 5358, 5398, 5511`).
+
+Its data source is read from the DS-area record's `dse` status field and mapped
+through **per-microarchitecture** `pebs_data_source[]` tables
+(`load_latency_data` / `__grt_latency_data`); latency is `pebs->lat` and the data
+address `pebs->dla` `[source-verified]`
+(`arch/x86/events/intel/ds.c:125-260, 455-708, 2131-2202`). The truth thus lives
+in a hardware-written memory buffer decoded by a µarch-specific table — a
+different shape of ground truth from IBS's per-op MSR reads — yet it lands in the
+_same_ `perf_mem_data_src` union `[source-verified]`
+(`include/uapi/linux/perf_event.h:1319-1459`), which is why one decoder covers both.
+
+| Axis                | AMD IBS                                                                     | Intel PEBS                                                           |
+| ------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Tagging model       | random retired µop, instruction-based (independent of any PMC)              | counter-overflow assist — extends a specific PMC event               |
+| Precise levels      | `precise_ip` 1–2, skid 0 by construction                                    | `precise_ip` 1–3; level 3 (PDIR/PDist) is zero-skid, needs a counter |
+| Data-source truth   | per-op `IBS_OP_DATA2/3` MSR reads → `g_data_src[8]` / `g_zen4_data_src[32]` | DS-area record `dse` field → per-µarch `pebs_data_source[]`          |
+| Latency (`WEIGHT`)  | `dc_miss_lat`, load-miss only                                               | `pebs->lat`                                                          |
+| Load-latency filter | `config1` threshold `[128, 2048]` cyc (`IBS_CAPS_OPLDLAT`)                  | `mem-loads,ldlat=N`                                                  |
+| `perf mem` event    | single `mem-ldst` on `ibs_op`                                               | `mem-loads,ldlat=%u` + `mem-stores` split                            |
+
+---
+
+## From data address to NUMA node
+
+`[hw-verified: x86_64-linux]` for the API round-trip; the [NUMA concern][index]'s
+_attribution edge_.
+
+The `perf_mem_data_src` locality signal is deliberately **coarse**. When IBS sees
+a remote-node access (`op_data2.rmt_node`) the kernel unconditionally ORs in
+`REM | HOPS(1)` (or `REM_RAM1` for DRAM) — never a node number `[source-verified]`
+(`arch/x86/events/amd/ibs.c:1113-1119, 1128-1134`), with the in-tree rationale:
+
+> "HOPS_1 because IBS doesn't provide remote socket detail"
+
+So `DATA_SRC` alone answers _local vs remote_, not _which node_. (PEBS is
+similarly coarse; SPE's is per-implementation.) Node-precise attribution needs a
+second, complementary oracle: resolve the sampled **data address** to a node
+directly. Linux offers two [page→node oracles][numa-oracles], both raw syscalls
+(**not** glibc functions) `[source-verified + hw-verified: x86_64-linux]`
+(`arch/x86/entry/syscalls/syscall_64.tbl:237-239, 279`;
+`include/uapi/asm-generic/unistd.h:601-608`; `numaif.h:11-46`):
+
+- **`get_mempolicy(mode, NULL, 0, addr, MPOL_F_NODE | MPOL_F_ADDR)`** — writes the
+  node of the page containing `addr` into `mode` (syscall `239` on x86_64,
+  `236` on the asm-generic table).
+- **`move_pages(0, n, pages, NULL, status, 0)`** in _query_ mode (`nodes == NULL`)
+  — fills `status[i]` with each page's node, or a negative `-errno` (syscall `279`
+  on x86_64, `239` asm-generic).
+
+The [probe][probe] queries both for every resolved data address and cross-checks
+them against the buffer's home node; on the test box both return `0` for every
+sample, and the two oracles agree.
+
+> [!WARNING]
+> **Single-node host — round-trip, not classification.** This box has one NUMA
+> node (`/sys/devices/system/node` holds only `node0`), so every sampled address
+> resolves to node 0 and the two oracles _trivially_ agree. What is demonstrated
+> is the address→node API round-trip and single-node consistency;
+> cross-node _classification_ is **not** shown — that needs a multi-socket box
+> `[hw-verified: x86_64-linux]`.
+
+**No `numa.pc`, so no linking.** numactl ships no `numa.pc`, so `pkg-config numa`
+fails; the library is a plain `libnuma.so` (`-lnuma`), and its own
+`get_mempolicy`/`move_pages` are themselves thin syscall wrappers
+`[hw-verified: x86_64-linux]` (`pkg-config --exists numa` → "No package 'numa'
+found"; numactl `93c1fe5`, v2.0.19). Linking `libnuma` would turn a host that
+lacks it into a _build_-time failure, so the probe calls the two syscalls
+directly — identical kernel path, zero external C dependency, green on any host.
+For the node/distance-enumeration side of the same concern, see [libnuma][libnuma].
+
+---
+
+## ARM SPE: the AUX-buffer analog
+
+`[source-verified]` — no `aarch64-linux` hardware on hand; source + literature only.
+
+The **Statistical Profiling Extension** is the ARM member of the family, but it
+does not emit ordinary perf sample records. It is an [AUX-buffer][aux] PMU:
+hardware streams profiling packets into a second, high-bandwidth mmap region that
+userspace decodes after the fact. The driver exposes format attrs `pa_enable`
+(`PMSCR_EL1.PA`, physical-address collection), `load_filter` / `store_filter`
+(`PMSFCR_EL1`), `min_latency` (`PMSLATFR_EL1.MINLAT`, 12-bit), and an event
+filter (`PMSEVFR_EL1`) `[source-verified]`
+(`drivers/perf/arm_spe_pmu.c:81-91, 203-324`). Each decoded record carries
+`virt_addr` + `phys_addr` + `context_id` + `latency` for the sampled op
+`[source-verified]` (`tools/perf/util/arm-spe-decoder/arm-spe-decoder.h:112-125`)
+— the same PC-plus-data-address-plus-latency payload IBS and PEBS deliver, only
+streamed through AUX rather than a single sample record.
+
+The split worth carrying into the ARM survey: SPE's _packet framing_ is
+architected, but its **data source is implementation-defined**. Userspace decodes
+`record->source` by **MIDR dispatch** — a Neoverse "common" table plus separate
+AmpereOne and HiSilicon HIP tables — into the same `perf_mem_data_src` levels
+`[source-verified]` (`tools/perf/util/arm-spe.c:585-705`,
+`arm_spe__synth_data_source_common` at `:651`; enums `arm-spe-decoder.h:77-108`).
+Even the "common" table is a guess pinned to today's parts:
+
+> "Even though four levels of cache hierarchy are possible, no known production
+> Neoverse systems currently include more than three levels so for the time being
+> we assume three exist."
+
+Full treatment of ARM PMUv3 + SPE, including the architected-vs-implementation
+event split, is in [arm][arm].
+
+---
+
+## The seven concerns
+
+This page is the survey's precise-sampling spoke. Its place in the seven-concern
+spine:
+
+| #   | Concern                                     | Coverage here                                                                                                  |
+| --- | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 1   | Scalar [counting][counting]                 | Out of scope → [linux-perf-events][linux]                                                                      |
+| 2   | Overflow / IP [sampling][overflow]          | Touched: precise sampling _is_ the low-skid variant of IP sampling (`precise_ip`) — see [Overview](#overview)  |
+| 3   | Precise data-source & data-address sampling | **This page** — the [ABI](#how-it-works-three-engines-one-abi) + all three engine sections                     |
+| 4   | Symbolization                               | Out of scope → [elfutils][elfutils] (and W1's `sampling-symbolize.d`)                                          |
+| 5   | Tracing / event-space                       | Out of scope → [linux-perf-events][linux]                                                                      |
+| 6   | NUMA topology & placement                   | Its _attribution edge_: [From data address to NUMA node](#from-data-address-to-numa-node) → [libnuma][libnuma] |
+| 7   | Event [naming & encoding][naming-concept]   | Out of scope → [event-naming][naming]                                                                          |
+
+---
+
+## Strengths
+
+- **Zero (or near-zero) skid on the IP** — IBS is skid 0 by construction; PEBS
+  reaches zero-skid at `precise_ip == 3`. The sampled PC is the culprit, so memory
+  hot spots pin to the exact load.
+- **Full data-source truth per sample** — level, snoop, TLB, op type, data VA/PA,
+  and latency, captured by hardware at retirement where the interrupt handler
+  could never reconstruct it.
+- **One ABI across three vendors** — `perf_mem_data_src` + the four sample fields
+  are engine-agnostic, so a backend writes a single decoder.
+- **Composable with the address→node oracle** — the union's coarse locality bit
+  plus `get_mempolicy`/`move_pages` yields node-precise attribution with no extra
+  kernel privilege beyond what the physical address already needs.
+- **Load-latency pre-filtering in hardware** (IBS `IBS_CAPS_OPLDLAT`, PEBS
+  `ldlat`) keeps only the expensive accesses, cutting sample volume at the source.
+
+## Weaknesses
+
+- **Vendor-specific and non-portable capture** — IBS ≠ PEBS ≠ SPE in tagging
+  model, precise levels, and data-source encoding; only the _output_ union is
+  shared. AMD has _no_ PEBS-style `cpu`/`precise_ip` fallback at all.
+- **The locality bit is deliberately coarse** — "remote" is `HOPS(1)`, never a
+  node; node attribution _requires_ the second address→node oracle.
+- **Attribute-shape footguns** — IBS rejects a bare `exclude_kernel`/`exclude_hv`
+  with `-EINVAL` and needs the `swfilt` bit; the usual perf habits fail silently.
+- **Physical addresses and kernel visibility are [privilege][privilege]-gated** —
+  `PHYS_ADDR` (and SPE physical-address collection) drop on a hardened host.
+- **SPE's data source is implementation-defined** — MIDR-dispatched userspace
+  tables that lag new silicon, unlike its architected packet framing.
+- **Path context is a separate mechanism** — the _leading_ control flow lives in
+  [branch records][branch-records] (LBR/BRBE), not in the data-source sample.
+
+## Key design decisions and trade-offs
+
+| Decision                                                        | Rationale                                                                              | Trade-off                                                                                |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Capture in hardware at retirement (vs. in the PMI handler)      | Only the hardware still holds the cache-lookup outcome, data address, and true PC      | Vendor-specific silicon; each engine (IBS/PEBS/SPE) has its own capture path             |
+| Normalize every engine to `perf_mem_data_src` + 4 sample fields | One decoder in the consumer; engine choice is a runtime capability probe               | The union is a lowest-common-denominator — it flattens vendor-specific detail            |
+| Keep the locality signal coarse ("remote" bit, not a node)      | The sampling hardware genuinely lacks remote-socket detail (`ibs.c:1113`)              | Node attribution needs a second, complementary address→node oracle round-trip            |
+| Resolve data addresses via raw `get_mempolicy`/`move_pages`     | No `numa.pc`; libnuma is a thin syscall wrapper — direct syscalls stay dependency-free | Two syscalls per sampled address; single-node hosts can only demonstrate the round-trip  |
+| IBS micro-op tagging (vs. PEBS counter-overflow assist)         | Instruction-based, event-independent sampling with skid 0 at levels 1–2                | Only levels 1–2 (no zero-skid level 3); needs the `swfilt` bit for kernel/user filtering |
+| Stream SPE through an AUX buffer (vs. per-sample records)       | High-bandwidth hardware profiling without a PMI per sample                             | A separate decode pipeline; data-source is implementation-defined, MIDR-dispatched       |
+
+---
+
+## Sources
+
+- **Linux kernel** at `e43ffb69e043` (v7.1-rc6) — [tree][linux-src]:
+  - `include/uapi/linux/perf_event.h:1319-1459` — the `perf_mem_data_src` union
+    and `PERF_MEM_*` constants (the vendor-neutral ABI).
+  - `arch/x86/events/amd/ibs.c` — IBS→perf conversion, data-source tables,
+    `forward_event_to_ibs`, `swfilt`, `ldlat` (`:240-258, 281-287, 346-370,
+1016-1253, 1296-1317, 1464-1478`).
+  - `arch/x86/include/asm/amd/ibs.h:12-26`, `arch/x86/include/asm/perf_event.h:644`
+    — Zen 4 `DataSrc` enum and `IBS_CAPS_ZEN4`.
+  - `arch/x86/events/intel/ds.c`, `arch/x86/events/intel/core.c` — PEBS DS-area
+    decode and `precise_ip == 3` scheduling.
+  - `tools/perf/util/mem-events.c:370-559`,
+    `tools/perf/arch/x86/util/mem-events.c:24-34` — perf's decode strings and the
+    AMD `mem-ldst` event.
+  - `drivers/perf/arm_spe_pmu.c`, `tools/perf/util/arm-spe.c`,
+    `tools/perf/util/arm-spe-decoder/arm-spe-decoder.h` — SPE format attrs, record
+    layout, MIDR-dispatched data-source synthesis.
+  - `arch/x86/entry/syscalls/syscall_64.tbl`, `include/uapi/asm-generic/unistd.h`
+    — `get_mempolicy` / `move_pages` syscall numbers.
+- **AMD64 Architecture Programmer's Manual, Vol. 2: System Programming**
+  (publication `24593`, §13.3 Instruction-Based Sampling) — the architectural
+  framing of what an IBS-tagged op reports. The _extended_ Zen 4 `DataSrc`
+  encodings are documented in the family **PPR 55898** (cited by
+  `arch/x86/include/asm/amd/ibs.h:5-8`).
+- **Intel SDM, Vol. 3** (PEBS, chapters 20–21) — cited by section; the PDF is
+  gated and not reproduced here.
+- **numactl** `93c1fe5` (v2.0.19) — `numa.h` / `numaif.h`
+  (`get_mempolicy`/`move_pages`/`MPOL_F_*`).
+- **Runnable probe:** [`./examples/mem-latency-numa.d`][probe] — the end-to-end
+  IBS + NUMA demonstration whose output is quoted above (CI-compiled and run).
+- **Concepts:** [precise sampling & skid][skid], [data-source attribution][data-source],
+  [AUX buffer][aux], [NUMA page→node oracles][numa-oracles].
+- **Related deep-dives:** [linux-perf-events][linux] · [libnuma][libnuma] ·
+  [arm][arm] · [elfutils][elfutils] · [event-naming][naming].
+
+<!-- References -->
+
+[index]: ./
+[sampling]: ./concepts.md#sampling
+[counting]: ./concepts.md#counting
+[skid]: ./concepts.md#precise-sampling-and-skid
+[data-source]: ./concepts.md#data-source-attribution
+[overflow]: ./concepts.md#overflow-sampling
+[pmi]: ./concepts.md#pmi-performance-monitoring-interrupt
+[aux]: ./concepts.md#aux-buffer
+[numa-oracles]: ./concepts.md#numa-topology-and-page-node-oracles
+[privilege]: ./concepts.md#privilege-gating
+[branch-records]: ./concepts.md#branch-records
+[naming-concept]: ./concepts.md#event-naming-and-encoding
+[linux]: ./linux-perf-events.md
+[libnuma]: ./libnuma.md
+[arm]: ./arm.md
+[elfutils]: ./elfutils.md
+[naming]: ./event-naming.md
+[probe]: ./examples/mem-latency-numa.d
+[linux-src]: https://github.com/torvalds/linux/tree/e43ffb69e043

--- a/docs/research/cpu-pmu/riscv.md
+++ b/docs/research/cpu-pmu/riscv.md
@@ -1,0 +1,550 @@
+# RISC-V PMU
+
+RISC-V PMU: a firmware-mediated counter stack whose sampling and branch-record
+capabilities are spec-ratified but only partly landed in Linux.
+
+| Field                    | Value                                                                                        |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| Privilege layering       | kernel (S-mode) → SBI ecall → M-mode firmware                                                |
+| Counting                 | `Zicntr` / `Zihpm` counters + **SBI PMU** extension (EID `0x504D55`)                         |
+| Sampling                 | **Sscofpmf** — LCOFI local interrupt, `sip`/`sie` **bit 13**                                 |
+| Guest (VS-mode) sampling | + **Ssaia/Smaia** (AIA) — KVM injects via `HVIEN` bit 13                                     |
+| Branch records           | **Smctr/Ssctr** (CTR v1.0, ratified **2024-11-22**) — **no Linux consumer** at v7.1-rc6      |
+| Precise data sampling    | **none** — no PEBS/SPE analog in ratified RISC-V                                             |
+| Firmware                 | [OpenSBI][opensbi] (reference SBI implementation)                                            |
+| Kernel drivers           | `riscv_pmu.c` · `riscv_pmu_sbi.c` · `riscv_pmu_legacy.c` @ Linux **v7.1-rc6**                |
+| Verification scope       | `[source-verified]` + `[literature]` **only** — no RISC-V silicon, no `[hw-verified]` claims |
+
+> [!IMPORTANT]
+> **Scope: spec and source, not silicon.** Every claim on this page is grounded in
+> ratified RISC-V specification text or in Linux/OpenSBI source at a pinned SHA — no
+> RISC-V hardware was measured, so there are no `[hw-verified]` figures. Unlike the
+> other deep-dives in this tree, this page ships **no runnable `examples/` probe**:
+> nothing an x86 CI runner could execute would exercise the SBI/Sscofpmf path
+> meaningfully, so the grounding is primary-source line citations instead of a
+> compiled program. The survey's internal QA ledger records the two prompt
+> hypotheses this page **refutes** (see [Concern 5](#concern-5-event-space-branch-records-ctr)).
+
+---
+
+## Overview
+
+### What it solves
+
+RISC-V exposes performance counters through a **three-level privilege indirection**
+that is unlike x86 (`rdpmc` + `wrmsr` from ring 0) or ARM (`PMEVTYPER<n>_EL0`
+written directly by EL1). On RISC-V, supervisor mode — where Linux runs — can
+_read_ the counters but **cannot select, start, or stop them**. Only M-mode may
+write the `mcountinhibit` and `mhpmeventX` control CSRs. The kernel therefore
+drives counting by asking firmware to do it, over the **SBI PMU extension**, and
+[OpenSBI][opensbi] performs the actual register writes.
+
+| Level                         | Runs                          | Reads counters                               | Selects / starts / stops events                             |
+| ----------------------------- | ----------------------------- | -------------------------------------------- | ----------------------------------------------------------- |
+| **U / S-mode (unprivileged)** | user code, Linux kernel       | yes — `cycle`, `instret`, `hpmcounterX` CSRs | **no**                                                      |
+| **S-mode via SBI**            | `riscv_pmu_sbi.c` perf driver | HW counters directly; FW counters via SBI    | requests through an SBI `ecall` (`config_match`/start/stop) |
+| **M-mode firmware (OpenSBI)** | the SBI implementation        | —                                            | **yes** — writes `mhpmeventX`, `mcountinhibit`              |
+
+The counting CSRs come from the base ISA's `Zicntr` (`cycle`, `time`, `instret`)
+and `Zihpm` (`hpmcounter3..31`) extensions; a firmware SBI implementation may even
+refuse the SBI PMU extension entirely if `mcountinhibit` is unimplemented, since
+without it firmware cannot atomically freeze a group
+(`riscv-sbi-doc@8a545eff src/ext-pmu.adoc:3-12`).
+
+### Design philosophy
+
+The SBI PMU extension is deliberately shaped to back a Linux `perf` PMU. From its
+specification (`riscv-sbi-doc@8a545eff src/ext-pmu.adoc:22-29`):
+
+> _"The SBI PMU extension provides: 1. An interface for supervisor-mode software to
+> discover and configure per-hart hardware/firmware counters 2. A typical Linux perf
+> compatible interface for hardware/firmware performance counters and events 3. Full
+> access to microarchitecture's raw event encodings"_
+
+Three consequences shape the whole stack:
+
+1. **Counter allocation is firmware's job.** The kernel never picks a physical
+   counter; it hands firmware an event and asks it to _find_ a counter that can
+   monitor it ([`config_match`](#how-it-works)). This keeps the S-mode driver
+   microarchitecture-agnostic at the cost of an `ecall` per configuration.
+2. **The event→register mapping is implementation-defined.** The SBI standardizes
+   event _classes_ ([`event_idx`](#event-encoding-the-sbi-event-idx)); the concrete
+   `mhpmeventX` selector values are per-vendor, supplied to firmware out-of-band via
+   the device tree. This is the RISC-V flavour of
+   [architected-vs-implementation-defined events][arch-vs-impl].
+3. **Sampling is a separate, optional extension.** Base counting is always
+   available; overflow interrupts, privilege filtering, and (eventually) branch
+   records each ride on a distinct ratified extension the platform may or may not
+   implement. The kernel treats each as a runtime-probed capability — the theme of
+   [the seven concerns](#the-seven-concerns) below.
+
+---
+
+## How it works
+
+### Event encoding: the SBI `event_idx`
+
+Every event the kernel wants counted is named by a 20-bit `event_idx`
+(`riscv-sbi-doc@8a545eff src/ext-pmu.adoc:37-59`):
+
+| `type` (`event_idx[19:16]`) | Class      | `code` (`event_idx[15:0]`)                                            |
+| --------------------------- | ---------- | --------------------------------------------------------------------- |
+| `0`                         | HW general | `1..10` — `CPU_CYCLES` … `REF_CPU_CYCLES`                             |
+| `1`                         | HW cache   | `cache_id[15:3]`, `op_id[2:1]`, `result_id[0]`                        |
+| `2`                         | raw v1     | selector programmed into `mhpmevent[0:47]`                            |
+| `3`                         | raw v2     | selector programmed into `mhpmevent[0:55]`                            |
+| `15`                        | firmware   | firmware-counted software events (RFENCE/IPI/SFENCE counts, traps, …) |
+
+HW-cache codes compose a cache id (`L1D`/`L1I`/`LL`/`DTLB`/`ITLB`/`BPU`/`NODE`)
+with an operation (`READ`/`WRITE`/`PREFETCH`) and a result (`ACCESS`/`MISS`)
+(`src/ext-pmu.adoc:62-160`). For raw events the supervisor passes an `event_data`
+blob that firmware programs into the low bits of `mhpmevent`, firmware owning the
+top bits (`src/ext-pmu.adoc:165-201`). See
+[Concern 7](#concern-7-event-naming-encoding) for how Linux maps `PERF_TYPE_RAW`
+onto this.
+
+### The counter lifecycle: `config_match` → start / stop / read
+
+The SBI PMU interface is a small set of function IDs
+(`riscv-sbi-doc@8a545eff src/ext-pmu.adoc:699-715`):
+
+| FID | Function                          | Since   |
+| --- | --------------------------------- | ------- |
+| 0   | `sbi_pmu_num_counters`            | base    |
+| 1   | `sbi_pmu_counter_get_info`        | base    |
+| 2   | `sbi_pmu_counter_config_matching` | base    |
+| 3   | `sbi_pmu_counter_start`           | base    |
+| 4   | `sbi_pmu_counter_stop`            | base    |
+| 5   | `sbi_pmu_counter_fw_read`         | base    |
+| 6   | `sbi_pmu_counter_fw_read_hi`      | SBI 2.0 |
+| 7   | `sbi_pmu_snapshot_set_shmem`      | SBI 2.0 |
+| 8   | `sbi_pmu_event_get_info`          | SBI 3.0 |
+
+Linux allocates a counter by calling `SBI_EXT_PMU_COUNTER_CFG_MATCH` — firmware
+picks a free counter able to monitor the event and returns its index
+(`linux@e43ffb69 drivers/perf/riscv_pmu_sbi.c:538-594`, `pmu_sbi_ctr_get_idx`) —
+then starts, stops, and reads it via the matching calls (`:799-856`, `:739-779`).
+`counter_get_info` (FID 1) packs the counter's CSR number in `bits[11:0]`, its
+`Width` (minus one) in `[17:12]`, and a `Type` bit at `[XLEN-1]` distinguishing a
+hardware counter (`0`) from a firmware counter (`1`)
+(`src/ext-pmu.adoc:285-296`). That `Type` bit decides how the kernel reads it: a
+**hardware** counter is a direct CSR read (`riscv_pmu_ctr_read_csr(info.csr)`), a
+**firmware** counter is another SBI call, `SBI_EXT_PMU_COUNTER_FW_READ`
+(`riscv_pmu_sbi.c:756-776`).
+
+### Firmware-side selector translation
+
+OpenSBI cannot invent the per-vendor `mhpmevent` selector for an architected
+event, so a platform supplies the mapping out-of-band — via the device-tree
+properties `riscv,event-to-mhpmcounters` and `riscv,event-to-mhpmevent`, or via
+platform hooks; **without them SBI PMU is not enabled**
+(`opensbi@26257121 docs/pmu_support.md:1-45`,
+`opensbi@26257121 lib/utils/fdt/fdt_pmu.c:49,75,121`). At `config_match` time
+firmware translates the `event_idx` to a raw selector with
+`sbi_platform_pmu_xlate_to_mhpmevent(...)`, then writes it into the counter's
+control register with `csr_write_num(CSR_MHPMEVENT3 + ctr_idx - 3, …)`
+(`opensbi@26257121 lib/sbi/sbi_pmu.c:516-557`). The generic platform simply
+zero-extends the `event_idx` as the selector for HW-general and HW-cache events.
+
+### User-space direct reads: the RISC-V self-monitoring story
+
+RISC-V's [self-monitoring / user-space counter read][self-mon] path is
+`rdcycle`/`rdinstret`/`rdhpmcounter`, gated by the `scounteren` CSR. The SBI driver
+programs `scounteren` to control which counters an unprivileged read can see,
+toggling the mapped event's bit as the counter is `mmap`'d and un-`mmap`'d
+(`riscv_pmu_sbi.c:781-797`, `:1157-1160`), and supports the
+`perf_event_mmap_page` user-read seam that x86's `rdpmc` path also uses
+(`:1322-1355`). This is the lowest-overhead acquisition path — the natural fit for
+per-iteration bracketing inside a benchmark loop — but, exactly as
+[the concepts note][self-mon], its availability is arch- and OS-policy-dependent.
+
+---
+
+## The seven concerns
+
+This tree analyses every backend against the same seven-concern spine. RISC-V's
+headline is how many cells are **explicit absences** — the survey's value here is
+recording precisely _what the ratified ISA does not yet standardize_ and what has
+not yet reached Linux.
+
+| #   | Concern                                                                   | RISC-V status                                               |
+| --- | ------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| 1   | [Scalar counting](#concern-1-scalar-counting)                             | ✅ SBI PMU; `cycle`/`instret` legacy fallback               |
+| 2   | [Overflow / IP sampling](#concern-2-overflow-ip-sampling)                 | ⚠️ conditional on **Sscofpmf**; skidded IP; guest needs AIA |
+| 3   | [Precise data-source sampling](#concern-3-precise-data-source-sampling)   | ❌ **absent** — no PEBS/SPE analog                          |
+| 4   | [Code-space decode](#concern-4-code-space-decode-symbolization)           | ✅ ISA-neutral ELF/DWARF; no HW branch stack yet            |
+| 5   | [Event-space & branch records](#concern-5-event-space-branch-records-ctr) | ⚠️ **CTR ratified, no Linux consumer**                      |
+| 6   | [NUMA & topology](#concern-6-numa-topology)                               | ◐ SBI `CACHE_NODE` counter only; topology is ISA-neutral    |
+| 7   | [Event naming & encoding](#concern-7-event-naming-encoding)               | ✅ SBI classes + impl-defined selectors; perf vendor JSON   |
+
+### Concern 1: Scalar counting
+
+**Available.** [Counting][counting] is the mature path: the driver discovers
+counters, allocates them by `config_match`, and reads them per the lifecycle
+above. When SBI PMU (≥ 0.3) is absent the kernel falls back to
+`riscv_pmu_legacy.c`, which exposes only two [fixed counters][fixed-config] —
+`cycle` (index 0) and `instret` (index 2), 63-bit — with **no start/stop, no
+interrupt, and no exclude** (`PERF_PMU_CAP_NO_INTERRUPT | PERF_PMU_CAP_NO_EXCLUDE`)
+(`linux@e43ffb69 drivers/perf/riscv_pmu_legacy.c:15-32,40-44,110-130`). A harness
+that stays within the physical counter budget avoids
+[multiplexing][mux] the same way it does on any other backend; because firmware
+owns allocation, a group that firmware cannot place is simply refused rather than
+scaled.
+
+### Concern 2: Overflow / IP sampling
+
+**Available, but conditional on the Sscofpmf extension.** [Overflow
+sampling][overflow] needs an interrupt on counter overflow — the RISC-V
+[PMI][pmi]. That interrupt is defined by **Sscofpmf**, which adds to
+`mhpmevent[63:58]` the fields `OF, MINH, SINH, UINH, VSINH, VUINH`: `OF` is a
+sticky overflow-and-interrupt-disable bit, and the `xINH` bits inhibit counting
+per privilege mode (`riscv-isa-manual@fbae3b43 src/priv/sscofpmf.adoc:29-64`).
+When a counter overflows with `OF == 0`, hardware raises a **Local Count-Overflow
+Interrupt (LCOFI)** — standard local interrupt **bit 13** of `mip`/`mie`/`sip`/`sie`,
+delegable to S-mode via `mideleg` (`sscofpmf.adoc:69-91`;
+kernel `IRQ_PMU_OVF = 13`, `RV_IRQ_PMU` at
+`linux@e43ffb69 arch/riscv/include/asm/csr.h:101,537`). The specification is
+explicit about the dual role of `OF` (`sscofpmf.adoc:69-73`):
+
+> _"If an `hpmcounter` overflows while the associated OF bit is zero, then a "`count
+overflow interrupt request`" is generated. If the OF bit is one, then no interrupt
+> request is generated. Consequently the OF bit also functions as a count overflow
+> interrupt disable for the associated `hpmcounter`."_
+
+To let the S-mode handler find which counters overflowed without an SBI round-trip,
+Sscofpmf adds `scountovf` (CSR `0xda0`) — a **read-only** 32-bit shadow of the `OF`
+bits of `mhpmevent3..31`, per-bit gated by `mcounteren`/`hcounteren`
+(`sscofpmf.adoc:111-129`; `csr.h:317`). The overflow handler reads `scountovf` (or
+the SBI snapshot bitmap, below), stops counters, and for each sampling event whose
+`OF` bit is set calls `perf_event_overflow(event, &data, regs)`
+(`riscv_pmu_sbi.c:1041-1146`, esp. `:1091` `get_irq_regs`, `:1136`
+`perf_event_overflow`).
+
+> [!WARNING]
+> **The sampled IP is inherently skidded.** `PERF_SAMPLE_IP` is the trapped program
+> counter (`xepc`) at the point the LCOFI is taken — not a hardware-tagged
+> retirement address. RISC-V has no mechanism to remove [skid][precise-skid]; the
+> IP lands some distance past the instruction that caused the overflow, exactly the
+> bias [precise sampling][precise] corrects on x86 (PEBS) and ARM (SPE). See
+> [Concern 3](#concern-3-precise-data-source-sampling).
+
+**Degradation without Sscofpmf.** The kernel enables sampling _only_ if `RV_IRQ_PMU`
+(Sscofpmf) — or the T-Head C9xx / Andes vendor errata IRQs — is present; otherwise
+`pmu_sbi_setup_irqs` returns `-EOPNOTSUPP` and the PMU advertises
+`PERF_PMU_CAP_NO_INTERRUPT | PERF_PMU_CAP_NO_EXCLUDE`, logging _"Perf
+sampling/filtering is not supported as sscof extension is not available"_
+(`riscv_pmu_sbi.c:1192-1218,1449-1454`). This is the RISC-V analogue of the way the
+sparkles [baseline harness][baseline] degrades under a restrictive
+[`perf_event_paranoid`][priv-gating]: sampling and privilege filtering are runtime
+capabilities to probe, never to assume.
+
+**Privilege filtering rides on the same extension.** `exclude_kernel → SINH`,
+`exclude_user → UINH`, and the guest variants `→ VSINH/VUINH` are threaded through
+the SBI `config_flags` `SET_{V,}{U,S,M}INH` bits, which firmware applies to
+`mhpmevent` — **and firmware only applies them when Sscofpmf is present**
+(`pmu_update_inhibit_flags` guards on `SBI_HART_EXT_SSCOFPMF`)
+(`riscv_pmu_sbi.c:517-536`; `src/ext-pmu.adoc:332-354`;
+`opensbi@26257121 lib/sbi/sbi_pmu.c:504-514,534-543`). So `exclude_user`/
+`exclude_kernel` is not free with base counting — it is a Sscofpmf capability,
+matching the `NO_EXCLUDE` fallback.
+
+**SBI counter snapshot (SBI 2.0).** FID 7 registers a shared-memory page carrying a
+`counter_overflow_bitmap` (valid only under Sscofpmf) and 64-bit
+`counter_values[]`, so the overflow handler reads overflow state and values without
+per-counter SBI calls (`src/ext-pmu.adoc:549-609`; consumer
+`riscv_pmu_sbi.c:1076-1078,919-946`).
+
+#### Guest (VS-mode) sampling needs AIA on top
+
+Host sampling needs only Sscofpmf. **Guest** sampling needs more. KVM builds a real
+host `perf_event` per guest counter with an overflow handler
+`kvm_riscv_pmu_overflow` that calls
+`kvm_riscv_vcpu_set_interrupt(vcpu, IRQ_PMU_OVF)`
+(`linux@e43ffb69 arch/riscv/kvm/vcpu_pmu.c:293-331,334-361`). But injecting bit 13
+into a guest is not something the base hypervisor extension can do — `hvip` can only
+inject the three standard VS interrupts (soft/timer/external). Delivery of the LCOFI
+to a guest therefore requires **AIA** (Ssaia/Smaia): `kvm_riscv_aia_enable` sets
+`csr_set(CSR_HVIEN, BIT(IRQ_PMU_OVF))`, guarded by both
+`__riscv_isa_extension_available(NULL, RISCV_ISA_EXT_SSCOFPMF)` and
+`kvm_riscv_aia_available()` (`arch/riscv/kvm/aia.c:565-567,581-582`;
+guest-side sync `arch/riscv/kvm/vcpu.c:391-396`).
+
+> [!NOTE]
+> Do not overstate this as "sampling needs AIA". The precise statement: **host**
+> sampling needs only Sscofpmf; **guest** sampling needs Sscofpmf **and** AIA. Absent
+> Sscofpmf a guest falls back to the legacy driver reading only `cycle`/`instret`
+> (KVM returns 0 for those and traps other `hpmcounter` reads as illegal)
+> (`arch/riscv/kvm/vcpu_pmu.c:388-402`).
+
+### Concern 3: Precise data-source sampling
+
+**Absent.** There is **no PEBS/IBS/SPE analog** in ratified RISC-V. A full-tree
+search of the unified ISA manual for a sampled-data-address, load-latency, or
+[data-source-attribution][data-src] mechanism found nothing relevant — only the
+unrelated RVWMO "data source register" and PMA "imprecise trap" text
+(search over `riscv-isa-manual@fbae3b43 src/**`). Concretely, there is no RISC-V
+producer for `PERF_SAMPLE_ADDR`, `PERF_SAMPLE_PHYS_ADDR`, or
+`PERF_SAMPLE_DATA_SRC`: the SBI/Sscofpmf sampling path carries **IP plus counter
+deltas only**. The closest standardized construct is the SBI HW-cache **`NODE`**
+event (`SBI_PMU_HW_CACHE_NODE`, "NUMA node cache event") — a _counter_, not a
+per-sample data-source tag (`riscv-sbi-doc@8a545eff src/ext-pmu.adoc:140`).
+
+This immaturity is corroborated by field experience. The "Dissecting RISC-V
+Performance" roofline paper `[literature]` reports needing a _"workaround to
+circumvent hardware bugs in one of the popular RISC-V implementations, enabling
+robust event sampling"_ and deliberately builds a **PMU-independent** compiler
+roofline because hardware PMUs are unreliable
+([arXiv 2507.22451][roofline], abstract). In the tree's [comparison][comparison]
+the whole precise-sampling / data-source column reads "unavailable" for RISC-V.
+
+### Concern 4: Code-space decode & symbolization
+
+**ISA-neutral.** The RISC-V perf PMU registers as an ordinary `perf_pmu` (name
+`"cpu"`, `PERF_TYPE_RAW`) producing standard `perf_event` samples
+(`linux@e43ffb69 drivers/perf/riscv_pmu_sbi.c:1475`), so
+address → module → symbol → line [symbolization][symbolize] is the same ELF/DWARF
+pipeline every architecture uses — [`libelf`/`libdw`/`libdwfl`][elfutils], with no
+RISC-V-specific seam. Likewise there is **no hardware call-stack or branch-stack
+producer** at v7.1-rc6 (no CTR consumer — see
+[Concern 5](#concern-5-event-space-branch-records-ctr)), so [callchains][unwind]
+rely on frame-pointer or DWARF-CFI userspace unwinding exactly as elsewhere. When
+CTR lands it would supply the LBR-style branch stack that AutoFDO and path-sensitive
+analyses want (`riscv-ctr@42e299ca intro.adoc:4-6`).
+
+### Concern 5: Event-space & branch records (CTR)
+
+The RISC-V [branch-record][branch-records] extension is **CTR — Control Transfer
+Records (Smctr/Ssctr), v1.0, ratified 2024-11-22.** It is the direct LBR/BRBE
+analog: a circular FIFO recording qualified control transfers, each entry holding a
+source PC (`ctrsource`), target PC (`ctrtarget`), and metadata (`ctrdata`), with a
+software-selectable depth of `2^(DEPTH+4)` = **16 … 256** entries, accessed via the
+indirect-CSR window `siselect` `0x200–0x2FF`
+(`riscv-ctr@42e299ca header.adoc:4-6,39-47`, `intro.adoc:4-8`,
+`body.adoc:161-208,285-296`). The header carries the ratified-state banner
+(`header.adoc:39-47`):
+
+> _"This document is in the [Ratified state]. No changes are allowed. Any desired or
+> needed changes can be the subject of a follow-on new extension. Ratified extensions
+> are never revised."_
+
+`ctrdata.TYPE[3:0]` classifies each transfer into 16 kinds
+(`body.adoc:340-373,574-595`):
+
+| `TYPE` | Transfer         | `TYPE`  | Transfer                                  |
+| ------ | ---------------- | ------- | ----------------------------------------- |
+| `1`    | Exception        | `9`     | Direct call                               |
+| `2`    | Interrupt        | `10`    | Indirect jump                             |
+| `3`    | Trap return      | `11`    | Direct jump                               |
+| `4`    | Not-taken branch | `12`    | Co-routine swap                           |
+| `5`    | Taken branch     | `13`    | Function return                           |
+| `8`    | Indirect call    | `14/15` | Other indirect / direct jump-with-linkage |
+
+Filtering is rich: `mctrctl`/`sctrctl` select **privilege modes** (U/S/M) and
+apply **per-transfer-type inhibits** (`EXCINH`, `INTRINH`, `TRETINH`, `TKBRINH`,
+`NTBREN`, `INDCALLINH`, `DIRCALLINH`, `INDJMPINH`, `DIRJMPINH`, `CORSWAPINH`,
+`RETINH`, …), plus **RASEMU** (return-address-stack emulation mode) and an optional
+per-record cycle count `CC` (mantissa + exponent) (`body.adoc:10-99,340-373`). CTR
+depends on S-mode and the `Sscsrind` indirect-CSR extension
+(`intro.adoc:28`; `src/priv/smctr.adoc`).
+
+The seam that ties CTR to sampling is **freeze-on-LCOFI**: `LCOFIFRZ` sets
+`sctrstatus.FROZEN` on a local count-overflow interrupt so the branch history
+leading to the sampled `xepc` is preserved for the ISR — the exact LBR-at-sample
+pattern (`body.adoc:55,734`):
+
+> _"Freeze on LCOFI ensures that the execution path leading to the sampled
+> instruction (`xepc`) is preserved, and that the local counter overflow interrupt
+> (LCOFI) and associated Interrupt Service Routine (ISR) do not displace any recorded
+> transfer history state."_
+
+> [!WARNING]
+> **CTR is ratified but has no Linux consumer at v7.1-rc6.** `drivers/perf/riscv_ctr.c`
+> **does not exist** in the tree, and a full-tree grep for
+> `ssctr|smctr|control_transfer|RISCV_ISA_EXT_S[MS]CTR` across `arch/riscv/`,
+> `drivers/perf/`, and `include/` returns only unrelated hits
+> (`linux@e43ffb69`, "Linux 7.1-rc6", 2026-05-31). The ratified branch-record
+> capability exists only as spec: no kernel driver publishes a
+> `PERF_SAMPLE_BRANCH_STACK` on RISC-V yet. This refutes a prompt hypothesis and is
+> the page's headline gap — carried in [the comparison's open questions][comparison-open].
+
+CTR is also already folded into the unified ISA manual as `src/priv/smctr.adoc`
+("`ext:smctr[]` … Version 1.0"), so the ratified extension has two concurring
+primary sources; this page cites the standalone `riscv-ctr` repo for line precision.
+
+Beyond CTR and counters, there is **no Intel-PT / Arm-ETM-style full
+instruction-trace standard**. The only other standardized "event space" is SBI
+**firmware events** (type `15`: RFENCE/IPI/SFENCE/HFENCE counts, misaligned and
+access-fault traps, …) — and those are counts, not traces
+(`riscv-sbi-doc@8a545eff src/ext-pmu.adoc:203-259`).
+
+### Concern 6: NUMA & topology
+
+**Collapses to a single counter.** There is no architected NUMA-source PMU
+classification analogous to the vendor [data-source][data-src] engines. The only
+NUMA-aware PMU construct is the SBI HW-cache `NODE` event above — a counter, not a
+per-sample tag (`src/ext-pmu.adoc:140`; kernel cache-event map
+`linux@e43ffb69 drivers/perf/riscv_pmu_sbi.c:281-300`). Node and topology discovery
+itself is the ISA-neutral OS/ACPI/DT path — [`libnuma`][numa] and sysfs — not a
+RISC-V-specific seam. There is likewise **no standardized uncore / system-PMU
+framework** ([uncore PMU][uncore]) analogous to Arm CMN/DSU/DMC in `drivers/perf/`
+at this SHA — only the `riscv_pmu*.c` core plus SBI and legacy drivers exist
+(`ls linux@e43ffb69 drivers/perf/riscv*`).
+
+### Concern 7: Event naming & encoding
+
+**Two layers: standardized classes, implementation-defined selectors.** The SBI
+standardizes the `event_idx` [class encoding][naming-concept] above (HW-general,
+HW-cache, raw-v1/v2, firmware), but the **actual `mhpmevent` selector values are
+per-vendor** — RISC-V architects _no_ hardware event numbers, only the SBI classes,
+matching its position on the [architected-vs-implementation-defined axis][arch-vs-impl].
+Linux distinguishes raw / firmware / platform-firmware events via `config[63:62]` and
+maps `PERF_TYPE_RAW` onto the SBI raw class (`riscv_pmu_sbi.c:416-478`;
+`src/ext-pmu.adoc:165-201`).
+
+The perf tool carries per-microarchitecture JSON tables under
+`tools/perf/pmu-events/arch/riscv/`, keyed by `mvendorid-marchid-mimpid`:
+
+| Vendor        | Microarchitectures (JSON dirs)                     |
+| ------------- | -------------------------------------------------- |
+| `sifive`      | `bullet`, `bullet-07`, `bullet-0d`, `p550`, `p650` |
+| `thead`       | `c900-legacy`                                      |
+| `openhwgroup` | `cva6`                                             |
+| `starfive`    | `dubhe-80`                                         |
+| `andes`       | `ax45`                                             |
+
+Entries are `{EventName, EventCode, BriefDescription}` (or `ArchStdEvent`
+references for the standard firmware events)
+(`linux@e43ffb69 tools/perf/pmu-events/arch/riscv/mapfile.csv` and the per-vendor
+`*.json`). The cross-ISA naming story — how these relate to libpfm4, PAPI, and the
+other ISAs' tables — is [`event-naming.md`][naming]'s subject.
+
+---
+
+## Strengths
+
+- **Microarchitecture-agnostic S-mode driver.** Firmware owns counter allocation
+  and selector translation, so the kernel driver is small and portable; adding a new
+  core is a device-tree map plus (optionally) a perf JSON, not a kernel change.
+- **Clean, ratified sampling primitive.** Sscofpmf's LCOFI + `scountovf` shadow give
+  a well-specified overflow-interrupt path with per-privilege-mode inhibit bits
+  standardized in the ISA rather than bolted on per vendor.
+- **User-space direct reads are first-class.** `rdcycle`/`rdinstret` gated by
+  `scounteren`, wired through `perf_event_mmap_page`, give a genuinely low-overhead
+  counting path suited to per-iteration benchmark bracketing.
+- **Branch records are already ratified.** CTR is a complete, ratified LBR/BRBE-class
+  design (16 transfer types, depth 16–256, RASEMU, freeze-on-LCOFI) — the
+  specification work is done, ahead of silicon and software.
+- **Firmware-counted software events** (RFENCE/IPI/trap counts) come "for free" as a
+  standardized class alongside hardware events.
+
+## Weaknesses
+
+- **No precise sampling at all.** No PEBS/IBS/SPE analog: no de-skidded IP, no
+  sampled data address, no data-source or load-latency attribution. Memory-hierarchy
+  analysis that other backends get from precise sampling is simply unavailable.
+- **Branch records are spec-only.** CTR is ratified but has **no Linux consumer** at
+  v7.1-rc6 — no `PERF_SAMPLE_BRANCH_STACK` on RISC-V, so AutoFDO / path-sensitive
+  tooling has nothing to consume.
+- **Sampling and privilege filtering are optional.** Without Sscofpmf the PMU is
+  counting-only (`NO_INTERRUPT | NO_EXCLUDE`); `exclude_user`/`exclude_kernel` cannot
+  be assumed.
+- **An extra indirection on every configuration.** Counter config crosses an SBI
+  `ecall` into M-mode firmware; the S-mode driver never touches the control CSRs
+  directly.
+- **Fragmented, immature implementations.** Per the roofline paper, real RISC-V PMUs
+  carry hardware bugs and platform-specific defects that force workarounds
+  `[literature]`.
+- **No uncore / system-PMU framework** and no NUMA data-source classification beyond a
+  single `CACHE_NODE` counter.
+
+---
+
+## Key design decisions and trade-offs
+
+| Decision                                                                 | Rationale                                                                                       | Trade-off                                                                                                                                               |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Counting via M-mode firmware over an SBI ecall (not direct S-mode)       | S-mode cannot write the control CSRs; firmware indirection keeps the kernel driver portable     | An `ecall` per configuration; behaviour depends on the firmware/platform DT map being present                                                           |
+| Firmware picks the physical counter (`config_match`)                     | Kernel stays microarchitecture-agnostic; no per-core counter-allocation logic in Linux          | The kernel cannot pin a specific counter; placement policy lives in opaque firmware                                                                     |
+| Sampling as a separate extension (Sscofpmf), probed at runtime           | Small cores can ship counting-only silicon; the interrupt path is opt-in                        | Sampling **and** privilege filtering degrade to `NO_INTERRUPT \| NO_EXCLUDE` without Sscofpmf                                                           |
+| Skidded `xepc` as the sampled IP; no precise mechanism                   | Keeps the sampling path to a single overflow interrupt + trap frame                             | Biased profiles on out-of-order cores; no data-address / data-source attribution at all                                                                 |
+| Guest LCOFI delivery layered on AIA (`HVIEN`) rather than base H-ext     | The base hypervisor extension can only inject three standard VS interrupts                      | Guest sampling adds an Ssaia/Smaia dependency on top of Sscofpmf                                                                                        |
+| Event classes standardized; `mhpmevent` selectors implementation-defined | Portable event _names_ without dictating hardware encodings                                     | Portable names exist only as far as per-microarchitecture JSON/DT maps are maintained                                                                   |
+| **Model RISC-V as a capability subset in the sparkles backend**          | Cleanly mirrors the ratified/landed reality and the runtime-probe discipline the tree advocates | Advertise counting always, sampling only under Sscofpmf, privilege filtering with it, **branch records never (yet)**, and precise/data-source **never** |
+
+The last row is the survey's recommendation for how a portable harness should treat
+RISC-V: not as a reduced x86, but as a distinct capability set to advertise and probe
+— counting is a given, sampling is conditional, and precise/branch-record features are
+absent (one permanently, one pending a Linux driver). This is the same
+capability-not-assumption stance the [privilege-gating concept][priv-gating] and the
+[baseline harness][baseline] apply elsewhere.
+
+---
+
+## Sources
+
+**Linux kernel `[source-verified]`** — `linux@e43ffb69e0438cddd72aaa30898b4dc446f664f8`
+(v7.1-rc6, 2026-05-31):
+
+- `drivers/perf/riscv_pmu_sbi.c` — SBI PMU driver: allocation, start/stop/read,
+  overflow handler, `scounteren`, snapshot, `PERF_TYPE_RAW` mapping
+- `drivers/perf/riscv_pmu_legacy.c` — `cycle`/`instret`-only fallback
+- `drivers/perf/riscv_pmu.c` — shared core; `tools/perf/pmu-events/arch/riscv/**` vendor JSON
+- `arch/riscv/kvm/{vcpu_pmu,vcpu,aia}.c` — guest counters and AIA-mediated LCOFI injection
+- `arch/riscv/include/asm/csr.h` — `IRQ_PMU_OVF`, `scountovf` CSR number
+
+**RISC-V specifications `[source-verified]`:**
+
+- [RISC-V ISA Manual][isa-manual] `@fbae3b43` — `src/priv/sscofpmf.adoc` (Sscofpmf,
+  LCOFI, `scountovf`), `src/priv/smctr.adoc` (CTR in the unified manual)
+- [RISC-V SBI Specification][sbi-doc] `@8a545eff` — `src/ext-pmu.adoc` (SBI PMU:
+  `event_idx`, FIDs, snapshot, firmware events)
+- [RISC-V Control Transfer Records (Smctr/Ssctr) v1.0][ctr-repo] `@42e299ca` —
+  `header.adoc`, `intro.adoc`, `body.adoc` (ratified 2024-11-22; PDF asset on the
+  [v1.0 "Ratified release"][ctr-release])
+- [OpenSBI][opensbi] `@26257121` — `lib/sbi/sbi_pmu.c`, `lib/utils/fdt/fdt_pmu.c`,
+  `docs/pmu_support.md` (selector translation, DT maps)
+
+**Literature `[literature]`:**
+
+- [Dissecting RISC-V Performance: Practical PMU Profiling and Hardware-Agnostic
+  Roofline Analysis on Emerging Platforms][roofline] — arXiv 2507.22451 (PMU
+  immaturity, sampling workaround)
+
+**Related pages:** [concepts][concepts] · [Linux perf_events][linux] ·
+[precise sampling][precise] · [ARMv8+][arm] · [event naming & encoding][naming] ·
+[comparison][comparison].
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[counting]: ./concepts.md#counting
+[sampling]: ./concepts.md#sampling
+[fixed-config]: ./concepts.md#fixed-and-configurable-counters
+[mux]: ./concepts.md#multiplexing-and-scaling
+[self-mon]: ./concepts.md#self-monitoring-and-user-space-counter-reads
+[pmi]: ./concepts.md#pmi-performance-monitoring-interrupt
+[overflow]: ./concepts.md#overflow-sampling
+[precise-skid]: ./concepts.md#precise-sampling-and-skid
+[data-src]: ./concepts.md#data-source-attribution
+[branch-records]: ./concepts.md#branch-records
+[symbolize]: ./concepts.md#symbolization
+[unwind]: ./concepts.md#unwinding
+[uncore]: ./concepts.md#uncore-pmu
+[numa]: ./concepts.md#numa-topology-and-page-node-oracles
+[arch-vs-impl]: ./concepts.md#architected-vs-implementation-defined-events
+[naming-concept]: ./concepts.md#event-naming-and-encoding
+[priv-gating]: ./concepts.md#privilege-gating
+[linux]: ./linux-perf-events.md
+[precise]: ./precise-sampling.md
+[elfutils]: ./elfutils.md
+[naming]: ./event-naming.md
+[arm]: ./arm.md
+[comparison]: ./comparison.md
+[baseline]: ./sparkles-baseline.md
+[comparison-open]: ./comparison.md#open-questions-gaps
+[isa-manual]: https://github.com/riscv/riscv-isa-manual/blob/fbae3b43b3feefefe88a8576596d0f06425c2697/src/priv/sscofpmf.adoc
+[sbi-doc]: https://github.com/riscv-non-isa/riscv-sbi-doc/blob/8a545effe9b50484ff897d9815d7d9015cdef203/src/ext-pmu.adoc
+[ctr-repo]: https://github.com/riscv/riscv-control-transfer-records/blob/42e299ca4f72df6931589068a34956685825c247/body.adoc
+[ctr-release]: https://github.com/riscv/riscv-control-transfer-records/releases/tag/v1.0
+[opensbi]: https://github.com/riscv-software-src/opensbi/blob/262571217c75c649115633d8075cb6a40d940733/lib/sbi/sbi_pmu.c
+[roofline]: https://arxiv.org/abs/2507.22451

--- a/docs/research/cpu-pmu/sparkles-baseline.md
+++ b/docs/research/cpu-pmu/sparkles-baseline.md
@@ -1,0 +1,320 @@
+# The sparkles counter layer: the baseline
+
+Today's CPU-PMU acquisition layer in the sparkles benchmarking harness —
+`sparkles:test-runner --bench` plus the [`wired` runtime bench][wired-bench] —
+described as **observed behavior**, with its current limits. This page is the
+_system under audit_: the [comparison][comparison] page's delta table maps each
+capability the survey found onto where this layer stands, and the
+[backend proposal][proposal] is the plan that closes the gaps.
+
+**Last reviewed:** July 11, 2026
+
+> [!IMPORTANT]
+> Per the survey's ground rules, this page records what the code _does_, not
+> what it was assumed to do — the sparkles source is **not** a source of truth
+> for any other page in this tree. Where the survey's findings and this layer's
+> behavior diverge, the divergence is recorded here and in the
+> [delta table][comparison-delta], never silently reconciled.
+
+| Field           | Value                                                                                                                                                            |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Modules         | [`perf.d`][src-perf] · [`perf_group.d`][src-group] · [`tier0.d`][src-tier0] · [`syscalls.d`][src-syscalls] · [`metrics.d`][src-metrics] · [`bench.d`][src-bench] |
+| Location        | `libs/test-runner-impl/src/sparkles/test_runner/`                                                                                                                |
+| Acquisition API | `perf_event_open(2)` via druntime `core.sys.linux.perf_event` (pure D, no C shim)                                                                                |
+| Modes           | [Counting][c-counting] only — no sampling of any kind                                                                                                            |
+| OS coverage     | Linux; identical-surface stubs (`available == false`) everywhere else                                                                                            |
+| User docs       | [`--bench` how-to][bench-docs]                                                                                                                                   |
+| Consumer        | [`libs/wired/bench/runtime`][wired-bench] (11 JSON engines × 5 ops × 4 datasets)                                                                                 |
+
+---
+
+## Overview
+
+The layer is a set of **counting tiers** feeding one **metric-catalog seam**.
+Each tier is an independent acquisition source that opens once per bench run,
+brackets the timed body of every benchmark case, and projects per-iteration
+averages; the catalog ([`metrics.d`][src-metrics]) renders whatever tiers are
+present into table columns and JSON fields, tagging every column
+`quantitative` (near-zero perturbation, safe to headline) or `diagnostic`
+(perturbs; explains a result). The tiers:
+
+- **Hardware counters** ([`perf.d`][src-perf]) — one process-wide
+  [event group][c-group] of 7 events; `diagnostic`.
+- **Tier 0** ([`tier0.d`][src-tier0]) — `getrusage(2)` + `/proc/self/io`;
+  always available, no privilege; `quantitative`.
+- **Syscall tracepoints** ([`syscalls.d`][src-syscalls]) — an in-process
+  `strace -c` built from tracepoint events; `quantitative`.
+- **Client metrics** — user-supplied `Metric` values (e.g. the wired bench's
+  bytes-per-second rate), computed against the timed median.
+
+Two properties define the design. First, **counting is separated from
+timing**: the timing pass (median ns/iter over 32 samples) runs with no
+counters enabled, then a second pass re-runs the body under counters — so
+`ioctl`/`read` bracketing never pollutes the reported ns/iter. Second, **every
+tier degrades to absence**: a failed `perf_event_open` (raised
+[`perf_event_paranoid`][c-privilege], seccomp, no PMU, non-Linux) or unreadable
+tracefs yields `available == false` and _omitted columns_, never an error and
+never silently-wrong numbers.
+
+---
+
+## How the layer works today
+
+### The measurement protocol ([`bench.d`][src-bench])
+
+The timing protocol is the Rust-libtest `Bencher` shape: double the per-sample
+iteration count until one sample takes ≥ `--bench-min-time` (default 5 ms),
+then take 32 samples and report median / MAD / min / max ns per iteration,
+timed with raw `MonoTime` ticks (`bench.d:294-331`). `blackBox` defeats
+constant-folding via empty inline asm under LDC (`bench.d:48-66`).
+
+Counters hook in _after_ timing. `BenchStats` carries one `Nullable!XStats`
+slot per tier (`bench.d:128-144`), and a `CounterGroups` bundle owns the three
+tiers' lifecycles (`bench.d:377-419`). For each case, `measureCase` calls
+`counters.countInto(row, runTimed, between, iterations, config)`, which runs
+each _available_ tier's counting pass capped at `perfMaxIters = 100_000`
+iterations (`bench.d:434-440`). The module documentation states the extension
+contract: adding a source is _one field plus one line in each of
+`open`/`close`/`countInto`_ — plus a cells/family pair in the
+[catalog](#the-metric-catalog-seam).
+
+### Hardware counters ([`perf.d`][src-perf])
+
+One process-wide [group][c-group] opened at bench-mode start (`pid: 0`,
+`cpu: -1` — this process, any CPU), leader-first (`perf.d:74-88, 199-201`):
+
+| #   | Event                               | Type                |
+| --- | ----------------------------------- | ------------------- |
+| 0   | `PERF_COUNT_HW_CPU_CYCLES`          | hardware (leader)   |
+| 1   | `PERF_COUNT_HW_INSTRUCTIONS`        | hardware            |
+| 2   | `PERF_COUNT_HW_BRANCH_INSTRUCTIONS` | hardware            |
+| 3   | `PERF_COUNT_HW_BRANCH_MISSES`       | hardware            |
+| 4   | `PERF_COUNT_HW_CACHE_REFERENCES`    | hardware (LLC pair) |
+| 5   | `PERF_COUNT_HW_CACHE_MISSES`        | hardware (LLC pair) |
+| 6   | `PERF_COUNT_SW_PAGE_FAULTS`         | software            |
+
+The leader carries `read_format = PERF_FORMAT_GROUP |
+PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING`
+(`perf.d:194-197`), so one blocking `read(2)` returns
+`{nr, time_enabled, time_running, values…}`. There is **no `rdpmc`/mmap-page
+[self-monitoring][c-rdpmc] path** — every read is a syscall.
+
+Availability is a **calibration handshake**, not a static probe
+(`perf.d:129-154`): `tryOpen` opens the full group, spins ~2 ms, and checks the
+running/enabled ratio. Below 0.98 — i.e. the group was
+[multiplexed][c-multiplex] — it _reopens without the LLC pair_
+(`cacheDropped`), because a rotation-scaled estimate is an estimate, not a
+count. If even the reduced group gets zero PMU time it gives up
+(`available == false`). A permission fallback tries kernel+user first, then
+user-only (`exclude_kernel = 1`, reported as `userOnly`) (`perf.d:158-168`).
+On this survey's test box the LLC drop fires in practice: the NMI watchdog
+pins one of Zen 4's six PMCs, so the full 7-event group cannot fit
+([bench-baseline][wired-baseline] records it).
+
+> [!NOTE]
+> The dropped-LLC-pair heuristic is the layer's answer to
+> [multiplex scaling][c-multiplex]: rather than report `enabled/running`-scaled
+> estimates (the kernel-documented approach the survey's
+> [counting probe][ex-counting] demonstrates), it shrinks the group until the
+> counts are exact. The trade-off — fewer columns, but never estimated ones —
+> is deliberate, and the [proposal][proposal] revisits it.
+
+### Shared group mechanics ([`perf_group.d`][src-group])
+
+Both `perf_event` tiers share one counting bracket (`perf_group.d:71-90`):
+`RESET` once per pass, then per iteration `ENABLE → timed body → DISABLE`,
+with the untimed `between` callback (result release, verification) outside the
+enabled window. Reads scale by the pass's own `time_enabled`/`time_running`
+deltas — taken against a per-pass baseline because `PERF_EVENT_IOC_RESET`
+zeroes counter values but **not** the cumulative time fields
+(`perf_group.d:61-121`). Values project to per-iteration doubles unrounded;
+a short read or an enabled-but-never-scheduled group yields `nan` fields /
+`scale = 0` rather than fabricated zeros.
+
+### Tier 0 ([`tier0.d`][src-tier0])
+
+The no-privilege tier: `getrusage(RUSAGE_SELF)` (minor/major faults,
+voluntary/involuntary context switches) plus `/proc/self/io` (`syscr`, `syscw`,
+`rchar`, `wchar`, `read_bytes`, `write_bytes`), read with raw
+`open`/`read`/`close` because `std.file` reports `/proc` files as size 0
+(`tier0.d:357-369`). Its instrumentation self-cost is measured at open (median
+of 9 empty brackets) and subtracted clamped-at-zero, so a no-I/O body reads ≈0
+(`tier0.d:218-248, 335-341`). Fields degrade individually — a kernel without
+`CONFIG_TASK_IO_ACCOUNTING` yields `nan` for `read_bytes`/`write_bytes` while
+`syscr`/`rchar` still count (`tier0.d:122-154`).
+
+### Syscall tracepoints ([`syscalls.d`][src-syscalls])
+
+An [event-space][c-eventspace] tier: a `perf_event` group with
+`raw_syscalls:sys_enter` as leader (total syscall count) plus up to 62 named
+`syscalls:sys_enter_<name>` siblings, tracepoint ids read from tracefs
+(`syscalls.d:77-98, 125-158`). `inherit = 1` follows threads spawned after the
+open — worker pools created in untimed setup aggregate in; threads that existed
+_before_ the open do not (`syscalls.d:168`). The tier needs readable tracefs
+`id` files — root-only (`0700`) on hardened hosts, including the survey's test
+box — and `perf_event_paranoid ≤ 1`; otherwise the columns are omitted and
+`status()` says why (`syscalls.d:116-119`).
+
+### The metric catalog seam
+
+Everything downstream renders through two small types (`metrics.d:29-63`):
+
+```d
+enum MetricClass { quantitative, diagnostic }
+enum MetricFormat { ratio, count, percent }
+
+struct MetricCell        // one rendered value
+{
+    string name;         // stable id: "ipc", "instr", "B/s", "syscalls:read"
+    string header;       // column label
+    double value = double.nan;  // nan renders as an em dash
+    MetricFormat format;
+    MetricClass cls;
+}
+
+struct MetricDescriptor  // one catalog entry
+{
+    string name;
+    string header;
+    MetricFormat format;
+    MetricClass cls;
+    string source;       // "client" | "perf" | "tier0" | "syscall"
+    bool available;      // producible on this run
+    bool isDefault;      // shown without a --metrics filter
+}
+```
+
+Each tier contributes a projection pair — `XCells(in XStats)` producing row
+cells and `XFamily(bool available)` producing descriptors — concatenated by
+`rowCells`/`catalog` (`metrics.d:250-260, 514-539`). `--metrics` glob-selects
+columns (`visibleMetrics`, `metrics.d:679-692`) and _transitively opens the
+tiers it needs_ (`selectsSource`, `metrics.d:645-660`) — asking for `ipc`
+opens the perf group without `--perf`. `--list-metrics` renders the catalog
+with class and source. The `--bench-json` emitter serializes the same
+descriptors as `columns` and the same cells as per-row `metrics`, `nan` →
+`null` (`bench_json.d`).
+
+This seam is the composition point the [backend proposal][proposal] targets:
+table rendering, filtering, listing, and JSON are all source-agnostic over
+`MetricCell`/`MetricDescriptor`.
+
+### The wired bench consumer
+
+The [`wired` runtime bench][wired-bench] measures 11 JSON engines × 5
+operations × 4 datasets through ordinary `@benchmark` cases and **reuses this
+layer wholesale** — its module header states hardware counters come from the
+runner's `--perf`; there is no private perf backend. Each case registers one
+client `B/s` metric; correctness verification (fingerprints, `TwitterStats`)
+rides the untimed release hook. [`bench-baseline.md`][wired-baseline] then
+derives per-byte figures (IPC, cycles/B, instructions/B) from the same
+`PerfStats` cells — the numbers behind the "wired decode is
+instruction-budget-bound, not IPC-bound" conclusion.
+
+---
+
+## The seven concerns, as covered today
+
+The survey's [analysis spine][index-spine], applied to this layer. Absences
+are the point — they are the audit's raw material.
+
+| #   | Concern                            | Today                                                                                                                                                     |
+| --- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | [Scalar counting][c-counting]      | ✅ 7-event fixed group; calibration LLC-drop; user-only fallback; **no [rdpmc][c-rdpmc]**, syscall `read(2)` per pass                                     |
+| 2   | [Overflow/IP sampling][c-sampling] | ❌ Absent — the harness reports aggregates only; no ring buffer, no samples                                                                               |
+| 3   | [Precise / data-source][c-datasrc] | ❌ Absent — no IBS/PEBS/SPE use, no data addresses, no latency distribution                                                                               |
+| 4   | [Symbolization][c-symbolization]   | ❌ Absent — no address-space model, no debug-info decode (nothing to symbolize without samples)                                                           |
+| 5   | [Event-space][c-eventspace]        | ⚠️ Partial — syscall tracepoint _counting_ (62 named max); root-gated tracefs; no other tracepoints, no gating/windowing                                  |
+| 6   | [NUMA & topology][c-numa]          | ❌ Absent — no topology awareness, no node pinning, no page→node classification                                                                           |
+| 7   | [Event naming][c-naming]           | ⚠️ Fixed generic names — the 7 `PERF_COUNT_*` events are hardcoded; `--metrics` selects _columns_, not _events_; no per-µarch tables, no raw-event access |
+
+Cross-OS coverage is a stub: every tier compiles to an identical-surface
+`available == false` shell off Linux. The survey found real per-OS floors the
+layer does not reach — macOS offers unprivileged per-process
+instructions/cycles via `proc_pid_rusage` (a natural tier-0 analog,
+[macos.md][macos] `[hw-verified: aarch64-darwin]`), and Windows offers
+`CycleTime` via thread profiling plus admin-gated ETW counting
+([windows.md][windows]).
+
+---
+
+## Gap analysis: what the audit starts from
+
+1. **The event set is closed.** Seven generic events, hardcoded. No
+   [naming layer][c-naming], no raw `type:config` escape hatch, no
+   per-microarchitecture tables — on the survey's Zen 4 box, nothing beyond
+   the generic seven is reachable, and the LLC pair is dropped besides. The
+   survey's [libpfm4 probe][ex-pfm4] shows what a name→encoding layer buys
+   (and its own hazards: stale auto-detect on new silicon).
+2. **Counting is syscall-priced.** A `read(2)` + two `ioctl(2)` per iteration
+   bracket. The [rdpmc/mmap-page path][c-rdpmc] the kernel exposes for exactly
+   this shape (self-monitoring a bracketed region) is unused — relevant per
+   the [counting probe][ex-counting] once per-iteration bracketing of very
+   short bodies is on the table.
+3. **No mode beyond counting.** Concerns 2-4 are wholesale absent. The layer
+   can say a regression _happened_ (IPC fell, cache misses rose) but never
+   _where_ — no flat profile, no data-address attribution, no unwound stacks.
+4. **Multiplexing is avoided, not modeled.** The calibration drop keeps counts
+   exact but silently narrows coverage; the `enabled/running` scaling the
+   kernel documents (and the [probe][ex-counting] validates to ~1% on a
+   10-on-6 oversubscription) is never used, even where estimates would be
+   acceptable and labeled.
+5. **Thread coverage is inherit-shaped.** `pid:0, cpu:-1` + `inherit` on the
+   tracepoint group covers threads spawned after open; pre-existing threads
+   and short-lived children are blind spots the harness does not report.
+6. **Off-Linux is absence, not a smaller backend.** The stubs are honest but
+   empty; the per-OS floors ([macOS rusage tier][macos], [Windows
+   HCP/ETW][windows]) are unimplemented, so cross-platform runs lose _all_
+   counters instead of degrading to the local floor.
+7. **Availability reporting is coarse.** `status()` strings say a tier is
+   off; they do not enumerate _which capability_ (of the survey's seven
+   concerns) is missing and why — the "capability unavailable, not silently
+   degraded" contract the [proposal][proposal] formalizes.
+
+---
+
+## Sources
+
+- Observed sources (this repo): [`perf.d`][src-perf], [`perf_group.d`][src-group],
+  [`tier0.d`][src-tier0], [`syscalls.d`][src-syscalls], [`metrics.d`][src-metrics],
+  [`bench.d`][src-bench], [`bench_json.d`][src-json]; user docs
+  [`benchmark.md`][bench-docs]; consumer [`libs/wired/bench/runtime`][wired-bench]
+  and [`bench-baseline.md`][wired-baseline]. Line references are to the tree at
+  the survey date (July 2026).
+- The survey pages this baseline is audited against: [comparison][comparison],
+  [linux-perf-events][linux], [precise-sampling][precise],
+  [event-naming][naming], [macos][macos], [windows][windows].
+
+<!-- References -->
+
+[src-perf]: ../../../libs/test-runner-impl/src/sparkles/test_runner/perf.d
+[src-group]: ../../../libs/test-runner-impl/src/sparkles/test_runner/perf_group.d
+[src-tier0]: ../../../libs/test-runner-impl/src/sparkles/test_runner/tier0.d
+[src-syscalls]: ../../../libs/test-runner-impl/src/sparkles/test_runner/syscalls.d
+[src-metrics]: ../../../libs/test-runner-impl/src/sparkles/test_runner/metrics.d
+[src-bench]: ../../../libs/test-runner-impl/src/sparkles/test_runner/bench.d
+[src-json]: ../../../libs/test-runner-impl/src/sparkles/test_runner/bench_json.d
+[bench-docs]: ../../libs/test-runner/how-to/benchmark.md
+[wired-bench]: ../../../libs/wired/bench/runtime/
+[wired-baseline]: ../../specs/wired/bench-baseline.md
+[comparison]: ./comparison.md
+[comparison-delta]: ./comparison.md#the-delta-table-the-survey-vs-the-sparkles-baseline
+[proposal]: ./backend-proposal.md
+[index-spine]: ./#the-seven-concerns
+[linux]: ./linux-perf-events.md
+[precise]: ./precise-sampling.md
+[naming]: ./event-naming.md
+[macos]: ./macos.md
+[windows]: ./windows.md
+[ex-counting]: ./examples/counting-group.d
+[ex-pfm4]: ./examples/pfm4-name-roundtrip.d
+[c-counting]: ./concepts.md#counting
+[c-sampling]: ./concepts.md#overflow-sampling
+[c-datasrc]: ./concepts.md#data-source-attribution
+[c-symbolization]: ./concepts.md#symbolization
+[c-eventspace]: ./concepts.md#event-space-and-tracepoints
+[c-numa]: ./concepts.md#numa-topology-and-page-node-oracles
+[c-naming]: ./concepts.md#event-naming-and-encoding
+[c-group]: ./concepts.md#event-group
+[c-multiplex]: ./concepts.md#multiplexing-and-scaling
+[c-rdpmc]: ./concepts.md#self-monitoring-and-user-space-counter-reads
+[c-privilege]: ./concepts.md#privilege-gating

--- a/docs/research/cpu-pmu/windows.md
+++ b/docs/research/cpu-pmu/windows.md
@@ -1,0 +1,587 @@
+# Windows CPU-PMU acquisition (HCP · ETW · ring-0 drivers)
+
+The Windows mapping of the survey's [seven concerns][concepts]. Where Linux exposes
+one open, uniform hub — [`perf_event_open(2)`][linux] — Windows splits the same
+counting and sampling roles across **three disjoint surfaces** that share no common
+seam: a curated usermode **Hardware Counter Profiling (HCP)** API, the **ETW**
+kernel-logger PMC/LBR pipeline, and a **closed ring-0 driver** model (Intel VTune
+SEP, AMD uProf) for arbitrary events.
+
+| Field             | Value                                                                                                                                                                                  |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OS / SDK          | Windows 7 → Windows Server 23H2 (feature timeline; HCP min **Win7 / Server 2008 R2**, PMC ETW classes min **Win8**, LBR min **Win10 19H1**)                                            |
+| Counting API      | HCP `EnableThreadProfiling`/`ReadThreadProfilingData` (`winbase.h`, Kernel32); ETW `-pmc` PMCs logged on kernel events                                                                 |
+| Overflow sampling | ETW PMC-overflow → `PERF_PMC_PROFILE` event (`TraceProfileSourceConfigInfo`; `xperf -pmcprofile … -stackwalk pmcinterrupt`)                                                            |
+| Precise sampling  | **Absent publicly** — no data-address/PEBS class in `TRACE_QUERY_INFO_CLASS`; kernel PEBS plumbing exists but is walled off (see [Concern 3](#concern-3-precise-data-source-sampling)) |
+| Branch records    | **LBR** via `TraceLbrConfigurationInfo` (`TraceLbrEventListInfo`), branch-only, public since Win10 19H1                                                                                |
+| Event catalog     | Curated HAL profile-sources via [`wpr -pmcsources`][wpt-pmu] / `xperf -pmcsources`; raw events registerable system-globally since Win10 1903                                           |
+| Consumers read    | [`krabsetw`][krabs] `@ 6900de05` (open ETW consumer); [`windows-d`][winmd] `@ f34527e` (win32metadata → D projection); druntime `core.sys.windows` (ldc 1.41.0)                        |
+| Verification      | `[literature]` (saved Microsoft Learn docs, named by file, retrieved 2026-07-10) + `[source-verified]` (krabsetw / windows-d / druntime reads); **no hardware**                        |
+
+> [!IMPORTANT]
+> **No Windows hardware was available for this survey.** Every claim on this page
+> is either `[literature]` — read from an official Microsoft Learn page saved to
+> `$REPOS/papers/cpu-pmu/<file>.html` (retrieved 2026-07-10, all HTTP 200) — or
+> `[source-verified]` — read from a pinned open-source tree ([`krabsetw`][krabs]
+> `@ 6900de05`, [`windows-d`][winmd] `@ f34527e`) or ldc-1.41.0 druntime. There is
+> **no `[hw-verified]` tag anywhere.** Several load-bearing facts (the internal
+> PEBS enum, the extended group-mask enable path) come from **undocumented** APIs
+> that krabs uses and Microsoft does not commit to; those are flagged inline with a
+> GitHub alert at each use. Encodings and version floors trace to saved copies of
+> the official documentation (retrieved 2026-07-10), not to a running system.
+
+---
+
+## Overview
+
+### What it acquires
+
+There is no Windows equivalent of `perf_event_open` — no single call that opens a
+counter, selects an event by encoding, groups siblings atomically, and streams
+samples through a ring buffer. Instead each of the survey's concerns lands on a
+_different_ surface, and two of them (arbitrary events, precise data-source
+sampling) fall off the public API entirely. The organizing fact is **curation**:
+Windows exposes a small, HAL-vetted vocabulary of events, and the raw hardware
+event space is reachable only through a kernel driver or a system-global
+registration — never inline per acquisition. The WPT documentation states the
+policy directly ([`recording-pmu-events`][wpt-pmu]):
+
+> _"Only a small subset of PMU events in CPU vendor's documents are implemented in
+> Windows HAL by default. However, WPR provides a way to extend PMU events that are
+> not exposed as the available profile sources."_
+
+That sentence frames the whole page. Everywhere Linux says _"any `config` value,
+subject to `perf_event_paranoid`"_, Windows says _"a curated list, plus a
+privileged escape hatch"_ — the [capability-curation][curation] stance the survey's
+[comparison][comparison] contrasts against Linux's open model. ([macOS][macos]
+curates even more strictly, allowlisting events even for root.)
+
+### Design philosophy: three surfaces, no common seam
+
+The three surfaces are not layers of one stack; they are unrelated APIs owned by
+different teams, with different privilege models, different event vocabularies, and
+no shared data type:
+
+- **HCP** (`winbase.h`, Kernel32) is a _per-thread accumulated-count_ API. It is
+  the only usermode-friendly counting path, but its sole driver-free datum is
+  `CycleTime`; real PMCs require a kernel driver to program the counters first.
+- **ETW** (`evntrace.h`) is the real event-space and sampling backbone: a
+  system-wide logger that emits PMC counts on selected kernel events, PMC-overflow
+  IP samples, and LBR branch records into a trace session consumed after the fact.
+- **Ring-0 drivers** (VTune SEP, AMD uProf) own arbitrary-event acquisition. They
+  are closed-source; the only _supported_ enumeration of what the HAL will expose
+  is `wpr -pmcsources`.
+
+A portable harness therefore cannot "open a counter" on Windows the way it does on
+Linux; it must pick a surface per concern and accept that three of the seven roles
+(precise sampling, arbitrary events, sampled-address → NUMA node) have no
+usermode-portable answer at all.
+
+---
+
+## How it works
+
+### (a) Hardware Counter Profiling: per-thread counting
+
+HCP is the documented usermode counting path: `EnableThreadProfiling`,
+`ReadThreadProfilingData`, `DisableThreadProfiling`, `QueryThreadProfiling` — all in
+`winbase.h`, exported from Kernel32.dll, minimum **Windows 7 / Server 2008 R2**.
+`[literature]` The signature is:
+
+```c
+// winbase.h
+BOOL EnableThreadProfiling(
+    HANDLE ThreadHandle, DWORD Flags, DWORD64 HardwareCounters,
+    HANDLE *PerformanceDataHandle);
+```
+
+Three properties make it structurally unlike `perf_event_open`. First, **the
+`HardwareCounters` bitmask selects counters by _index_, never by event encoding**
+([`enablethreadprofiling`][hcp-enable]):
+
+> _"You can specify up to 16 performance counters. Each bit relates directly to the
+> zero-based hardware counter index for the hardware performance counters that you
+> configured."_
+
+Second, those counters must have been **configured globally by a kernel driver**
+before profiling begins — HCP itself cannot program a PMU:
+
+> _"To profile hardware performance counters, you need a driver to configure the
+> counters. The performance counters are configured globally for the system … see
+> the KeSetHardwareCounterConfiguration function in the Windows Driver Kit (WDK)."_
+> `[literature]`
+
+Third, `EnableThreadProfiling`'s `ThreadHandle` **"must be the current thread"** — a
+thread can profile only itself. `[literature]`
+
+The read side fills a `PERFORMANCE_DATA` (`winnt.h`) with `CycleTime`,
+`ContextSwitchCount`, `WaitReasonBitMap`, and — only under the
+`READ_THREAD_PROFILING_FLAG_HARDWARE_COUNTERS` flag — an array
+`HARDWARE_COUNTER_DATA HwCounters[MAX_HW_COUNTERS]` (16 slots). The **only
+guaranteed hardware datum without a driver is `CycleTime`** ("cycle time of the
+thread … excludes time spent interrupted"); there is no retired-instructions or
+other named PMC field — every real PMC value flows through `HwCounters[]`, which is
+populated only when a driver has configured the counters. `[literature]` Each slot is
+a bare `HARDWARE_COUNTER_DATA = { HARDWARE_COUNTER_TYPE Type; DWORD Reserved; DWORD64
+Value; }`, and `HARDWARE_COUNTER_TYPE` has exactly one real value, `PMCCounter`
+(plus the `MaxHardwareCounterType` sentinel) — there is **no generic event-encoding
+type** at the HCP layer. `[literature]`
+
+The driver routine is `KeSetHardwareCounterConfiguration` (`ntddk.h`, WDK), and its
+effect is **global and single-tenant** ([`kesethardwarecounterconfiguration`][wdk-ke]):
+
+> _"The operating system supports only one profiling application at a time.
+> Concurrent instances of a thread-profiling application are not supported. A thread
+> can enable thread profiling for itself but not for other threads."_
+
+Drivers coordinate counter ownership through `HalAllocateHardwareCounters` /
+`HalFreeHardwareCounters`, and a single `KeSetHardwareCounterConfiguration` call
+"sets the hardware counter configuration to use for thread profiling across all
+processors." `[literature]` The upshot: HCP is a real per-thread counting API, but it
+delegates the entire PMU-programming step to a WDK driver that owns the machine's
+counters system-wide — the opposite of Linux's per-fd, kernel-arbitrated model.
+
+ETW offers a second counting mode, "PMU events on ETW events": PMC values are logged
+whenever selected ETW events fire (e.g. `CSwitch`), producing WPA's
+Cycles-per-Instruction table. `[literature]`
+
+```bash
+# Count PMCs sampled at each context switch (WPA CPI table)
+xperf -pmc InstructionRetired,TotalCycles CSWITCH strict
+```
+
+### (b) The ETW pipeline
+
+ETW is a producer/consumer logging system, and PMU acquisition rides it as a set of
+_configuration classes_ layered on the ordinary session lifecycle. The control side
+is `StartTrace` (with an `EVENT_TRACE_PROPERTIES` or `_V2` block) → `EnableTraceEx2`
+→ the PMU config call `TraceSetInformation` → `ProcessTrace`; field extraction on the
+consumer side uses `TdhGetProperty`. `[literature]` The PMU knobs are members of
+`TRACE_QUERY_INFO_CLASS` (`evntrace.h`), passed to
+[`TraceSetInformation`][etw-tsi] — minimum Win7, but the PMC classes require Win8:
+
+| Class (value)                         | Role                                                             | Min version |
+| ------------------------------------- | ---------------------------------------------------------------- | ----------- |
+| `TraceSampledProfileIntervalInfo` (5) | Timer sample interval                                            | Win7        |
+| `TraceProfileSourceConfigInfo` (6)    | Profiling sources collected into the `PERF_PMC_PROFILE` event    | Win8        |
+| `TraceProfileSourceListInfo` (7)      | Query available profile sources                                  | Win8        |
+| `TracePmcEventListInfo` (8)           | PMC-on-event counting list                                       | Win8        |
+| `TracePmcCounterListInfo` (9)         | PMC counter list                                                 | Win8        |
+| `TraceProviderBinaryTracking` (18)    | Provider-GUID → module-path map into buffers / the `.etl` header | Win10 1709  |
+| `TraceLbrConfigurationInfo` (20)      | LBR (branch record) configuration                                | Win10 19H1  |
+| `TraceLbrEventListInfo` (21)          | LBR event list                                                   | Win10 19H1  |
+| `TraceMaxPmcCounterQuery` (22)        | Max profiling sources usable simultaneously                      | Win10 19H1  |
+| `TracePmcCounterOwners` (25)          | PMCs currently in use system-wide                                | Win10 21H2  |
+| `TraceContextRegisterInfo` (28)       | GP register contents at the moment a related event fires         | Server 23H2 |
+
+The counter budget is shared and small: with CPU sampling enabled only **3** PMCs
+are usable (the timer needs one); **4** if attached to context-switch events —
+`TraceMaxPmcCounterQuery` reports the ceiling, `TracePmcCounterOwners` the current
+occupants. `[literature]`
+
+The **open consumption model** is [`krabsetw`][krabs] (`[source-verified]`). A
+session is a `krabs::trace<T>` (`T` = `ut` user-trace or `kt` kernel-trace);
+`trace_manager<T>::open()` calls `register_trace()` → `enable_providers()` →
+`open_trace()`, then `process_trace()` (`ProcessTrace`). Each `EVENT_RECORD` is
+dispatched by `ProviderId` to the matching `krabs::provider`, which parses fields via
+the TDH schema — the open analog of Linux's [`libtraceevent`][libtraceevent] + tracefs
+`format` files. `[source-verified]` The documented per-session config seam is
+`trace_manager<T>::set_trace_information` → `TraceSetInformation`, through which a
+consumer sets `TracePmcCounterListInfo` / `TraceLbrConfigurationInfo`.
+`[source-verified]`
+
+Reaching the newer kernel-logger providers requires an **undocumented** path. The
+classic 32-bit `EnableFlags` cannot address them, so krabs reads and writes the
+extended **`PERFINFO_GROUPMASK`** via `NtQuerySystemInformation` /
+`NtSetSystemInformation(SystemPerformanceTraceInformation, …)`;
+`PERF_PMC_PROFILE = 0x20000400` is one such group-mask bit. `[source-verified]`
+
+> [!WARNING]
+> **The group-mask enable path is undocumented.** krabs annotates it itself
+> ([`kt.hpp:63-66`][krabs-kt]): _"Enables the configured kernel rundown flags. This
+> ETW feature is undocumented and should be used with caution."_ A backend that
+> depends on it inherits that risk — Microsoft does not commit to the
+> `PERFINFO_GROUPMASK` bit layout or the `SystemPerformanceTraceInformation`
+> contract across releases.
+
+### (c) The closed ring-0 driver model
+
+Arbitrary events — anything outside the curated HAL profile-sources — require a
+**kernel driver**. Intel's VTune ships **SEP**, AMD's uProf ships its own; both are
+closed-source, and both program the PMU below the ETW/HCP layer. The only
+_supported_ way to enumerate what the HAL will expose is
+`wpr -pmcsources` / `xperf -pmcsources`. `[literature]` This is the same driver
+requirement HCP's `KeSetHardwareCounterConfiguration` documents from the other
+direction: usermode Windows never programs an event selector itself.
+
+---
+
+## The seven concerns
+
+The uniform survey spine, each concern stating the Windows mechanism or its explicit
+absence.
+
+| #   | Concern                                                                 | Windows answer                                                                                   |
+| --- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| 1   | [Scalar counting](#concern-1-scalar-counting)                           | HCP `EnableThreadProfiling` (driver-free = `CycleTime` only) + ETW `-pmc`                        |
+| 2   | [Overflow / IP sampling](#concern-2-overflow-ip-sampling)               | ETW PMC-overflow → `PERF_PMC_PROFILE`; `-pmcprofile … -stackwalk pmcinterrupt`                   |
+| 3   | [Precise data-source sampling](#concern-3-precise-data-source-sampling) | **Absent publicly** — LBR only; PEBS internal-only; context regs Server 23H2                     |
+| 4   | [Code-space decode](#concern-4-code-space-decode)                       | DbgHelp/PDB; build-id analog = PDB GUID+Age; symbol servers                                      |
+| 5   | [Event space & tracing](#concern-5-event-space-tracing)                 | ETW + krabsetw; admin / Performance-Log-Users / `SeSystemProfilePrivilege`                       |
+| 6   | [NUMA & topology](#concern-6-numa-topology)                             | `GetLogicalProcessorInformationEx` / `VirtualAllocExNuma`; `QueryWorkingSetEx.Node` (query only) |
+| 7   | [Event naming & encoding](#concern-7-event-naming-encoding)             | Curated `-pmcsources` + Win10-1903 raw `ProfileSource` registration; cross-ISA                   |
+
+### Concern 1: Scalar counting
+
+Two paths, covered in [How it works (a)](#a-hardware-counter-profiling-per-thread-counting).
+HCP gives per-thread accumulated [counts][counting]; without a WDK driver the only
+hardware datum is `CycleTime`, and real PMCs need `KeSetHardwareCounterConfiguration`
+to program the (system-global, single-tenant) counters first. Counters are selected
+by **index**, not by event encoding, and there is no user-visible
+[event-group][event-group] seam — the counters read whatever the global driver
+config holds. ETW's `-pmc` mode is the alternative: PMCs logged on kernel events into
+a trace session. `[literature]`
+
+### Concern 2: Overflow / IP sampling
+
+ETW's PMC-overflow mode is the [overflow-sampling][overflow] analog: a counter counts
+down _N_ events, overflow raises an interrupt, and the handler captures a sample.
+`TraceProfileSourceConfigInfo` selects which sources land in the sample
+([`trace_query_info_class`][etw-tqic]):
+
+> _"Configures the list of profiling sources that will be collected when the
+> performance monitoring counter profile event fires. The collected counters will be
+> emitted as part of the `PERF_PMC_PROFILE` event."_ `[literature]`
+
+The interval is "in number of events of that type" — the [PMI][pmi]-per-N model.
+
+```bash
+# Sample the interrupted IP + stack every 100000 retired instructions
+xperf -on … +pmc_profile -pmcprofile instructionretired -stackwalk pmcinterrupt
+```
+
+```xml
+<!-- WPRP form: sample on PMC overflow -->
+<HardwareCounter>
+  <SampledCounters>
+    <SampledCounter Value="InstructionRetired" Interval="100000"/>
+  </SampledCounters>
+</HardwareCounter>
+```
+
+The sample carries the interrupted instruction pointer and, with
+`-stackwalk pmcinterrupt`, a call stack — never a data address. `[literature]`
+
+### Concern 3: Precise data-source sampling
+
+**Absent from the public surface.** This is the sharpest Windows finding, and it is
+_not_ merely "unimplemented": the full `TRACE_QUERY_INFO_CLASS` enumeration (values
+0–28) was read, and it contains PMC, profile-source, LBR, stack, and context-register
+classes but **no PEBS / data-address / memory-latency class**. The
+[`recording-pmu-events`][wpt-pmu] documentation describes only IP + stack capture
+(`-stackwalk pmcinterrupt`), never a sampled data address. `[literature]`
+
+Yet the kernel _does_ have PEBS plumbing — it is simply walled off from third
+parties. The **undocumented** internal `EVENT_TRACE_INFORMATION_CLASS` enum
+reproduced in krabs lists `EventTracePebsTracingInformation` alongside
+`EventTraceProfileCounterListInformation` and
+`EventTraceProfileEventListInformation`; krabs reaches these through
+`NtSetSystemInformation`, not the documented API. `[source-verified]`
+
+> [!NOTE]
+> **PEBS exists in the kernel but is not exposed.** The presence of
+> `EventTracePebsTracingInformation` in the internal enum
+> ([`perfinfo_groupmask.hpp:155-176`][krabs-pgm]) proves the capability is plumbed;
+> the absence of any matching class in the documented `TRACE_QUERY_INFO_CLASS` proves
+> it is not offered to third-party code. There is no supported way to obtain
+> [data-source attribution][data-source] on Windows.
+
+The two public analogs are both narrower than Intel [PEBS][precise] / ARM SPE (the
+cross-vendor precise-sampling story is [precise-sampling.md][precise-page]'s subject):
+
+- **LBR** [branch records][branch-records] — `TraceLbrConfigurationInfo` (20) /
+  `TraceLbrEventListInfo` (21), public since Win10 19H1 / Server 1903. This is the
+  LBR/BRBE analog, but **branch-only**: no data virtual/physical address, no latency
+  packet. `[literature]`
+- `TraceContextRegisterInfo` (28), Server 23H2+ — "CPU register contents at the moment
+  the specified related event is fired" — general-purpose registers, not a
+  data-address/latency record. `[literature]`
+
+### Concern 4: Code-space decode
+
+[Symbolization][symbolization] uses **DbgHelp**: `SymInitialize`, `SymFromAddr`,
+`SymGetLineFromAddr64`, `StackWalk64`. `[source-verified]` (present in both druntime
+and windows-d — see the [D-bindings callout](#d-bindings)). PDB debug info is
+**out-of-band** — a separate `.pdb` file, unlike DWARF-in-ELF — and is resolved via
+symbol servers keyed by `_NT_SYMBOL_PATH`. The [build-id][build-id] analog is the
+**PDB GUID + Age** carried in the CodeView `RSDS` debug directory; matching it guards
+the stale-binary hazard exactly as an ELF build-id does. `[literature]` The
+address-space model (Linux's `PERF_RECORD_MMAP2`) is supplied by ETW image-load
+events (loader keyword) plus `TraceProviderBinaryTracking` (18, Win10 1709+), which
+emits a provider-GUID → module-path map. `[literature]` Module enumeration lives in
+`psapi` (`EnumProcessModules`, `GetModuleInformation`, `GetMappedFileNameW`).
+`[source-verified]`
+
+### Concern 5: Event space & tracing
+
+ETW _is_ the [event-space][event-space] concern on Windows, and [`krabsetw`][krabs]
+is the open consumption model — the pipeline and the undocumented
+`PERFINFO_GROUPMASK` enable path are covered in
+[How it works (b)](#b-the-etw-pipeline). Access is gated
+([`starttrace`][etw-start]):
+
+> _"Only users with administrative privileges, users in the Performance Log Users
+> group, and services running as LocalSystem …"_ `[literature]`
+
+PMC / system-logger sessions additionally require `SeSystemProfilePrivilege` —
+effectively elevation. This is the Windows face of the survey's
+[privilege-gating][gating] concern.
+
+### Concern 6: NUMA & topology
+
+Topology enumeration is `GetLogicalProcessorInformationEx` (with the
+`RelationNumaNode` relationship in `SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX`),
+`GetNumaHighestNodeNumber`, `GetNumaProcessorNodeEx`; node-targeted allocation is
+`VirtualAllocExNuma`. `[source-verified]` The [page → node oracle][numa] — Linux's
+`move_pages()` in query mode — has one analog: `QueryWorkingSetEx`, whose
+`PSAPI_WORKING_SET_EX_INFORMATION.VirtualAttributes` union
+(`PSAPI_WORKING_SET_EX_BLOCK`) carries a per-page **`Node`** field. `[source-verified]`
+
+But this answers "which node backs _this VA_?", not "which node served _this sampled
+access_?" Because [Concern 3](#concern-3-precise-data-source-sampling) has no
+sampled-address path, **there is no sampled-data-address → NUMA-node attribution on
+Windows** the way `PERF_SAMPLE_PHYS_ADDR` + `move_pages` provides on Linux. Page → node
+is queryable only for a VA already known to the profiler. `[literature]` (derived from
+the concern-3 absence).
+
+### Concern 7: Event naming & encoding
+
+The named-event surface is a **curated architectural profile-source set** enumerated
+by `wpr -pmcsources` / `xperf -pmcsources`: `Timer`, `TotalIssues`,
+`BranchInstructions`, `CacheMisses`, `BranchMispredictions`, `TotalCycles`,
+`UnhaltedCoreCycles`, `InstructionRetired`, `UnhaltedReferenceCycles`, `LLCReference`,
+`LLCMisses` (plus `*Fixed` names for fixed counters). `[literature]` This is the
+curated counterpart to [`libpfm4`][event-naming]'s name → `{type, config}` table; the
+cross-OS naming problem it lands in is [event-naming.md][event-naming-page]'s subject.
+
+Raw, non-architectural events **are** registerable **since Win10 1903** — but only as
+a **system-global registration**, never as an inline per-acquisition encoding. The
+registration lives in a WPRP fragment or the registry, keyed by exact CPU
+family/model:
+
+```xml
+<!-- WPRP: register a raw Intel event as a named profile source (system-global) -->
+<MicroArchitecturalConfig>
+  <ProfileSource Architecture="INTEL" Event="0x48" Unit="0x01"
+                 ExtendedBits="01000100" Name="…" Interval="…"/>
+</MicroArchitecturalConfig>
+```
+
+```text
+Registry equivalent (per exact CPU family/model):
+  HKLM\SYSTEM\CurrentControlSet\Control\WMI\ProfileSource\<Model>\<Name>
+  values: Event, Unit, Interval
+```
+
+The Intel `ExtendedBits` field decodes to "CMask CMaskInvert AnyThread EdgeDetect".
+This is the [`perf_event_attr.{type, config}`][event-naming] analog **minus** the
+inline-per-open flexibility: the encoding lives in a registered table, not in the
+acquisition call. Notably the naming surface is **CPU-vendor-neutral and cross-ISA** —
+the same ETW/profile-source layer serves Intel, AMD, and **ARM64** (the WPT doc's
+example registers a Qualcomm Snapdragon custom counter), abstracting across ISAs at
+the profile-source layer where Linux keeps a per-arch `perf_event_attr.config`.
+`[literature]`
+
+---
+
+## The W1 role-replacement table
+
+Each Linux (W1) acquisition mechanism and its nearest Windows equivalent, with the
+source that grounds it and the verification tag.
+
+| Linux (W1) role                                           | Windows equivalent                                                                    | Source                                                                  | Tag                                |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------- |
+| [`perf_event_open`][linux] counting (`PERF_FORMAT_GROUP`) | HCP `EnableThreadProfiling` / `ReadThreadProfilingData`; ETW `-pmc` on events         | `winbase.h`; [`recording-pmu-events`][wpt-pmu]                          | `[literature]`                     |
+| `perf_event_open` sampling + ring buffer                  | ETW PMC-overflow (`TraceProfileSourceConfigInfo` → `PERF_PMC_PROFILE`); `-pmcprofile` | [`trace_query_info_class`][etw-tqic]; `recording-pmu-events`            | `[literature]`                     |
+| [PEBS][precise] / `PERF_SAMPLE_DATA_SRC` precise          | **none public**; LBR (`TraceLbrConfigurationInfo`); PEBS internal-only                | `trace_query_info_class`; [`perfinfo_groupmask.hpp:155-176`][krabs-pgm] | `[source-verified]`/`[literature]` |
+| [`libdwfl`][elfutils] addr → line + inline                | DbgHelp `SymGetLineFromAddr64` + PDB / DIA SDK                                        | [`dbghelp`][dbg-line]; druntime `dbghelp.d`                             | `[source-verified]`/`[literature]` |
+| [`libtraceevent`][libtraceevent] + tracefs `format`       | ETW TDH schema + krabs provider/parser                                                | [`krabsetw`][krabs] `etw.hpp`, `kernel_providers.hpp`                   | `[source-verified]`                |
+| [`libnuma`][libnuma] `set_mempolicy` / `move_pages`       | `VirtualAllocExNuma`; `QueryWorkingSetEx.Node` (query only)                           | [`windows-d`][winmd] `memory`, `processstatus`; [`numa`][numa-qws]      | `[source-verified]`/`[literature]` |
+| [`libpfm4`][event-naming] name → `{type, config}`         | `-pmcsources` curated names + `ProfileSource` registry `Event`/`Unit`                 | [`recording-pmu-events`][wpt-pmu]                                       | `[literature]`                     |
+| [Build-id][build-id] (ELF `NT_GNU_BUILD_ID`)              | PDB **GUID + Age** (CodeView `RSDS`)                                                  | (PE/PDB standard)                                                       | `[literature]`                     |
+
+---
+
+## D bindings
+
+> [!IMPORTANT]
+> **druntime covers only two of the seven Windows roles.** ldc-1.41.0
+> `core.sys.windows` has DbgHelp and psapi — and **nothing else**: no ETW, no
+> HCP/thread-profiling, no NUMA/topology `*Ex` at all (a full grep found none of
+> `EnableThreadProfiling`, `TraceSetInformation`, `GetLogicalProcessorInformationEx`,
+> `VirtualAllocExNuma`, `QueryWorkingSetEx`). `winperf.d` is the registry PDH
+> counter path, not the PMU. Three of the four Windows surfaces have **zero**
+> druntime coverage. `[source-verified]`
+
+What druntime **does** ship, and can be reused directly:
+
+- `dbghelp.d` — lazily-loaded function pointers via `GetProcAddress`: `SymInitialize`,
+  `StackWalk64`, `SymSetOptions`, `SymGetLineFromAddr64`, `SymGetSymFromAddr64`,
+  `SymLoadModule64` (`dbghelp.d:27-92`). `[source-verified]`
+- `psapi.d` — `EnumProcessModules`, `GetModuleInformation`, `GetMappedFileNameW`
+  (`psapi.d:102,108,133`). `[source-verified]`
+
+The gaps are all already generated by [`windows-d`][winmd] `@ f34527e` (a
+win32metadata → D projection). **Recommendation for the backend proposal: pull these
+four generated modules rather than hand-write `extern(Windows)` prototypes.**
+`[source-verified]`
+
+| Role    | `windows-d` module                                                               | Key symbols (line)                                                                                                                                                           |
+| ------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HCP     | `…/system/performance/hardwarecounterprofiling.d`                                | `EnableThreadProfiling` (51); `PERFORMANCE_DATA` with `HARDWARE_COUNTER_DATA[16] HwCounters` (44); `HARDWARE_COUNTER_DATA` (26-32)                                           |
+| ETW     | `…/system/diagnostics/etw.d`                                                     | `TRACE_QUERY_INFO_CLASS` (143); `EVENT_TRACE_PROPERTIES` (1539); `StartTraceW` (2279)                                                                                        |
+| NUMA    | `…/system/systeminformation.d`, `…/memory/package.d`, `…/system/processstatus.d` | `GetLogicalProcessorInformationEx` (769), `GetNumaHighestNodeNumber` (1009); `VirtualAllocExNuma` (743); `QueryWorkingSetEx` / `PSAPI_WORKING_SET_EX_BLOCK.Node` (80,99,102) |
+| DbgHelp | `…/system/diagnostics/debug_/package.d`                                          | `SymInitialize` (7046), `SymFromAddr` (7176), `SymGetLineFromAddr64` (7252)                                                                                                  |
+
+---
+
+## Strengths
+
+- **Per-thread accumulated counting works in usermode** without a session — HCP's
+  `CycleTime` needs no driver, and `HwCounters[]` surfaces up to 16 PMCs once a driver
+  configures them.
+- **ETW is a genuinely rich event-space backbone** — PMC-on-event counting, PMC
+  overflow IP+stack sampling, and LBR branch records, all through one logger with a
+  documented config-class surface and an open consumer ([`krabsetw`][krabs]).
+- **Cross-ISA event naming at the profile-source layer** — the same `-pmcsources`
+  vocabulary and `ProfileSource` registration serve Intel, AMD, and ARM64, above the
+  vendor encoding.
+- **Out-of-band PDB + GUID/Age build-id** give a clean stale-binary guard and a
+  mature symbol-server ecosystem for [symbolization][symbolization].
+- **NUMA topology and placement are fully covered** by Win32 (`*InformationEx`,
+  `VirtualAllocExNuma`), and per-page node is queryable via `QueryWorkingSetEx`.
+
+## Weaknesses
+
+- **No unified acquisition API** — three disjoint surfaces (HCP, ETW, ring-0 driver)
+  with different privilege models, vocabularies, and data types, versus Linux's single
+  `perf_event_open`.
+- **Arbitrary events need a closed kernel driver** (VTune SEP / AMD uProf); the HAL
+  exposes only a curated profile-source list to unprivileged callers.
+- **No public precise / data-source sampling** — PEBS is plumbed in the kernel but
+  walled off ([`EventTracePebsTracingInformation`][krabs-pgm]); the only public
+  precise-ish signals are branch-only LBR and (Server 23H2) GP-register capture.
+- **No sampled-address → NUMA-node attribution** — page → node is queryable only for a
+  known VA, never for a sampled memory access.
+- **Counter model is system-global and single-tenant** — one profiling application at
+  a time; counters selected by index, programmed by a driver for the whole machine.
+- **The load-bearing kernel-logger paths are undocumented** — the extended
+  `PERFINFO_GROUPMASK` enable and the internal PEBS enum are krabs-reverse-engineered,
+  not contract.
+- **druntime coverage is minimal** — only DbgHelp + psapi; ETW/HCP/NUMA must come from
+  `windows-d` or be hand-written.
+
+## Key design decisions and trade-offs
+
+| Decision                                                     | Rationale                                                      | Trade-off                                                                         |
+| ------------------------------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Three disjoint surfaces (HCP / ETW / ring-0 driver)          | Each role served by the team/subsystem that owns it            | No common seam; a harness picks per concern and stitches three data models        |
+| HCP delegates PMU programming to a WDK driver                | Keeps the usermode API tiny and safe; counters owned centrally | Driver-free = `CycleTime` only; real PMCs need ring-0 config, system-global       |
+| Counters selected by **index**, not event encoding           | Usermode never touches raw event selectors                     | Cannot express an arbitrary event inline; the encoding lives in a driver/registry |
+| Single-tenant, system-global counter configuration           | One arbiter avoids cross-tool counter contention               | Only one profiling application at a time; no per-fd scheduling like Linux         |
+| Curated HAL profile-sources + global raw registration escape | Small vetted vocabulary; raw events possible but controlled    | No inline `perf_event_attr.config`; raw events need a system-global registration  |
+| PEBS kept internal to the kernel                             | (Microsoft's choice; capability exists)                        | No public precise/data-source sampling; third parties get LBR + context regs only |
+| ETW as the sampling + event-space backbone                   | One logger, documented config classes, TDH-typed events        | Newer providers need the undocumented `PERFINFO_GROUPMASK` path                   |
+| Out-of-band PDB + GUID/Age identity                          | Ships stripped binaries; symbol servers resolve on demand      | Symbolization needs `_NT_SYMBOL_PATH` + exact GUID+Age match                      |
+
+---
+
+## Sources
+
+- [`_hcp/` — Hardware Counter Profiling overview][hcp-overview] ·
+  [`EnableThreadProfiling`][hcp-enable] · [`ReadThreadProfilingData`][hcp-read] —
+  `winbase.h` per-thread counting, index-not-encoding, driver requirement. `[literature]`
+- [`PERFORMANCE_DATA`][ns-perfdata] · [`HARDWARE_COUNTER_DATA`][ns-hcdata] ·
+  [`HARDWARE_COUNTER_TYPE`][ne-hctype] — `winnt.h` structures; `CycleTime` the only
+  driver-free datum; `PMCCounter` the only real type. `[literature]`
+- [`KeSetHardwareCounterConfiguration`][wdk-ke] — WDK driver routine; global,
+  single-tenant counter configuration. `[literature]`
+- [`TraceSetInformation`][etw-tsi] · [`TRACE_QUERY_INFO_CLASS`][etw-tqic] ·
+  [`EVENT_TRACE_PROPERTIES`][etw-props] · [`StartTraceW`][etw-start] — ETW control +
+  PMU config classes with version floors. `[literature]`
+- [WPT — Recording PMU Events][wpt-pmu] · [Using xperf profiles][wpt-xperf] — `-pmc`,
+  `-pmcprofile`, `-pmcsources`, WPRP `HardwareCounter`, raw `ProfileSource`
+  registration, the curated-HAL-subset quote. `[literature]`
+- [`SymFromAddr`][dbg-sym] · [`SymGetLineFromAddr64`][dbg-line] — DbgHelp
+  symbolization; PDB GUID+Age build-id analog. `[literature]`
+- [`GetLogicalProcessorInformationEx`][numa-glpi] · [`VirtualAllocExNuma`][numa-vaen] ·
+  [`QueryWorkingSetEx`][numa-qws] — Win32 topology, placement, page → node query.
+  `[literature]`
+- [`krabsetw`][krabs] `@ 6900de05` — open ETW consumer: `etw.hpp` (trace lifecycle,
+  `set_trace_information`), `kt.hpp` (undocumented group-mask enable),
+  [`perfinfo_groupmask.hpp:155-176`][krabs-pgm] (internal `EVENT_TRACE_INFORMATION_CLASS`
+  incl. `EventTracePebsTracingInformation`), `kernel_providers.hpp`. `[source-verified]`
+- [`windows-d`][winmd] `@ f34527e` — win32metadata → D projection carrying every gap
+  druntime lacks (HCP, ETW, NUMA), recommended for the backend proposal.
+  `[source-verified]`
+- druntime `core.sys.windows` (ldc-1.41.0) — `dbghelp.d:27-92`, `psapi.d:102,108,133`
+  present; ETW/HCP/NUMA absent (grep). `[source-verified]`
+- Claim-by-claim provenance and the full saved-docs URL map are recorded in the
+  survey's internal QA ledger (repos and captures pinned by SHA/date).
+
+> [!NOTE]
+> **No runnable CI example ships with this page.** The survey's convention is a
+> [CI-compiled probe][linux] per deep-dive, but there is no Windows host in CI and
+> no Windows hardware was available; every claim here is `[literature]` (saved docs)
+> or `[source-verified]` (open-source reads). A D program built against the
+> [`windows-d`][winmd] HCP/ETW modules would compile only on Windows and could only
+> print a `SKIP:` line off-platform, so it is deferred to the
+> [backend proposal][comparison] rather than shipped as a non-load-bearing example.
+
+<!-- References -->
+
+[concepts]: ./concepts.md
+[counting]: ./concepts.md#counting
+[event-group]: ./concepts.md#event-group
+[overflow]: ./concepts.md#overflow-sampling
+[pmi]: ./concepts.md#pmi-performance-monitoring-interrupt
+[precise]: ./concepts.md#precise-sampling-and-skid
+[data-source]: ./concepts.md#data-source-attribution
+[branch-records]: ./concepts.md#branch-records
+[symbolization]: ./concepts.md#symbolization
+[build-id]: ./concepts.md#build-id
+[event-space]: ./concepts.md#event-space-and-tracepoints
+[numa]: ./concepts.md#numa-topology-and-page-node-oracles
+[event-naming]: ./concepts.md#event-naming-and-encoding
+[curation]: ./concepts.md#capability-curation
+[gating]: ./concepts.md#privilege-gating
+[linux]: ./linux-perf-events.md
+[precise-page]: ./precise-sampling.md
+[elfutils]: ./elfutils.md
+[libtraceevent]: ./libtraceevent.md
+[libnuma]: ./libnuma.md
+[event-naming-page]: ./event-naming.md
+[macos]: ./macos.md
+[comparison]: ./comparison.md
+[krabs]: https://github.com/microsoft/krabsetw/tree/6900de05d8ad7a38867719974f0406d5fd57af02
+[krabs-kt]: https://github.com/microsoft/krabsetw/blob/6900de05d8ad7a38867719974f0406d5fd57af02/krabs/krabs/kt.hpp#L63-L66
+[krabs-pgm]: https://github.com/microsoft/krabsetw/blob/6900de05d8ad7a38867719974f0406d5fd57af02/krabs/krabs/perfinfo_groupmask.hpp#L155-L176
+[winmd]: https://github.com/rumbu13/windows-d/tree/f34527ed18958ca94749c3934167ff66ec0156cc
+[hcp-overview]: https://learn.microsoft.com/windows/win32/api/_hcp/
+[hcp-enable]: https://learn.microsoft.com/windows/win32/api/winbase/nf-winbase-enablethreadprofiling
+[hcp-read]: https://learn.microsoft.com/windows/win32/api/winbase/nf-winbase-readthreadprofilingdata
+[ns-perfdata]: https://learn.microsoft.com/windows/win32/api/winnt/ns-winnt-performance_data
+[ns-hcdata]: https://learn.microsoft.com/windows/win32/api/winnt/ns-winnt-hardware_counter_data
+[ne-hctype]: https://learn.microsoft.com/windows/win32/api/winnt/ne-winnt-hardware_counter_type
+[wdk-ke]: https://learn.microsoft.com/windows-hardware/drivers/ddi/ntddk/nf-ntddk-kesethardwarecounterconfiguration
+[etw-tsi]: https://learn.microsoft.com/windows/win32/api/evntrace/nf-evntrace-tracesetinformation
+[etw-tqic]: https://learn.microsoft.com/windows/win32/api/evntrace/ne-evntrace-trace_query_info_class
+[etw-props]: https://learn.microsoft.com/windows/win32/api/evntrace/ns-evntrace-event_trace_properties
+[etw-start]: https://learn.microsoft.com/windows/win32/api/evntrace/nf-evntrace-starttracew
+[wpt-pmu]: https://learn.microsoft.com/windows-hardware/test/wpt/recording-pmu-events
+[wpt-xperf]: https://learn.microsoft.com/windows-hardware/test/wpt/using-xperf-profiles
+[dbg-sym]: https://learn.microsoft.com/windows/win32/api/dbghelp/nf-dbghelp-symfromaddr
+[dbg-line]: https://learn.microsoft.com/windows/win32/api/dbghelp/nf-dbghelp-symgetlinefromaddr64
+[numa-glpi]: https://learn.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex
+[numa-vaen]: https://learn.microsoft.com/windows/win32/api/memoryapi/nf-memoryapi-virtualallocexnuma
+[numa-qws]: https://learn.microsoft.com/windows/win32/api/psapi/nf-psapi-queryworkingsetex

--- a/lychee.exclude
+++ b/lychee.exclude
@@ -78,3 +78,8 @@
 ^https?://cgit\.git\.savannah\.gnu\.org/
 # Ignore specs/event-horizon/ links until the feat/event-horizon branch is merged
 specs/event-horizon/
+# The cpu-pmu research baseline (docs/research/cpu-pmu/sparkles-baseline.md)
+# documents the test-runner counter modules that land with PR #88
+# (feat/test-runner-perf); until that merges, its relative source links have
+# no target on main. Drop this block once PR #88 is merged.
+/libs/test-runner-impl/src/sparkles/test_runner/(perf|perf_group|tier0|syscalls|metrics|bench_json)\.d$

--- a/lychee.toml
+++ b/lychee.toml
@@ -36,6 +36,7 @@ exclude_path = [
     '^AGENTS\.md$',
     '^docs/research/parsing/grounding/',
     '^docs/research/units-of-measure/grounding/',
+    '^docs/research/cpu-pmu/grounding/',
 ]
 
 # Don't check URLs inside code blocks (they're often illustrative, not real)

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -119,6 +119,20 @@
                 ]) d-toolchain.env
               )
             );
+            # The cpu-pmu research probes (docs/research/cpu-pmu/examples) link
+            # C libraries via `libs "dw" "elf"` / `libs "pfm"`. Inside the
+            # devshell the shellHook exports these paths (nix/shells); carry
+            # them in the wrapper too so `nix run .#ci -- --example-files`
+            # links them outside any shell.
+            exampleLibPath = lib.optionalString pkgs.stdenv.isLinux (
+              lib.makeSearchPath "lib" [
+                pkgs.elfutils.out
+                pkgs.libpfm
+              ]
+            );
+            exampleLibArgs = lib.optionalString (
+              exampleLibPath != ""
+            ) "--prefix LIBRARY_PATH : ${exampleLibPath} --prefix LD_LIBRARY_PATH : ${exampleLibPath}";
           in
           ''
             install -Dm755 build/${finalAttrs.pname} $out/bin/${finalAttrs.pname}
@@ -134,6 +148,7 @@
               wrapProgram $out/bin/${finalAttrs.pname} \
                 --prefix PATH : ${path} \
                 ${setEnv} \
+                ${exampleLibArgs} \
                 --run 'ulimit -n ${toString d-toolchain.nofileLimit} 2>/dev/null || true'
             '';
 

--- a/nix/shells/default.nix
+++ b/nix/shells/default.nix
@@ -144,6 +144,14 @@
             pkgs.wayland
             pkgs.wayland.dev
             pkgs.xvfb-run
+
+            # CPU-PMU research probes (docs/research/cpu-pmu/examples): the
+            # symbolization/unwind probes link `libs "dw" "elf"` and the
+            # event-naming probe links `libs "pfm"`. Neither library is found
+            # by `nix shell` alone (no setup hooks run), so they're shell
+            # packages here with LIBRARY_PATH/LD_LIBRARY_PATH exports below.
+            pkgs.elfutils
+            pkgs.libpfm
           ]
           ++ lib.optional greeting pkgs.figlet
           ++ d-toolchain.packages;
@@ -162,6 +170,13 @@
             export LIBRARY_PATH="${pythonEnv}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
             export LD_LIBRARY_PATH="${pythonEnv}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             export PYTHONPATH="${pythonEnv}/${pythonEnv.sitePackages}''${PYTHONPATH:+:$PYTHONPATH}"
+
+            ${lib.optionalString pkgs.stdenv.isLinux ''
+              # CPU-PMU research probes: libdw/libelf (elfutils) and libpfm for
+              # `dub run --single` linking (`libs "dw" "elf"` / `libs "pfm"`).
+              export LIBRARY_PATH="${pkgs.elfutils.out}/lib:${pkgs.libpfm}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+              export LD_LIBRARY_PATH="${pkgs.elfutils.out}/lib:${pkgs.libpfm}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            ''}
 
             ${lib.optionalString greeting "figlet 'sparkles : *'"}
           ''


### PR DESCRIPTION
## What

A source-grounded research tree under `docs/research/cpu-pmu/` on native CPU-PMU integration for the benchmarking harness (`test-runner --bench` + the wired runtime bench), per the [research-docs guidelines](docs/guidelines/research-docs.md):

- **Umbrella + concepts + 10 deep-dives** on a uniform seven-concern analysis spine: the Linux `perf_event_open` hub and its decoder libraries (`elfutils`, `libtraceevent`, `libnuma`), precise memory sampling (**IBS hw-verified on Zen 4**; PEBS/ARM SPE source-verified), the **ARMv8+**/**RISC-V** ISA mappings, the **Windows** (HCP/ETW) and **macOS** (kpc/kperf/rusage, measured on an M4 Max) backends, and the event-naming layers (libpfm4, PAPI, LIKWID, vendor tables).
- **`comparison.md`** — capability matrix (7 concerns × ISA × OS, absences explicit), consensus + trade-offs, and the **delta table** mapping each capability to where the sparkles layer stands.
- **`sparkles-baseline.md` / `backend-proposal.md`** — the observed-behavior baseline of today's `perf.d`/`metrics.d` layer (the audit target) and a 6-milestone backend proposal sketched in D against the `MetricDescriptor`/`MetricClass` + `CounterGroups` seam.
- **5 runnable probes** in `examples/` (pure-D `perf_event_open`, ring-buffer sampling + libdwfl symbolization, DWARF-CFI unwind of a frame-pointer-less build, IBS mem-latency + page→node oracles, libpfm4 name→encoding round trip) — registered in the `ci` helper's example defaults; each `SKIP`s cleanly off-capability.
- **`grounding/`** — internal QA ledgers (pinned repo SHAs, per-page claim tables, a 22-row discrepancy register of corrected hypotheses), excluded from the site and lychee.

## Headline findings

- The Zen 4 test box has **no PEBS** (`cpu` PMU `max_precise=0`) — IBS is the sole precise engine, and its bare `exclude_*` attrs are `EINVAL` (needs `swfilt`).
- `PERF_RECORD_MMAP2` is emitted only for mappings created while enabled — a real build-id/stale-binary hazard for a self-profiling harness.
- **Apple changed PMU event numbering at M4** to PMUv3-architected values (confirmed from both macOS kpep DBs and xnu source); macOS `kpc` is root-only, the unprivileged floor is `proc_pid_rusage`, and the DTrace `cpc` provider does not exist.
- RISC-V CTR is ratified (2024-11-22) but has **no Linux consumer**; host sampling needs only Sscofpmf (AIA is guest-delivery only).
- **No event-naming layer spans OSes**, and stock libpfm 4.13.0 cannot detect this Zen 4 model — the proposal's backends must own their vocabulary.

## Relationship to #88

`sparkles-baseline.md` documents the counter layer that lands with #88 (`feat/test-runner-perf`) and links its modules; until that merges, those six relative `.d` links have no target on `main`, so they are temporarily excluded in `lychee.exclude` (commented block — drop it once #88 is in). VitePress ignores `.d` links, so `docs:build` is unaffected.

## Verification

- `npm run docs:build` green; every intra-tree anchor validated against the built HTML ids.
- `dub run :ci -- -x --files 'docs/research/cpu-pmu/examples/*.d'` → 5/5 pass (Linux 6.18.26, Ryzen 9 7940HX; probes `SKIP` cleanly elsewhere).
- lychee (CI wrapper, offline) → 0 errors across the tree.
- The devshell now carries `elfutils` + `libpfm` on the linker path so `ci --example-files` links the three C-linking probes in CI.

macOS evidence is recorded transcripts (M4 Max, macOS 26.3.1, SIP enabled, unprivileged) — CI cannot reach that box. ARM-Linux/RISC-V/Windows columns are source/literature-verified by construction (no such hardware); the gated primaries (Arm ARM DDI 0487 K.a, SPE whitepaper, Intel SDM, Zen 4 PPR) are cited by section per the guardrails.