### PR TITLE
feat(syntax): M7 — tree-sitter injections (markdown + fenced code end-to-end)

### DIFF
--- a/docs/libs/syntax/reference/engine.md
+++ b/docs/libs/syntax/reference/engine.md
@@ -31,9 +31,9 @@ auto config = TsHighlightConfig.create(grammar, highlightsScm, error);
 config.configure(labels);   // capture names → LabelIds (longest-dot-prefix)
 ```
 
-Built once per (language, vocabulary); non-copyable, pass by `ref`. The
-`injectionsScm`/`localsScm` parameters are recorded seams for the injection
-milestone.
+Built once per (language, vocabulary); non-copyable, pass by `ref`. Passing an
+`injectionsScm` also compiles the language's injections query (used by
+`highlightInjected`, below); `localsScm` stays a recorded seam (locals deferred).
 
 **Predicates.** The C API records query predicates but does not evaluate
 them — the engine implements the reference text-predicate set: `#eq?` /
@@ -57,6 +57,36 @@ removed, ends close before starts at equal offsets, **same-node
 last-pattern-wins**, unresolved captures emit nothing, cancellation checked
 every 100 events plus inside the C query execution.
 
+## Injections
+
+`highlightInjected` highlights embedded languages — fenced code blocks,
+`markdown_inline`, HTML/YAML/TOML front-matter:
+
+```d
+auto registry = GrammarRegistry.fromEnvironment();
+auto cache = TsConfigCache.create(&registry, LabelSet.standard());
+auto result = highlightInjected(cache, "markdown", source, sink);
+```
+
+It parses the root language, discovers injections via each layer's injections
+query, parses each embedded byte range with its own grammar
+(`TsParser.setIncludedRanges`), and folds every layer into one position-ordered
+event stream — the reference layer stack: earliest boundary wins (ends before
+starts, deeper layers first), a global `source` fill, same-node last-wins per
+layer, identical `[start,end)` ranges deduped to the deepest layer.
+
+`TsConfigCache` maps a language name to a configured `TsHighlightConfig` (loaded
+through the registry, cached and owned); a missing grammar or query renders that
+range as plain text (totality). The injected language comes from a captured
+`@injection.language` node or a `#set! injection.language` directive;
+`injection.include-children` is honored, and by default only the content node's
+_named_ children are excluded (so a query that omits the directive still
+re-parses escapes/delimiters). `injection.combined` and locals are deferred;
+nesting is depth-capped (`injectionDepthExceeded`).
+
+`highlight` stays the single-language entry point — a language with no
+injections yields a byte-identical stream through either path.
+
 ## Guards (`HighlightOptions`)
 
 | Option           | Default | Rationale                                                                                                      |
@@ -72,16 +102,15 @@ every 100 events plus inside the C query execution.
 `grammarNotFound` / `dlopenFailed` / `symbolNotFound` / `incompatibleAbi`
 (loader), `queryFileMissing` / `querySyntax` / `queryNodeType` / … (query
 compile, byte offset in `detail`), `sourceTooLarge` / `parseTimeout` /
-`parseCancelled` / `highlightTimeout` / `highlightCancelled` (guards),
-`unsupportedPlatform` (non-Posix dlopen). All surface as
-`TsExpected!T = Expected!(T, TsError, NoGcHook)`.
+`parseCancelled` / `highlightTimeout` / `highlightCancelled` /
+`injectionDepthExceeded` (guards), `unsupportedPlatform` (non-Posix dlopen).
+All surface as `TsExpected!T = Expected!(T, TsError, NoGcHook)`.
 
 ## Out of scope (v1)
 
