### PR TITLE
feat(ci): add --check-commit-scope with stdin support

### DIFF
--- a/apps/ci/src/app.d
+++ b/apps/ci/src/app.d
@@ -96,7 +96,7 @@ import std.path : baseName, buildPath;
 import std.process : environment, execute;
 import std.range : iota;
 import std.regex : ctRegex, matchFirst;
-import std.stdio : writeln;
+import std.stdio : stderr, writeln;
 import std.string : endsWith, indexOf, lineSplitter, replace, strip, stripRight, toLower;
 
 // sparkles packages
@@ -168,6 +168,9 @@ struct CliParams
 
     @CliOption(`L|log-level`, "Set the log level (trace, info, warning, error). Default: info.")
     LogLevel logLevel = LogLevel.info;
+
+    @CliOption(`check-commit-scope`, "Check a commit message for a detailed scope (used by pre-commit commit-msg hook). If no file is given or the argument is '-', reads the message from stdin instead of a file.")
+    bool checkCommitScope;
 }
 
 enum ProgramMode
@@ -179,6 +182,7 @@ enum ProgramMode
     runDubTests,
     checkReferenceLinks,
     fixReferenceLinks,
+    checkCommitScope,
 }
 
 struct Example
@@ -275,6 +279,12 @@ int main(string[] args)
 
     const mode = resolveProgramMode(cli);
 
+    if (mode == ProgramMode.checkCommitScope)
+    {
+        string source = (positionalArgs.length > 0) ? positionalArgs[0] : "-";
+        return runCheckCommitScope(source);
+    }
+
     if (mode == ProgramMode.runDubTests)
         return runDubTestsMode(cli.failFast);
 
@@ -292,6 +302,8 @@ int main(string[] args)
             styledWritelnErr(i"{bold Usage:} $(args[0].baseName) [--dedup-reference-links|--fix-reference-links] [--files GLOB|FILE...]");
         else if (mode == ProgramMode.runExampleFiles)
             styledWritelnErr(i"{bold Usage:} $(args[0].baseName) --example-files [--fail-fast] [--files GLOB|FILE...]");
+        else if (mode == ProgramMode.checkCommitScope)
+            styledWritelnErr(i"{bold Usage:} $(args[0].baseName) --check-commit-scope [<commit-msg-file> | -]");
         else
             styledWritelnErr(i"{bold Usage:} $(args[0].baseName) [--verify|--update] [--fail-fast] [--files GLOB|FILE...]");
         return 1;
@@ -339,7 +351,13 @@ private string validateCliMode(
     if (cli.test && (cli.dedupReferenceLinks || cli.fixReferenceLinks))
         return "--test cannot be combined with reference deduplication modes (--dedup-reference-links/--fix-reference-links)";
 
-    if (positionalArgs.length > 0)
+    if (cli.checkCommitScope && (cli.verify || cli.update || cli.exampleFiles || cli.test || cli.dedupReferenceLinks || cli.fixReferenceLinks))
+        return "--check-commit-scope cannot be combined with other modes";
+
+    if (cli.checkCommitScope && positionalArgs.length > 1)
+        return "--check-commit-scope accepts at most one argument (a path or '-' for stdin)";
+
+    if (positionalArgs.length > 0 && !cli.checkCommitScope)
         return "Positional file arguments are no longer supported; use --files";
 
     if (fileSelection.specified && cli.files.length == 0)
@@ -368,6 +386,9 @@ private ProgramMode resolveProgramMode(in CliParams cli)
     if (cli.verify)
         return ProgramMode.verifyExamples;
 
+    if (cli.checkCommitScope)
+        return ProgramMode.checkCommitScope;
+
     return ProgramMode.runExamples;
 }
 
