### PR TITLE
docs(test-runner): measurement-layer spec, delivery plan, and open-issues ledger

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -452,6 +452,14 @@ export default withMermaid(
               ],
             },
             {
+              text: 'Test Runner',
+              collapsed: false,
+              items: [
+                { text: 'Specification', link: '/specs/test-runner/SPEC' },
+                { text: 'Delivery Plan', link: '/specs/test-runner/PLAN' },
+              ],
+            },
+            {
               text: 'Versions',
               collapsed: false,
               items: [

--- a/docs/research/cpu-pmu/backend-proposal.md
+++ b/docs/research/cpu-pmu/backend-proposal.md
@@ -18,6 +18,13 @@ results. Every milestone cross-links the prior art it borrows from.
 | Evidence base    | [comparison.md][comparison] capability matrix + the per-subject deep-dives                 |
 | Shape            | 6 milestones: seam → Linux depth → macOS floor → Windows floor → precise memory → sampling |
 
+> [!NOTE]
+> Sequencing and delivery tracking live in the test-runner
+> [delivery plan](../../specs/test-runner/PLAN.md), which interleaves these
+> six milestones (as **B1–B6**) with the workload-harness track and carries
+> the research-derived amendments per milestone. This page remains the
+> design rationale.
+
 ---
 
 ## 1. Abstract & problem statement

--- a/docs/research/cpu-pmu/comparison.md
+++ b/docs/research/cpu-pmu/comparison.md
@@ -140,20 +140,20 @@ identical perf ABI with firmware owning the counters via SBI).
 Each survey capability against [today's layer][baseline], with the
 [proposal][proposal] milestone that closes the gap.
 
-| Capability (best practice found)                                           | sparkles today                                                  | Gap                                                                   | Closes in                                             |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------- |
-| Grouped counting, exact (all-or-nothing groups)                            | ✅ 7-event group, calibration-drop of LLC pair                  | none — matches the survey's exact-counts stance                       | —                                                     |
-| Labeled multiplex estimates (`enabled/running` scaling, ~1% at 10-on-6)    | ❌ avoided entirely (columns dropped instead)                   | estimates never offered, coverage silently narrows                    | M2 (`countingScaled`)                                 |
-| Raw / per-µarch event selectors + naming tables                            | ❌ 7 hardcoded generics                                         | no vocabulary beyond `PERF_COUNT_*`; nothing µarch-specific reachable | M2 (`countingRaw`, `eventNaming`)                     |
-| [Self-monitoring][c-rdpmc] reads (rdpmc seqlock, ~10× cheaper bracket)     | ❌ `read(2)`/`ioctl(2)` per pass                                | syscall-priced brackets on very short bodies                          | M2 (`selfMonitoring`)                                 |
-| Overflow/IP sampling + flat profiles                                       | ❌ absent                                                       | "what regressed" but never "where"                                    | M6 (`ipSampling`)                                     |
-| Precise memory sampling (IBS skid-0 on this hardware; `perf_mem_data_src`) | ❌ absent                                                       | no latency distributions, no data addresses                           | M5 (`preciseMemory`)                                  |
-| Symbolization + build-id validation (libdwfl; stale-binary hazard)         | ❌ absent                                                       | nothing to attribute samples to                                       | M6 (`symbolization`)                                  |
-| Event-space gating (tracepoints beyond syscalls; PSI, sched)               | ⚠️ syscall counting only, root-gated tracefs correctly detected | no scheduling/fault/pressure context                                  | later (M11 of the [metric-catalog roadmap][baseline]) |
-| NUMA topology + page→node oracles                                          | ❌ absent                                                       | single-node today, but zero awareness even of that                    | M5 (`numaAttribution`)                                |
-| macOS floor (`proc_pid_rusage` unprivileged instructions/cycles)           | ❌ stub                                                         | loses _all_ counters on a platform that offers a real floor           | M3                                                    |
-| Windows floor (`CycleTime` driver-free; ETW when elevated)                 | ❌ stub                                                         | same cliff                                                            | M4                                                    |
-| Capability reporting ("unavailable because X")                             | ⚠️ per-tier `status()` strings                                  | absences not enumerated per capability                                | M1                                                    |
+| Capability (best practice found)                                           | sparkles today                                                  | Gap                                                                   | Closes in                                   |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------- |
+| Grouped counting, exact (all-or-nothing groups)                            | ✅ 7-event group, calibration-drop of LLC pair                  | none — matches the survey's exact-counts stance                       | —                                           |
+| Labeled multiplex estimates (`enabled/running` scaling, ~1% at 10-on-6)    | ❌ avoided entirely (columns dropped instead)                   | estimates never offered, coverage silently narrows                    | M2 (`countingScaled`)                       |
+| Raw / per-µarch event selectors + naming tables                            | ❌ 7 hardcoded generics                                         | no vocabulary beyond `PERF_COUNT_*`; nothing µarch-specific reachable | M2 (`countingRaw`, `eventNaming`)           |
+| [Self-monitoring][c-rdpmc] reads (rdpmc seqlock, ~10× cheaper bracket)     | ❌ `read(2)`/`ioctl(2)` per pass                                | syscall-priced brackets on very short bodies                          | M2 (`selfMonitoring`)                       |
+| Overflow/IP sampling + flat profiles                                       | ❌ absent                                                       | "what regressed" but never "where"                                    | M6 (`ipSampling`)                           |
+| Precise memory sampling (IBS skid-0 on this hardware; `perf_mem_data_src`) | ❌ absent                                                       | no latency distributions, no data addresses                           | M5 (`preciseMemory`)                        |
+| Symbolization + build-id validation (libdwfl; stale-binary hazard)         | ❌ absent                                                       | nothing to attribute samples to                                       | M6 (`symbolization`)                        |
+| Event-space gating (tracepoints beyond syscalls; PSI, sched)               | ⚠️ syscall counting only, root-gated tracefs correctly detected | no scheduling/fault/pressure context                                  | [delivery plan][plan] M5 (PSI) / M9 (sched) |
+| NUMA topology + page→node oracles                                          | ❌ absent                                                       | single-node today, but zero awareness even of that                    | M5 (`numaAttribution`)                      |
+| macOS floor (`proc_pid_rusage` unprivileged instructions/cycles)           | ❌ stub                                                         | loses _all_ counters on a platform that offers a real floor           | M3                                          |
+| Windows floor (`CycleTime` driver-free; ETW when elevated)                 | ❌ stub                                                         | same cliff                                                            | M4                                          |
+| Capability reporting ("unavailable because X")                             | ⚠️ per-tier `status()` strings                                  | absences not enumerated per capability                                | M1                                          |
 
 ---
 
@@ -223,6 +223,7 @@ mac-bsn transcripts quoted in [macos.md][macos]/[arm.md][arm].
 [spine]: ./#the-seven-concerns
 [baseline]: ./sparkles-baseline.md
 [proposal]: ./backend-proposal.md
+[plan]: ../../specs/test-runner/PLAN.md
 [linux]: ./linux-perf-events.md
 [elfutils]: ./elfutils.md
 [libtraceevent]: ./libtraceevent.md

--- a/docs/specs/test-runner/PLAN.md
+++ b/docs/specs/test-runner/PLAN.md
@@ -1,0 +1,403 @@
+# `sparkles:test-runner` — Benchmark-measurement delivery plan
+
+_Companion to [SPEC.md](./SPEC.md): the milestones that make the marked
+target sections true. Each milestone is independently green (builds + tests +
+lints). Two tracks interleave: the **M-track** (workload harness — the
+[I/O-bench roadmap](#shipped-m1-m3-and-riders)'s M4–M11) and the **B-track**
+(native PMU backends — the research
+[backend proposal](../../research/cpu-pmu/backend-proposal.md)'s milestones
+1–6, referenced here as B1–B6 to keep both numbering schemes unambiguous).
+The audit of the shipped layer is
+[sparkles-baseline.md](../../research/cpu-pmu/sparkles-baseline.md); the
+gap-to-milestone mapping is the
+[delta table](../../research/cpu-pmu/comparison.md#the-delta-table-the-survey-vs-the-sparkles-baseline)._
+
+## Shipped: M1-M3 and riders
+
+Merged via PR [#88](https://github.com/PetarKirov/sparkles/pull/88) and
+audited by the baseline page:
+
+- **M1 — metric catalog** (`metrics.d`): `MetricDescriptor`/`MetricCell`/
+  `MetricClass`, `--metrics`/`--list-metrics`, transitive source opening
+  (SPEC §5).
+- **M2 — tier-0 counters** (`tier0.d`): `getrusage` + `/proc/self/io` deltas
+  with calibrated self-cost subtraction (SPEC §6.1).
+- **M3 — syscall tracepoints** (`syscalls.d`): in-process `strace -c` via
+  `perf_event` tracepoints, tracefs-root-gated (SPEC §6.1, §9).
+- Riders: `--bench-json` + `--bench-min-time`, `skipTest`, `--group-by`/
+  `--sort-by`, the live results ticker, per-pass enabled/running multiplex
+  deltas, raw-tick timing, `benchCase` matrix benchmarks (SPEC §3, §4, §7,
+  §8).
+
+The delta-table row "grouped counting, exact" is closed ("none — matches");
+every other row maps to a milestone below.
+
+## Design invariants
+
+Carried from the original roadmap, amended by the research:
+
+- **The catalog seam composes everything** (SPEC §5): a new source is one
+  `Nullable!XStats` field, three lifecycle lines, and a cells/family pair.
+- **Two source shapes** (SPEC §6.1): bracketed (per-iteration ioctl window)
+  and snapshot/delta (window-friendly). **Degrade, never fail**; capability
+  is a **runtime probe result**, never a compile-time assumption.
+- **Quantitative vs diagnostic is structural** (SPEC §1): reported/gated
+  numbers read only quantitative fields; diagnostic renders separately.
+- **Acquisition stays pure D.** druntime's `core.sys.linux.perf_event`
+  models the full ring-buffer/record/mmap-page ABI — even the B6 sampler
+  needs no C shim. C libraries enter only as _soft_ dependencies that
+  degrade to advertised absence: libpfm4 (B2) and libdw (B6) via dlopen or
+  an opt-in build config; **never libnuma** (no `numa.pc`, the syscalls are
+  not in glibc — call raw `get_mempolicy`/`move_pages`); no libtraceevent
+  (it decodes caller-supplied buffers only — M9 scopes a small pure-D decode
+  core instead). **Naming data is offline-only**: LIKWID / intel-perfmon /
+  kernel pmu-events JSONs are references to harvest, never runtime deps.
+  Nix: nixpkgs libpfm ships no `.pc` → devshell `buildInputs` +
+  `NIX_LDFLAGS`, needed in **both** the shellHook and the `ci` wrapper (the
+  research probes' proven CI path); elfutils (tested 0.194) enters
+  `buildInputs` likewise if B6 takes the link-time arm.
+- **Verification-bed honesty** (SPEC §9): the hardware beds are Zen 4 Linux
+  (Ryzen 9 7940HX, `perf_event_paranoid = −1`) and M4 Max macOS (mac-bsn,
+  unprivileged transcripts). ARM-Linux, RISC-V, Intel PEBS, multi-node NUMA,
+  and Windows have **no hardware bed** — those aspects ship
+  source-verified/literature-gated, with `skipTest` degradation and no
+  `[hw-verified]` claims. All paranoid > −1 behavior is literature-derived
+  until probed ([open-issues § O1](./open-issues.md)).
+- **Units seam** (SPEC §5.3): symbol-as-label, `Mode` as the rate stand-in;
+  all format semantics behind `scaled`/`fixed` so the `sparkles.quantities`
+  convergence is localized ([open-issues § O6](./open-issues.md)).
+
+## Milestone order
+
+Interleaved by value; B-track numbers alias
+[backend-proposal.md](../../research/cpu-pmu/backend-proposal.md) §2–§7.
+
+| #   | ID  | Milestone                                                                | Gate / permissions                          |
+| --- | --- | ------------------------------------------------------------------------ | ------------------------------------------- |
+| 1   | B1  | Capability seam (`Capability`/`CapabilityReport`, backend trait)         | none                                        |
+| 2   | B2  | Linux counting depth (raw events, naming, labeled scaling, rdpmc)        | none (soft libpfm4)                         |
+| 3   | M4  | `@workload` window mode + wall decomposition                             | none                                        |
+| 4   | M5  | PSI stall integrals                                                      | `CONFIG_PSI`                                |
+| 5   | B3  | macOS floor (`proc_pid_rusage` counting tier)                            | none (mac-bsn verification)                 |
+| 6   | M6  | Page-cache regime control + residency verify                             | `drop_caches` = root                        |
+| 7   | M7  | Storage provenance fingerprint                                           | none                                        |
+| 8   | M8  | cgroup-v2 isolation + `memory.max` sweep                                 | root / systemd delegation                   |
+| 9   | B5  | Precise memory tier (IBS-first) + NUMA oracles + `LatencyHistogram`      | paranoid; IBS hardware                      |
+| 10  | B6  | Sampling & symbolization (`--bench-profile`)                             | paranoid; `perf_event_mlock_kb`; soft libdw |
+| 11  | M9  | Off-CPU profiler (rebuilt on B6) + biolatency floor                      | tracefs root (Tier B)                       |
+| 12  | M10 | CO-safe open-loop load generator                                         | none                                        |
+| —   | B4  | Windows floor (`CycleTime`; ETW elevated tier)                           | **blocked: no Windows hardware**            |
+| —   | M11 | Gated spikes (eBPF, block tracepoints, SCHED_FIFO, ARM SPE/BRBE, RISC-V) | caps / hardware                             |
+
+Sequencing rationale: B1 is pure reporting value and gives every later
+milestone one absence vocabulary; B2 deepens the mode the harness lives in
+today (raw events make wired's per-byte tables µarch-portable); M4 is the
+keystone the workload track (M5–M8) hangs off; B3 kills the
+"all counters vanish off Linux" cliff cheaply; B5/B6 add the _where_
+dimension and are the only milestones with new soft C dependencies; M9 is
+deliberately after B6 so its Tier B reuses the sampling infrastructure
+instead of hand-rolling one; M10 is independent and can move earlier if
+needed. Each milestone gets a detailed re-plan when reached.
+
+Milestones that cite SPEC sections make those `(target)` passages true;
+milestones without a citation (M7, M8, M10, M11) fold their surface into
+SPEC as new sections when they land.
+
+## B1 — Capability seam
+
+_(backend-proposal §2; SPEC §6.2.)_ `Capability` bitflag enum (one flag per
+survey concern plus real-world sub-splits: `counting`, `countingRaw`,
+`countingScaled`, `selfMonitoring`, `ipSampling`, `preciseMemory`,
+`symbolization`, `eventTracing`, `numaAttribution`, `eventNaming`);
+`CapabilityReport { available; unavailableBecause }`; a DbI
+`isCounterBackend` trait making `CounterGroups`' implicit contract nameable,
+with optional primitives detected by presence. `--list-metrics` gains a
+per-backend capability block; the bench header prints one line per
+absent-but-requested capability.
+
+Hardening from the grounding ledger: the proposal's D sketches are
+**uncompiled design artifacts** (ledger P2) — compile-validate the trait
+against `metrics.d` before freezing the seam. Workload-track sources (M5
+PSI, M6 regime, M8 cgroup) adopt `CapabilityReport` too.
+
+Acceptance: on the dev box the report reproduces the survey's findings —
+`preciseMemory` present via `ibs_op`, `eventTracing` absent (tracefs `0700`);
+`--perf` table output unchanged.
+
+## B2 — Linux counting depth
+
+_(backend-proposal §3; SPEC §6.3, §7.)_ Four capabilities, all probed:
+
+- **`countingRaw`** — `raw:r<hex>` selectors → `PERF_TYPE_RAW`; unlocks
+  umask-qualified µarch events.
+- **`eventNaming`** via **soft** libpfm4, with the proven recipe: encode
+  through `PFM_OS_PERF_EVENT` (privilege modifiers land in
+  `attr.exclude_*`, not config bits); **force tables from CPUID** — stock
+  libpfm 4.13.0 misses Zen 4 model 0x61 — using `LIBPFM_ENCODE_INACTIVE=1`
+  plus an explicit `table::` prefix, **not** `LIBPFM_FORCE_PMU` (exclusive:
+  it breaks generic `cycles`/`instructions` resolution); the D binding must
+  pin `pfm_perf_encode_arg_t` at exactly 40 bytes on LP64 (the ABI0 size
+  check). Reference implementation:
+  [`pfm4-name-roundtrip.d`](../../research/cpu-pmu/examples/pfm4-name-roundtrip.d).
+  Absent libpfm → `eventNaming` advertised absent; numeric selectors still
+  work.
+- **`countingScaled`** (opt-in, labeled): enabled/running scaling per the
+  uAPI formula, with the SPEC §6.3 quality gates — `running == 0` renders
+  "not counted", never 0; sub-millisecond running slices are flagged (the
+  probe measured a 5.7× scale error on a 0.58 ms slice); `--bench-json`
+  marks estimated cells ([open-issues § O4](./open-issues.md)). Default
+  stays exact-or-drop. The seam includes the **group-refused** branch
+  (RISC-V refuses unplaceable groups outright).
+- **`selfMonitoring`** — rdpmc mmap-page seqlock fast path for very short
+  bodies; `cap_user_rdpmc` is arch-set and policy-disableable, so probe and
+  keep the `read(2)` fallback; PMUSERENR (ARM) / `scounteren` (RISC-V) share
+  the flag per-ISA. **Measure the "~10× cheaper" literature claim on-host
+  before advertising it** ([open-issues § O2](./open-issues.md)).
+
+## M4 — `@workload` window mode
+
+_(SPEC §1, §3, §4.)_ New `@workload` marker + `isWorkload` trait;
+`WorkloadWindow` (deliberately **not** `BenchStats` — its per-iteration
+fields misrepresent a single window), `runWorkload`, in-body
+`workloadWindow`; the phase-model driver and `WallDecomposition` with its
+honesty caveats (only runqueue + disk are true per-cause durations; PSI-io
+can overlap runqueue, so the residual clamps at 0 with a status note).
+Renders as its own table. Research amendments: sources report through B1's
+`CapabilityReport`; never assume 4 KiB pages / 64 B lines in window
+accounting (Apple Silicon: 16 KiB / 128 B). JSON serialization of windows is
+[open-issues § O7](./open-issues.md).
+
+## M5 — PSI stall integrals
+
+_(SPEC §4.)_ `PsiSource` (snapshot/delta): parse the monotonic `total=<µs>`
+accumulator from `/proc/pressure/{io,memory,cpu}` (ignore the decaying
+averages); window delta = stall-time integral (quantitative); feeds
+`WallDecomposition.offCpuDisk`. Per-cgroup `*.pressure` reuses the parser
+under M8. `CONFIG_PSI=n` → absence via B1's vocabulary.
+
+## B3 — macOS floor
+
+_(backend-proposal §4; SPEC §9.)_ `proc_pid_rusage(RUSAGE_INFO_V4)` →
+`ri_instructions`/`ri_cycles` as a snapshot-pair tier: true unprivileged
+instructions/cycles/IPC — richer than Linux tier-0 — with the honest scope
+note (process-wide fixed counters, not per-bracket configurable events).
+Capability ads for the rest: kpc is root-or-blessed-pid with the
+`RESTRICT_TO_KNOWN` allowlist (102 events on T6041) and single-owner `EBUSY`
+(Instruments running) as a distinct status; **no DTrace cpc provider
+exists — never plan that route**; sampling is xctrace-brokered only.
+kpep-plist parsing (world-readable, keyed by `hw.cpufamily`) is the naming
+groundwork — **never hardcode Apple selectors**: M4/M5 chips remapped the
+common events onto PMUv3 architected numbers while M1–M3 use Apple numbers,
+and the fixed-counter count is itself unresolved
+([open-issues § O8](./open-issues.md)). Portability rider shared with M7: on
+P/E-core hosts (`hw.nperflevels`) record per-run core-type provenance.
+Verification: mac-bsn transcripts (no darwin CI; build with `ldc2` directly —
+dub fork-ENOMEMs on that box).
+
+## M6 — Page-cache regime control
+
+_(SPEC §4.)_ `CacheRegime { cold, warm, steadyState }`; in-body
+`workloadFiles(regime, paths)`; cold = `posix_fadvise(DONTNEED)` per file
+(drop_caches only as root, else downgrade + note); warm = explicit preload;
+residency verified via `mmap` + `mincore` before/after, stamped on every row
+(`CacheRegimeStamp{requested, effective, residentFraction*, note}`).
+Validity probes: tmpfs ⇒ cold impossible (`effective = steadyState`); zfs ⇒
+cold partial (ARC survives — noted). Amendments: page-size portability
+(16 KiB pages change `mincore` stride and working-set math); B5's
+data-source columns are the future diagnostic "why" for regime effects.
+
+## M7 — Storage provenance fingerprint
+
+Run-level `StorageProvenance{fsType, mountOptions, ioScheduler, deviceClass,
+readaheadKb, thpState, ioModel}` from pure `/proc` + `/sys` reads; declared
+(not sniffable) properties render "declared, not measured"; prints as a
+header banner; degrades field-by-field. Amendment: **re-probe topology per
+boot** — SNC/NPS BIOS modes multiply visible NUMA nodes and re-scope uncore
+counters; never cache node counts across configuration changes.
+
+## M8 — cgroup-v2 isolation and `memory.max` sweep
+
+`CgroupV2{tryCreate, moveSelfIn, setMemoryMax, readStat, destroy}` +
+`CgroupStat` (workingset_refault, file, ioR/Wbytes, cpuUsageUs,
+memPressureTotalUs). Two uses: clean per-window accounting, and
+`memoryMaxSweep(caps, body)` → a performance-vs-cache-size curve rendered as
+sibling rows. Permission reality: root or systemd user delegation
+(`systemd-run --user --scope -p Delegate=yes`); anything less →
+`tryCreate` fails → keep per-process counters, report absence via B1.
+
+## B5 — Precise memory tier
+
+_(backend-proposal §6; SPEC §8.1, §9.)_ Engine-select-then-configure:
+**probe the `ibs_op` sysfs PMU before `cpu/caps/max_precise`** — gating on
+`max_precise` alone silently excludes all AMD. The hw-verified IBS recipe:
+`sample_type = IP|ADDR|DATA_SRC|WEIGHT|PHYS_ADDR`; **privilege filtering via
+the `swfilt` bit (`config2:0`) — bare `exclude_kernel` is `EINVAL` on Zen 4
+and `exclude_hv` is never accepted**; the degrade ladder drops `PHYS_ADDR`
+first (the privilege-gated field); hardware load-latency pre-filter
+(`config1` threshold in [128, 2048] cycles) iff `IBS_CAPS_OPLDLAT`. One
+vendor-neutral `perf_mem_data_src` decoder (the composite
+`mem_lvl_num`/`mem_remote`/`mem_hops`/`mem_snoopx` fields, not the
+deprecated `PERF_MEM_LVL_*` namespace). `WEIGHT` latency aggregates **only
+over DC-miss load samples** (valid-bit gating); hit/miss level histograms
+render separately. Page→node attribution via raw
+`get_mempolicy(MPOL_F_NODE|MPOL_F_ADDR)`/`move_pages` (per-arch syscall
+numbers tabulated in the probe). libpfm strips precise attrs on AMD — the
+IBS-vs-PEBS split lives in backend logic, not the naming layer. The PEBS
+branch is structurally present but Intel-hardware-gated (`skipTest`); SPE is
+deferred (AUX buffer + MIDR-dispatched decode tables; no aarch64-linux bed).
+Cross-node classification tests `skipTest` on single-node hosts. Reference
+implementation:
+[`mem-latency-numa.d`](../../research/cpu-pmu/examples/mem-latency-numa.d).
+All columns `diagnostic`. **Introduces the shared GC-free `LatencyHistogram`
+module** (log-linear buckets) as its percentile carrier — M9 and M10 consume
+it later (first consumer introduces, keeping every milestone green).
+
+## B6 — Sampling and symbolization
+
+_(backend-proposal §7; SPEC §7, §8.1.)_ `--bench-profile`: a third pass
+(like counting — never touching the timing pass) that turns "IPC fell" into
+"IPC fell in `sumSquares` at `readers.d:137`".
+
+- **Pure-D ring consumer**: acquire-load `data_head`, process, release-store
+  `data_tail`; account `PERF_RECORD_LOST` so aggregates are never silently
+  biased. Ring size gated by `perf_event_mlock_kb`.
+- **Address-space model synthesized from `/proc/self/maps` at enable time** —
+  `PERF_RECORD_MMAP2` arrives only for mappings created while enabled
+  (hw-verified: zero records for pre-existing code) — with build-id
+  validation modeled on perf's `dso__build_id_mismatch` (the stale-binary
+  hazard is a bench-harness reality: rebuilt binary vs old-run comparison).
+- **Symbolization via soft libdw**: `dwfl_report_elf` →
+  `dwfl_module_addrinfo` (**`offset`/`sym` arguments non-NULL — NULL
+  segfaults, hardware-hit**) → `dwfl_module_getsrc`; **inline attribution
+  from day one** (`dwarf_getscopes` chains, innermost-first) — benchmark
+  binaries are `-O` builds, so hot LDC-inlined leaves otherwise
+  misattribute to their callers; **`pc -= 1` before symbolizing
+  non-activation caller frames**. Absent libdw ⇒ `symbolization` advertised
+  absent, samples still counted.
+- **Optional DWARF-CFI unwind** (`REGS_USER` + `STACK_USER`; hw-verified
+  5-frame backtrace on a `--frame-pointer=none` build); the perf→DWARF
+  register map is **x86-64-only** — per-ISA gate.
+- Output: per-case flat top-N profile (with inline chains) as a `diagnostic`
+  section. Reference implementations:
+  [`sampling-symbolize.d`](../../research/cpu-pmu/examples/sampling-symbolize.d),
+  [`unwind-stack-user.d`](../../research/cpu-pmu/examples/unwind-stack-user.d).
+
+## M9 — Off-CPU profiler and biolatency floor
+
+Rebuilt on B6. Tier A (zero-perm floor): helper-thread sampling of
+`/proc/self/task/*/{stat,wchan}` → off-CPU %-by-state + wchan histogram.
+Tier B: **B6's ring consumer pointed at `sched:sched_switch`** — callchain
+at switch-out, switch-out→in pairing per tid, symbolization from B6 (the
+old hand-rolled maps/symtab/demangle layer is dropped). Tier B additionally
+needs what B6 does not provide: **typed tracepoint decode** of the
+`PERF_SAMPLE_RAW` blob against the tracefs `format` schema — name-based
+field lookup, never fixed struct casts (offsets shift across kernels), plus
+a string/array getter (`prev_comm`) — scoped as a small pure-D decode core
+(libtraceevent's decode split without the C dependency; it does no tracefs
+I/O anyway). Tier B's gate is tracefs readability (root-only `0700` on
+hardened hosts — the same gate as `--syscalls`, independent of paranoid).
+**biolatency here is the `/proc/diskstats` delta floor only**; the
+block-tracepoint tier stays in M11. Consumes B5's `LatencyHistogram`.
+Rendered as labeled blocks below the numeric table.
+
+## M10 — Open-loop load generator
+
+`driveOpenLoop(request, LoadSchedule)`: precomputed intended send times
+(fixed or Poisson), absolute-deadline wakeups
+(`clock_nanosleep(TIMER_ABSTIME)`), **latency measured from the intended
+send time** — the structural coordinated-omission fix; a naive actual-send
+clock is prohibited. Overload surfaces as queue depth + schedule skew, never
+silent throttling. Driver hot path is allocation-free; server counters are
+per-tid or cgroup-scoped so driver overhead never pollutes them. Intended
+latency histogram (B5's `LatencyHistogram`) is the quantitative headline;
+service latency and backpressure are diagnostic.
+
+## B4 — Windows floor (blocked)
+
+_(backend-proposal §5; SPEC §9.)_ Blocked on a Windows hardware bed — the
+Wine cross pipeline only proves the degrade path, and nothing on this
+platform is hw-verified. Scope when unblocked: driver-free `CycleTime` via
+`EnableThreadProfiling`/`ReadThreadProfilingData` (winbase.h, Win 7+);
+elevated ETW PMC tier (admin + `SeSystemProfilePrivilege`; 3–4 PMC hard
+budget with **no enabled/running scaling — size groups to fit or split
+runs**); `QueryWorkingSetEx` as the `move_pages` analog for NUMA groundwork;
+bindings vendored from the windows-d generated modules, not hand-written
+`extern(Windows)`. Explicit infeasibility verdicts to encode: public
+PEBS-class sampling absent; arbitrary event registration is system-global
+only (out of scope). Version floors: LBR Win10 19H1+, raw ProfileSource
+1903+.
+
+## M11 — Gated spikes
+
+Feasibility-spike-first items, each behind a runtime permission probe:
+
+- **eBPF off-CPU** (in-kernel aggregation): pursue only after a spike proves
+  cross-kernel verifier acceptance and the permission probe passes; dead by
+  default where `unprivileged_bpf_disabled=2`.
+- **Block-tracepoint biolatency** (system-wide; paranoid ≤ 0 / CAP_PERFMON).
+- **Load-gen follow-ons**: subprocess/socket targets, `SCHED_FIFO` driver
+  pinning (CAP_SYS_NICE), client-tail ↔ server-PSI correlation.
+- **ARM-Linux validation bundle** (when an aarch64-linux bed exists):
+  big.LITTLE cpumask-PMU discipline plus a "counted 0 with enabled > 0"
+  sanity check (wrong-cluster opens count zero silently); `exclude_idle` is
+  `EOPNOTSUPP` on PMUv3; event presence is **three-tier** (`PMCEID*`
+  bitmaps for the common `0x00–0x3F` set; `0x40+` IMPDEF; `0x4000+`
+  arch-extension); SPE and BRBE as separate gated items.
+- **RISC-V bundle** (spec-driven; no hardware): a capability subset by
+  construction — counting always (SBI), sampling iff Sscofpmf, `exclude_*`
+  iff Sscofpmf, precise/data-source permanently absent, branch records
+  blocked until a `riscv_ctr.c` consumer lands; skid on the sampled `xepc`
+  is unremovable (document, don't fix); event names only from vendored
+  kernel pmu-events JSON (libpfm4/PAPI/LIKWID have no RISC-V tables).
+
+## Cross-cutting honesty
+
+Ship these caveats; never paper over them:
+
+- **Quantitative vs diagnostic is enforced structurally** — reductions
+  producing reported/gated numbers read only quantitative fields.
+- **"Not counted" is not zero**; multiplex estimates are labeled everywhere
+  they appear, including `--bench-json`.
+- **Off-CPU by cause without eBPF is partial**: runqueue + disk are real
+  durations; lock/sleep is a count annotation on a clamped residual.
+- **Cache regime is stamped `effective`** (tmpfs ⇒ cold impossible; zfs ⇒
+  partial; drop_caches ⇒ root) so mismatched runs are never compared.
+- **Coordinated omission is an invariant** (intended-time latency
+  mandatory).
+- **Permissions degrade, never fail** — and the paranoid/tracefs/per-field
+  gates are independent axes, each probed separately; the paranoid > −1
+  matrix is literature-derived until probed.
+- **The MMAP2/build-id stale-binary hazard** applies to every self-profiling
+  feature: synthesize mappings, validate build-ids.
+- **The event vocabulary is harness-owned** — no naming layer spans OSes.
+- **User-stack quality is build-flag dependent**, softened by B6's CFI
+  unwind; **big.LITTLE wrong-cluster opens count zero silently** — keep the
+  sanity check.
+
+## Verification
+
+Every milestone lands as independently green commits: full suites
+(`dub test :test-runner-impl -- --self-test`, `dub test :base`,
+`nix run .#ci -- --test --fail-fast`), plus per-milestone gates:
+
+- **B1** — `--list-metrics` shows the capability block; on the dev box the
+  report matches the survey (preciseMemory via `ibs_op`; eventTracing
+  absent); `--perf` table output unchanged.
+- **B2** — `--metrics=raw:r<hex>` counts on the dev box; libpfm-absent build
+  still passes with `eventNaming` reported absent; scaled cells carry the
+  estimate marker; rdpmc bracket cost measured and recorded.
+- **M4/M5** — window rows render with decomposition; Σ(parts) ≤ wall with
+  clamped residual; PSI-less kernel degrades with a reason.
+- **B3** — mac-bsn transcript shows instructions/cycles/IPC columns
+  unprivileged; Linux/stub builds unchanged.
+- **M6–M8** — regime stamps present on every row; tmpfs downgrade observed;
+  unprivileged cgroup run reports absence and still passes.
+- **B5/B6/M9** — parity runs against the research probes
+  (`mem-latency-numa.d`, `sampling-symbolize.d`, `unwind-stack-user.d`);
+  `skipTest` on hosts lacking IBS/paranoid headroom; profile sections render
+  below tables, never as columns.
+- **M10** — CO self-test: an injected stall shows up in intended-time
+  latency; schedule-skew reported.
+
+Every backend ships its Linux (or per-OS) body plus an identical-surface
+stub, and environment-dependent tests call `skipTest(reason)`.

--- a/docs/specs/test-runner/SPEC.md
+++ b/docs/specs/test-runner/SPEC.md
@@ -1,0 +1,377 @@
+# `sparkles:test-runner` — Measurement-layer specification
+
+_Audience: developers and coding agents building against the runner. This
+document is normative at the contract level — it states what the layer
+provides (and, for marked sections, what it is specified to provide once its
+milestone lands), not why. For the delivery plan, see [PLAN.md](./PLAN.md);
+for unresolved behavioral questions, see [open-issues.md](./open-issues.md);
+for tutorial/how-to exposition, see the
+[library docs](../../libs/test-runner/index.md). The design evidence base is
+the [CPU-PMU research catalog](../../research/cpu-pmu/index.md) — in
+particular the [audit baseline](../../research/cpu-pmu/sparkles-baseline.md)
+and the [backend proposal](../../research/cpu-pmu/backend-proposal.md)._
+
+Sections describing behavior that is not yet implemented carry an explicit
+**(target — Bn/Mn)** marker naming the [PLAN.md](./PLAN.md) milestone that
+makes them true. Unmarked statements describe shipped behavior.
+
+## 1. Overview
+
+`sparkles:test-runner` is a general-purpose `unittest` runner (parallel
+runtime tests plus `@ctfe`, `@betterC`, and `@wasm` modes) with a
+benchmark-measurement layer under `--bench`. This specification covers the
+whole surface at contract level and the measurement layer in depth.
+
+The measurement layer has **two measurement models**:
+
+- **`@benchmark`** — per-iteration statistics: the timed body runs many times;
+  the runner reports median / median-absolute-deviation / min / max
+  nanoseconds per iteration, plus per-iteration counter averages.
+- **`@workload`** _(target — M4)_ — window statistics: the body runs once (or
+  a few reps); the runner reports counter **deltas and integrals across the
+  window**, including a wall-clock decomposition into on-CPU and attributable
+  off-CPU time.
+
+Three invariants shape everything:
+
+1. **Counting is separated from timing.** The timing pass runs with no
+   counters enabled; counters bracket a separate pass. No repaint, GC, or
+   counter I/O ever runs concurrently with a timed body.
+2. **Every metric is classed** `quantitative` (near-zero perturbation — the
+   only class a reported or gated number may read) or `diagnostic` (perturbs;
+   explains a result; rendered separately, never blended into a headline).
+3. **Capability is a runtime probe result.** Every acquisition source opens
+   through a probe handshake and **degrades to reported absence, never
+   fails the run and never fabricates numbers**. _(target — B1: absences are
+   enumerated per capability with a reason, not just per-tier status
+   strings.)_
+
+## 2. Package and module layout
+
+The runner is two dub packages:
+
+- **`sparkles:test-runner`** (`libs/test-runner`) — a thin `sourceLibrary`
+  shim (compile-time discovery + registration) compiled into each test
+  binary.
+- **`sparkles:test-runner-impl`** (`libs/test-runner-impl`) — the prebuilt
+  implementation library, linked across an `extern(C)` seam.
+
+Measurement modules (all under
+`libs/test-runner-impl/src/sparkles/test_runner/`):
+
+| Module         | Role                                                              |
+| -------------- | ----------------------------------------------------------------- |
+| `bench.d`      | protocol driver, `benchIter`/`benchCase`/`blackBox`, `BenchStats` |
+| `perf.d`       | hardware-counter tier (`perf_event` group)                        |
+| `perf_group.d` | shared counting bracket + multiplex-delta scaling                 |
+| `tier0.d`      | no-privilege tier (`getrusage` + `/proc/self/io`)                 |
+| `syscalls.d`   | syscall-tracepoint tier                                           |
+| `metrics.d`    | the metric catalog seam (§5)                                      |
+| `bench_json.d` | the `--bench-json` emitter (§8.3)                                 |
+| `reporting.d`  | tables, live displays, progress                                   |
+| `skip.d`       | `skipTest`                                                        |
+
+Planned modules _(targets)_: `capability.d` (B1), `workload.d`/`psi.d` (M4/M5),
+`cache_regime.d`/`provenance.d`/`cgroup.d` (M6–M8), `histogram.d` (B5),
+`sampling.d`/`symbolize.d` (B6), `offcpu.d` (M9), `loadgen.d` (M10), plus
+per-OS backend variants inside the existing modules (B3/B4).
+
+## 3. Attribute and in-body surface
+
+Marker UDAs live in `sparkles.test_runner.attributes` and must be imported
+unconditionally (not under `version (unittest)`).
+
+- **`@benchmark`** — the test is skipped by normal runs and measured by
+  `--bench`. **`@benchmark(iterations: N)`** pins the iteration count instead
+  of auto-scaling: per sample for batched timing; a per-call `benchCase` runs
+  exactly N timed calls, one sample each.
+- **`benchIter(scope void delegate())`** — measure only the closure; the rest
+  of the body is setup. Outside `--bench` the closure runs exactly once.
+- **`benchCase(name:, labels:, timed:, after:, setup:, teardown:, metrics:)`**
+  — register one row of a matrix benchmark. Under `--bench` the case is
+  _registered_ and measured after the body returns (deferred execution:
+  varying state must be captured by value); outside `--bench` it runs once
+  immediately. `timed`'s result flows to `after`, which runs untimed to
+  verify/release it; a throwing `after` or an `Expected` error isolates into
+  a single in-table error row while the rest of the matrix measures. A soft
+  error returned on the inert (non-`--bench`) path is re-raised as an
+  exception. Label keys/values and `name` must not contain `\x1f` (the group
+  separator) — violation is a registration-time error.
+- **`blackBox(x)`** — identity the optimizer cannot see through; route
+  measured inputs and results through it.
+- **`skipTest(reason)`** (`sparkles.test_runner.skip`, `@safe pure nothrow
+@nogc`) — skip the enclosing test at runtime: a yellow `⊘` line plus an
+  `N skipped` summary segment; never fails the run. Under `--bench` a
+  case-level skip renders as a yellow row.
+- **Client metrics** — `Metric(Unit unit, double amount, Mode mode)`:
+  `rate` reports `amount ÷ iteration-time` as `<unit>/s`; `level` reports the
+  per-iteration amount as-is. `Unit` is an open-basis symbol (`"B"`, `"req"`,
+  …); see §5.3.
+- **`@workload`** _(target — M4)_ — window-model marker with a cache-regime
+  request and rep count; in-body `workloadWindow`/`workloadFiles` primitives.
+
+## 4. Measurement protocol
+
+Normative for `@benchmark`:
+
+1. **Auto-scaling** — the per-sample iteration count doubles until one sample
+   takes at least `BenchConfig.minSampleTime` (default 5 ms;
+   `--bench-min-time=MS` overrides), then `sampleCount` (32) samples are
+   collected. Timing uses raw `MonoTime` ticks (no hectonanosecond
+   quantization).
+2. **Statistics** — median, median absolute deviation, min, max ns/iter. No
+   mean is reported.
+3. **Per-call vs batched** — `benchCase` times each call individually (one
+   sample per call; `--bench-min-time` is the minimum _total_ measured time,
+   samples accumulate past 32 until met); `benchIter`/whole-body timing is
+   batched (`--bench-min-time` is the per-sample auto-scale target).
+   `@benchmark(iterations: N)` pins both shapes and makes the budget inert.
+4. **Counting passes** — after timing, each _available_ source re-runs the
+   body under its counters, capped at `perfMaxIters` (100 000) iterations,
+   with the untimed release/verify hook outside the enabled window. Counter
+   values project to per-iteration doubles, unrounded.
+5. **Serial execution** — benchmarks never run in the test thread pool.
+   Registered cases are scheduled grouped by their streaming key (the
+   `--group-by` group, else the source test's qualified name).
+6. **Assert-enabled builds warn** — `--bench` on a debug/assert build prints a
+   stderr warning; real numbers require an optimized unittest build type.
+
+Thread coverage is inherit-shaped: counters follow threads spawned after the
+source opens; pre-existing threads and short-lived children are blind spots
+(see [open-issues.md § O3](./open-issues.md)).
+
+For `@workload` _(target — M4)_: the driver phase model is `setup →
+regime-prep (M6) → snapshot-before all sources → body × reps →
+snapshot-after → residency-verify (M6) → assemble deltas`. The wall-clock
+decomposition reports `onCpuUser`/`onCpuKernel` (rusage), `offCpuRunqueue`
+(schedstat), `offCpuDisk` (PSI, M5), and a clamped `offCpuOther` residual —
+only runqueue and disk are true per-cause durations; lock/sleep time is never
+fabricated.
+
+## 5. The metric catalog
+
+### 5.1 Types
+
+Everything downstream renders through two types (`metrics.d`):
+
+```d
+enum MetricClass  { quantitative, diagnostic }
+enum MetricFormat { ratio, count, percent }
+
+struct MetricCell        // one rendered value
+{
+    string name;         // stable id: "ipc", "instr", "B/s", "syscalls:read"
+    string header;       // column label
+    double value = double.nan;  // nan renders as an em dash
+    MetricFormat format;
+    MetricClass cls;
+}
+
+struct MetricDescriptor  // one catalog entry
+{
+    string name;
+    string header;
+    MetricFormat format;
+    MetricClass cls;
+    string source;       // "client" | "perf" | "tier0" | "syscall" | …
+    bool available;      // producible on this run
+    bool isDefault;      // shown without a --metrics filter
+}
+```
+
+### 5.2 Contract
+
+- Each source contributes a projection pair — `XCells(in XStats)` for row
+  cells and `XFamily(bool available)` for descriptors. **Adding a source is
+  one `Nullable!XStats` field on `BenchStats` plus one line in each of
+  `open`/`close`/`countInto`, plus the cells/family pair.** Table rendering,
+  `--metrics` filtering, `--list-metrics`, and `--bench-json` then work
+  unchanged.
+- `--metrics=LIST` selects columns by exact name, comma list, `*`-glob,
+  `all`, or `?`/`help` (print the catalog). Selection **transitively opens
+  the sources it needs** (naming a perf metric opens the perf pass; naming
+  `syscalls`/`syscalls:<name>` opens the tracepoint pass). A selector that
+  matches nothing warns on stderr — selectors are never silently dropped.
+- Client metric names that shadow built-ins get a `user.` prefix.
+- With no filter, the default column set is stable across releases within a
+  schema version (regression guard: `--perf` output is byte-compatible).
+
+### 5.3 Units seam
+
+`Unit.symbol` is a **label, not semantics** (the open-basis "mint-by-name"
+identity); `Metric.Mode` is a two-valued stand-in for a time-exponent
+dimension (`rate` = `unit·s⁻¹`). All unit/rate/format semantics live behind
+one seam — the `scaled`/`fixed` formatters — so the future
+`sparkles.quantities` binding is a localized swap (see
+[open-issues.md § O6](./open-issues.md)).
+
+## 6. The backend contract
+
+### 6.1 The source shape (shipped)
+
+Every acquisition source implements, on all platforms:
+
+```
+tryOpen(...)    // probe handshake; may calibrate
+available()     // bool: producible on this run
+status()        // human reason when unavailable
+count(...)      // bracket a counting pass; fill the row's XStats
+close()
+```
+
+with a `version (linux)` (or per-OS) real body and an identical-surface stub
+elsewhere. Two source shapes exist: _bracketed_ (ioctl ENABLE → body →
+DISABLE per iteration: perf, syscalls) and _snapshot/delta_ (pairs around the
+pass: tier-0; window-friendly for M4+).
+
+### 6.2 The capability model (target — B1)
+
+Backends advertise what this host, this run, can measure:
+
+```d
+enum Capability : uint
+{
+    none, counting, countingRaw, countingScaled, selfMonitoring,
+    ipSampling, preciseMemory, symbolization, eventTracing,
+    numaAttribution, eventNaming,   // one flag per survey concern
+}
+
+struct CapabilityReport
+{
+    Capability available;
+    string[Capability] unavailableBecause;  // per-absence reason
+}
+```
+
+`tryOpen` returns a `CapabilityReport`; a DbI `isCounterBackend` trait names
+the required primitives, and optional primitives (precise sampling, page
+classification, name resolution) unlock optional capabilities by presence.
+`--list-metrics` renders a per-backend capability block; the bench header
+prints one line per absent-but-requested capability. Workload-track sources
+(PSI, cgroup, cache regime) adopt the same report — one absence vocabulary
+program-wide.
+
+### 6.3 Degradation rules (normative)
+
+- **Absence is reported, never fatal.** An unavailable source yields omitted
+  columns plus a status line (a reasoned capability entry under B1).
+- **"Not counted" is not zero.** A counter group with `time_running == 0`
+  (never scheduled) reports its cells unavailable (`nan` → em dash) — never
+  `0`, never a scaled estimate.
+- **Exact by default; estimates are labeled.** The default counting group is
+  calibrated at open and shrunk (the LLC pair drops first) until counts are
+  exact. _(target — B2)_ Opt-in `countingScaled` renders
+  `enabled/running`-scaled estimates with an explicit marker, flags scales
+  derived from sub-millisecond running slices, and marks estimated cells in
+  `--bench-json`.
+- **Group-refused is a distinct branch** _(target — B2)_: a platform that
+  refuses an unplaceable group outright (RISC-V SBI) degrades like
+  never-scheduled, not like multiplexed.
+- **Privilege gates are independent axes.** `perf_event_paranoid`, tracefs
+  file permissions, and per-field gates (e.g. physical addresses) are probed
+  separately; each degrades on its own.
+
+## 7. CLI contract
+
+The authoritative option list lives in the
+[CLI reference](../../libs/test-runner/reference/cli.md); this section pins
+the contracts.
+
+- **Mode exclusivity** — `--bench`, `--ctfe-trace`, and `--better-c`/`--wasm`
+  are mutually exclusive (hard error); `--better-c` with `--wasm` is one
+  extraction family; `--list`/`--list-metrics` are queries that win over any
+  mode.
+- **Readable failures** — malformed options, unknown flags, and stray
+  positionals produce one-line errors, never stack traces.
+- **Warn, don't drop** — unknown `--metrics`, `--sort-by`, and `--syscalls`
+  selectors warn on stderr; the run proceeds with the remainder.
+- **Selector equivalences** — `sc:<name>` ≡ `syscalls:<name>` everywhere a
+  metric name is accepted.
+- **Sorting** — `--sort-by=KEY` orders ascending within each group; error
+  rows always sort last under every order; default is `median/iter`.
+- **Grouping** — `--group-by=KEYS` streams one table per label-key group;
+  `=all` uses every label key; `=list` prints the keys and exits (reporting
+  registration failures with a non-zero exit).
+- **Exit status** — `0` iff everything passed or was skipped (`skipTest` or a
+  toolchain-missing mode); non-zero otherwise. A `--bench-json` write failure
+  fails the run.
+- _(target — B2)_ `--metrics` accepts raw selectors (`raw:r<hex>`) and,
+  when event naming is available, native µarch event names. _(target — B6)_
+  `--bench-profile` enables the sampling pass.
+
+## 8. Output surfaces
+
+### 8.1 Tables
+
+- Timing and metric columns align on the **decimal point**; consecutive
+  streamed tables share their column geometry (floors only widen during a
+  run). Grouped tables carry `benchmark: <group>` in the top border over an
+  `implementation` column.
+- Unavailable cells render as an em dash. Error rows carry the first line of
+  the error in-table (full traces print to the console) and sort last.
+- Diagnostic-class output beyond columns (profiles, histograms — targets B5,
+  B6, M9) renders as labeled blocks **below** the numeric table, never as
+  throughput-lookalike columns.
+
+### 8.2 Live displays
+
+One suppression policy for all three live displays (runtime progress line,
+bench table ticker on stdout, bench stderr spinner): suppressed when piped,
+under `--no-colours`, `$NO_COLOR`, or `TERM=dumb`. Repaints are bracketed in
+DEC-2026 synchronized output and happen only at case boundaries — no painter
+thread. Piped output is byte-stable and prints each table once.
+
+### 8.3 The `--bench-json` document
+
+One deterministic JSON document, `{schema: 1, meta, columns, rows}`:
+
+- `meta` — `{date, hostname, os, arch, compiler, cpu, minSampleTimeMs,
+sampleCount}`: host/toolchain provenance plus the run's effective knobs
+  (baselines are self-describing).
+- `columns` — the available catalog descriptors `{name, header, format,
+class, source}`; `metrics` keys in rows match `--list-metrics` names.
+- `rows` — measurement order, unaffected by `--sort-by`/`--group-by` (group
+  dimensions travel in each row's sorted `labels`): `{name, labels,
+iterations, samples, medianNs, deviationNs, minNs, maxNs, metrics, error}`.
+  Error rows keep `labels` and `error` with `null` timing fields; `nan`
+  cells are `null`.
+- Number policy: `nan`/infinity → `null`; integral values below 2⁵³ print as
+  integers; others to 6 significant digits. Output is byte-deterministic for
+  committing.
+
+Schema evolution (estimate marking, `@workload` windows) is tracked in
+[open-issues.md](./open-issues.md) (O4, O7).
+
+## 9. Portability and privilege
+
+Per-OS floors, with shipped-vs-target markers. The full evidence base is the
+research [capability matrix](../../research/cpu-pmu/comparison.md).
+
+| Platform              | Floor (unprivileged)                                                      | Beyond the floor                                                                                                                      | Status                                           |
+| --------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Linux x86_64          | tier-0 (`getrusage` + `/proc/self/io`); perf counting at `paranoid ≤ 2`\* | tracepoints (tracefs, usually root); precise memory (B5); sampling (B6)                                                               | shipped / targets                                |
+| macOS (Apple Silicon) | `proc_pid_rusage` → true instructions/cycles/IPC, process-scope           | kpc: root-or-blessed-pid + kernel allowlist, single-owner `EBUSY`; sampling via xctrace only; **no DTrace cpc provider**              | target — B3                                      |
+| Windows               | `CycleTime` via thread profiling (driver-free)                            | ETW PMC counting (admin + `SeSystemProfilePrivilege`, 3–4 PMC hard budget, no multiplex scaling); public precise sampling: **absent** | target — B4 (blocked: no hardware bed)           |
+| ARM-Linux             | generic events port as-is (PMUv3)                                         | big.LITTLE: events must open on the pinned core's PMU (wrong cluster counts silent zero); SPE/BRBE gated                              | target — M11 (source-verified only)              |
+| RISC-V                | counting always (SBI-mediated)                                            | sampling iff Sscofpmf; `exclude_*` iff Sscofpmf; precise/data-source: **permanently absent**; branch records: no kernel consumer      | target — M11 (capability subset by construction) |
+
+\* All hardware verification to date ran at `perf_event_paranoid = −1`;
+behavior at stricter levels is literature-derived until probed
+([open-issues.md § O1](./open-issues.md)).
+
+Normative portability rules:
+
+- Never assume 4 KiB pages / 64 B cache lines (Apple Silicon: 16 KiB /
+  128 B).
+- Topology and storage provenance are re-probed per boot (BIOS NUMA modes
+  re-scope nodes and uncore counters).
+- The event-name vocabulary is **harness-owned**: no naming layer spans
+  operating systems (libpfm4/LIKWID are Linux-only; kpep and ETW
+  profile-sources are OS-local). Naming _data_ (kernel pmu-events, kpep
+  plists, vendor JSON) is harvested offline, never a runtime dependency.
+- C libraries are soft dependencies at most (libpfm4 for naming, libdw for
+  symbolization): absence degrades to an advertised missing capability.
+  `libnuma` is never linked — page→node classification uses the raw
+  `get_mempolicy`/`move_pages` syscalls.
+- Environment-dependent tests use `skipTest(reason)`, so a degraded host
+  skips visibly and never fails.

--- a/docs/specs/test-runner/open-issues.md
+++ b/docs/specs/test-runner/open-issues.md
@@ -1,0 +1,129 @@
+# `sparkles:test-runner` — Open specification issues
+
+_Companion to [SPEC.md](./SPEC.md) and [PLAN.md](./PLAN.md). A running list
+of behavioral questions that are **not yet resolved** in the normative spec.
+Each entry records where it bites, the options, and any current leaning.
+Resolve by folding a decision into SPEC.md, then delete the entry here (and
+reference the commit). Survey-level hardware questions that do not touch the
+spec's behavior stay in the research catalog's
+[open questions](../../research/cpu-pmu/comparison.md#open-questions-gaps)._
+
+## O1 — The paranoid degradation matrix is unprobed
+
+**Where:** SPEC §9.
+
+All hardware evidence to date was gathered at `perf_event_paranoid = −1`;
+the per-level behavior at 0/1/2 (which sources survive, with which reasons)
+is literature-derived. The spec currently gates "perf counting at
+paranoid ≤ 2" on the literature value.
+
+**Options:** (A) probe on a hardened host and pin the per-level degradation
+normatively; (B) keep the matrix descriptive (best-effort reasons from
+`errno`) and never promise per-level behavior.
+
+**Leaning:** (A) — probe once, then normatize; the capability report (B1)
+is the natural carrier.
+
+## O2 — The rdpmc bracket benefit is unmeasured
+
+**Where:** SPEC §6.2 (`selfMonitoring`); PLAN B2.
+
+The "~10× cheaper than `read(2)`" figure motivating the rdpmc fast path is
+an order-of-magnitude literature claim, not measured on this hardware
+(grounding ledger M8).
+
+**Options:** (A) measure the bracket cost on-host as part of B2 and record
+it before `selfMonitoring` may advertise or auto-select; (B) ship the fast
+path opt-in with no performance claim.
+
+**Leaning:** (A) — B2's verification gate already requires the measurement.
+
+## O3 — The thread-coverage contract
+
+**Where:** SPEC §4 (protocol), §6 (backend contract).
+
+Counter coverage is inherit-shaped: `pid:0, cpu:-1` + `inherit` covers
+threads spawned after a source opens; pre-existing threads and short-lived
+children are blind spots the harness does not report.
+
+**Options:** (A) document-only (status quo, stated in SPEC §4); (B) per-TID
+attach for pre-existing pools; (C) report a coverage stamp per row so
+partially-covered runs are visibly marked.
+
+**Leaning:** (C) as the near boundary — a stamp fits the provenance-badge
+pattern (cache regime, M6) — with (B) as a later refinement if a real
+consumer needs it.
+
+## O4 — Estimate marking format
+
+**Where:** SPEC §6.3, §8.3; PLAN B2.
+
+`countingScaled` cells are estimates and must be visibly marked in the table
+and machine-readably marked in `--bench-json`. The JSON schema has no
+estimate field today.
+
+**Options:** (A) per-cell flag — `metrics` values become
+`{value, estimated}` objects under a schema bump; (B) a row-level
+`estimatedMetrics: [names]` array, keeping cell values plain numbers;
+(C) separate `metricsEstimated` sibling object.
+
+**Leaning:** (B) — keeps every existing consumer's numeric path intact and
+the schema bump additive.
+
+## O5 — The cross-OS event-name vocabulary
+
+**Where:** SPEC §5, §9; PLAN B2/B3/B4.
+
+No naming layer spans operating systems, so the harness owns its vocabulary.
+Undecided: one abstract namespace resolved per-OS, or per-source prefixes.
+
+**Options:** (A) abstract names (`instructions`, `cache-miss`) mapped
+per-OS, failing where unmappable; (B) per-source prefixes (`raw:`, `pfm:`,
+`kpep:`, `pmcsource:`) with only the generic seven shared.
+
+**Leaning:** (B) — mirrors the shipped `sc:`/`syscalls:` precedent, keeps
+resolution failures local and honest; a shared abstract core can grow later
+without breaking prefixed names.
+
+## O6 — `sparkles.quantities` convergence
+
+**Where:** SPEC §5.3.
+
+The units seam awaits the sibling units-of-measure work, whose unit-identity
+model (open vs closed dimension basis) is deliberately unsettled. Until it
+lands, `Unit.symbol` stays a label and `Mode` stays the rate stand-in.
+
+**Options:** track the sibling spec; migration is localized to the
+`scaled`/`fixed` seam by design.
+
+**Leaning:** wait — no benchmark-side action until the quantities spec
+exists.
+
+## O7 — `@workload` rows in `--bench-json`
+
+**Where:** SPEC §8.3; PLAN M4.
+
+`WorkloadWindow` is deliberately not `BenchStats`, so window results do not
+fit the current `rows` shape (per-iteration timing fields would
+misrepresent a single window).
+
+**Options:** (A) a `windows` sibling array in the same document under a
+schema bump; (B) a distinct document (`--workload-json`); (C) force windows
+into `rows` with `iterations: 1` and null deviation.
+
+**Leaning:** (A) — one self-describing document per run; (C) is ruled out
+by the misrepresentation argument that motivated the separate type.
+
+## O8 — Apple counter-model unknowns
+
+**Where:** SPEC §9; PLAN B3.
+
+kpep advertises `fixed_counters: 3` on every generation while kpc's FIXED
+class and Linux's driver model 2 — the identity of the third fixed counter
+is unresolved (grounding ledger R18). Separately, Linux has no Apple M4 PMU
+table and its 8-bit event field cannot express kpep's wider selectors.
+
+**Options:** record and proceed — B3's floor (`proc_pid_rusage`) does not
+touch kpc counters; resolve if/when a kpc backend is attempted.
+
+**Leaning:** record only; blocks nothing in B3.


### PR DESCRIPTION
Promotes the test-runner benchmark roadmap from session notes into the repo's `docs/specs/` convention, aligned with the `docs/research/cpu-pmu/` survey (#94) — the survey's declared follow-up ("audit the shipped layer, then sequence the gaps") lands here as a spec tree.

## What's in the tree

**[`SPEC.md`](https://github.com/PetarKirov/sparkles/blob/docs/test-runner-roadmap/docs/specs/test-runner/SPEC.md)** — the normative contract surface, wired-style (numbered sections, self-contained): the two measurement models (`@benchmark` per-iteration; `@workload` window), the metric-catalog and backend contracts, CLI/output guarantees (mode exclusivity, warn-don't-drop selectors, the `--bench-json` schema, live-display suppression), and a per-OS portability/privilege matrix. Sections describing unshipped behavior carry explicit `(target — Bn/Mn)` markers, so the spec is the destination the plan delivers.

**[`PLAN.md`](https://github.com/PetarKirov/sparkles/blob/docs/test-runner-roadmap/docs/specs/test-runner/PLAN.md)** — the unified delivery plan. Two arcs interleaved by value:

- the **workload track** (M4–M11 of the I/O-bench roadmap: `@workload` window + wall decomposition, PSI, cache regime, provenance, cgroup-v2, off-CPU, CO-safe load-gen, gated spikes), and
- the **backend track** (the research [backend-proposal](https://github.com/PetarKirov/sparkles/blob/main/docs/research/cpu-pmu/backend-proposal.md)'s six milestones, sequenced as **B1–B6**: capability seam → Linux counting depth → macOS floor → Windows floor → precise memory → sampling/symbolization).

Execution order: B1 → B2 → M4 → M5 → B3 → M6 → M7 → M8 → B5 → B6 → M9 → M10, with B4 (Windows) blocked on hardware and M11 as gated spikes (now also carrying the ARM/RISC-V validation bundles). Each milestone is amended with the survey's hw-verified recipes and hazards — e.g. `swfilt` not `exclude_kernel` on IBS, `LIBPFM_ENCODE_INACTIVE` + `table::` prefix not `LIBPFM_FORCE_PMU`, probe `ibs_op` before `max_precise`, MMAP2-only-while-enabled address-space synthesis, non-NULL `dwfl_module_addrinfo` args, inline attribution from day one, "not counted" ≠ 0. M9's off-CPU Tier B is re-scoped onto B6's sampling infrastructure plus a small pure-D tracepoint-format decoder (dropping the previously planned hand-rolled symtab layer).

**[`open-issues.md`](https://github.com/PetarKirov/sparkles/blob/docs/test-runner-roadmap/docs/specs/test-runner/open-issues.md)** — eight unresolved behavioral questions (paranoid degradation matrix, estimate marking in JSON, cross-OS event-name vocabulary, workload rows in `--bench-json`, …), each with options and a leaning, resolved by folding decisions into SPEC.md.

## Cross-references

- The [delta table](https://github.com/PetarKirov/sparkles/blob/main/docs/research/cpu-pmu/comparison.md)'s event-space-gating row now names the delivery-plan milestones that close it (M5 for PSI, M9 for sched tracepoints) instead of the retired session-roadmap reference.
- `backend-proposal.md` notes its milestones are sequenced as B1–B6 by the plan; its internal M1–M6 numbering is untouched.
- VitePress sidebar gains a Test Runner group under Specs, mirroring the wired group.

## Verification

- `npm run docs:build` green; new pages render; cross-file anchors verified against dist HTML ids.
- `lychee --offline` over the changed files: 0 errors.
- Read-back checks: every "Closes in" row of the delta table maps to a plan milestone; every plan milestone names the SPEC sections it makes true (or is marked as adding new ones).

Grounding: full read of the 15 research pages + 5 probes + grounding ledger, with an adversarial completeness pass of the plan against the digests before writing.

---

Session: [roadmap alignment](https://claude.ai/code/a1618bb3-758c-406d-a7ce-0c3c28a1bf24)