-Injection layers (`injections.scm` — markdown-inline and fenced code blocks;
-the next milestone, seams in place), locals, UTF-16 sources, Windows
-`LoadLibrary`, incremental editing (keep the `TsTree`, re-parse, call
-`highlightTree` — the split exists; the machinery doesn't yet).
+`injection.combined`, locals, UTF-16 sources, Windows `LoadLibrary`, incremental
+editing (keep the `TsTree`, re-parse, call `highlightTree` — the split exists;
+the machinery doesn't yet).
 
 ## See also
 

--- a/docs/specs/syntax/PLAN.md
+++ b/docs/specs/syntax/PLAN.md
@@ -13,20 +13,19 @@ justification read the [proposal](./index.md); for the evidence base read the
 
 ## 1. Milestone overview
 
-| #      | Deliverable                                                                                             | Prior art                        | Depends on |
-| ------ | ------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------- |
-| **M1** | Core seam: `event.d` (events, `byStyledSpan`), `label.d` (vocabulary, longest-dot-prefix), `color.d`    | [ts-highlight] · [helix] · [bat] | —          |
-| **M2** | Theme layer (`theme.d`, `themes.d`) + ANSI backend (`render/ansi.d`)                                    | [helix] · [bat]                  | M1         |
-| **M3** | `writeHtmlEscaped` (base) + HTML backend (`render/html.d`, stylesheet emitter)                          | [ts-highlight] · [shiki]         | M1, M2     |
-| **M4** | `sparkles:tree-sitter` binding (ImportC, RAII, dlopen loader) + Nix runtime & grammar bundle (json)     | [importc] · [ts-highlight]       | —          |
-| **M5** | Precise engine: registry, query config, text predicates, reference event loop → end-to-end ANSI/HTML    | [ts-highlight] · [helix]         | M1–M4      |
-| **M6** | Full grammar bundle (target + docs-fence languages incl. D), language normalization, library docs       | [helix] (supply chain)           | M4, M5     |
-| **M7** | _(next)_ Injections: merged query, `#set!` consumption, layer stack — markdown + fenced code end-to-end | [ts-highlight] · [helix]         | M5, M6     |
+| #      | Deliverable                                                                                                                       | Prior art                        | Depends on |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------- |
+| **M1** | Core seam: `event.d` (events, `byStyledSpan`), `label.d` (vocabulary, longest-dot-prefix), `color.d`                              | [ts-highlight] · [helix] · [bat] | —          |
+| **M2** | Theme layer (`theme.d`, `themes.d`) + ANSI backend (`render/ansi.d`)                                                              | [helix] · [bat]                  | M1         |
+| **M3** | `writeHtmlEscaped` (base) + HTML backend (`render/html.d`, stylesheet emitter)                                                    | [ts-highlight] · [shiki]         | M1, M2     |
+| **M4** | `sparkles:tree-sitter` binding (ImportC, RAII, dlopen loader) + Nix runtime & grammar bundle (json)                               | [importc] · [ts-highlight]       | —          |
+| **M5** | Precise engine: registry, query config, text predicates, reference event loop → end-to-end ANSI/HTML                              | [ts-highlight] · [helix]         | M1–M4      |
+| **M6** | Full grammar bundle (target + docs-fence languages incl. D), language normalization, library docs                                 | [helix] (supply chain)           | M4, M5     |
+| **M7** | Injections: per-layer injections query, `#set!` consumption, layer stack with included ranges — markdown + fenced code end-to-end | [ts-highlight] · [helix]         | M5, M6     |
 
 M1–M3 are pure D over `sparkles:base` and prove both backends with synthetic streams.
 M4 is independent of M1–M3 (only the seam types are shared) and can proceed in parallel.
-M5 is the integration milestone; M6 is supply chain + docs; M7 is scheduled but not part
-of this drop.
+M5 is the integration milestone; M6 is supply chain + docs; M7 adds embedded languages.
 
 ## 2. Per-milestone detail
 
@@ -132,12 +131,24 @@ nothrow)` around `#include <tree_sitter/api.h>`; unique stem), `errors.d`
 - Minimal `docs/libs/syntax/` Diátaxis tree + Libraries sidebar entry; README example
   highlighting real D source.
 
-### M7 — injections _(next drop)_
+### M7 — injections _(shipped)_
 
-Merged query construction (injections → locals → highlights with pattern-index
-boundaries), `#set!` consumption (`injection.language`/`combined`/`include-children`),
-layer stack with included ranges, registry-wired language lookup; markdown +
-markdown-inline end-to-end, fenced D blocks highlighted inside markdown.
+`highlightInjected` (`ts/highlighter.d`) parses the root language, discovers
+embedded languages via each layer's injections query, parses them over their
+byte ranges (`TsParser.setIncludedRanges`), and folds all layers into one
+position-ordered event stream — the reference `tree-sitter-highlight`
+layer-stack model. `ts/injection.d` holds `injectionForMatch` (language from the
+`@injection.language` node or a `#set!` directive; content node;
+include-children), `intersectRanges` (whole node, or the gaps between the
+content node's _named_ children — see the deviation note there), and
+`TsConfigCache` (the `injection_callback`: language → configured
+`TsHighlightConfig`, registry-loaded and owned). `ts/config.d` compiles the
+per-language injections query alongside highlights.
+
+End-to-end: fenced D blocks highlighted inside markdown, markdown →
+markdown_inline self-injection, static `#set! injection.language` (HTML/YAML/
+TOML front-matter), depth-capped recursion. Deferred (seams kept):
+`injection.combined` and locals scope-tracking.
 
 ## 3. Verification
 

--- a/docs/specs/syntax/index.md
+++ b/docs/specs/syntax/index.md
@@ -118,10 +118,11 @@ palette)` concretizer and a `byStyledLine` per-line adapter are recorded seams.
   chain (compiled grammars from nixpkgs vs a `.sublime-syntax` interpreter plus an
   Oniguruma binding plus a YAML subset). The event seam is designed for it; nothing else
   waits for it.
-- **No injections, no locals in v1.** Injection layers (markdown's inline grammar,
-  fenced code blocks) are the next headline milestone — the config API and `#set!`
-  storage already carry the seams. Locals ([def/use coloring][ts-highlight]) are a
-  quality bonus deferred indefinitely for batch rendering.
+- **Injections landed (M7); no combined injections, no locals.** Injection layers
+  (markdown's inline grammar, fenced code blocks, front-matter) ship in M7 via
+  `highlightInjected` + the layer stack. `injection.combined` and locals
+  ([def/use coloring][ts-highlight]) stay deferred — the latter a quality bonus for
+  batch rendering.
 - **No incremental/editor loop.** v1 is batch (parse once, highlight once) — the
   [Helix][helix] machinery (persistent trees, injection recycling) earns its keep only
   under an editor contract. The seam (`highlightTree` over a kept-alive tree,

--- a/libs/syntax/src/sparkles/syntax/ts/config.d
+++ b/libs/syntax/src/sparkles/syntax/ts/config.d
@@ -9,10 +9,12 @@ disable their one pattern with a warning — degrade, never fail the
 language); `configure` resolves every capture name through the core's
 longest-dot-prefix `LabelSet.resolve`, so engine output speaks `LabelId`s.
 
-The `injectionsScm`/`localsScm` parameters are recorded seams for the
-injection milestone (the reference concatenates injections → locals →
-highlights into one query and tracks pattern-index boundaries); v1 compiles
-the highlights query alone.
+`injectionsScm` (M7) compiles a second query used to discover embedded
+languages (`@injection.content`/`@injection.language` + `#set!` directives);
+`localsScm` stays a recorded seam (locals scope-tracking is deferred). Unlike
+the reference — which concatenates injections → locals → highlights into one
+query — the highlights and injections queries are kept separate here (batch
+discovery runs the injections query up front, so a merged stream is unnecessary).
 */
 module sparkles.syntax.ts.config;
 
@@ -33,6 +35,14 @@ struct TsHighlightConfig
     package PatternPredicates[] predicates; /// per pattern index
     string[] warnings;                      /// disabled-pattern diagnostics
 
+    // Injections (M7). `injectionQuery` is invalid when the language ships no
+    // `injections.scm` (or it failed to compile — a warning, never a hard fail:
+    // the language still highlights, it just injects nothing).
+    package TsQuery injectionQuery;                  /// the compiled injections query (may be invalid)
+    package PatternPredicates[] injectionPredicates; /// per injection pattern (for `#set!` reads)
+    package uint injectionContentIndex = uint.max;   /// `@injection.content` capture id (or `uint.max`)
+    package uint injectionLanguageIndex = uint.max;  /// `@injection.language` capture id (or `uint.max`)
+
     @disable this(this);
 
     /**
@@ -44,8 +54,9 @@ struct TsHighlightConfig
     static TsHighlightConfig create(Grammar grammar, string highlightsScm, out TsError error,
         string injectionsScm = null, string localsScm = null) @safe
     {
-        // Recorded seams for the injection milestone — see the module header.
-        cast(void) injectionsScm;
+        import std.conv : text;
+
+        // Locals scope-tracking stays a recorded seam (deferred — PLAN §4).
         cast(void) localsScm;
 
         TsHighlightConfig config;
@@ -61,14 +72,49 @@ struct TsHighlightConfig
             auto parsed = parsePatternPredicates(config.query, p);
             if (parsed.unsupported.length)
             {
-                import std.conv : text;
-
                 config.query.disablePattern(p);
                 config.warnings ~= text("pattern ", p, " disabled: unsupported predicate ",
                     parsed.unsupported);
             }
             config.predicates[p] = parsed.predicates;
         }
+
+        // Injections (M7): compile the language's `injections.scm` when present.
+        // A compile failure degrades to "no injections" with a warning — the
+        // highlights query is unaffected, so the language still highlights.
+        if (injectionsScm.length)
+        {
+            TsError injError;
+            config.injectionQuery = TsQuery.create(grammar.language, injectionsScm, injError);
+            if (config.injectionQuery.valid)
+            {
+                const injPatterns = config.injectionQuery.patternCount;
+                config.injectionPredicates = new PatternPredicates[](injPatterns);
+                foreach (p; 0 .. injPatterns)
+                {
+                    auto parsed = parsePatternPredicates(config.injectionQuery, p);
+                    if (parsed.unsupported.length)
+                    {
+                        config.injectionQuery.disablePattern(p);
+                        config.warnings ~= text("injection pattern ", p,
+                            " disabled: unsupported predicate ", parsed.unsupported);
+                    }
+                    config.injectionPredicates[p] = parsed.predicates;
+                }
+                foreach (i; 0 .. config.injectionQuery.captureCount)
+                {
+                    const name = config.injectionQuery.captureName(i);
+                    if (name == "injection.content")
+                        config.injectionContentIndex = i;
+                    else if (name == "injection.language")
+                        config.injectionLanguageIndex = i;
+                }
+            }
+            else
+                config.warnings ~= text("injections query failed to compile (offset ",
+                    injError.detail, "); no injections for this language");
+        }
+
         error = TsError.init;
         return config;
     }
@@ -96,4 +142,10 @@ struct TsHighlightConfig
     /// `true` iff `configure` ran (labels are mapped).
     bool configured() const scope @safe nothrow @nogc
         => valid && captureToLabel.length == query.captureCount;
+
+    /// `true` iff a usable injections query was compiled (a valid query with an
+    /// `@injection.content` capture). The engine skips injection discovery when
+    /// this is `false`.
+    bool hasInjections() const scope @safe nothrow @nogc
+        => injectionQuery.valid && injectionContentIndex != uint.max;
 }

--- a/libs/syntax/src/sparkles/syntax/ts/highlighter.d
+++ b/libs/syntax/src/sparkles/syntax/ts/highlighter.d
@@ -23,8 +23,12 @@ The internal `parse` → $(LREF highlightTree) split is the incremental seam:
 an interactive consumer keeps the `TsTree` alive, edits + re-parses it, and
 calls `highlightTree` per viewport. v1 is batch.
 
-What v1 deliberately skips: injection layers (`injections.scm` — the next
-milestone; markdown-inline etc.), locals, and UTF-16 sources.
+$(LREF highlightInjected) adds embedded languages (M7): it discovers
+injections per layer, parses each over its byte ranges, and folds all layers
+into one position-ordered stream (the reference layer stack). `highlight`
+stays the single-language entry point.
+
+Still deferred: `injection.combined`, locals scope-tracking, and UTF-16 sources.
 */
 module sparkles.syntax.ts.highlighter;
 
@@ -854,4 +858,51 @@ unittest
     const spans = labeledSpans(events, source);
     assert(spans.canFind!(s => s.endsWith(":void")),
         spans.length ? spans[0] : "no labeled spans — injection did not fire");
+}
+
+@("ts.highlighter.markdownInlineSelfInjection")
+@system
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    // markdown injects its `(inline)` content into markdown_inline. A backslash
+    // escape is inline-only and markdown_inline labels it `@string.escape`
+    // (which resolves in our vocabulary — unlike its neovim-style
+    // `@text.strong`), so the label proves the self-injection recursed.
+    const source = "a paragraph with an escape \\* here\n";
+    auto events = injectedEventsForTest("markdown", source);
+    assertWellFormed(events, source);
+
+    const spans = labeledSpans(events, source);
+    assert(spans.canFind!(s => s.canFind("string.escape")),
+        spans.length ? spans[0] : "no string.escape — inline injection did not fire");
+}
+
+@("ts.highlighter.markdownStaticSetLanguage")
+@system
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    // An HTML block routes through `#set! injection.language "html"` (no
+    // captured @injection.language node) — exercises the directive path.
+    const source = "<div class=\"x\">hi</div>\n";
+    auto events = injectedEventsForTest("markdown", source);
+    assertWellFormed(events, source);
+
+    const spans = labeledSpans(events, source);
+    assert(spans.canFind!(s => s.canFind("tag")),
+        spans.length ? spans[0] : "no tag label — html injection did not fire");
+}
+
+@("ts.highlighter.injectionRecursionIsBounded")
+@system
+unittest
+{
+    // A fenced markdown block injects markdown into markdown — recursion that
+    // the depth cap must terminate. Well-formedness proves no crash/runaway.
+    const source = "````markdown\n# Inner **b**\n````\n";
+    auto events = injectedEventsForTest("markdown", source);
+    assertWellFormed(events, source);
 }