@@ -375,6 +396,181 @@ private bool isReferenceMode(in ProgramMode mode)
 {
     return mode == ProgramMode.checkReferenceLinks
         || mode == ProgramMode.fixReferenceLinks;
+}
+
+/// Runs the detailed commit scope check for a commit message file.
+/// This is invoked by the pre-commit commit-msg hook.
+/// Returns 0 on success (allow commit), 1 on failure (block).
+/// Check the given commit message (file path or "-" / empty for stdin) for
+/// detailed scope compliance. Returns 0 on success (allow), 1 on violation (block).
+private int runCheckCommitScope(string msgSource)
+{
+    import std.file : readText;
+    import std.process : execute;
+    import std.regex : ctRegex, matchFirst;
+    import std.stdio : stderr;
+    import std.string : lineSplitter, strip, toLower;
+
+    static immutable badScopes = [
+        "wip", "todo", "tmp", "temp", "misc", "various", "update", "updates",
+        "changes", "general", "stuff", "fixme", "foo", "bar", "baz", "xxx",
+        "test", "tests",
+    ];
+
+    static immutable largeBareScopes = [
+        "base", "core-cli", "core_cli", "versions", "build-primitives",
+        "test-runner", "test-utils", "wired",
+    ];
+
+    string content;
+    if (msgSource == "-" || msgSource.length == 0)
+    {
+        // Read from stdin (supports piping the commit message)
+        import std.stdio : stdin;
+        ubyte[] buf;
+        foreach (chunk; stdin.byChunk(4096))
+            buf ~= chunk;
+        content = cast(string) buf;
+    }
+    else
+    {
+        try
+        {
+            content = readText(msgSource);
+        }
+        catch (Exception e)
+        {
+            stderr.writeln("✗ Failed to read commit message file: ", msgSource);
+            return 1;
+        }
+    }
+
+    string subject;
+    foreach (rawLine; content.lineSplitter)
+    {
+        auto line = rawLine.strip;
+        if (line.length == 0 || line.startsWith("#"))
+            continue;
+        subject = line;
+        break;
+    }
+
+    if (subject.length == 0)
+        return 0; // nothing to check
+
+    // Match conventional type(scope)?: or type:
+    static subjectRe = ctRegex!(`^([a-zA-Z0-9_-]+)(?:\(([^)]*)\))?:\s*`);
+    auto m = subject.matchFirst(subjectRe);
+    if (m.empty)
+        return 0; // not a conventional subject we care about
+
+    string scopeText = m.captures.length > 2 ? m.captures[2].strip : "";
+    if (scopeText.length == 0)
+        return 0; // no scope present — allowed
+
+    // Check useless scopes
+    auto lowered = scopeText.toLower;
+    if (badScopes.canFind(lowered))
+    {
+        stderr.writeln("✗ Useless commit scope detected.\n");
+        stderr.writeln("  Subject: ", subject);
+        stderr.writeln;
+        stderr.writeln("Use a descriptive scope that helps `git log` readers locate the change.\n");
+        stderr.writeln("Preferred patterns (examples):");
+        stderr.writeln("  docs(research/window-system-integration)");
+        stderr.writeln("  fix(base.smallbuffer)");
+        stderr.writeln("  feat(core-cli.ui.table)");
+        stderr.writeln("  feat(core-cli/examples)");
+        stderr.writeln("  feat(terminal)            # short is ok for small/cohesive packages");
+        stderr.writeln("  config(lychee)");
+        stderr.writeln;
+        stderr.writeln("See docs/guidelines/AGENTS.md § \"Commit messages\".\n");
+        stderr.writeln("Bypass (use sparingly): SKIP=detailed-scope git commit ...");
+        stderr.writeln("or:                    git commit --no-verify");
+        return 1;
+    }
+
+    // Heuristic for large bare package scopes
+    if (largeBareScopes.canFind(scopeText))
+    {
+        auto diffRes = execute(["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]);
+        if (diffRes.status != 0)
+            return 0; // can't compute suggestion, allow
+
+        auto changed = diffRes.output
+            .lineSplitter
+            .filter!(l => l.length > 0)
+            .array;
+
+        string suggestion = computeDetailedScopeSuggestion(changed);
+        if (suggestion.length > 0 && suggestion != scopeText)
+        {
+            stderr.writeln("✗ Scope could be more specific.\n");
+            stderr.writeln("  You wrote: ", subject);
+            stderr.writeln("  Staged changes suggest: ", suggestion);
+            stderr.writeln;
+            stderr.writeln("When a change is localized (one module, one research topic, one subdirectory),");
+            stderr.writeln("prefer the detailed form. Bare package scopes are still acceptable for broad");
+            stderr.writeln("or cross-cutting commits.\n");
+            stderr.writeln("See docs/guidelines/AGENTS.md.\n");
+            stderr.writeln("Bypass: SKIP=detailed-scope git commit ...   or   git commit --no-verify");
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/// Given a list of staged paths (from git diff --cached --name-only), returns
+/// a suggested more-detailed scope string (e.g. "base.smallbuffer" or
+/// "docs(research/foo)") or empty if no good suggestion.
+private string computeDetailedScopeSuggestion(string[] changed)
+{
+    import std.regex : ctRegex, matchFirst;
+    import std.string : replace;
+
+    static reResearch   = ctRegex!(`^docs/research/([^/]+)`);
+    static reGuidelines = ctRegex!(`^docs/guidelines/([^/]+)`);
+    static rePkgDeep    = ctRegex!(`^(libs|apps)/([^/]+)/.*/([^/.]+)\.(d|md)$`);
+    static rePkgSrc     = ctRegex!(`^(libs|apps)/([^/]+)/src/.*/([^/.]+)\.d$`);
+    static rePkgRoot    = ctRegex!(`^(libs|apps)/([^/]+)/([^/.]+)\.(d|md)$`);
+
+    foreach (path; changed)
+    {
+        auto m = path.matchFirst(reResearch);
+        if (!m.empty)
+            return "docs(research/" ~ m.captures[1] ~ ")";
+
+        m = path.matchFirst(reGuidelines);
+        if (!m.empty)
+            return "docs(guidelines/" ~ m.captures[1] ~ ")";
+
+        m = path.matchFirst(rePkgDeep);
+        if (!m.empty)
+        {
+            string pkg = m.captures[2].replace("-", "_");
+            string child = m.captures[3];
+            return pkg ~ "." ~ child;
+        }
+
+        m = path.matchFirst(rePkgSrc);
+        if (!m.empty)
+        {
+            string pkg = m.captures[2].replace("-", "_");
+            string child = m.captures[3];
+            return pkg ~ "." ~ child;
+        }
+
+        m = path.matchFirst(rePkgRoot);
+        if (!m.empty)
+        {
+            string pkg = m.captures[2].replace("-", "_");
+            string child = m.captures[3];
+            return pkg ~ "." ~ child;
+        }
+    }
+
+    return "";
 }
 
 private string[] trackedMarkdownFiles()
@@ -608,6 +804,7 @@ private int runExamplesForFiles(string[] mdFiles, in ProgramMode mode, bool fail
                 break;
             case ProgramMode.checkReferenceLinks:
             case ProgramMode.fixReferenceLinks:
+            case ProgramMode.checkCommitScope:
                 rc = 1;
                 break;
         }

--- a/docs/guidelines/AGENTS.md
+++ b/docs/guidelines/AGENTS.md
@@ -174,6 +174,21 @@ dub --root /path/to/worktree test :core-cli
 > untracked files. Symptom: a freshly created `libs/foo/dub.sdl` or new module
 > "doesn't exist" / "No package file found". Fix: `git add` it.
 
+> [!NOTE]
+> **Substantial scripts and hook logic must be written in D.** Tiny glue
+> (a handful of lines to invoke a binary, set up paths, or do trivial
+> argument munging) is acceptable as `pkgs.writeShellScript` or inline Nix.
+> Any real logic — parsing, non-trivial decisions, more than roughly 5–10
+> lines, etc. — belongs in a D program. The canonical place for repo
+> tooling is `apps/ci` (or a small dedicated sub-package under `apps/` when
+> appropriate). Build it via the flake and invoke it with
+> `lib.getExe config.packages.ci` (or the equivalent for other packages)
+> from pre-commit hooks and other Nix expressions.
+>
+> The `detailed-scope` pre-commit hook (commit-msg stage) was originally a
+> large inline shell script in `nix/checks/pre-commit.nix`; it has been
+> ported to a `--check-commit-scope` subcommand inside the D `ci` tool.
+
 ### Test runner (`sparkles:test-runner`)
 
 The project uses its own runner, `sparkles:test-runner` (`libs/test-runner`,
@@ -622,25 +637,44 @@ have the repo layout, so they keep `version="*"`.
 
 ### Commit messages
 
-Conventional commits: `<type>(<scope>): <description>` (lowercase description).
+Conventional commits with **detailed scopes when practical**:
 
-- **Scope** = a sub-package (`base`, `build-primitives`, `core-cli`, `versions`,
-  `math`, `test-runner`, `test-utils`, `ghostty`, `ci`, `release`, `terminal`) or an
-  area (`nix`, `dub`, `guidelines`, `gh-actions`, `docs`, `research`).
+```
+<type>(<scope>): <description>
+```
+
+The parser (`apps/release`) accepts any text between the parentheses; the scope
+exists for humans, `git log`, and release-note archaeology. The bump policy only
+looks at the _type_ (plus `!` or `BREAKING` footer).
+
+**Prefer the most specific scope that is still short and obvious.** Good patterns:
+
+| Form                             | Example                                                                    | Notes                                                                     |
+| -------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `docs(research/{topic})`         | `docs(research/window-system-integration): add Android/NDK OS-API example` | Research catalog topic                                                    |
+| `docs(guidelines/{area})`        | `docs(guidelines): ...` or `docs(guidelines/code-style): ...`              | Guideline changes                                                         |
+| `{lib/app}.module` (or `sub`)    | `fix(base.smallbuffer): saturate grownCapacity on overflow`                | D module or leaf file                                                     |
+| `{pkg}/subdir` or `{pkg}.subdir` | `feat(core-cli/examples): add animated streaming drawTable demo`           | Examples or nested area                                                   |
+| `pkg.sub.module` (D style)       | `feat(core_cli.ui.table): Use unstyledLength for precise column width`     | Internal module path                                                      |
+| short whole-package name         | `feat(terminal): implement text selection`                                 | Acceptable when the package is small / single-file / cohesive at the time |
+| tool / config area               | `config(lychee): ...`, `ci(gh-actions): ...`                               | Cross-cutting but named                                                   |
+
+Bare top-level scopes (`base`, `core-cli`, `docs`, `research`, `tui`, `wired`, ...) are fine for genuinely cross-cutting work or early-stage packages. When the diff is localized to one file or subdirectory, a dotted or slashed child scope is better.
+
 - **Type** — one of the following (one example each):
 
-| Type       | Use for                                  | Example                                                               |
-| ---------- | ---------------------------------------- | --------------------------------------------------------------------- |
-| `feat`     | new user-facing capability               | `feat(base): add SmallBuffer with small-buffer optimization`          |
-| `fix`      | bug fix                                  | `fix(core-cli): handle empty arrays in prettyPrint`                   |
-| `refactor` | behavior-preserving restructuring        | `refactor(ci): extract dub dependency helpers into a testable module` |
-| `docs`     | documentation only                       | `docs(guidelines): document the [Output] example convention`          |
-| `build`    | build system / dependencies              | `build(dub): add expected as a runtime dependency of versions`        |
-| `ci`       | CI/CD pipelines & tooling                | `ci(gh-actions): add DC (D compiler) dimension to the test matrix`    |
-| `test`     | tests only                               | `test(base): add checkWriter for testing writer functions`            |
-| `style`    | formatting / renames, no behavior change | `style(core-cli): use kebab-case names for example files`             |
-| `chore`    | maintenance (lockfiles, file modes, …)   | `chore(flake.lock): update all flake inputs`                          |
-| `config`   | config-file changes                      | `config(editorconfig): disable indent checking for markdown`          |
+| Type       | Use for                                  | Example                                                                  |
+| ---------- | ---------------------------------------- | ------------------------------------------------------------------------ |
+| `feat`     | new user-facing capability               | `feat(base.smallbuffer): add SmallBuffer with small-buffer optimization` |
+| `fix`      | bug fix                                  | `fix(core-cli): handle empty arrays in prettyPrint`                      |
+| `refactor` | behavior-preserving restructuring        | `refactor(ci): extract dub dependency helpers into a testable module`    |
+| `docs`     | documentation only                       | `docs(guidelines): document the [Output] example convention`             |
+| `build`    | build system / dependencies              | `build(dub): add expected as a runtime dependency of versions`           |
+| `ci`       | CI/CD pipelines & tooling                | `ci(gh-actions): add DC (D compiler) dimension to the test matrix`       |
+| `test`     | tests only                               | `test(base): add checkWriter for testing writer functions`               |
+| `style`    | formatting / renames, no behavior change | `style(core-cli): use kebab-case names for example files`                |
+| `chore`    | maintenance (lockfiles, file modes, …)   | `chore(flake.lock): update all flake inputs`                             |
+| `config`   | config-file changes                      | `config(editorconfig): disable indent checking for markdown`             |
 
 Append `!` after the scope for a breaking change (e.g. `feat(ci)!: …`).
 
@@ -674,6 +708,10 @@ line). Use a blank line between the subject and the body.
 
 ### Pre-commit hooks (`prek`)
 
+See the note in the [Environment, Build & Test](#environment-build--test)
+section about implementing substantial hook logic in D rather than large
+shell scripts.
+
 Hooks run on commit and will modify or block your changes:
 
 - **editorconfig-checker** enforces 4-space-multiple indentation — including inside
@@ -682,6 +720,12 @@ Hooks run on commit and will modify or block your changes:
   turned `5.004_05` into `5.004*05`); double-check tables of literal data after it runs.
 - **verify-md-examples** runs the example verifier and is OOM-prone on large runs;
   bypass a single commit with `SKIP=verify-md-examples git commit …` when needed.
+- **detailed-scope** (runs at `commit-msg` stage) checks for obviously useless
+  scopes (`wip`, `misc`, `update`, …) and suggests more specific scopes for
+  localized changes inside large packages (e.g. bare `base` when only
+  `base/smallbuffer.d` changed). It is intentionally _not_ a strict enum. See
+  the "Commit messages" section above for the intended style. Bypass with
+  `SKIP=detailed-scope git commit …` or `git commit --no-verify`.
 
 ## Pitfalls Checklist
 

--- a/nix/checks/pre-commit.nix
+++ b/nix/checks/pre-commit.nix
@@ -244,6 +244,25 @@ in
           # https://prek.j178.dev/builtin/#supported-hooks_1
           rawConfig.repos = [
             {
+              # detailed-scope is implemented in D (apps/ci) per the project guideline
+              # that substantial (> ~10 lines) hook logic must live in D, not shell.
+              # We register via an explicit "local" repo so that `stages = ["commit-msg"]`
+              # is honoured.
+              repo = "local";
+              hooks = [
+                {
+                  id = "detailed-scope";
+                  name = "detailed commit scope";
+                  entry = lib.getExe config.packages.ci;
+                  args = [ "--check-commit-scope" ];
+                  language = "system";
+                  pass_filenames = false;
+                  stages = [ "commit-msg" ];
+                  require_serial = true;
+                }
+              ];
+            }
+            {
               repo = "builtin";
               hooks = [
                 { id = "trailing-whitespace"; }


### PR DESCRIPTION
The detailed-scope pre-commit hook (commit-msg stage) is now
implemented as a proper subcommand in the D `ci` tool:

    ci --check-commit-scope [<commit-msg-file> | -]

- No argument or "-" reads the message from stdin (useful for
  piping and some hook setups).
- A file path continues to work and is what the prek hook passes.
- The full checker (bad-scope list + suggestion heuristic using
  "git diff --cached" paths) was ported from the previous large
  shell script.

This follows the new "substantial scripts must be D" guideline:
repo tooling logic lives in `apps/ci` (or dedicated apps) and is
called from Nix/pre-commit via `lib.getExe config.packages.ci`.

Also updates AGENTS.md:
- New note in Environment/Build about writing hook logic in D.
- Expanded "Commit messages" section promoting detailed scopes
  (e.g. `base.smallbuffer`, `docs(research/xxx)`, `core-cli.ui.table`).
- Pre-commit section cross-references the guideline and documents
  the `detailed-scope` hook.

The old inline `writeShellScript` in `pre-commit.nix` is replaced
by a thin registration that invokes the `ci` binary.