### PR TITLE
docs(research): safe SQL interpolation case study (D IES)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -814,6 +814,10 @@ export default withMermaid(
                   text: 'Comparison & Synthesis',
                   link: '/research/sql/comparison',
                 },
+                {
+                  text: 'Case Study: Safe SQL Interpolation',
+                  link: '/research/sql/safe-interpolation',
+                },
               ],
             },
             {

--- a/docs/research/sql/comparison.md
+++ b/docs/research/sql/comparison.md
@@ -65,8 +65,8 @@ Two structural observations fall straight out of the matrix:
    thinnest driver to the heaviest ORM — makes bound parameters the default and reserves a
    loudly-named escape hatch (`sql.unsafe`, `$queryRawUnsafe`, `Arel.sql`, `sql.raw`,
    `FromSqlRaw`, `Fragment.const`) for raw text. The interesting variation is _how the safe
-   default is expressed_ (a tagged template, a builder, a macro, a quotation), not _whether_
-   it exists.
+   default is expressed_ (a tagged template, a builder, a macro, a quotation) — dissected,
+   with D's IES, in the [safe-interpolation case study][safe-interp] — not _whether_ it exists.
 2. **Compile-time query checking is the real fault line.** It cleaves the field into three
    camps: **statically-checked** (Quill, Diesel, sqlx, sqlc, jOOQ, Kysely, Drizzle, Squeal,
    Opaleye, Beam, ent, Prisma, esqueleto — a _wrong column or type won't compile_),
@@ -291,6 +291,7 @@ bugs, and which an effects-first, explicit-by-design library is precisely positi
 
 [index]: ./index.md
 [concepts]: ./concepts.md
+[safe-interp]: ./safe-interpolation.md
 [models]: ./concepts.md#query-construction-models
 [schema]: ./concepts.md#schema-migrations-code-generation
 [effect-ts]: ./effect-ts.md

--- a/docs/research/sql/concepts.md
+++ b/docs/research/sql/concepts.md
@@ -98,7 +98,8 @@ map or implicit flush. That boundary is the survey's central design question for
 
   Each mechanism has an **escape hatch** for raw SQL (`sql.unsafe`, `sql"..."`, `queryRaw`)
   that re-exposes injection risk — a library's ergonomics are partly about how rarely you
-  reach for it.
+  reach for it. The [safe-interpolation case study][safe-interp] compares these mechanisms in
+  depth (and adds D's interpolated expression sequences).
 
 ---
 
@@ -283,6 +284,7 @@ Architecture_, 2002) that separate a **full ORM** from the lower rungs:
 
 [index]: ./index.md
 [comparison]: ./comparison.md
+[safe-interp]: ./safe-interpolation.md
 [effect-ts]: ./effect-ts.md
 [quill]: ./quill.md
 [doobie]: ./doobie.md

--- a/docs/research/sql/grounding/_sources.md
+++ b/docs/research/sql/grounding/_sources.md
@@ -86,6 +86,19 @@ no history — the pin is the HEAD SHA only, and line numbers are as-of that HEA
 > Go 1.27 development tip; `src/database/sql/` + `src/database/sql/driver/`); `jmoiron/sqlx`
 > (`$REPOS/go/sqlx` @ `41dac16`) is the ergonomic layer above it.
 
+### Case study — safe SQL interpolation (D IES)
+
+| Repo                   | Path                                  | Pinned SHA | As of      |
+| ---------------------- | ------------------------------------- | ---------- | ---------- |
+| interpolation-examples | `$REPOS/dlang/interpolation-examples` | `a8a5d4d`  | 2023-10-30 |
+
+> [!NOTE]
+> `safe-interpolation.md` grounds its D claims in Adam D. Ruppe's `interpolation-examples`
+> (`lib/sql.d` + `06-sql.d`) at the pin above, plus the repo's own
+> [IES guideline](../../guidelines/interpolated-expression-sequences.md) and
+> `core.interpolation` (druntime). Its runnable `[Output]` example is CI-verified
+> (`ci --verify`). Foreign-library claims restate the already-ledgered deep-dives.
+
 ## Per-page → repo mapping
 
 Format: page → local repo (+ the sub-tree used for quote grounding). Per-claim locators

--- a/docs/research/sql/grounding/index.md
+++ b/docs/research/sql/grounding/index.md
@@ -22,7 +22,8 @@ evidence — excluded from the VitePress build (`srcExclude`) and from lychee.
 ## Per-page ledgers
 
 Populated as each wave lands. Waves: **W1** effects core · **W2** Haskell typed cluster ·
-**W3** typed builders / thin · **W4** full ORMs · **W5** raw / baseline · **W6** synthesis.
+**W3** typed builders / thin · **W4** full ORMs · **W5** raw / baseline · **W6** synthesis ·
+**CS** case study (safe SQL interpolation).
 
 | Page                 | Ledger                                               | Claims | ✓   | ⚠   | Wave |
 | -------------------- | ---------------------------------------------------- | ------ | --- | --- | ---- |
@@ -59,6 +60,7 @@ Populated as each wave lands. Waves: **W1** effects core · **W2** Haskell typed
 | go-database-sql      | [go-database-sql.md](./go-database-sql.md)           | 54     | 50  | 0   | W5   |
 | postgres-js          | [postgres-js.md](./postgres-js.md)                   | 65     | 63  | 1   | W5   |
 | jdbi                 | [jdbi.md](./jdbi.md)                                 | 64     | 60  | 0   | W5   |
+| safe-interpolation   | [safe-interpolation.md](./safe-interpolation.md)     | 12     | 10  | 0   | CS   |
 
 ## Master discrepancy register
 

--- a/docs/research/sql/grounding/safe-interpolation.md
+++ b/docs/research/sql/grounding/safe-interpolation.md
@@ -1,0 +1,42 @@
+# Grounding ledger — safe-interpolation.md
+
+Source (D specifics): `$REPOS/dlang/interpolation-examples` @ `a8a5d4d` (2023-10-30) +
+the repo's `docs/guidelines/interpolated-expression-sequences.md` + `core.interpolation`
+(druntime). `$REPOS` = `/home/petar/code/repos`. This is a **synthesis/case-study** page:
+its foreign-library claims restate the already-ledgered deep-dives (Effect TS, postgres.js,
+doobie, skunk, Quill, Ecto, sqlx, sqlc, EF Core, persistent+esqueleto); this ledger grounds
+the **D-specific** claims and the runnable example.
+
+## Claims
+
+| #   | Claim                                                                                                         | Type           | Source (local + locator)                                                         | Evidence                                                                                                                                                                                                      | Status                          |
+| --- | ------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| 1   | An `i"..."` IES is not a string; it expands to a typed segment tuple (Header/Literal/Expression/value/Footer) | quote/behavior | `docs/guidelines/interpolated-expression-sequences.md` §3 (`:127-163`)           | "The compiler transforms it into a **sequence** of typed segments … `InterpolationHeader, ...segments..., InterpolationFooter`"                                                                               | ✓                               |
+| 2   | IES does NOT implicitly convert to `string` — a deliberate anti-injection decision                            | quote          | `docs/guidelines/interpolated-expression-sequences.md` §2 (`:100`)               | "IES does not implicitly convert to `string`. This is a deliberate safety decision to prevent injection vulnerabilities."                                                                                     | ✓                               |
+| 3   | Library dispatches on segment type: literal→text, expression→skip, value→placeholder+bind                     | behavior       | `$REPOS/dlang/interpolation-examples/lib/sql.d:40-48` (SQLite path)              | `static if (is(arg == InterpolatedLiteral!str, string str)) sql ~= str; … else sql ~= "?" ~ to!string(++number);`                                                                                             | ✓                               |
+| 4   | The parameterized SQL skeleton is computed at compile time (CTFE), not per call                               | behavior       | `$REPOS/dlang/interpolation-examples/lib/sql.d:36-50`                            | `enum string query = () { string sql; … foreach(idx, arg; Args) … }();` (an `enum` = CTFE constant)                                                                                                           | ✓                               |
+| 5   | The same user code emits different placeholders per engine (SQLite `?N`, Postgres `$N`, MySQL `?`)            | behavior       | `lib/sql.d:48` (`"?"~number`), `:78` (`"$"~idx`), `:100` (`"?"`)                 | three `execi` overloads; comment `:12-13` "all do it slightly differently … the user code works the same"                                                                                                     | ✓                               |
+| 6   | `06-sql.d` demo: hostile `name` is bound, not injected                                                        | quote          | `$REPOS/dlang/interpolation-examples/06-sql.d:12-17`                             | "you might think this is sql injection... but it isn't! the lib uses the rich metadata … prepared statements …"; `string name = "' DROP TABLE', '"; db.execi(i"INSERT INTO sample VALUES ($(id), $(name))");` | ✓                               |
+| 7   | `InterpolatedExpression!"code"` carries the source text of the expression (metadata only)                     | quote          | `docs/guidelines/interpolated-expression-sequences.md` §3 (`:141`, `:168`)       | "`InterpolatedExpression!\"code\"` … Source text of next expression"; ".expression enum"                                                                                                                      | ✓                               |
+| 8   | Runnable demo output matches the `[Output]` block                                                             | figure         | CI: `ci --verify docs/research/sql/safe-interpolation.md` (this session)         | `✓ ran │ ✓ output matches` — `SQL: INSERT INTO sample (id, name) VALUES ($1, $2)` / `params: ["1", "'; DROP TABLE sample; --"]`                                                                               | ✓                               |
+| 9   | `static foreach` over IES needs a per-iteration scope (`{{ }}`) for pattern captures                          | behavior       | ldc2 1.41 compile (this session) + guideline `styled_template` example (`:547`)  | first `{ }` build failed ("`s` is already defined"); `{{ }}` (as in `styled_template`) compiles                                                                                                               | ✓                               |
+| 10  | `core.interpolation` is druntime (no external dep); IES = accepted DIP1036                                    | fact           | `lib/sql.d:3` (`import core.interpolation;`); guideline References (`:764,778`)  | druntime import; "DIP1036 — String Interpolation"                                                                                                                                                             | ◯ (DIP acceptance web-attested) |
+| 11  | Python PEP 750 t-strings produce a `Template`, not a `str`, for safe interpolation                            | fact           | web (PEP 750)                                                                    | forward-looking; flagged web-attested in the page                                                                                                                                                             | ◯                               |
+| 12  | C# `$"..."` can bind to `string` (unsafe) or `FormattableString` (safe); EF Core dual overloads               | behavior       | restated from [`ef-core.md`](../ef-core.md) (`FromSqlInterpolated`/`FromSqlRaw`) | ledgered in `grounding/ef-core.md`                                                                                                                                                                            | ✓ (via deep-dive)               |
+
+## Discrepancies
+
+None. The `{{ }}` scope requirement (row 9) is a D idiom, not a page error — the page's
+embedded example uses `{{ }}` and CI-verifies.
+
+## Unsourced / opinion
+
+The "families rank cleanly by how early/enforced the split is" framing and the
+`sparkles:sql` implications are editorial synthesis (grounded in the mechanisms above and the
+[comparison](../comparison.md) design brief).
+
+## Net
+
+12 claims — 9 ✓ local-primary (D source + guideline + CI run), 1 ✓ via a sibling deep-dive
+ledger, 2 ◯ web-attested (DIP1036 acceptance date, PEP 750). 0 discrepancies. The runnable
+example is CI-verified.

--- a/docs/research/sql/index.md
+++ b/docs/research/sql/index.md
@@ -18,8 +18,9 @@ This survey answers seven questions:
    [concepts: the abstraction ladder][ladder] and the [master catalog](#master-catalog).
 2. **How is SQL made injection-safe, and how do the mechanisms differ?** Runtime
    tagged-templates vs typed builders vs compile-time quotation vs macro-checked raw SQL.
-   See [concepts: statements, parameters & injection][safety] and the
-   [by-query-model taxonomy](#by-query-construction-model).
+   See [concepts: statements, parameters & injection][safety], the
+   [by-query-model taxonomy](#by-query-construction-model), and the
+   [safe-interpolation case study][safe-interp] (which features D's IES).
 3. **Compile-time or runtime query construction — who checks the query, and when?**
    Type-level schemas and macros ([Quill][quill], `sqlx`, `Squeal`, `jOOQ`) vs runtime AST
    builders. See the [comparison][comparison].
@@ -196,6 +197,7 @@ deep-dives (some forward-dated pending their wave).</sub>
   query DSL, `Idiom`/`NamingStrategy`) → [doobie][doobie] + [skunk][skunk] (the cats-effect
   free-monad and pure-FP-Postgres alternatives) → the [comparison][comparison].
 - **"I want the safe-SQL-without-an-ORM story."** [concepts: injection safety][safety] →
+  the [safe-interpolation case study][safe-interp] (the technique + D's IES) →
   [Effect TS][effect-ts] / [doobie][doobie] (tagged templates) → [sqlx][sqlx] / [sqlc][sqlc]
   (macro-checked / codegen'd raw SQL) → [hasql][hasql] / [Dapper][dapper] (micro-mappers).
 - **"I want the typed-query-builder lineage."** [Slick][slick] → [Squeal][squeal] /
@@ -224,6 +226,8 @@ Grouped by category; see the [master catalog](#master-catalog) for the one-line 
   [JDBI][jdbi].
 - **Synthesis:** [Comparison & Synthesis][comparison] — the cross-cutting analysis + the
   effects-first `sparkles:sql` design brief.
+- **Case study:** [Safe SQL Interpolation][safe-interp] — how each ecosystem makes the
+  `${value}` syntax injection-safe, featuring D's interpolated expression sequences (IES).
 
 ---
 
@@ -278,3 +282,4 @@ Grouped by category; see the [master catalog](#master-catalog) for the one-line 
 [pgjs]: ./postgres-js.md
 [jdbi]: ./jdbi.md
 [comparison]: ./comparison.md
+[safe-interp]: ./safe-interpolation.md

--- a/docs/research/sql/safe-interpolation.md
+++ b/docs/research/sql/safe-interpolation.md
@@ -1,0 +1,344 @@
+# Safe SQL Interpolation: A Case Study
+
+A focused cross-cutting study of the one technique this survey's design centre depends on
+most: **making the ergonomic `` sql`... ${value} ...` `` interpolation syntax the
+_injection-safe_ one**. Every library in the [master catalog][index] makes parameter
+binding its default ([concepts: statements, parameters & injection][safety]); this page
+asks _how_ — which **language facility** each ecosystem uses to let a library tell a trusted
+literal from an untrusted value — and culminates in **D's interpolated expression sequences
+(IES)**, the mechanism a `sparkles:sql` safe-SQL layer would be built on.
+
+**Last reviewed:** July 12, 2026
+
+> [!NOTE]
+> This is a synthesis/case-study page, not a library deep-dive. Its claims about a specific
+> library restate that library's deep-dive (follow the links for verbatim citations); its
+> D-specific claims are grounded in the repo's
+> [IES guideline](../../guidelines/interpolated-expression-sequences.md),
+> [`core.interpolation`][core-interpolation], and Adam D. Ruppe's
+> [`interpolation-examples`][ie-repo] (pinned locally), plus a CI-verified runnable demo.
+
+---
+
+## The problem: string-building _is_ the vulnerability
+
+SQL injection is not really a database problem; it is a **string problem**. The moment a
+query is assembled by concatenating trusted SQL text with untrusted data —
+
+```d
+// The archetypal vulnerability (any language):
+string q = "SELECT * FROM users WHERE name = '" ~ userInput ~ "'";
+// userInput = "'; DROP TABLE users; --"  ->  the data becomes SQL
+```
+
+— the boundary between _structure_ (the query) and _data_ (the values) is erased. The
+industry answer is **parameter binding**: send the query text and the data on separate
+channels, so data is never parsed as SQL ([concepts: prepared statement][safety]). The
+catch is ergonomics: the safe API (positional `?` placeholders + a parallel array of
+arguments) is clumsy and easy to misalign, while the dangerous API (`"..." + value`) is the
+one that reads naturally. **Safe interpolation** closes that gap: it makes the natural
+`${value}` syntax compile to a parameterized statement, so the readable path _is_ the safe
+path.
+
+## The core pattern: separate structure from data
+
+Strip away the syntax and every safe-interpolation mechanism does the identical thing:
+
+1. The query **structure** is taken **only from trusted source-code literals**.
+2. Every **interpolated value** becomes a **bound parameter** (`?` / `$n` / `:name`).
+
+What differs is the **language facility** that lets a library _see_ the literal-vs-value
+boundary at the call site. That facility is the whole story, and the ecosystems split into
+five families.
+
+---
+
+## The mechanisms, by language facility
+
+### Runtime tagged templates (JavaScript/TypeScript)
+
+JS tagged templates hand the callee the literal segments and the interpolated values as
+**separate arguments** — `` sql`a ${x} b` `` calls `sql(["a ", " b"], x)`. The value can
+never join the literal array, so the tag binds it. [postgres.js][pgjs] makes the _same_
+`sql` function both the query tag and the fragment/identifier builder; [Effect TS][effect-ts]
+wraps the identical idea in an effect system, where every non-`Fragment` interpolation
+becomes a bound `Parameter` and a `Statement` _is_ an `Effect`. Resolved at **runtime**.
+
+```ts
+// postgres.js / Effect TS — the ${id} is bound, not concatenated
+const rows = await sql`SELECT * FROM users WHERE id = ${userId}`;
+```
+
+### Macro string interpolators (Scala)
+
+Scala's `StringContext` splits `sql"a $x b"` into `parts` (the literals) and `args` (the
+values); a macro-backed interpolator emits `?` for each arg and binds it. [doobie][doobie]'s
+`sql"..."` / `fr"..."` (each `$x` needs a `Put[A]`) and [skunk][skunk]'s typed fragments
+work this way — skunk's docs even state it **"never interpolates statement arguments."**
+Expansion is compile-time; values bind at runtime.
+
+### Quasi-quotation and AST macros (query-as-data)
+
+The strongest form does not build a string _at all_: a macro reifies the query as an
+**abstract syntax tree**, and interpolated values enter as **lifts** (bound params). Text is
+produced only when a dialect renders the AST.
+
+- [Quill][quill] — `quote { query[Person].filter(_.id == lift(id)) }` is a compile-time
+  macro producing a `Quoted[T]` = AST + `Planter` lifts; the only injection surface is the
+  explicit `#$` splice in its `sql"..."` escape.
+- [Ecto][ecto] — query **macros** build an `%Ecto.Query{}`; the **`^` pin operator** marks a
+  value as a bound parameter, and `fragment(...)` is the guarded raw escape.
+- [persistent + esqueleto][pe] — a Template-Haskell **quasi-quoter**
+  (`[persistLowerCase| … |]`) reifies the schema; esqueleto's `val` binds parameters.
+
+### Macro-checked raw SQL (Rust/Go)
+
+You still write SQL as a string literal, but a build step **validates** it and binds the
+holes. [sqlx][sqlx]'s `query!("… WHERE id = $1", id)` checks the SQL against a real database
+at compile time and infers the result type; [sqlc][sqlc] parses `-- name:`-annotated SQL
+with an embedded real grammar and generates typed code. The value is always a separate,
+bound argument.
+
+### Interpolated strings that decompose into a format + args (.NET)
+
+C# interpolated strings are the subtle case. `$"… {x} …"` can bind to a plain `string`
+(**unsafe** — the hole is concatenated) _or_ to a `FormattableString` (**safe** — the hole is
+a captured argument). [EF Core][ef-core]'s `FromSqlInterpolated($"… {id} …")` turns each hole
+into a `@p0` parameter, while its `FromSqlRaw(string)` sibling carries the verbatim warning to
+**"never pass a concatenated or interpolated string."** The safety therefore rides on
+_choosing the right overload_ — a plain `$"..."` assigned to `string` silently loses the
+boundary. This is the foot-gun D's design closes (below).
+
+### Emerging: dedicated template strings (Python)
+
+Python 3.14's **t-strings** (PEP 750) make `t"… {x} …"` evaluate to a `Template` object —
+explicitly **not** a `str` — precisely so database and HTML libraries can bind or escape the
+interpolations rather than receive a pre-built string. That a mainstream language is adding a
+new literal form _whose whole purpose is safe interpolation_ is independent validation of the
+design direction. _(Forward-looking; web-attested.)_
+
+---
+
+## The D approach: Interpolated Expression Sequences (IES)
+
+D's [IES][d-spec-ies] (accepted as [DIP1036][dip1036], runtime types in
+[`core.interpolation`][core-interpolation]) is the **most static** point on this whole
+spectrum — the tagged-template idea moved to compile time and into the type system.
+
+An `i"..."` literal is **not a string**. The compiler expands it, at compile time, into a
+**typed tuple of segments**:
+
+```d
+int id = 1;
+string name = "Alice";
+auto ies = i"INSERT INTO sample (id, name) VALUES ($(id), $(name))";
+
+// expands to a sequence equivalent to:
+//   InterpolationHeader(),
+//   InterpolatedLiteral!"INSERT INTO sample (id, name) VALUES (",  // trusted literal
+//   InterpolatedExpression!"id",   // the SOURCE TEXT "id" — metadata only
+//   id,                            // the runtime VALUE (untrusted)
+//   InterpolatedLiteral!", ",
+//   InterpolatedExpression!"name",
+//   name,                          // the runtime VALUE (untrusted)
+//   InterpolatedLiteral!")",
+//   InterpolationFooter()
+```
+
+A library consumes it with a three-branch `static if` over the segment types — literal text
+goes into the SQL verbatim, the expression-source is skipped, and every **value** becomes a
+placeholder plus a bound parameter. Adam D. Ruppe's real-world binding
+([`interpolation-examples/lib/sql.d`][ie-sql]) does exactly this, emitting the _right_
+placeholder per engine (`?1`/`?2` for SQLite, `$1`/`$2` for Postgres, `?` for MySQL) from the
+**same** user code:
+
+```d
+// lib/sql.d (SQLite path) — the load-bearing loop, abridged
+foreach (idx, arg; Args)
+    static if (is(arg == InterpolatedLiteral!str, string str))
+        sql ~= str;                         // trusted literal -> query text
+    else static if (is(arg == InterpolatedExpression!code, string code))
+        {}                                  // expression source -> skip (metadata)
+    else
+        sql ~= "?" ~ to!string(++number);   // value -> placeholder; bound below
+```
+
+Its demo ([`06-sql.d`][ie-06]) drives the point home with a hostile value, and its own
+comment answers the obvious worry:
+
+> _"you might think this is sql injection... but it isn't! the lib uses the rich metadata
+> provided by the interpolated sequence to use prepared statements appropriate for the db
+> engine under the hood."_
+
+```d
+int id = 1;
+string name = "' DROP TABLE', '";
+db.execi(i"INSERT INTO sample VALUES ($(id), $(name))");   // safe: name is bound
+```
+
+### A runnable, injection-neutralizing demo
+
+The mechanism, self-contained (no database, no external dependency — `core.interpolation` is
+in druntime). `buildQuery` accepts an IES and returns the parameterized SQL alongside its
+out-of-band binds; the `InterpolationHeader`/`InterpolationFooter` parameters are type-level
+guards that make the function callable _only_ with `i"..."`, never a plain string:
+
+```d
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "readme_safe_sql_interpolation"
++/
+
+import core.interpolation;
+import std.array : appender;
+import std.conv : to;
+import std.stdio : writeln;
+
+// A query paired with its out-of-band bind parameters — never a single string.
+struct SafeQuery
+{
+    string sql;
+    string[] params;
+}
+
+SafeQuery buildQuery(Seq...)(InterpolationHeader, Seq data, InterpolationFooter)
+{
+    auto sql = appender!string;
+    string[] params;
+    int n;
+    static foreach (item; data)
+    {{
+        // A literal fragment from the SOURCE CODE — trusted, goes in verbatim.
+        static if (is(typeof(item) == InterpolatedLiteral!s, string s))
+            sql ~= s;
+        // The source text of an interpolated expression ("id", "name") — metadata only.
+        else static if (is(typeof(item) == InterpolatedExpression!c, string c))
+        {
+        }
+        // Anything else is the runtime VALUE — untrusted: bind it out-of-band.
+        else
+        {
+            sql ~= "$" ~ (++n).to!string;
+            params ~= item.to!string;
+        }
+    }}
+    return SafeQuery(sql[], params);
+}
+
+void main()
+{
+    int id = 1;
+    string name = "'; DROP TABLE sample; --"; // hostile input
+
+    auto q = buildQuery(i"INSERT INTO sample (id, name) VALUES ($(id), $(name))");
+
+    writeln("SQL:    ", q.sql);
+    writeln("params: ", q.params);
+}
+```
+
+```[Output]
+SQL:    INSERT INTO sample (id, name) VALUES ($1, $2)
+params: ["1", "'; DROP TABLE sample; --"]
+```
+
+The hostile `name` lands in `params` as `$2`; it never touches the SQL text. This example is
+compiled and run by CI ([AGENTS § runnable examples](../../guidelines/AGENTS.md#runnable-readme-examples)).
+
+### Two properties that set IES apart
+
+- **The SQL skeleton is a compile-time constant.** The `InterpolatedLiteral` segments carry
+  their text as _template parameters_, so the parameterized query string is computed by
+  [CTFE][ctfe] — there is no per-call string-building, which matters for `@nogc`/hot paths.
+  (Ruppe's `lib/sql.d` computes its `enum string query` entirely at compile time.)
+- **An IES cannot silently decay into a `string`.** The [IES guideline][ies-guide] states it
+  plainly: _"IES does not implicitly convert to `string`. This is a deliberate safety
+  decision to prevent injection vulnerabilities."_ Where C#'s `$"..."` can be assigned to a
+  `string` and lose its bound-parameter structure, `i"...$(x)"` **will not compile** where a
+  `string` is expected — the boundary is enforced by the type system, closing the .NET
+  overload foot-gun by construction.
+
+D also keeps, uniquely alongside Python's coming t-strings, the **source text of each
+interpolation** (`InterpolatedExpression!"code"`) — irrelevant to binding, but a free win for
+structured logging and query debugging.
+
+---
+
+## Comparison
+
+| Ecosystem / facility                                        | Syntax              | Boundary resolved  | Prevents accidental string-building? | Keeps expression source? |
+| ----------------------------------------------------------- | ------------------- | ------------------ | ------------------------------------ | ------------------------ |
+| JS tagged templates ([pg.js][pgjs], [Effect TS][effect-ts]) | `` sql`… ${x}` ``   | Runtime            | Yes (tag receives arrays)            | No                       |
+| Scala `StringContext` ([doobie][doobie], [skunk][skunk])    | `sql"… $x"`         | Compile (expand)   | Partial                              | No                       |
+| Quotation / AST ([Quill][quill], [Ecto][ecto])              | `quote{…}` / `^x`   | Compile            | Yes (query is an AST)                | n/a                      |
+| Macro-checked SQL ([sqlx][sqlx], [sqlc][sqlc])              | `query!("… $1", x)` | Compile (vs DB)    | Yes                                  | No                       |
+| C# `FormattableString` ([EF Core][ef-core])                 | `$"… {x}"`          | Runtime            | **No** (degrades to `string`)        | No                       |
+| Python t-strings (PEP 750)                                  | `t"… {x}"`          | Runtime            | Yes (`Template` ≠ `str`)             | Yes                      |
+| **D IES** ([DIP1036][dip1036])                              | `i"… $(x)"`         | **Compile (CTFE)** | **Yes (IES ≠ `string`)**             | **Yes**                  |
+
+The families rank cleanly by _how early_ and _how enforced_ the structure/data split is. D's
+IES sits at the strong corner: the split is resolved at compile time, the parameterized query
+is a compile-time constant, and the type system refuses the unsafe fallback — while remaining
+a general language feature (the same `i"..."` powers HTML escaping, URL encoding, and the
+repo's own [`styled_template`](../../../libs/base/src/sparkles/base/styled_template.d)).
+
+---
+
+## Implications for `sparkles:sql`
+
+For the effects-first design this survey informs, IES is the obvious substrate for the
+safe-SQL layer, and it composes cleanly with the ideas the [comparison][comparison] draws
+from the effect systems:
+
+- **The `sql` capability is an IES-accepting query constructor.** A function of the shape
+  `(InterpolationHeader, Args…, InterpolationFooter)` that yields a prepared statement — the D
+  analogue of [Effect TS][effect-ts]'s move where the injected service _is_ the `sql` tag, so
+  obtaining "the database" and "the safe way to write a query" are one act.
+- **Dialect rendering at compile time.** Compute the parameterized skeleton via CTFE and pick
+  the placeholder style (`?` / `$n` / `:name`) from a [Quill][quill]-style `Idiom` — Ruppe's
+  `lib/sql.d` already demonstrates per-engine placeholders from one call site.
+- **The boundary is type-enforced, not convention.** Because an IES cannot decay into a
+  `string`, the safe path is the _only_ path — no `FromSqlRaw`-style escape hatch is reachable
+  by accident; a raw-SQL escape must be spelled out explicitly (`.unsafe`), matching every
+  well-designed library in the survey.
+- **It stays below the ORM line.** Safe interpolation gives typed, composable, injection-proof
+  queries with zero identity-map / unit-of-work machinery — exactly the "functional data
+  mapper that stops below the full-ORM rung" the [comparison][comparison] recommends.
+
+---
+
+## Sources
+
+- **D IES:** the repo's [Interpolated Expression Sequences guideline][ies-guide];
+  [`core.interpolation`][core-interpolation]; the [D spec on interpolation][d-spec-ies];
+  [DIP1036][dip1036]. Real-world binding: Adam D. Ruppe's
+  [`interpolation-examples`][ie-repo] — [`lib/sql.d`][ie-sql] and [`06-sql.d`][ie-06].
+- **Foreign mechanisms:** each restates its own deep-dive — [Effect TS][effect-ts],
+  [postgres.js][pgjs], [doobie][doobie], [skunk][skunk], [Quill][quill], [Ecto][ecto],
+  [sqlx][sqlx], [sqlc][sqlc], [EF Core][ef-core], [persistent + esqueleto][pe] — and the
+  shared vocabulary in [concepts][safety].
+- **Python t-strings:** PEP 750 (web-attested, forward-looking).
+
+<!-- References -->
+
+[index]: ./index.md
+[comparison]: ./comparison.md
+[safety]: ./concepts.md#statements-parameters-and-sql-injection
+[effect-ts]: ./effect-ts.md
+[pgjs]: ./postgres-js.md
+[doobie]: ./doobie.md
+[skunk]: ./skunk.md
+[quill]: ./quill.md
+[ecto]: ./ecto.md
+[sqlx]: ./sqlx.md
+[sqlc]: ./sqlc.md
+[ef-core]: ./ef-core.md
+[pe]: ./persistent-esqueleto.md
+[ies-guide]: ../../guidelines/interpolated-expression-sequences.md
+[d-spec-ies]: https://dlang.org/spec/istring.html
+[core-interpolation]: https://dlang.org/phobos/core_interpolation.html
+[dip1036]: https://github.com/dlang/DIPs/blob/master/DIPs/other/DIP1036.md
+[ctfe]: https://dlang.org/spec/function.html#interpretation
+[ie-repo]: https://github.com/adamdruppe/interpolation-examples
+[ie-sql]: https://github.com/adamdruppe/interpolation-examples/blob/master/lib/sql.d
+[ie-06]: https://github.com/adamdruppe/interpolation-examples/blob/master/06-sql.d


### PR DESCRIPTION
Follow-up to #99 (which merged the SQL & ORM survey). This adds the one thing that landed
just after the merge: a **case study on safe SQL interpolation**.

## What

`docs/research/sql/safe-interpolation.md` — a cross-cutting study of *how each ecosystem
makes the ergonomic `${value}` interpolation syntax injection-safe*, grouped by language
facility:

- **Runtime tagged templates** (postgres.js, Effect TS) · **Scala `StringContext`** (doobie,
  skunk) · **quasi-quotation / AST macros** (Quill, Ecto, persistent) · **macro-checked raw
  SQL** (sqlx, sqlc) · **C# `FormattableString`** (EF Core — the `$"..."`→`string` foot-gun) ·
  **Python PEP 750 t-strings** (forward-looking).
- **Featured: D's interpolated expression sequences (IES / DIP1036)** — the most *static*
  point on the spectrum and the mechanism a `sparkles:sql` safe-SQL layer would build on.
  Grounded in Adam D. Ruppe's `interpolation-examples` (`lib/sql.d` + `06-sql.d`) and the
  repo's IES guideline.
- A **comparison table** and a `sparkles:sql` **implications** section (the `sql` IES-accepting
  constructor *is* the injected capability; compile-time-constant SQL skeleton via CTFE; an IES
  can't decay into a `string`, closing the C# foot-gun).

## Runnable, CI-verified example

Ships a self-contained `[Output]` demo — `buildQuery(i"INSERT ... ($(id), $(name))")` →
`("... VALUES ($1, $2)", ["1", "'; DROP TABLE sample; --"])` — proving the hostile value is
**bound**, not injected. Verified locally with the repo's own `ci --verify` (`✓ output
matches`), so `verify-md-examples` covers it in CI.

Wired into the umbrella, `concepts.md`, `comparison.md`, the sidebar, and the grounding ledger
(`interpolation-examples` pinned @ `a8a5d4d`). `docs:build` green.

🤖 Generated with [Claude Code](https://claude.ai/code)