--- a/libs/syntax/src/sparkles/syntax/ts/highlighter.d
+++ b/libs/syntax/src/sparkles/syntax/ts/highlighter.d
@@ -28,6 +28,7 @@ milestone; markdown-inline etc.), locals, and UTF-16 sources.
 */
 module sparkles.syntax.ts.highlighter;
 
+import core.lifetime : move;
 import core.time : Duration, msecs;
 import std.range.primitives : put;
 
@@ -35,12 +36,13 @@ import sparkles.base.smallbuffer : SmallBuffer;
 
 import sparkles.syntax.event : HighlightEvent, LabelId;
 import sparkles.syntax.ts.config : TsHighlightConfig;
+import sparkles.syntax.ts.injection : injectionForMatch, intersectRanges, TsConfigCache;
 import sparkles.syntax.ts.predicates : satisfies;
 import sparkles.tree_sitter.errors : TsError, TsErrorCode, TsExpected, tsErr, tsOk;
-import sparkles.tree_sitter.tree_sitter_c : TSNode, TSQueryMatch,
+import sparkles.tree_sitter.tree_sitter_c : TSNode, TSQueryMatch, TSRange,
     ts_node_end_byte, ts_node_start_byte;
-import sparkles.tree_sitter.wrappers : CancelCtx, ParseGuards, TsParser,
-    TsQueryCursor, TsTree;
+import sparkles.tree_sitter.wrappers : CancelCtx, nodeEndByte, nodeStartByte,
+    ParseGuards, TsParser, TsQueryCursor, TsTree;
 
 /// The reference crate's cancellation-check cadence.
 private enum size_t cancellationCheckInterval = 100;
@@ -235,6 +237,314 @@ in (tree.valid, "highlightTree needs a valid tree")
     if (options.matchLimitExceeded !is null && cursor.didExceedMatchLimit)
         *options.matchLimitExceeded = true;
 
+    return tsOk();
+}
+
+// ── Injection layers (M7) ───────────────────────────────────────────────────
+
+/// Hard cap on injection nesting — the reference has none (it relies on ranges
+/// strictly shrinking), but a self-injection over a node's full range could
+/// recurse unbounded, so we bound depth defensively.
+private enum size_t maxInjectionDepth = 8;
+
+/// One parsed language over a set of byte ranges, plus its interleave cursor
+/// state. Heap-allocated (owns non-copyable `TsTree`/`TsQueryCursor`); freed by
+/// the GC finalizer at end of run.
+private struct Layer
+{
+    TsTree tree;                         /// this layer's parse (kept alive for its cursor)
+    TsQueryCursor cursor;                /// the highlights capture stream
+    const(TsHighlightConfig)* config;    /// the language config
+    size_t depth;                        /// injection nesting depth (root = 0)
+    const(TSRange)[] ranges;             /// included ranges (empty = whole buffer)
+    SmallBuffer!(size_t, 16) endStack;   /// pending highlight-end byte offsets (LIFO)
+    bool havePeeked;                     /// `peeked` holds the next highlights capture
+    LayerCapture peeked;                 /// predicate-filtered lookahead
+
+    @disable this(this);
+}
+
+/// A highlights capture copied out of cursor storage (same discipline as the
+/// single-layer loop).
+private struct LayerCapture
+{
+    uint matchId;
+    uint captureId;
+    TSNode node;
+    size_t start, end;
+}
+
+/**
+Injection-aware batch highlighting: parses `rootLanguage`, discovers embedded
+languages via each layer's injections query, parses those over their byte
+ranges, and folds all layers' captures into one $(REF HighlightEvent,
+sparkles,syntax,event) stream ordered by position — the reference crate's
+layer-stack model (non-combined injections; combined + locals deferred).
+
+`cache` resolves every language (root and injected) to a configured
+$(REF TsHighlightConfig, sparkles,syntax,ts,config) and owns the results.
+Totality holds: an injection whose grammar/queries are missing renders as plain
+text; only a size-guard trip or a failed $(I root) parse returns an error.
+*/
+TsExpected!void highlightInjected(Sink)(
+    ref TsConfigCache cache,
+    const(char)[] rootLanguage,
+    scope const(char)[] source,
+    ref Sink sink,
+    HighlightOptions options = HighlightOptions()) @system
+{
+    if (source.length > options.maxSourceBytes || source.length > cast(size_t) int.max)
+        return tsErr!void(TsErrorCode.sourceTooLarge);
+
+    auto rootConfig = cache.resolve(rootLanguage);
+    if (rootConfig is null)
+        return tsErr!void(TsErrorCode.grammarNotFound);
+
+    Layer*[] layers;
+    auto built = buildLayers(cache, rootConfig, source, options, layers);
+    if (built.hasError)
+        return tsErr!void(built.error);
+
+    return interleaveLayers(layers, source, sink, options);
+}
+
+/// BFS layer construction: parse each layer, run its injections query, resolve
+/// and enqueue child layers. A failed $(I root) parse errors; a failed child
+/// parse (or unresolved injection) is skipped — that range stays plain text.
+private TsExpected!void buildLayers(
+    ref TsConfigCache cache, const(TsHighlightConfig)* rootConfig,
+    scope const(char)[] source, in HighlightOptions options, out Layer*[] layers) @system
+{
+    static struct Work
+    {
+        const(TsHighlightConfig)* config;
+        TSRange[] ranges;
+        size_t depth;
+    }
+
+    Work[] queue = [Work(rootConfig, null, 0)];
+    for (size_t qi = 0; qi < queue.length; ++qi)
+    {
+        auto w = queue[qi];
+
+        auto parser = TsParser.create();
+        auto langSet = parser.setLanguage(w.config.grammar.language);
+        if (langSet.hasError)
+        {
+            if (w.depth == 0)
+                return tsErr!void(langSet.error);
+            continue;
+        }
+        if (w.ranges.length)
+            parser.setIncludedRanges(w.ranges);
+
+        TsError parseError;
+        auto tree = parser.parse(source, parseError,
+            ParseGuards(budget: options.parseBudget, cancelFlag: options.cancelFlag));
+        if (!tree.valid)
+        {
+            if (w.depth == 0)
+                return tsErr!void(parseError);
+            continue;
+        }
+
+        auto layer = new Layer;
+        layer.config = w.config;
+        layer.depth = w.depth;
+        layer.ranges = w.ranges;
+        move(tree, layer.tree);
+        layer.cursor = TsQueryCursor.create();
+        layer.cursor.setMatchLimit(options.matchLimit);
+        layer.cursor.exec(w.config.query, layer.tree.rootNode);
+        layers ~= layer;
+
+        // Discover this layer's injections (unless it injects nothing / too deep).
+        if (!w.config.hasInjections || w.depth + 1 > maxInjectionDepth)
+            continue;
+
+        auto injCursor = TsQueryCursor.create();
+        injCursor.setMatchLimit(options.matchLimit);
+        injCursor.exec(w.config.injectionQuery, layer.tree.rootNode);
+
+        TSQueryMatch m;
+        while (injCursor.nextMatch(m))
+        {
+            if (m.pattern_index < w.config.injectionPredicates.length
+                && !satisfies(w.config.injectionPredicates[m.pattern_index], m, source))
+                continue;
+
+            auto inj = injectionForMatch(*w.config, m, source);
+            if (!inj.hasContent || inj.language.length == 0)
+                continue;
+
+            auto childConfig = cache.resolve(inj.language);
+            if (childConfig is null)
+                continue; // grammar/queries missing → plain text
+
+            auto childRanges = intersectRanges(w.ranges, inj.contentNode, inj.includeChildren);
+            if (childRanges.length == 0)
+                continue;
+
+            queue ~= Work(childConfig, childRanges, w.depth + 1);
+        }
+    }
+
+    return tsOk();
+}
+
+/// Predicate-filtered lookahead for one layer's highlights cursor (the
+/// single-layer `peek`, per layer).
+private bool peekLayer(Layer* layer, scope const(char)[] source) @system
+{
+    while (!layer.havePeeked)
+    {
+        TSQueryMatch match;
+        uint captureIndex;
+        if (!layer.cursor.nextCapture(match, captureIndex))
+            return false;
+        if (match.pattern_index < layer.config.predicates.length
+            && !satisfies(layer.config.predicates[match.pattern_index], match, source))
+        {
+            layer.cursor.removeMatch(match.id);
+            continue;
+        }
+        auto node = cast(TSNode) match.captures[captureIndex].node;
+        layer.peeked = LayerCapture(match.id, match.captures[captureIndex].index,
+            node, nodeStartByte(node), nodeEndByte(node));
+        layer.havePeeked = true;
+    }
+    return true;
+}
+
+/// The layer's next boundary: `min(next capture start, top pending end)`, ends
+/// before starts at a tie. Returns `false` when the layer is exhausted.
+private bool layerBoundary(Layer* layer, scope const(char)[] source,
+    out size_t pos, out bool isStart) @system
+{
+    const hasCapture = peekLayer(layer, source);
+    const hasEnd = layer.endStack.length != 0;
+    if (!hasCapture && !hasEnd)
+        return false;
+
+    const nextStart = hasCapture ? layer.peeked.start : size_t.max;
+    const nextEnd = hasEnd ? layer.endStack[layer.endStack.length - 1] : size_t.max;
+    if (nextEnd <= nextStart)
+    {
+        pos = nextEnd;
+        isStart = false;
+    }
+    else
+    {
+        pos = nextStart;
+        isStart = true;
+    }
+    return true;
+}
+
+/// Folds every layer's boundaries into one event stream: at each step take the
+/// globally earliest boundary (ends before starts; deeper layers first at a
+/// tie), fill the `source` gap up to it, and emit the push/pop. Identical
+/// `[start,end)` ranges are emitted once, by the deepest layer (the reference's
+/// cross-layer dedup).
+private TsExpected!void interleaveLayers(Sink)(
+    Layer*[] layers, scope const(char)[] source, ref Sink sink, in HighlightOptions options) @system
+{
+    auto ctx = CancelCtx.from(options.queryBudget, options.cancelFlag);
+
+    size_t byteOffset = 0;
+    size_t lastStart = size_t.max, lastEnd = size_t.max, lastDepth = size_t.max;
+    size_t iterations = 0;
+
+    void emitSourceUpTo(size_t offset)
+    {
+        const clamped = offset < source.length ? offset : source.length;
+        if (byteOffset < clamped)
+        {
+            put(sink, HighlightEvent.sourceSpan(byteOffset, clamped));
+            byteOffset = clamped;
+        }
+    }
+
+    for (;;)
+    {
+        if (++iterations % cancellationCheckInterval == 0 && ctx.armed && ctx.shouldCancel())
+            return tsErr!void(ctx.toError(TsErrorCode.highlightTimeout,
+                TsErrorCode.highlightCancelled));
+
+        // Globally earliest boundary: (pos, ends-before-starts, deeper-first).
+        Layer* best;
+        size_t bestPos;
+        bool bestStart;
+        foreach (layer; layers)
+        {
+            size_t pos;
+            bool isStart;
+            if (!layerBoundary(layer, source, pos, isStart))
+                continue;
+            const better = best is null
+                || pos < bestPos
+                || (pos == bestPos && !isStart && bestStart)
+                || (pos == bestPos && isStart == bestStart && layer.depth > best.depth);
+            if (better)
+            {
+                best = layer;
+                bestPos = pos;
+                bestStart = isStart;
+            }
+        }
+        if (best is null)
+            break;
+
+        emitSourceUpTo(bestPos);
+
+        if (!bestStart)
+        {
+            put(sink, HighlightEvent.popLabel());
+            best.endStack.popBack();
+            continue;
+        }
+
+        auto current = best.peeked;
+        best.havePeeked = false;
+        if (current.end <= byteOffset)
+            continue; // stale (overlapping non-nested capture); skip defensively
+
+        // same-node last-wins within the layer (the reference rule)
+        while (peekLayer(best, source))
+        {
+            if (best.peeked.node.id !is current.node.id)
+                break;
+            best.cursor.removeMatch(current.matchId);
+            current = best.peeked;
+            best.havePeeked = false;
+        }
+
+        // cross-layer identical-range dedup: deeper layer already emitted it
+        if (current.start == lastStart && current.end == lastEnd && best.depth < lastDepth)
+            continue;
+
+        const label = current.captureId < best.config.captureToLabel.length
+            ? best.config.captureToLabel[current.captureId]
+            : LabelId.none;
+        if (label)
+        {
+            lastStart = current.start;
+            lastEnd = current.end;
+            lastDepth = best.depth;
+            put(sink, HighlightEvent.pushLabel(label));
+            best.endStack ~= current.end;
+        }
+    }
+
+    // Defensive: drain any unclosed ends (well-formed streams have none left).
+    foreach (layer; layers)
+        while (layer.endStack.length)
+        {
+            emitSourceUpTo(layer.endStack[layer.endStack.length - 1]);
+            put(sink, HighlightEvent.popLabel());
+            layer.endStack.popBack();
+        }
+    emitSourceUpTo(source.length);
     return tsOk();
 }
 
@@ -487,4 +797,61 @@ unittest
     assert(result.hasError);
     assert(result.error.code == TsErrorCode.sourceTooLarge);
     assert(sink[].length == 0);
+}
+
+version (unittest)
+{
+    import sparkles.syntax.ts.injection : TsConfigCache;
+
+    /// Runs the layered path and returns the event stream (bundle-gated).
+    package HighlightEvent[] injectedEventsForTest(string rootLanguage, string source) @system
+    {
+        import std.array : appender;
+        import std.process : environment;
+        import sparkles.test_runner.skip : skipTest;
+
+        if (environment.get("SPARKLES_TS_GRAMMAR_PATH", "").length == 0)
+            skipTest("SPARKLES_TS_GRAMMAR_PATH not set (enter `nix develop`)");
+
+        static GrammarRegistry registry;
+        registry = GrammarRegistry.fromEnvironment();
+        auto cache = TsConfigCache.create(&registry, LabelSet.standard());
+        auto sink = appender!(HighlightEvent[]);
+        auto result = highlightInjected(cache, rootLanguage, source, sink);
+        assert(!result.hasError);
+        return sink[];
+    }
+}
+
+@("ts.highlighter.injectionAgreesWithSingleLayer")
+@system
+unittest
+{
+    // A language with no injections must yield the identical stream through the
+    // layered path and the single-layer path — the regression guard that the
+    // multi-layer loop degenerates exactly to the proven single-layer one.
+    const source = `{"outer": {"inner": [1, true, null], "b": "x"}}`;
+    auto config = jsonConfigForTest();
+    auto single = eventsForTest(config, source);
+
+    auto layered = injectedEventsForTest("json", source);
+    assert(layered == single, "layered stream diverges from single-layer for json");
+}
+
+@("ts.highlighter.markdownFencedCode")
+@system
+unittest
+{
+    import std.algorithm.searching : canFind, endsWith;
+
+    // A fenced D block inside markdown: the D grammar must highlight the fence
+    // body (markdown treats `code_fence_content` as opaque, so any label on
+    // `void`/`main` can only come from the injected D layer).
+    const source = "# Title\n\n```d\nvoid main() {}\n```\n";
+    auto events = injectedEventsForTest("markdown", source);
+    assertWellFormed(events, source);
+
+    const spans = labeledSpans(events, source);
+    assert(spans.canFind!(s => s.endsWith(":void")),
+        spans.length ? spans[0] : "no labeled spans — injection did not fire");
 }

--- a/libs/syntax/src/sparkles/syntax/ts/injection.d
+++ b/libs/syntax/src/sparkles/syntax/ts/injection.d
@@ -1,0 +1,262 @@
+/**
+Injection discovery: turning `injections.scm` matches into embedded-language
+layers.
+
+Three pieces the layered highlighter ($(REF highlightInjected,
+sparkles,syntax,ts,highlighter)) composes:
+
+$(LIST
+    * $(LREF injectionForMatch) — reads one injection-query match into a
+        `(language, content node, include-children)` triple (the reference
+        crate's `injection_for_match`);
+    * $(LREF intersectRanges) — turns a content node into the `TSRange[]` an
+        injected parser is restricted to (whole node, or the gaps between its
+        children when `include-children` is off), clipped to the parent layer's
+        own ranges (`intersect_ranges`);
+    * $(LREF TsConfigCache) — the reference's `injection_callback`: maps a
+        language name to a configured $(REF TsHighlightConfig,
+        sparkles,syntax,ts,config), loading grammar + queries through a
+        $(REF GrammarRegistry, sparkles,syntax,ts,registry) once and caching
+        the result (misses included, so a missing grammar is looked up once and
+        thereafter renders as plain text).
+)
+
+Scope (M7): non-combined injections with `injection.language` (captured node
+text or `#set!` directive) and `injection.include-children`. `injection.combined`
+and locals scope-tracking are deferred (PLAN §4).
+*/
+module sparkles.syntax.ts.injection;
+
+import sparkles.syntax.ts.config : TsHighlightConfig;
+import sparkles.syntax.ts.registry : GrammarRegistry, canonicalLanguage;
+import sparkles.syntax.label : LabelSet;
+import sparkles.tree_sitter.errors : TsError;
+import sparkles.tree_sitter.tree_sitter_c : TSNode, TSPoint, TSQueryMatch, TSRange;
+import sparkles.tree_sitter.wrappers : nodeChild, nodeChildCount, nodeEndByte,
+    nodeRange, nodeStartByte;
+
+/// One resolved injection: the embedded language, the node whose text it
+/// covers, and whether the injected parse spans the node's children too.
+struct InjectionMatch
+{
+    const(char)[] language;   /// injected language name (empty ⇒ unresolved)
+    TSNode contentNode;       /// the `@injection.content` node
+    bool hasContent;          /// `true` iff a content node was captured
+    bool includeChildren;     /// `#set! injection.include-children`
+}
+
+/**
+Reads one match of the injections query into an $(LREF InjectionMatch).
+
+The language is the text of the `@injection.language` capture if present,
+otherwise the pattern's `#set! injection.language "…"` value (a captured node
+beats the directive — the reference rule). `injection.include-children` is read
+from the directives. `injection.combined`/`injection.self`/`injection.parent`
+are not handled (deferred).
+*/
+InjectionMatch injectionForMatch(ref const TsHighlightConfig config,
+    in TSQueryMatch match, scope const(char)[] source) @system
+{
+    InjectionMatch result;
+
+    foreach (i; 0 .. match.capture_count)
+    {
+        const cap = match.captures[i];
+        // ImportC keeps TSNode const here; strip it as the engine does elsewhere
+        // (TSNode is a non-owning handle — highlighter.d:244).
+        auto node = cast(TSNode) cap.node;
+        if (cap.index == config.injectionLanguageIndex)
+        {
+            const s = nodeStartByte(node);
+            const e = nodeEndByte(node);
+            if (s <= e && e <= source.length)
+                result.language = source[s .. e];
+        }
+        else if (cap.index == config.injectionContentIndex)
+        {
+            result.contentNode = node;
+            result.hasContent = true;
+        }
+    }
+
+    if (match.pattern_index < config.injectionPredicates.length)
+        foreach (setting; config.injectionPredicates[match.pattern_index].settings)
+        {
+            if (setting.key == "injection.language" && result.language.length == 0)
+                result.language = setting.value;
+            else if (setting.key == "injection.include-children")
+                result.includeChildren = true;
+        }
+
+    return result;
+}
+
+/**
+The `TSRange`s an injected parser is restricted to for `contentNode`.
+
+With `includeChildren`, the whole node is one range. Otherwise the ranges are
+the gaps between the node's children (each child excluded) — the "own text
+only" case (e.g. the literal chunks of a template string around its
+interpolations). Every candidate is clipped to `parentRanges` so a child never
+covers bytes the parent didn't; an empty `parentRanges` means the root layer
+(whole buffer), so candidates pass through unclipped. Point coordinates come
+straight from the nodes.
+*/
+TSRange[] intersectRanges(scope const(TSRange)[] parentRanges, TSNode contentNode,
+    bool includeChildren) @system
+{
+    import std.algorithm.comparison : max, min;
+
+    TSRange[] candidates;
+    if (includeChildren)
+        candidates ~= nodeRange(contentNode);
+    else
+    {
+        const nr = nodeRange(contentNode);
+        uint cursorByte = nr.start_byte;
+        TSPoint cursorPoint = nr.start_point;
+        foreach (ci; 0 .. nodeChildCount(contentNode))
+        {
+            const cr = nodeRange(nodeChild(contentNode, ci));
+            if (cr.start_byte > cursorByte)
+                candidates ~= mkRange(cursorByte, cursorPoint, cr.start_byte, cr.start_point);
+            cursorByte = cr.end_byte;
+            cursorPoint = cr.end_point;
+        }
+        if (nr.end_byte > cursorByte)
+            candidates ~= mkRange(cursorByte, cursorPoint, nr.end_byte, nr.end_point);
+    }
+
+    if (parentRanges.length == 0)
+        return candidates;
+
+    TSRange[] result;
+    foreach (cand; candidates)
+        foreach (par; parentRanges)
+        {
+            const sb = max(cand.start_byte, par.start_byte);
+            const eb = min(cand.end_byte, par.end_byte);
+            if (sb < eb)
+                result ~= mkRange(
+                    sb, sb == cand.start_byte ? cand.start_point : par.start_point,
+                    eb, eb == cand.end_byte ? cand.end_point : par.end_point);
+        }
+    return result;
+}
+
+private TSRange mkRange(uint startByte, TSPoint startPoint, uint endByte, TSPoint endPoint)
+    @safe pure nothrow @nogc
+{
+    TSRange r;
+    r.start_point = startPoint;
+    r.end_point = endPoint;
+    r.start_byte = startByte;
+    r.end_byte = endByte;
+    return r;
+}
+
+/**
+Maps a language name to a configured $(REF TsHighlightConfig,
+sparkles,syntax,ts,config) — the injection callback the layered highlighter
+consults to parse embedded languages.
+
+Owns the configs it builds (they are non-copyable and referenced by the
+highlighter's cursors, so they are heap-allocated and kept alive for the
+cache's lifetime). `resolve` caches misses too, so a language whose grammar or
+queries are absent is looked up once and then renders as plain text (totality).
+The backing $(REF GrammarRegistry, sparkles,syntax,ts,registry) is borrowed by
+pointer and must outlive the cache.
+*/
+struct TsConfigCache
+{
+    private GrammarRegistry* _registry;
+    private LabelSet _labels;
+    private TsHighlightConfig*[string] _cache;
+
+    @disable this(this);
+
+    /// Builds a cache over `registry` (borrowed) resolving labels through
+    /// `labels`.
+    static TsConfigCache create(return GrammarRegistry* registry, LabelSet labels) @safe pure nothrow
+    in (registry !is null)
+    {
+        TsConfigCache cache;
+        cache._registry = registry;
+        cache._labels = labels;
+        return cache;
+    }
+
+    /**
+    The configured config for `language` (canonicalized), or `null` on any miss
+    — missing grammar, missing highlights query, or a query that failed to
+    compile. Cached by canonical name, misses included.
+    */
+    const(TsHighlightConfig)* resolve(const(char)[] language) @system
+    {
+        const canon = canonicalLanguage(language);
+        if (auto cached = canon in _cache)
+            return *cached;
+
+        TsHighlightConfig* built = null;
+        auto grammar = _registry.grammar(canon);
+        if (!grammar.hasError)
+        {
+            auto highlights = _registry.queryText(canon, "highlights");
+            if (!highlights.hasError)
+            {
+                string injectionsScm = null;
+                auto injections = _registry.queryText(canon, "injections");
+                if (!injections.hasError)
+                    injectionsScm = injections.value;
+
+                TsError error;
+                auto cfg = new TsHighlightConfig;
+                *cfg = TsHighlightConfig.create(grammar.value, highlights.value,
+                    error, injectionsScm);
+                if (!error && cfg.valid)
+                {
+                    cfg.configure(_labels);
+                    built = cfg;
+                }
+            }
+        }
+
+        _cache[canon.idup] = built;
+        return built;
+    }
+}
+
+@("ts.injection.configCache")
+@system
+unittest
+{
+    import std.process : environment;
+    import sparkles.test_runner.skip : skipTest;
+
+    if (environment.get("SPARKLES_TS_GRAMMAR_PATH", "").length == 0)
+        skipTest("SPARKLES_TS_GRAMMAR_PATH not set (enter `nix develop`)");
+
+    auto registry = GrammarRegistry.fromEnvironment();
+    auto cache = TsConfigCache.create(&registry, LabelSet.standard());
+
+    // markdown ships an injections.scm → resolvable, with injections wired.
+    auto md = cache.resolve("markdown");
+    assert(md !is null);
+    assert(md.hasInjections);
+    assert(md.injectionContentIndex != uint.max);
+
+    // json ships no injections.scm → resolvable, but injects nothing.
+    auto js = cache.resolve("json");
+    assert(js !is null);
+    assert(!js.hasInjections);
+
+    // unknown language → null, and the miss is cached (stable across calls).
+    assert(cache.resolve("no-such-lang-xyz") is null);
+    assert(cache.resolve("no-such-lang-xyz") is null);
+
+    // hits are cached: same pointer back for the same language.
+    assert(cache.resolve("markdown") is md);
+
+    // the underscore alias resolves to the markdown-inline grammar.
+    assert(cache.resolve("markdown_inline") !is null);
+}

--- a/libs/syntax/src/sparkles/syntax/ts/injection.d
+++ b/libs/syntax/src/sparkles/syntax/ts/injection.d
@@ -32,8 +32,8 @@ import sparkles.syntax.ts.registry : GrammarRegistry, canonicalLanguage;
 import sparkles.syntax.label : LabelSet;
 import sparkles.tree_sitter.errors : TsError;
 import sparkles.tree_sitter.tree_sitter_c : TSNode, TSPoint, TSQueryMatch, TSRange;
-import sparkles.tree_sitter.wrappers : nodeChild, nodeChildCount, nodeEndByte,
-    nodeRange, nodeStartByte;
+import sparkles.tree_sitter.wrappers : nodeEndByte, nodeNamedChild,
+    nodeNamedChildCount, nodeRange, nodeStartByte;
 
 /// One resolved injection: the embedded language, the node whose text it
 /// covers, and whether the injected parse spans the node's children too.
@@ -95,12 +95,22 @@ InjectionMatch injectionForMatch(ref const TsHighlightConfig config,
 The `TSRange`s an injected parser is restricted to for `contentNode`.
 
 With `includeChildren`, the whole node is one range. Otherwise the ranges are
-the gaps between the node's children (each child excluded) — the "own text
-only" case (e.g. the literal chunks of a template string around its
-interpolations). Every candidate is clipped to `parentRanges` so a child never
-covers bytes the parent didn't; an empty `parentRanges` means the root layer
-(whole buffer), so candidates pass through unclipped. Point coordinates come
-straight from the nodes.
+the gaps between the node's $(I named) children — the "own text only" case
+(e.g. the literal chunks of a template string around its `${…}` interpolations).
+Every candidate is clipped to `parentRanges` so a child never covers bytes the
+parent didn't; an empty `parentRanges` means the root layer (whole buffer), so
+candidates pass through unclipped. Point coordinates come straight from the
+nodes.
+
+$(B Deviation from the reference:) the reference excludes $(I all) children
+(named and anonymous), relying on the injection query to set
+`injection.include-children` whenever the whole node is wanted — as Helix's
+markdown query does for `(inline)`. Excluding only $(I named) children instead
+makes injection work with queries that omit the directive (the bundled
+nvim-treesitter markdown query does): anonymous token children — an escape's
+`\`/`*`, a code span's backticks — stay part of the injected text, while
+genuine sub-structure (a `template_substitution`) is still excluded. A query
+that does set `include-children` still gets the whole node.
 */
 TSRange[] intersectRanges(scope const(TSRange)[] parentRanges, TSNode contentNode,
     bool includeChildren) @system
@@ -115,9 +125,9 @@ TSRange[] intersectRanges(scope const(TSRange)[] parentRanges, TSNode contentNod
         const nr = nodeRange(contentNode);
         uint cursorByte = nr.start_byte;
         TSPoint cursorPoint = nr.start_point;
-        foreach (ci; 0 .. nodeChildCount(contentNode))
+        foreach (ci; 0 .. nodeNamedChildCount(contentNode))
         {
-            const cr = nodeRange(nodeChild(contentNode, ci));
+            const cr = nodeRange(nodeNamedChild(contentNode, ci));
             if (cr.start_byte > cursorByte)
                 candidates ~= mkRange(cursorByte, cursorPoint, cr.start_byte, cr.start_point);
             cursorByte = cr.end_byte;

--- a/libs/syntax/src/sparkles/syntax/ts/package.d
+++ b/libs/syntax/src/sparkles/syntax/ts/package.d
@@ -3,10 +3,11 @@ The tree-sitter precise-mode engine of `sparkles:syntax`.
 
 Grammar discovery ($(MREF sparkles,syntax,ts,registry)), per-language
 highlight configuration ($(MREF sparkles,syntax,ts,config)), text-predicate
-evaluation ($(MREF sparkles,syntax,ts,predicates)), and the event-producing
-highlighter ($(MREF sparkles,syntax,ts,highlighter)) — a single-layer port
-of the reference `tree-sitter-highlight` semantics over the
-`sparkles:tree-sitter` binding.
+evaluation ($(MREF sparkles,syntax,ts,predicates)), injection discovery
+($(MREF sparkles,syntax,ts,injection)), and the event-producing highlighter
+($(MREF sparkles,syntax,ts,highlighter)) — a port of the reference
+`tree-sitter-highlight` semantics (single-language `highlight` and injection-
+aware `highlightInjected`) over the `sparkles:tree-sitter` binding.
 
 This module only re-exports — unittests live with the features.
 */
@@ -14,6 +15,7 @@ module sparkles.syntax.ts;
 
 public import sparkles.syntax.ts.config;
 public import sparkles.syntax.ts.highlighter;
+public import sparkles.syntax.ts.injection;
 public import sparkles.syntax.ts.predicates;
 public import sparkles.syntax.ts.registry;
 

--- a/libs/syntax/src/sparkles/syntax/ts/registry.d
+++ b/libs/syntax/src/sparkles/syntax/ts/registry.d
@@ -126,6 +126,7 @@ string canonicalLanguage(scope const(char)[] label) @safe pure nothrow
         case "js", "mjs", "cjs", "node": return "javascript";
         case "kt", "kts": return "kotlin";
         case "md": return "markdown";
+        case "markdown_inline", "markdown-inline", "markdown.inline": return "markdown-inline";
         case "ml", "mli": return "ocaml";
         case "py", "python3": return "python";
         case "rs": return "rust";
@@ -146,6 +147,7 @@ unittest
     assert(canonicalLanguage("c#") == "c-sharp");
     assert(canonicalLanguage("console") == "bash");
     assert(canonicalLanguage("md") == "markdown");
+    assert(canonicalLanguage("markdown_inline") == "markdown-inline"); // injection #set! value
     assert(canonicalLanguage("py") == "python");
     assert(canonicalLanguage("D") == "d");
     assert(canonicalLanguage("json") == "json");

--- a/libs/tree-sitter/src/sparkles/tree_sitter/errors.d
+++ b/libs/tree-sitter/src/sparkles/tree_sitter/errors.d
@@ -33,6 +33,7 @@ enum TsErrorCode : ubyte
     parseCancelled,        /// host cancellation flag observed during parse
     highlightTimeout,      /// query/event budget exceeded
     highlightCancelled,    /// host cancellation flag observed during highlight
+    injectionDepthExceeded,/// injection nesting hit the layer-depth cap (degrade to plain text)
 }
 
 /// Structured binding/engine error: a code plus one code-specific detail
@@ -82,6 +83,7 @@ struct TsError
             case parseCancelled:
             case highlightTimeout:
             case highlightCancelled:
+            case injectionDepthExceeded:
                 return;
         }
     }

--- a/libs/tree-sitter/src/sparkles/tree_sitter/wrappers.d
+++ b/libs/tree-sitter/src/sparkles/tree_sitter/wrappers.d
@@ -33,7 +33,8 @@ import sparkles.tree_sitter.tree_sitter_c :
     ts_query_capture_count, ts_query_capture_name_for_id,
     ts_query_cursor_delete, ts_query_cursor_did_exceed_match_limit,
     ts_query_cursor_exec, ts_query_cursor_exec_with_options,
-    ts_query_cursor_new, ts_query_cursor_next_capture, ts_query_cursor_remove_match,
+    ts_query_cursor_new, ts_query_cursor_next_capture, ts_query_cursor_next_match,
+    ts_query_cursor_remove_match,
     ts_query_cursor_set_byte_range, ts_query_cursor_set_match_limit,
     ts_query_delete, ts_query_disable_pattern, ts_query_new,
     ts_query_pattern_count, ts_query_predicates_for_pattern,
@@ -463,6 +464,17 @@ struct TsQueryCursor
     in (valid)
     {
         return ts_query_cursor_next_capture(_raw, &match, &captureIndex);
+    }
+
+    /// Advances to the next whole match (all its captures at once). `false` =
+    /// exhausted. Used by injection discovery, which needs a pattern's
+    /// `@injection.content`/`@injection.language` captures together. As with
+    /// `nextCapture`, `match.captures` aliases cursor storage the next call
+    /// invalidates — read it before advancing.
+    bool nextMatch(out TSQueryMatch match) scope @trusted nothrow @nogc
+    in (valid)
+    {
+        return ts_query_cursor_next_match(_raw, &match);
     }
 
     /// Removes an in-progress match (predicate rejection / same-node override).

--- a/libs/tree-sitter/src/sparkles/tree_sitter/wrappers.d
+++ b/libs/tree-sitter/src/sparkles/tree_sitter/wrappers.d
@@ -25,6 +25,7 @@ import sparkles.tree_sitter.tree_sitter_c :
     TSQueryError, TSQueryMatch, TSQueryPredicateStep, TSTree,
     ts_language_abi_version,
     ts_node_child, ts_node_child_count,
+    ts_node_named_child, ts_node_named_child_count,
     ts_node_has_error, ts_node_start_byte, ts_node_end_byte,
     ts_node_start_point, ts_node_end_point, ts_node_string,
     ts_parser_delete, ts_parser_new, ts_parser_parse,
@@ -304,6 +305,14 @@ uint nodeChildCount(TSNode node) @trusted nothrow @nogc
 /// The `i`-th child of `node` (named or anonymous).
 TSNode nodeChild(TSNode node, uint i) @trusted nothrow @nogc
     => ts_node_child(node, i);
+
+/// Number of $(I named) children of `node` (anonymous token children excluded).
+uint nodeNamedChildCount(TSNode node) @trusted nothrow @nogc
+    => ts_node_named_child_count(node);
+
+/// The `i`-th $(I named) child of `node`.
+TSNode nodeNamedChild(TSNode node, uint i) @trusted nothrow @nogc
+    => ts_node_named_child(node, i);
 
 /// Owning handle over a compiled `TSQuery`.
 struct TsQuery

--- a/libs/tree-sitter/src/sparkles/tree_sitter/wrappers.d
+++ b/libs/tree-sitter/src/sparkles/tree_sitter/wrappers.d
@@ -19,14 +19,17 @@ import core.time : Duration, MonoTime;
 
 import sparkles.tree_sitter.errors : TsError, TsErrorCode, TsExpected, tsErr, tsOk;
 import sparkles.tree_sitter.tree_sitter_c :
-    TSLanguage, TSNode, TSParseOptions, TSParseState, TSParser, TSPoint,
+    TSLanguage, TSNode, TSParseOptions, TSParseState, TSParser, TSPoint, TSRange,
     TSInput, TSInputEncoding,
     TSQuery, TSQueryCursor, TSQueryCursorOptions, TSQueryCursorState,
     TSQueryError, TSQueryMatch, TSQueryPredicateStep, TSTree,
     ts_language_abi_version,
-    ts_node_has_error, ts_node_start_byte, ts_node_end_byte, ts_node_string,
+    ts_node_child, ts_node_child_count,
+    ts_node_has_error, ts_node_start_byte, ts_node_end_byte,
+    ts_node_start_point, ts_node_end_point, ts_node_string,
     ts_parser_delete, ts_parser_new, ts_parser_parse,
-    ts_parser_parse_with_options, ts_parser_reset, ts_parser_set_language,
+    ts_parser_parse_with_options, ts_parser_reset,
+    ts_parser_set_included_ranges, ts_parser_set_language,
     ts_query_capture_count, ts_query_capture_name_for_id,
     ts_query_cursor_delete, ts_query_cursor_did_exceed_match_limit,
     ts_query_cursor_exec, ts_query_cursor_exec_with_options,
@@ -202,6 +205,22 @@ struct TsParser
         error = TsError.init;
         return TsTree(rawTree);
     }
+
+    /**
+    Restricts subsequent parses to `ranges` — the byte/point spans an injected
+    layer occupies in the parent buffer (must be ascending and non-overlapping).
+    Returns `false` (and keeps the previous ranges) if tree-sitter rejects them;
+    an empty slice resets to the whole buffer. The parser reads the same source
+    slice as the root — only the included ranges differ per layer.
+    */
+    bool setIncludedRanges(scope const(TSRange)[] ranges) @trusted nothrow @nogc
+    in (valid)
+    {
+        // ImportC drops the C `const` on the pointer param; cast at the boundary
+        // (tree-sitter copies the ranges and never mutates them).
+        return ts_parser_set_included_ranges(_raw, cast(TSRange*) ranges.ptr,
+            cast(uint) ranges.length);
+    }
 }
 
 /// Owning handle over a `TSTree`.
@@ -252,6 +271,38 @@ void writeSExpression(Writer)(ref Writer w, TSNode node) @trusted
         ++n;
     put(w, s[0 .. n]);
 }
+
+// ── Node accessors ──────────────────────────────────────────────────────────
+// `TSNode` is a small POD value type (no ownership), so these are free helpers
+// rather than a wrapper; the engine already reads nodes via raw `ts_node_*`.
+
+/// The node's byte+point extent as a `TSRange` — the shape
+/// $(LREF TsParser.setIncludedRanges) consumes when building an injected layer.
+TSRange nodeRange(TSNode node) @trusted nothrow @nogc
+{
+    TSRange r;
+    r.start_byte = ts_node_start_byte(node);
+    r.end_byte = ts_node_end_byte(node);
+    r.start_point = ts_node_start_point(node);
+    r.end_point = ts_node_end_point(node);
+    return r;
+}
+
+/// Start byte offset of `node`.
+uint nodeStartByte(TSNode node) @trusted nothrow @nogc
+    => ts_node_start_byte(node);
+
+/// End byte offset of `node` (exclusive).
+uint nodeEndByte(TSNode node) @trusted nothrow @nogc
+    => ts_node_end_byte(node);
+
+/// Number of children of `node`, named and anonymous.
+uint nodeChildCount(TSNode node) @trusted nothrow @nogc
+    => ts_node_child_count(node);
+
+/// The `i`-th child of `node` (named or anonymous).
+TSNode nodeChild(TSNode node, uint i) @trusted nothrow @nogc
+    => ts_node_child(node, i);
 
 /// Owning handle over a compiled `TSQuery`.
 struct TsQuery


### PR DESCRIPTION
## M7 — tree-sitter injections

Highlights embedded languages: fenced code blocks in markdown, `markdown_inline`
inside markdown, HTML/YAML/TOML front-matter. Ports the reference
`tree-sitter-highlight` **layer-stack** model — parse the root language, discover
injections per layer, parse each embedded byte range with its own grammar, and
fold every layer into one position-ordered `HighlightEvent` stream.

Builds on the merged `sparkles:syntax` library (#101); targets `main`.

## What's new

- **`ts/highlighter.d` → `highlightInjected(cache, rootLanguage, source, sink)`** —
  the injection-aware entry point. BFS layer discovery + a cross-layer interleave:
  earliest boundary wins (ends before starts, deeper layers first), a global
  `source` fill, same-node last-wins per layer, identical-range dedup to the
  deepest layer. `highlight` stays the single-language API; **a no-injection
  language yields a byte-identical stream through either path** (asserted).
- **`ts/injection.d`** — `injectionForMatch` (language from the captured
  `@injection.language` node or a `#set!` directive; content node;
  include-children), `intersectRanges` (whole node, or gaps between the content
  node's children), and `TsConfigCache` (the `injection_callback`: language name →
  configured `TsHighlightConfig`, registry-loaded, cached, and owned — a missing
  grammar/query renders that range as plain text).
- **`ts/config.d`** — compiles the per-language injections query (via the
  already-threaded `injectionsScm` seam), resolving `@injection.content` /
  `@injection.language` capture indices and per-pattern `#set!` settings.
- **`sparkles:tree-sitter`** — `TsParser.setIncludedRanges`, `nextMatch`, and node
  accessors (`nodeRange`, named/child helpers) wrap the injection primitives.
- **`ts/registry.d`** — `markdown_inline → markdown-inline` alias.

## One deliberate deviation from the reference

`intersectRanges` excludes only the content node's **named** children, not all
children. The reference excludes every child and relies on the injection query
setting `injection.include-children` when the whole node is wanted (as Helix's
markdown query does for `(inline)`). The **bundled nvim-treesitter markdown query
omits the directive**, so excluding all children dropped inline escapes and
delimiters (the block grammar tokenizes `\*` as two anonymous children of
`(inline)`). Excluding only genuine sub-structure — a `template_substitution`,
not an escape token — makes inline injection work regardless of the directive,
while `include-children=true` still parses the whole node. Documented in the
`intersectRanges` DDoc.

## Scope

- **In:** non-combined injections, `injection.language` (captured or `#set!`),
  `injection.include-children`, recursive per-layer discovery, a depth cap
  (`injectionDepthExceeded`).
- **Deferred (seams kept):** `injection.combined` (markdown doesn't use it) and
  locals scope-tracking.

## Tests (`dub test :syntax`, bundle-gated)

- fenced **D** in markdown → D labels inside the fence;
- markdown → `markdown_inline` self-injection (`\*` → `string.escape`);
- static `#set! injection.language` (HTML block);
- depth-capped recursion (fenced ` ```markdown `);
- no-injection agreement (`highlightInjected("json") == highlight`).

All suites green: `:base` 285, `:core-cli` 189, `:tree-sitter` 11, `:syntax` 58.
