### PR TITLE
feat(hue): interactive syntax-highlighting app + live theme previewer (@nogc core)

### DIFF
--- a/apps/hue/dub.sdl
+++ b/apps/hue/dub.sdl
@@ -1,0 +1,42 @@
+name "hue"
+description "Interactive syntax-highlighting file viewer and live theme previewer (sparkles:syntax)"
+authors "Petar Kirov"
+copyright "Copyright © 2026, Petar Kirov"
+license "BSL-1.0"
+
+targetType "executable"
+targetName "hue"
+targetPath "build"
+mainSourceFile "src/app.d"
+
+dflags "-preview=in" "-preview=dip1000"
+
+// Resolved via pkg-config in dependents' builds (sparkles:syntax pulls in
+// sparkles:tree-sitter, whose ImportC surface needs <tree_sitter/api.h>).
+dependency "sparkles:syntax" path="../.."
+dependency "sparkles:core-cli" path="../.."
+
+configuration "application" {
+    targetType "executable"
+}
+
+configuration "unittest" {
+    targetType "library"
+    excludedSourceFiles "src/app.d"
+
+    // hue has no unittests of its own, but `dub test` still compiles its
+    // dependency sources with -unittest — and sparkles:syntax / sparkles:
+    // tree-sitter call `skipTest` (in the impl package) from their env-gated
+    // tests. Pulling the runner as a plain `dependency` links impl as a static
+    // archive positioned before those objects, so ld.bfd (single-pass) never
+    // pulls `skip.o` → undefined reference. Source-include the shim + impl
+    // instead (the cycle-safe recipe base/core-cli use) so `skipTest` compiles
+    // directly into this build.
+    sourcePaths "../../libs/test-runner/src" "../../libs/test-runner-impl/src"
+    importPaths "../../libs/test-runner/src" "../../libs/test-runner-impl/src"
+
+    dflags "-checkaction=context" "-allinst"
+    dflags "-defaultlib=libphobos2.so" "-L-fuse-ld=gold" platform="linux-dmd"
+    dflags "--link-defaultlib-shared" "--linker=gold" platform="linux-ldc"
+    lflags "--export-dynamic" platform="linux-ldc"
+}

--- a/apps/hue/dub.sdl
+++ b/apps/hue/dub.sdl
@@ -9,6 +9,11 @@ targetName "hue"
 targetPath "build"
 mainSourceFile "src/app.d"
 
+// `app.d` string-imports itself (`import("app.d")`) as the default sample to
+// highlight, so it works from any install location instead of relying on the
+// build-time __FILE_FULL_PATH__.
+stringImportPaths "src"
+
 dflags "-preview=in" "-preview=dip1000"
 
 // Resolved via pkg-config in dependents' builds (sparkles:syntax pulls in

--- a/apps/hue/dub.selections.json
+++ b/apps/hue/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"expected": "0.4.1",
+		"silly": "1.1.1"
+	}
+}

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -1,20 +1,13 @@
-#!/usr/bin/env dub
-/+ dub.sdl:
-    name "highlight-file"
-    dependency "sparkles:syntax" path="../../.."
-    dependency "sparkles:core-cli" path="../../.."
-    targetPath "build"
-+/
-
-// The full precise-mode pipeline: file → tree-sitter parse → highlights
-// query → event stream → ANSI (stdout) or HTML. Grammars come from the nix
-// bundle ($SPARKLES_TS_GRAMMAR_PATH, exported by the devshell); without it
-// the program degrades to plain text — the totality law in action.
+// `hue` — the `sparkles:syntax` precise-mode pipeline as an interactive app:
+// file → tree-sitter parse → highlights query → event stream → ANSI (stdout)
+// or HTML. Grammars come from the nix bundle ($SPARKLES_TS_GRAMMAR_PATH,
+// exported by the devshell and baked into the nix package); without it the
+// program degrades to plain text — the totality law in action.
 //
-// Usage: highlight-file [--html] [--theme <theme>] [path] (defaults to this file itself)
+// Usage: hue [--html] [--theme <theme>] [path] (defaults to this file itself)
 //   Interactive TUI (tty, no --html): ↑/↓ to switch themes live; any other key quits.
 
-module highlight_file;
+module app;
 
 import std.array : appender;
 import std.file : exists, readText;

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -39,6 +39,22 @@ void writeCtl(CtlSeq seq)
     write(cast(string) seq);
 }
 
+// The first `n` lines of `s` (including the newline that ends line `n`), or all
+// of `s` when it has fewer. The previewer only ever shows the top of the file,
+// so slicing here keeps the highlight fold O(visible lines) instead of
+// O(file) — the difference between a 40-line viewport and a multi-thousand-line
+// source on every keystroke.
+const(char)[] firstLines(return scope const(char)[] s, size_t n) @safe pure nothrow @nogc
+{
+    if (n == 0)
+        return s;
+    size_t seen = 0;
+    foreach (i, char c; s)
+        if (c == '\n' && ++seen == n)
+            return s[0 .. i + 1];
+    return s;
+}
+
 int main(string[] args)
 {
     const cli = args.parseCliArgs!CliParams(
@@ -152,30 +168,49 @@ void main()
         write(sgr[]);
     }
 
+    // Color depth is a stable property of the session — probe once, not per
+    // frame. Resolved themes are memoized: switching revisits themes, and each
+    // resolveTheme allocates a fresh label→style table.
+    const depth = detectColorDepth();
+    ResolvedTheme[string] resolvedCache;
+
+    ref const(ResolvedTheme) resolveCached(string name)
+    {
+        if (auto r = name in resolvedCache)
+            return *r;
+        auto tp = name in builtinThemes;
+        resolvedCache[name] = resolveTheme(tp ? *tp : builtinDark, labels);
+        return resolvedCache[name];
+    }
+
     string lastRendered;
     while (true)
     {
         const cur = names[idx];
-        auto tp = cur in builtinThemes;
-        const(Theme)* thp = tp ? tp : &builtinDark;
-        const resolved = resolveTheme(*thp, labels);
-        const depth = detectColorDepth();
+        const resolved = resolveCached(cur);
         const chrome = StyleSpec(fg: resolved.defaults.fg, bg: resolved.defaults.bg);
 
-        import sparkles.base.smallbuffer : SmallBuffer;
-        SmallBuffer!(char, 8192) buf;
-        renderAnsi(source, events[], resolved, buf,
-            AnsiOptions(depth: depth, italics: true, emitBackground: true));
-        lastRendered = buf[].idup;
-
-        import std.string : splitLines;
         import std.algorithm.comparison : min;
-        auto codeLines = lastRendered.splitLines();
         const sz = terminalSize();
         enum win = 7;
         const reserved = 4u + win; // header + hint + 2 separators + theme list
         const maxCode = (sz.height > reserved) ? sz.height - reserved : 10;
-        auto view = codeLines.length > maxCode ? codeLines[0 .. maxCode] : codeLines;
+
+        // Render only the visible slice: highlighting the whole file every frame
+        // and then discarding all but `maxCode` lines was the theme-switch
+        // regression (O(file) render + idup + splitLines per keystroke).
+        // renderAnsi clamps spans to the sliced length, so the shared event
+        // stream needs no filtering.
+        const shown = source.firstLines(maxCode);
+
+        import sparkles.base.smallbuffer : SmallBuffer;
+        SmallBuffer!(char, 8192) buf;
+        renderAnsi(shown, events[], resolved, buf,
+            AnsiOptions(depth: depth, italics: true, emitBackground: true));
+        lastRendered = buf[].idup;
+
+        import std.string : splitLines;
+        auto view = lastRendered.splitLines();
 
         writeCtl(CtlSeq.syncBegin);
         // Open the theme's fg/bg before erasing: terminals with "back color

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -6,6 +6,9 @@
 //
 // Usage: hue [--html] [--theme <theme>] [path] (defaults to this file itself)
 //   Interactive TUI (tty, no --html): ↑/↓ to switch themes live; any other key quits.
+//
+// Startup here is GC (CLI parse, file read, tree-sitter parse, theme list); the
+// interactive render/output core lives in `previewer.d` and is @nogc.
 
 module app;
 
@@ -18,8 +21,10 @@ import sparkles.syntax;
 import sparkles.core_cli.args;
 
 import sparkles.base.term_control : CtlSeq;
-import sparkles.core_cli.key_input : Key, stdioKeySession;
-import sparkles.core_cli.term_caps : isTerminal, StdStream, terminalSize;
+import sparkles.core_cli.key_input : stdioKeySession;
+import sparkles.core_cli.term_caps : isTerminal, StdStream;
+
+import previewer : Previewer, runLoop, TermOut;
 
 struct CliParams
 {
@@ -30,36 +35,11 @@ struct CliParams
     string theme = "catppuccin-mocha";
 }
 
-// `CtlSeq` is a `string`-based enum; `std.stdio.write` formats enums by their
-// symbolic member name (e.g. "enterAltScreen"), not the underlying escape
-// sequence, so writing one directly silently prints garbage instead of
-// control codes. Route every use through an explicit cast to `string`.
-void writeCtl(CtlSeq seq)
-{
-    write(cast(string) seq);
-}
-
-// The first `n` lines of `s` (including the newline that ends line `n`), or all
-// of `s` when it has fewer. The previewer only ever shows the top of the file,
-// so slicing here keeps the highlight fold O(visible lines) instead of
-// O(file) — the difference between a 40-line viewport and a multi-thousand-line
-// source on every keystroke.
-const(char)[] firstLines(return scope const(char)[] s, size_t n) @safe pure nothrow @nogc
-{
-    if (n == 0)
-        return s;
-    size_t seen = 0;
-    foreach (i, char c; s)
-        if (c == '\n' && ++seen == n)
-            return s[0 .. i + 1];
-    return s;
-}
-
 int main(string[] args)
 {
     const cli = args.parseCliArgs!CliParams(
         HelpInfo(
-            "highlight-file",
+            "hue",
             "The full precise-mode pipeline: file -> tree-sitter parse -> highlights query -> event stream -> ANSI (stdout) or HTML.",
             null
         )
@@ -132,9 +112,15 @@ void main()
         return 0;
     }
 
-    string[] names = builtinThemes.keys.dup;
+    // Sorted theme names, plus the parallel theme values the previewer indexes
+    // per frame (avoids per-frame GC AA lookups; `.keys` already returns a
+    // fresh array, so no `.dup`).
+    string[] names = builtinThemes.keys;
     import std.algorithm.sorting : sort;
+    import std.algorithm.iteration : map;
+    import std.array : array;
     sort(names);
+    immutable(Theme)[] themes = names.map!(n => *(n in builtinThemes)).array;
 
     size_t idx = 0;
     foreach (i, n; names) if (n == themeName) { idx = i; break; }
@@ -151,113 +137,28 @@ void main()
     auto sess = sessFactory();
     scope (exit) sess.finish();
 
-    writeCtl(CtlSeq.enterAltScreen);
-    writeCtl(CtlSeq.hideCursor);
-    scope (exit)
-    {
-        writeCtl(CtlSeq.showCursor);
-        writeCtl(CtlSeq.exitAltScreen);
-    }
-
-    // Emits the SGR transition from `from` to `to` directly to stdout.
-    void emitSgr(in StyleSpec from, in StyleSpec to, ColorDepth depth)
-    {
-        import sparkles.base.smallbuffer : SmallBuffer;
-        SmallBuffer!(char, 64) sgr;
-        writeStyleTransition(sgr, from, to, depth);
-        write(sgr[]);
-    }
-
-    // Color depth is a stable property of the session — probe once, not per
-    // frame. Resolved themes are memoized: switching revisits themes, and each
-    // resolveTheme allocates a fresh label→style table.
     const depth = detectColorDepth();
-    ResolvedTheme[string] resolvedCache;
+    auto prev = Previewer(
+        title: baseName(sourcePath),
+        source: source,
+        events: events[],
+        labels: labels,
+        names: names,
+        themes: themes,
+    );
 
-    ref const(ResolvedTheme) resolveCached(string name)
-    {
-        if (auto r = name in resolvedCache)
-            return *r;
-        auto tp = name in builtinThemes;
-        resolvedCache[name] = resolveTheme(tp ? *tp : builtinDark, labels);
-        return resolvedCache[name];
-    }
+    auto sink = TermOut.standard();
+    sink.put(CtlSeq.enterAltScreen);
+    sink.put(CtlSeq.hideCursor);
+    sink.flush();
 
-    string lastRendered;
-    while (true)
-    {
-        const cur = names[idx];
-        const resolved = resolveCached(cur);
-        const chrome = StyleSpec(fg: resolved.defaults.fg, bg: resolved.defaults.bg);
+    runLoop(prev, sink, sess, idx, depth);
 
-        import std.algorithm.comparison : min;
-        const sz = terminalSize();
-        enum win = 7;
-        const reserved = 4u + win; // header + hint + 2 separators + theme list
-        const maxCode = (sz.height > reserved) ? sz.height - reserved : 10;
-
-        // Render only the visible slice: highlighting the whole file every frame
-        // and then discarding all but `maxCode` lines was the theme-switch
-        // regression (O(file) render + idup + splitLines per keystroke).
-        // renderAnsi clamps spans to the sliced length, so the shared event
-        // stream needs no filtering.
-        const shown = source.firstLines(maxCode);
-
-        import sparkles.base.smallbuffer : SmallBuffer;
-        SmallBuffer!(char, 8192) buf;
-        renderAnsi(shown, events[], resolved, buf,
-            AnsiOptions(depth: depth, italics: true, emitBackground: true));
-        lastRendered = buf[].idup;
-
-        import std.string : splitLines;
-        auto view = lastRendered.splitLines();
-
-        writeCtl(CtlSeq.syncBegin);
-        // Open the theme's fg/bg before erasing: terminals with "back color
-        // erase" (xterm, kitty, alacritty, ghostty, iTerm2, Windows Terminal —
-        // effectively universal) fill erased cells with the *current* SGR
-        // background, so the whole alt-screen viewport picks up the theme's
-        // backdrop with no per-line padding needed.
-        emitSgr(StyleSpec.init, chrome, depth);
-        writeCtl(CtlSeq.eraseDisplay);
-        writeCtl(CtlSeq.cursorHome);
-
-        writef(" %s  —  %s (%d/%d)\n", baseName(sourcePath), cur, idx + 1, names.length);
-        write(" ↑/↓ switch   any other key quits\n");
-        const sepLen = sz.width ? min(60, sz.width) : 60;
-        foreach (_; 0 .. sepLen) write('─');
-        write('\n');
-
-        // Code lines already carry their own per-span (incl. background)
-        // styling — start them from a clean slate rather than the chrome
-        // style above.
-        emitSgr(chrome, StyleSpec.init, depth);
-        foreach (l; view) write(l, "\n");
-        emitSgr(StyleSpec.init, chrome, depth);
-
-        foreach (_; 0 .. sepLen) write('─');
-        write('\n');
-
-        size_t vs = (idx < win / 2) ? 0 : idx - win / 2;
-        vs = (vs + win > names.length) ? (names.length > win ? names.length - win : 0) : vs;
-        foreach (i; vs .. (vs + win > names.length ? names.length : vs + win))
-            write(i == idx ? "❯ " : "  ", names[i], "\n");
-
-        emitSgr(chrome, StyleSpec.init, depth);
-        writeCtl(CtlSeq.syncEnd);
-
-        final switch (sess.next())
-        {
-            case Key.up:   idx = (idx == 0) ? names.length - 1 : idx - 1; break;
-            case Key.down: idx = (idx + 1 == names.length) ? 0 : idx + 1; break;
-            case Key.enter, Key.cancel, Key.other:
-                goto done;
-        }
-    }
-done:;
-
-    writeCtl(CtlSeq.showCursor);
-    writeCtl(CtlSeq.exitAltScreen);
-    write(lastRendered);
+    // Restore the terminal, then leave the last highlighted frame on the primary
+    // screen (the alt screen's contents are discarded on exit).
+    sink.put(CtlSeq.showCursor);
+    sink.put(CtlSeq.exitAltScreen);
+    sink.put(prev.lastCode());
+    sink.flush();
     return 0;
 }

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -13,7 +13,7 @@
 module app;
 
 import std.array : appender;
-import std.file : exists, readText;
+import std.file : readText;
 import std.path : baseName, extension;
 import std.stdio : stderr, write, writef, writeln;
 
@@ -48,21 +48,13 @@ int main(string[] args)
     bool html = cli.html;
     string themeName = cli.theme;
 
-    string sourcePath = args.length > 1 ? args[1] : __FILE_FULL_PATH__;
-    string source = (args.length > 1 || sourcePath.exists) ? readText(sourcePath) : q{
-module sample;
-
-import std.stdio : writeln;
-
-void main()
-{
-    writeln("Hello, syntax!");
-    int x = 42;
-    if (x > 0)
-        writeln("positive");
-}
-};
-    sourcePath = (args.length <= 1 && !sourcePath.exists) ? "sample.d" : sourcePath;
+    // With a path argument, highlight that file; otherwise highlight hue's own
+    // source, embedded at compile time via `import()`. That works from any
+    // install location — the build-time `__FILE_FULL_PATH__` would not exist in
+    // a released (nix-packaged or copied) binary.
+    const hasFile = args.length > 1;
+    const sourcePath = hasFile ? args[1] : "app.d";
+    const source = hasFile ? readText(sourcePath) : import("app.d");
     const lang = canonicalLanguage(sourcePath.extension.length ? sourcePath.extension[1 .. $] : "");
 
     const labels = LabelSet.standard();

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -30,6 +30,15 @@ struct CliParams
     string theme = "catppuccin-mocha";
 }
 
+// `CtlSeq` is a `string`-based enum; `std.stdio.write` formats enums by their
+// symbolic member name (e.g. "enterAltScreen"), not the underlying escape
+// sequence, so writing one directly silently prints garbage instead of
+// control codes. Route every use through an explicit cast to `string`.
+void writeCtl(CtlSeq seq)
+{
+    write(cast(string) seq);
+}
+
 int main(string[] args)
 {
     const cli = args.parseCliArgs!CliParams(
@@ -101,7 +110,7 @@ void main()
         }
         else
             renderAnsi(source, events[], theme, output,
-                AnsiOptions(depth: detectColorDepth(), italics: true));
+                AnsiOptions(depth: detectColorDepth(), italics: true, emitBackground: true));
 
         write(output[]);
         return 0;
@@ -119,19 +128,28 @@ void main()
     {
         auto output = appender!string;
         renderAnsi(source, events[], theme, output,
-            AnsiOptions(depth: detectColorDepth(), italics: true));
+            AnsiOptions(depth: detectColorDepth(), italics: true, emitBackground: true));
         write(output[]);
         return 0;
     }
     auto sess = sessFactory();
     scope (exit) sess.finish();
 
-    write(CtlSeq.enterAltScreen);
-    write(CtlSeq.hideCursor);
+    writeCtl(CtlSeq.enterAltScreen);
+    writeCtl(CtlSeq.hideCursor);
     scope (exit)
     {
-        write(CtlSeq.showCursor);
-        write(CtlSeq.exitAltScreen);
+        writeCtl(CtlSeq.showCursor);
+        writeCtl(CtlSeq.exitAltScreen);
+    }
+
+    // Emits the SGR transition from `from` to `to` directly to stdout.
+    void emitSgr(in StyleSpec from, in StyleSpec to, ColorDepth depth)
+    {
+        import sparkles.base.smallbuffer : SmallBuffer;
+        SmallBuffer!(char, 64) sgr;
+        writeStyleTransition(sgr, from, to, depth);
+        write(sgr[]);
     }
 
     string lastRendered;
@@ -141,24 +159,33 @@ void main()
         auto tp = cur in builtinThemes;
         const(Theme)* thp = tp ? tp : &builtinDark;
         const resolved = resolveTheme(*thp, labels);
+        const depth = detectColorDepth();
+        const chrome = StyleSpec(fg: resolved.defaults.fg, bg: resolved.defaults.bg);
 
         import sparkles.base.smallbuffer : SmallBuffer;
         SmallBuffer!(char, 8192) buf;
         renderAnsi(source, events[], resolved, buf,
-            AnsiOptions(depth: detectColorDepth(), italics: true));
+            AnsiOptions(depth: depth, italics: true, emitBackground: true));
         lastRendered = buf[].idup;
 
         import std.string : splitLines;
         import std.algorithm.comparison : min;
         auto codeLines = lastRendered.splitLines();
         const sz = terminalSize();
-        const reserved = 9u;
+        enum win = 7;
+        const reserved = 4u + win; // header + hint + 2 separators + theme list
         const maxCode = (sz.height > reserved) ? sz.height - reserved : 10;
         auto view = codeLines.length > maxCode ? codeLines[0 .. maxCode] : codeLines;
 
-        write(CtlSeq.syncBegin);
-        write(CtlSeq.eraseDisplay);
-        write(CtlSeq.cursorHome);
+        writeCtl(CtlSeq.syncBegin);
+        // Open the theme's fg/bg before erasing: terminals with "back color
+        // erase" (xterm, kitty, alacritty, ghostty, iTerm2, Windows Terminal —
+        // effectively universal) fill erased cells with the *current* SGR
+        // background, so the whole alt-screen viewport picks up the theme's
+        // backdrop with no per-line padding needed.
+        emitSgr(StyleSpec.init, chrome, depth);
+        writeCtl(CtlSeq.eraseDisplay);
+        writeCtl(CtlSeq.cursorHome);
 
         writef(" %s  —  %s (%d/%d)\n", baseName(sourcePath), cur, idx + 1, names.length);
         write(" ↑/↓ switch   any other key quits\n");
@@ -166,18 +193,23 @@ void main()
         foreach (_; 0 .. sepLen) write('─');
         write('\n');
 
+        // Code lines already carry their own per-span (incl. background)
+        // styling — start them from a clean slate rather than the chrome
+        // style above.
+        emitSgr(chrome, StyleSpec.init, depth);
         foreach (l; view) write(l, "\n");
+        emitSgr(StyleSpec.init, chrome, depth);
 
         foreach (_; 0 .. sepLen) write('─');
         write('\n');
 
-        enum win = 7;
         size_t vs = (idx < win / 2) ? 0 : idx - win / 2;
         vs = (vs + win > names.length) ? (names.length > win ? names.length - win : 0) : vs;
         foreach (i; vs .. (vs + win > names.length ? names.length : vs + win))
             write(i == idx ? "❯ " : "  ", names[i], "\n");
 
-        write(CtlSeq.syncEnd);
+        emitSgr(chrome, StyleSpec.init, depth);
+        writeCtl(CtlSeq.syncEnd);
 
         final switch (sess.next())
         {
@@ -189,6 +221,8 @@ void main()
     }
 done:;
 
+    writeCtl(CtlSeq.showCursor);
+    writeCtl(CtlSeq.exitAltScreen);
     write(lastRendered);
     return 0;
 }

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -144,13 +144,15 @@ int main(string[] args)
     sink.put(CtlSeq.hideCursor);
     sink.flush();
 
-    runLoop(prev, sink, sess, idx, depth);
+    const result = runLoop(prev, sink, sess, idx, depth);
 
-    // Restore the terminal, then leave the last highlighted frame on the primary
-    // screen (the alt screen's contents are discarded on exit).
+    // Restore the terminal (the alt screen's contents are discarded on exit).
+    // On selection (Enter), print the whole file highlighted with the chosen
+    // theme onto the primary screen; on quit/abort, print nothing.
     sink.put(CtlSeq.showCursor);
     sink.put(CtlSeq.exitAltScreen);
-    sink.put(prev.lastCode());
+    if (result.selected)
+        sink.put(prev.renderFull(result.idx, depth));
     sink.flush();
     return 0;
 }

--- a/apps/hue/src/previewer.d
+++ b/apps/hue/src/previewer.d
@@ -103,31 +103,51 @@ struct Previewer
     const(char)[] lastCode() const @safe pure nothrow @nogc
         => frame[][codeStart .. codeEnd];
 
-    /// Builds the whole frame for theme `idx` into `frame` (`@nogc nothrow`):
-    /// sync markers, the theme backdrop via back-color-erase, header, the
-    /// highlighted viewport, and the theme-list window. Re-resolves the theme
-    /// into `styleBuf` only when `idx` changed.
-    void buildFrame(size_t idx, ushort width, ushort height, ColorDepth depth)
-        @safe @nogc nothrow
+    /// Renders the $(I entire) source with theme `idx` into the frame buffer and
+    /// returns the bytes — used to print the whole highlighted file to the
+    /// primary screen once the user selects a theme (Enter), rather than the
+    /// viewport slice `buildFrame` shows. `@nogc` (the buffer spills to malloc,
+    /// never the GC, for a large file).
+    const(char)[] renderFull(size_t idx, ColorDepth depth) @safe @nogc nothrow
+    {
+        const theme = themeView(idx);
+        frame.clear();
+        renderAnsi(source, events, theme, frame,
+            AnsiOptions(depth: depth, italics: true, emitBackground: true));
+        return frame[];
+    }
+
+    /// Resolves theme `idx` into the reused `styleBuf` (only when it changed)
+    /// and returns a `ResolvedTheme` borrowing it. The borrow is sound because
+    /// renderAnsi takes `in ResolvedTheme` and never escapes the slice, and the
+    /// buffer is only rewritten on the next theme change.
+    private ResolvedTheme themeView(size_t idx) @safe @nogc nothrow
     in (idx < names.length)
     in (labels.length <= styleBuf.length, "label vocabulary larger than the style buffer")
     {
-        import std.algorithm.comparison : min;
-
         if (idx != resolvedIdx)
         {
             resolveThemeInto(themes[idx], labels, styleBuf[0 .. labels.length],
                 resolvedDefaults);
             resolvedIdx = idx;
         }
-        // A ResolvedTheme borrowing the reused (mutable) style table: sound
-        // because renderAnsi takes `in ResolvedTheme` and never escapes the
-        // slice, and the buffer is only rewritten on the next theme change.
-        const theme = () @trusted {
+        return () @trusted {
             return ResolvedTheme(labels,
                 cast(immutable(StyleSpec)[]) styleBuf[0 .. labels.length],
                 resolvedDefaults);
         }();
+    }
+
+    /// Builds the whole frame for theme `idx` into `frame` (`@nogc nothrow`):
+    /// sync markers, the theme backdrop via back-color-erase, header, the
+    /// highlighted viewport, and the theme-list window.
+    void buildFrame(size_t idx, ushort width, ushort height, ColorDepth depth)
+        @safe @nogc nothrow
+    in (idx < names.length)
+    {
+        import std.algorithm.comparison : min;
+
+        const theme = themeView(idx);
         const chrome = StyleSpec(fg: resolvedDefaults.fg, bg: resolvedDefaults.bg);
 
         enum win = 7;
@@ -155,7 +175,7 @@ struct Previewer
         frame.put("/");
         writeInteger(frame, names.length);
         frame.put(")\n");
-        frame.put(" ↑/↓ switch   any other key quits\n");
+        frame.put(" ↑/↓ switch   enter: print full file   any other key: quit\n");
         putSeparator(sepLen);
 
         // Code lines carry their own per-span styling — start from a clean slate.
@@ -193,11 +213,19 @@ struct Previewer
     const(char)[] frameBytes() const @safe pure nothrow @nogc => frame[];
 }
 
+/// How the previewer loop ended: the theme `idx` last shown, and whether the
+/// user `selected` it (pressed Enter) versus quit/aborted (any other key).
+struct LoopResult
+{
+    size_t idx;
+    bool selected;
+}
+
 /// The interactive core: repaint, flush, read a key, repeat — `@nogc nothrow`,
 /// so a theme switch allocates nothing. `@system` only because raw terminal I/O
-/// (the key delegate, `fwrite`) is inherently unsafe. Returns the last-shown
-/// theme index. `idx` starts at the caller's chosen theme.
-size_t runLoop(ref Previewer prev, ref TermOut sink, ref KeySession sess,
+/// (the key delegate, `fwrite`) is inherently unsafe. `idx` starts at the
+/// caller's chosen theme.
+LoopResult runLoop(ref Previewer prev, ref TermOut sink, ref KeySession sess,
     size_t idx, ColorDepth depth) @system @nogc nothrow
 {
     while (true)
@@ -215,8 +243,10 @@ size_t runLoop(ref Previewer prev, ref TermOut sink, ref KeySession sess,
             case Key.down:
                 idx = (idx + 1 == prev.themeCount()) ? 0 : idx + 1;
                 break;
-            case Key.enter, Key.cancel, Key.other:
-                return idx;
+            case Key.enter:
+                return LoopResult(idx, true);   // select → print the full file
+            case Key.cancel, Key.other:
+                return LoopResult(idx, false);  // quit → print nothing
         }
     }
 }
@@ -281,4 +311,33 @@ unittest
         prev.buildFrame(i % 2, 80, 24, ColorDepth.trueColor);
     const delta = GC.stats.allocatedInCurrentThread - before;
     assert(delta == 0, "buildFrame is not zero-GC in steady state");
+}
+
+@("previewer.renderFull.coversWholeFile")
+@system
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    // A source taller than a small viewport, with a distinctive last line.
+    static immutable src = "a0\na1\na2\na3\na4\na5\na6\na7\na8\nLAST_LINE\n";
+    static HighlightEvent[1] ev = [HighlightEvent.sourceSpan(0, src.length)];
+    static immutable(Theme)[1] themes = [builtinDark];
+    static immutable string[1] names = ["dark"];
+
+    Previewer prev;
+    prev.title = "t";
+    prev.source = src;
+    prev.events = ev[];
+    prev.labels = LabelSet.standard();
+    prev.names = names[];
+    prev.themes = themes[];
+
+    // height 14 → reserved 11 → maxCode 3 visible lines: the viewport truncates.
+    prev.buildFrame(0, 40, 14, ColorDepth.trueColor);
+    assert(!prev.lastCode().canFind("LAST_LINE"), "viewport should truncate");
+
+    const full = prev.renderFull(0, ColorDepth.trueColor);
+    assert(full.canFind("a0") && full.canFind("LAST_LINE"),
+        "renderFull must cover the whole file");
 }

--- a/apps/hue/src/previewer.d
+++ b/apps/hue/src/previewer.d
@@ -1,0 +1,284 @@
+// The interactive live theme previewer's allocation-free core.
+//
+// Startup (file read, tree-sitter parse, building the theme list) is GC and
+// lives in `app.d`; everything here — building a frame and pushing it to the
+// terminal, plus the key-driven loop — is `@nogc nothrow`, so a theme switch
+// never triggers a GC pause. The whole frame is assembled into one reused
+// `SmallBuffer` and flushed with a single `fwrite`; the theme is re-resolved
+// into one reused stack buffer on change (see `resolveThemeInto`).
+module previewer;
+
+import core.stdc.stdio : FILE, fflush, fwrite;
+
+import sparkles.base.smallbuffer : SmallBuffer;
+import sparkles.base.term_control : CtlSeq;
+import sparkles.base.text.writers : writeInteger;
+
+import sparkles.syntax : AnsiOptions, ColorDepth, HighlightEvent, LabelSet,
+    renderAnsi, ResolvedTheme, resolveThemeInto, StyleSpec, Theme,
+    writeStyleTransition;
+
+import sparkles.core_cli.key_input : Key, KeySession;
+import sparkles.core_cli.term_caps : StdStream, terminalSize;
+
+/// The first `n` lines of `s` (including the newline that ends line `n`), or all
+/// of `s` when it has fewer. The previewer only shows the top of the file, so
+/// slicing here keeps the highlight fold O(visible lines), not O(file).
+const(char)[] firstLines(return scope const(char)[] s, size_t n) @safe pure nothrow @nogc
+{
+    if (n == 0)
+        return s;
+    size_t seen = 0;
+    foreach (i, char c; s)
+        if (c == '\n' && ++seen == n)
+            return s[0 .. i + 1];
+    return s;
+}
+
+/// A minimal `@nogc` byte sink over a C `FILE*` (stdout). One `put` + `flush`
+/// per frame keeps the whole repaint to a single write; `fwrite` short-writes
+/// are looped over (mirrors `sparkles.base.logger`'s `fwriteAll`).
+struct TermOut
+{
+    private FILE* fp;
+
+    /// A sink writing to C stdout.
+    static TermOut standard() @trusted @nogc nothrow
+    {
+        import core.stdc.stdio : stdout;
+
+        return TermOut(stdout);
+    }
+
+    /// Writes all of `data`, looping over partial `fwrite`s.
+    void put(scope const(char)[] data) @trusted @nogc nothrow
+    {
+        size_t off = 0;
+        while (off < data.length)
+        {
+            const n = fwrite(data.ptr + off, 1, data.length - off, fp);
+            if (n == 0)
+                break; // write error; nothing a nothrow sink can do
+            off += n;
+        }
+    }
+
+    /// Emits a fixed control sequence (a `string`-typed enum).
+    void put(CtlSeq seq) @trusted @nogc nothrow
+    {
+        put(cast(string) seq);
+    }
+
+    void flush() @trusted @nogc nothrow
+    {
+        fflush(fp);
+    }
+}
+
+/// The reusable previewer state: parsed source + events, the theme list, and
+/// the reused frame/style buffers. Built once at startup, then driven by
+/// `runLoop`. `themes[idx]` and `names[idx]` are parallel.
+struct Previewer
+{
+    string title;                 /// file base name shown in the header
+    const(char)[] source;         /// the whole file (rendered viewport-sliced)
+    const(HighlightEvent)[] events; /// parsed once; re-rendered per frame
+    LabelSet labels;              /// the vocabulary `styleBuf` is sized against
+    const(string)[] names;        /// sorted theme names (parallel to `themes`)
+    immutable(Theme)[] themes;    /// theme data (parallel to `names`)
+
+    // Reused per-frame scratch — no per-frame heap (spills to malloc, never GC,
+    // only on very large terminals).
+    private SmallBuffer!(char, 16384) frame;
+    private StyleSpec[128] styleBuf = void; /// current resolved theme's table
+    private StyleSpec resolvedDefaults;
+    private size_t resolvedIdx = size_t.max; /// which theme is in styleBuf
+    private size_t codeStart, codeEnd;       /// the code slice within `frame`
+
+    /// The theme count (rows to page through).
+    size_t themeCount() const @safe pure nothrow @nogc => names.length;
+
+    /// The last-rendered highlighted code, sliced out of `frame` — written to
+    /// the primary screen after the alt screen is left.
+    const(char)[] lastCode() const @safe pure nothrow @nogc
+        => frame[][codeStart .. codeEnd];
+
+    /// Builds the whole frame for theme `idx` into `frame` (`@nogc nothrow`):
+    /// sync markers, the theme backdrop via back-color-erase, header, the
+    /// highlighted viewport, and the theme-list window. Re-resolves the theme
+    /// into `styleBuf` only when `idx` changed.
+    void buildFrame(size_t idx, ushort width, ushort height, ColorDepth depth)
+        @safe @nogc nothrow
+    in (idx < names.length)
+    in (labels.length <= styleBuf.length, "label vocabulary larger than the style buffer")
+    {
+        import std.algorithm.comparison : min;
+
+        if (idx != resolvedIdx)
+        {
+            resolveThemeInto(themes[idx], labels, styleBuf[0 .. labels.length],
+                resolvedDefaults);
+            resolvedIdx = idx;
+        }
+        // A ResolvedTheme borrowing the reused (mutable) style table: sound
+        // because renderAnsi takes `in ResolvedTheme` and never escapes the
+        // slice, and the buffer is only rewritten on the next theme change.
+        const theme = () @trusted {
+            return ResolvedTheme(labels,
+                cast(immutable(StyleSpec)[]) styleBuf[0 .. labels.length],
+                resolvedDefaults);
+        }();
+        const chrome = StyleSpec(fg: resolvedDefaults.fg, bg: resolvedDefaults.bg);
+
+        enum win = 7;
+        const reserved = 4u + win; // header + hint + 2 separators + theme list
+        const maxCode = (height > reserved) ? height - reserved : 10;
+        const shown = source.firstLines(maxCode);
+        const sepLen = width ? min(60, cast(size_t) width) : 60;
+
+        frame.clear();
+        frame.put(CtlSeq.syncBegin);
+        // Open the theme fg/bg before erasing: terminals with back-color-erase
+        // fill erased cells with the current SGR background, so the whole
+        // viewport picks up the theme backdrop with no per-line padding.
+        writeStyleTransition(frame, StyleSpec.init, chrome, depth);
+        frame.put(CtlSeq.eraseDisplay);
+        frame.put(CtlSeq.cursorHome);
+
+        // Header: " <file>  —  <theme> (i/n)".
+        frame.put(" ");
+        frame.put(title);
+        frame.put("  —  ");
+        frame.put(names[idx]);
+        frame.put(" (");
+        writeInteger(frame, idx + 1);
+        frame.put("/");
+        writeInteger(frame, names.length);
+        frame.put(")\n");
+        frame.put(" ↑/↓ switch   any other key quits\n");
+        putSeparator(sepLen);
+
+        // Code lines carry their own per-span styling — start from a clean slate.
+        writeStyleTransition(frame, chrome, StyleSpec.init, depth);
+        codeStart = frame[].length;
+        renderAnsi(shown, events, theme, frame,
+            AnsiOptions(depth: depth, italics: true, emitBackground: true));
+        codeEnd = frame[].length;
+        writeStyleTransition(frame, StyleSpec.init, chrome, depth);
+
+        putSeparator(sepLen);
+
+        // The scrolling theme-list window around `idx`.
+        size_t vs = (idx < win / 2) ? 0 : idx - win / 2;
+        vs = (vs + win > names.length) ? (names.length > win ? names.length - win : 0) : vs;
+        foreach (i; vs .. (vs + win > names.length ? names.length : vs + win))
+        {
+            frame.put(i == idx ? "❯ " : "  ");
+            frame.put(names[i]);
+            frame.put("\n");
+        }
+
+        writeStyleTransition(frame, chrome, StyleSpec.init, depth);
+        frame.put(CtlSeq.syncEnd);
+    }
+
+    private void putSeparator(size_t n) @safe @nogc nothrow
+    {
+        foreach (_; 0 .. n)
+            frame.put("─");
+        frame.put("\n");
+    }
+
+    /// The assembled frame bytes (valid until the next `buildFrame`).
+    const(char)[] frameBytes() const @safe pure nothrow @nogc => frame[];
+}
+
+/// The interactive core: repaint, flush, read a key, repeat — `@nogc nothrow`,
+/// so a theme switch allocates nothing. `@system` only because raw terminal I/O
+/// (the key delegate, `fwrite`) is inherently unsafe. Returns the last-shown
+/// theme index. `idx` starts at the caller's chosen theme.
+size_t runLoop(ref Previewer prev, ref TermOut sink, ref KeySession sess,
+    size_t idx, ColorDepth depth) @system @nogc nothrow
+{
+    while (true)
+    {
+        const sz = terminalSize(StdStream.stdout);
+        prev.buildFrame(idx, sz.width, sz.height, depth);
+        sink.put(prev.frameBytes());
+        sink.flush();
+
+        final switch (sess.next())
+        {
+            case Key.up:
+                idx = (idx == 0) ? prev.themeCount() - 1 : idx - 1;
+                break;
+            case Key.down:
+                idx = (idx + 1 == prev.themeCount()) ? 0 : idx + 1;
+                break;
+            case Key.enter, Key.cancel, Key.other:
+                return idx;
+        }
+    }
+}
+
+version (unittest)
+{
+    import sparkles.syntax : builtinDark;
+
+    // A minimal previewer over a tiny source and two (identical) themes.
+    private Previewer testPreviewer()
+    {
+        static immutable src = "module x;\nint y = 42;\n// note\n";
+        static HighlightEvent[1] ev = [HighlightEvent.sourceSpan(0, src.length)];
+        static immutable(Theme)[2] themes = [builtinDark, builtinDark];
+        static immutable string[2] names = ["catppuccin-mocha", "dracula"];
+
+        Previewer prev;
+        prev.title = "sample.d";
+        prev.source = src;
+        prev.events = ev[];
+        prev.labels = LabelSet.standard();
+        prev.names = names[];
+        prev.themes = themes[];
+        return prev;
+    }
+}
+
+@("previewer.buildFrame.structure")
+@system
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    auto prev = testPreviewer();
+    prev.buildFrame(0, 80, 24, ColorDepth.trueColor);
+    const f = prev.frameBytes();
+
+    assert(f.canFind("\x1b[?2026h"), "syncBegin missing");   // begin sync
+    assert(f.canFind("\x1b[?2026l"), "syncEnd missing");     // end sync
+    assert(f.canFind("\x1b[2J"), "eraseDisplay missing");    // back-color-erase
+    assert(f.canFind("catppuccin-mocha"), "theme name missing"); // header + list
+    assert(f.canFind("sample.d"), "title missing");
+    assert(prev.lastCode().length > 0, "no code slice recorded");
+    // The code slice sits inside the frame and highlights the source.
+    assert(f.canFind(prev.lastCode()));
+}
+
+@("previewer.buildFrame.steadyStateZeroAlloc")
+@system
+unittest
+{
+    import core.memory : GC;
+
+    auto prev = testPreviewer();
+
+    // Warm up: grow the frame buffer and resolve both themes once.
+    foreach (i; 0 .. 4)
+        prev.buildFrame(i % 2, 80, 24, ColorDepth.trueColor);
+
+    const before = GC.stats.allocatedInCurrentThread;
+    foreach (i; 0 .. 16)
+        prev.buildFrame(i % 2, 80, 24, ColorDepth.trueColor);
+    const delta = GC.stats.allocatedInCurrentThread - before;
+    assert(delta == 0, "buildFrame is not zero-GC in steady state");
+}

--- a/docs/libs/syntax/index.md
+++ b/docs/libs/syntax/index.md
@@ -32,8 +32,8 @@ renderAnsi(source, events[], resolveTheme(builtinDark, labels), ansi);
 
 Any engine failure is an `Expected` error value — the caller renders plain
 text instead (a highlighter's worst legal output is uncolored text, never a
-crash). The runnable version of this pipeline is
-[`libs/syntax/examples/highlight-file.d`][example].
+crash). The runnable version of this pipeline is the
+`hue` app (`apps/hue`).
 
 ## How this documentation is organised
 
@@ -61,7 +61,3 @@ crash). The runnable version of this pipeline is
 - The research this library reifies:
   [the syntax-highlighting cluster](../../research/parsing/syntax-highlighting.md)
   of the parsing survey.
-
-<!-- References -->
-
-[example]: https://github.com/PetarKirov/sparkles/blob/3cc01cfdc8ae867f0558e43c731885a004cb0130/libs/syntax/examples/highlight-file.d

--- a/docs/libs/syntax/tutorial/getting-started.md
+++ b/docs/libs/syntax/tutorial/getting-started.md
@@ -83,10 +83,7 @@ html ~= "</code></pre>";
 
 ## The whole program
 
-[`libs/syntax/examples/highlight-file.d`][example] is this tutorial as a
-runnable script — `dub run --single highlight-file.d` inside the devshell
-highlights its own source; `--html` switches backends.
-
-<!-- References -->
-
-[example]: https://github.com/PetarKirov/sparkles/blob/3cc01cfdc8ae867f0558e43c731885a004cb0130/libs/syntax/examples/highlight-file.d
+The `hue` app (`apps/hue`) is this tutorial as a runnable
+program — `dub run :hue` inside the devshell highlights its own source;
+`--html` switches backends, and in a tty it opens an interactive live
+theme previewer (↑/↓ to switch themes).

--- a/dub.sdl
+++ b/dub.sdl
@@ -7,6 +7,7 @@ license "BSL-1.0"
 targetPath "build"
 
 subPackage "apps/ci"
+subPackage "apps/hue"
 subPackage "apps/release"
 subPackage "apps/terminal"
 subPackage "libs/base"

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
         ./nix/packages/all.nix
         ./nix/packages/build-d-wasm-module.nix
         ./nix/packages/default.nix
+        ./nix/packages/hue.nix
         ./nix/packages/libghostty-vt.nix
         ./nix/packages/text-wasm.nix
         ./nix/packages/table-wasm.nix

--- a/libs/core-cli/src/sparkles/core_cli/key_input.d
+++ b/libs/core-cli/src/sparkles/core_cli/key_input.d
@@ -25,8 +25,8 @@ enum Key { up, down, enter, cancel, other }
 /// enter/use/finish lifecycle).
 struct KeySession
 {
-    Key delegate() next;
-    void delegate() finish;
+    Key delegate() @nogc nothrow next;
+    void delegate() @nogc nothrow finish;
 }
 
 /// Begins a raw-mode key session on stdin, or `null` when arrow-key
@@ -58,7 +58,7 @@ unittest
 /// Classifies a single input byte; `readEscape` is only invoked for a lone
 /// ESC (`0x1b`), and decides between a bare Esc keypress and the start of a
 /// CSI/SS3 escape sequence (typically via a short read timeout).
-private Key classifyByte(char b, scope Key delegate() @safe nothrow readEscape) @safe nothrow
+private Key classifyByte(char b, scope Key delegate() @safe nothrow @nogc readEscape) @safe nothrow @nogc
 {
     switch (b)
     {
@@ -135,7 +135,7 @@ version (Posix)
         tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
 
         auto restored = false;
-        void finish()
+        void finish() @nogc nothrow
         {
             if (restored) return;
             restored = true;
@@ -147,7 +147,7 @@ version (Posix)
     /// Reads one byte, retrying on `EINTR` (a `SIGWINCH` resize — see
     /// `term_caps.d`'s handler — must not spuriously cancel the prompt).
     /// Returns `1` (byte read), `0` (real EOF), or `-1` (other error).
-    private ptrdiff_t readBytePosix(ref char b) @trusted nothrow
+    private ptrdiff_t readBytePosix(ref char b) @trusted nothrow @nogc
     {
         import core.stdc.errno : EINTR, errno;
         import core.sys.posix.unistd : read, STDIN_FILENO;
@@ -160,7 +160,7 @@ version (Posix)
         }
     }
 
-    private Key readKeyPosix() @trusted nothrow
+    private Key readKeyPosix() @trusted nothrow @nogc
     {
         char b;
         if (readBytePosix(b) != 1)
@@ -168,7 +168,7 @@ version (Posix)
         return classifyByte(b, () => decodeEscapePosix());
     }
 
-    private Key decodeEscapePosix() @trusted nothrow
+    private Key decodeEscapePosix() @trusted nothrow @nogc
     {
         import core.sys.posix.poll : poll, pollfd, POLLIN;
         import core.sys.posix.unistd : STDIN_FILENO;
@@ -217,7 +217,7 @@ version (Windows)
         SetConsoleMode(handle, raw);
 
         auto restored = false;
-        void finish()
+        void finish() @nogc nothrow
         {
             if (restored) return;
             restored = true;
@@ -227,7 +227,7 @@ version (Windows)
     }
 
     /// Returns `1` (byte read), `0`/`-1` on EOF/error (mirrors `readBytePosix`).
-    private ptrdiff_t readByteWindows(HANDLE handle, ref char b) @trusted nothrow
+    private ptrdiff_t readByteWindows(HANDLE handle, ref char b) @trusted nothrow @nogc
     {
         import core.sys.windows.windows : DWORD, ReadFile;
 
@@ -237,7 +237,7 @@ version (Windows)
         return n;
     }
 
-    private Key readKeyWindows(HANDLE handle) @trusted nothrow
+    private Key readKeyWindows(HANDLE handle) @trusted nothrow @nogc
     {
         char b;
         if (readByteWindows(handle, b) != 1)
@@ -245,7 +245,7 @@ version (Windows)
         return classifyByte(b, () => decodeEscapeWindows(handle));
     }
 
-    private Key decodeEscapeWindows(HANDLE handle) @trusted nothrow
+    private Key decodeEscapeWindows(HANDLE handle) @trusted nothrow @nogc
     {
         import core.sys.windows.windows : WAIT_OBJECT_0, WaitForSingleObject;
 

--- a/libs/syntax/examples/highlight-file.d
+++ b/libs/syntax/examples/highlight-file.d
@@ -12,16 +12,21 @@
 // the program degrades to plain text — the totality law in action.
 //
 // Usage: highlight-file [--html] [--theme <theme>] [path] (defaults to this file itself)
+//   Interactive TUI (tty, no --html): ↑/↓ to switch themes live; any other key quits.
 
 module highlight_file;
 
 import std.array : appender;
 import std.file : exists, readText;
 import std.path : baseName, extension;
-import std.stdio : stderr, write, writeln;
+import std.stdio : stderr, write, writef, writeln;
 
 import sparkles.syntax;
 import sparkles.core_cli.args;
+
+import sparkles.base.term_control : CtlSeq;
+import sparkles.core_cli.key_input : Key, stdioKeySession;
+import sparkles.core_cli.term_caps : isTerminal, StdStream, terminalSize;
 
 struct CliParams
 {
@@ -45,19 +50,8 @@ int main(string[] args)
     bool html = cli.html;
     string themeName = cli.theme;
 
-    string sourcePath;
-    string source;
-    if (args.length > 1) {
-        sourcePath = args[1];
-        source = readText(sourcePath);
-    } else {
-        sourcePath = __FILE_FULL_PATH__;
-        if (sourcePath.exists) {
-            source = readText(sourcePath);
-        } else {
-            // Fallback for packaged runs (e.g. nix run-all-examples) where the
-            // compile-time source path is not present at runtime.
-            source = q{
+    string sourcePath = args.length > 1 ? args[1] : __FILE_FULL_PATH__;
+    string source = (args.length > 1 || sourcePath.exists) ? readText(sourcePath) : q{
 module sample;
 
 import std.stdio : writeln;
@@ -70,64 +64,138 @@ void main()
         writeln("positive");
 }
 };
-            sourcePath = "sample.d";
-        }
-    }
+    sourcePath = (args.length <= 1 && !sourcePath.exists) ? "sample.d" : sourcePath;
     const lang = canonicalLanguage(sourcePath.extension.length ? sourcePath.extension[1 .. $] : "");
 
     const labels = LabelSet.standard();
 
-    const(Theme)* themeVal = &builtinDark;
-    if (auto t = themeName in builtinThemes)
-    {
-        themeVal = t;
-    }
-    else
-    {
-        stderr.writef("Warning: theme '%s' not found. Falling back to default dark theme.\n", themeName);
-    }
+    auto t = themeName in builtinThemes;
+    if (!t) stderr.writef("Warning: theme '%s' not found. Falling back to default dark theme.\n", themeName);
+    const(Theme)* themeVal = t ? t : &builtinDark;
     const theme = resolveTheme(*themeVal, labels);
 
-    // Engine side: any failure falls back to plain text.
+    // Engine side: any failure falls back to plain text. Use the injection-aware
+    // path so that markdown (and other languages with injections.scm) get their
+    // fenced code blocks / inline content highlighted by nested grammars.
     auto events = appender!(HighlightEvent[]);
     auto registry = GrammarRegistry.fromEnvironment();
+    auto cache = TsConfigCache.create(&registry, labels);
 
-    bool highlighted = false;
-    auto grammar = registry.grammar(lang);
-    auto queryText = registry.queryText(lang);
-    if (!grammar.hasError && !queryText.hasError)
-    {
-        TsError error;
-        auto config = TsHighlightConfig.create(grammar.value, queryText.value, error);
-        if (!error)
-        {
-            config.configure(labels);
-            highlighted = !highlight(config, source, events).hasError;
-        }
-    }
-    if (!highlighted)
+    auto res = highlightInjected(cache, lang, source, events);
+    if (res.hasError)
     {
         stderr.writeln("note: no grammar for '", lang, "' — plain text");
         events ~= HighlightEvent.sourceSpan(0, source.length);
     }
 
-    auto output = appender!string;
-    if (html)
+    const interactive = !html &&
+        isTerminal(StdStream.stdin) && isTerminal(StdStream.stdout);
+
+    if (!interactive)
     {
-        import std.format : format;
-        string bgStr = theme.defaults.bg.isSet ? format("background: #%02x%02x%02x;", theme.defaults.bg.rgb.r, theme.defaults.bg.rgb.g, theme.defaults.bg.rgb.b) : "";
-        string fgStr = theme.defaults.fg.isSet ? format("color: #%02x%02x%02x;", theme.defaults.fg.rgb.r, theme.defaults.fg.rgb.g, theme.defaults.fg.rgb.b) : "";
-        output ~= format("<style>\npre { %s %s padding: 1em; }\n", bgStr, fgStr);
-        writeThemeStylesheet(theme, output);
-        output ~= "</style>\n<pre><code>";
-        renderHtml(source, events[], theme, output,
-            HtmlOptions(mode: HtmlMode.cssClasses));
-        output ~= "</code></pre>\n";
+        auto output = appender!string;
+        if (html)
+        {
+            import std.format : format;
+            string bgStr = theme.defaults.bg.isSet ? format("background: #%02x%02x%02x;", theme.defaults.bg.rgb.r, theme.defaults.bg.rgb.g, theme.defaults.bg.rgb.b) : "";
+            string fgStr = theme.defaults.fg.isSet ? format("color: #%02x%02x%02x;", theme.defaults.fg.rgb.r, theme.defaults.fg.rgb.g, theme.defaults.fg.rgb.b) : "";
+            output ~= format("<style>\npre { %s %s padding: 1em; }\n", bgStr, fgStr);
+            writeThemeStylesheet(theme, output);
+            output ~= "</style>\n<pre><code>";
+            renderHtml(source, events[], theme, output,
+                HtmlOptions(mode: HtmlMode.cssClasses));
+            output ~= "</code></pre>\n";
+        }
+        else
+            renderAnsi(source, events[], theme, output,
+                AnsiOptions(depth: detectColorDepth(), italics: true));
+
+        write(output[]);
+        return 0;
     }
-    else
+
+    string[] names = builtinThemes.keys.dup;
+    import std.algorithm.sorting : sort;
+    sort(names);
+
+    size_t idx = 0;
+    foreach (i, n; names) if (n == themeName) { idx = i; break; }
+
+    auto sessFactory = stdioKeySession();
+    if (sessFactory is null)
+    {
+        auto output = appender!string;
         renderAnsi(source, events[], theme, output,
             AnsiOptions(depth: detectColorDepth(), italics: true));
+        write(output[]);
+        return 0;
+    }
+    auto sess = sessFactory();
+    scope (exit) sess.finish();
 
-    write(output[]);
+    write(CtlSeq.enterAltScreen);
+    write(CtlSeq.hideCursor);
+    scope (exit)
+    {
+        write(CtlSeq.showCursor);
+        write(CtlSeq.exitAltScreen);
+    }
+
+    string lastRendered;
+    while (true)
+    {
+        const cur = names[idx];
+        auto tp = cur in builtinThemes;
+        const(Theme)* thp = tp ? tp : &builtinDark;
+        const resolved = resolveTheme(*thp, labels);
+
+        import sparkles.base.smallbuffer : SmallBuffer;
+        SmallBuffer!(char, 8192) buf;
+        renderAnsi(source, events[], resolved, buf,
+            AnsiOptions(depth: detectColorDepth(), italics: true));
+        lastRendered = buf[].idup;
+
+        import std.string : splitLines;
+        import std.algorithm.comparison : min;
+        auto codeLines = lastRendered.splitLines();
+        const sz = terminalSize();
+        const reserved = 9u;
+        const maxCode = (sz.height > reserved) ? sz.height - reserved : 10;
+        auto view = codeLines.length > maxCode ? codeLines[0 .. maxCode] : codeLines;
+
+        write(CtlSeq.syncBegin);
+        write(CtlSeq.eraseDisplay);
+        write(CtlSeq.cursorHome);
+
+        writef(" %s  —  %s (%d/%d)\n", baseName(sourcePath), cur, idx + 1, names.length);
+        write(" ↑/↓ switch   any other key quits\n");
+        const sepLen = sz.width ? min(60, sz.width) : 60;
+        foreach (_; 0 .. sepLen) write('─');
+        write('\n');
+
+        foreach (l; view) write(l, "\n");
+
+        foreach (_; 0 .. sepLen) write('─');
+        write('\n');
+
+        enum win = 7;
+        size_t vs = (idx < win / 2) ? 0 : idx - win / 2;
+        vs = (vs + win > names.length) ? (names.length > win ? names.length - win : 0) : vs;
+        foreach (i; vs .. (vs + win > names.length ? names.length : vs + win))
+            write(i == idx ? "❯ " : "  ", names[i], "\n");
+
+        write(CtlSeq.syncEnd);
+
+        final switch (sess.next())
+        {
+            case Key.up:   idx = (idx == 0) ? names.length - 1 : idx - 1; break;
+            case Key.down: idx = (idx + 1 == names.length) ? 0 : idx + 1; break;
+            case Key.enter, Key.cancel, Key.other:
+                goto done;
+        }
+    }
+done:;
+
+    write(lastRendered);
     return 0;
 }

--- a/libs/syntax/src/sparkles/syntax/render/ansi.d
+++ b/libs/syntax/src/sparkles/syntax/render/ansi.d
@@ -37,8 +37,10 @@ struct AnsiOptions
     /// Color tier to emit. `none` = verbatim passthrough.
     ColorDepth depth = ColorDepth.ansi256;
 
-    /// Emit per-run theme backgrounds. Off by default: respect the
-    /// terminal's own background.
+    /// Emit per-run theme backgrounds — including the theme's page
+    /// background (`ResolvedTheme.defaults.bg`) for runs whose own rule
+    /// styles fg only. Off by default: respect the terminal's own
+    /// background.
     bool emitBackground = false;
 
     /// Emit italics. Off by default (bat's defensive gate — some terminals
@@ -89,6 +91,12 @@ if (isHighlightEventRange!Events)
             spec.font = cast(FontStyle)(spec.font & ~FontStyle.italic);
         if (!options.emitBackground)
             spec.bg = Color.init;
+        else if (!spec.bg.isSet)
+            // Most rules style fg only. Unlike HTML's `<pre>` container,
+            // ANSI has no background inheritance, so without this an unset
+            // per-span bg would render as the terminal's own default (`49`)
+            // instead of the theme's page background showing through.
+            spec.bg = theme.defaults.bg;
 
         // Defensive clamp: a misbehaving producer must not crash a renderer.
         const lo = min(span.start, source.length);
@@ -289,6 +297,7 @@ version (unittest)
     {
         const theme = Theme(
             name: "test",
+            defaultBg: Color.fromPalette(235), // page background; only consulted with emitBackground
             rules: [
                 ThemeRule("keyword", StyleSpec(
                     fg: Color.fromRgb(0xcb, 0xa6, 0xf7), font: FontStyle.bold)),
@@ -344,6 +353,34 @@ unittest
     // none: verbatim passthrough
     checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
         AnsiOptions(depth: ColorDepth.none)))(source);
+}
+
+@("render.ansi.emitBackgroundFallsBackToPageBackground")
+@safe pure nothrow
+unittest
+{
+    const resolved = testTheme();
+    alias E = HighlightEvent;
+    const source = "if x";
+    const events = [
+        E.pushLabel(lbl("keyword")),
+        E.sourceSpan(0, 2), // "if" — the keyword rule styles fg only
+        E.popLabel(),
+        E.sourceSpan(2, 4), // " x" — unlabeled gap
+    ];
+
+    // "if" has no rule-specified background, but still picks up the theme's
+    // page background (48;5;235) instead of resetting to the terminal
+    // default; the unlabeled gap already carried it via `defaults`, so no
+    // redundant background code is re-emitted when the run changes.
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.ansi256, emitBackground: true)))(
+        "\x1b[1;38;5;183;48;5;235mif\x1b[22;39m x\x1b[0m");
+
+    // emitBackground off (default): no page background leaks in at all.
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.ansi256)))(
+        "\x1b[1;38;5;183mif\x1b[0m x");
 }
 
 @("render.ansi.italicsGateAndBackground")

--- a/libs/syntax/src/sparkles/syntax/theme.d
+++ b/libs/syntax/src/sparkles/syntax/theme.d
@@ -84,17 +84,23 @@ struct ResolvedTheme
 }
 
 /**
-Resolves `theme` against `labels`: for every vocabulary name, the longest
-rule selector that is a dot-prefix of the name wins (last rule wins among
-equal selectors); unmatched names get `StyleSpec.init`.
+Resolves `theme` into a caller-provided `styles` buffer (`@nogc`): for every
+vocabulary name, the longest rule selector that is a dot-prefix of the name
+wins (last rule wins among equal selectors); unmatched names get
+`StyleSpec.init`. `styles` must be exactly `labels.length` long and is written
+in full; `defaults` receives the normalized unlabeled-text style.
 
-Configure-time only (allocates the table once). A `defaultFg`/`defaultBg` of
-`Color.defaultColor` is normalized to unset in `defaults` — for a renderer,
-"the terminal default" and "unspecified" both mean "emit nothing".
+Allocation-free — the whole-table resolution logic without the array. A
+`@nogc nothrow` caller (e.g. an interactive previewer re-resolving on each
+theme switch into one reused buffer) can drive this directly; `resolveTheme`
+is the GC-allocating convenience wrapper. A `defaultFg`/`defaultBg` of
+`Color.defaultColor` is normalized to unset — for a renderer, "the terminal
+default" and "unspecified" both mean "emit nothing".
 */
-ResolvedTheme resolveTheme(in Theme theme, LabelSet labels) pure nothrow
+void resolveThemeInto(in Theme theme, LabelSet labels,
+    scope StyleSpec[] styles, out StyleSpec defaults) @safe pure nothrow @nogc
+in (styles.length == labels.length, "styles buffer must match the label vocabulary size")
 {
-    auto styles = new StyleSpec[](labels.length);
     foreach (i; 0 .. labels.length)
     {
         const labelName = labels.name(LabelId(cast(ushort) i));
@@ -113,9 +119,22 @@ ResolvedTheme resolveTheme(in Theme theme, LabelSet labels) pure nothrow
         styles[i] = found ? best : StyleSpec.init;
     }
 
-    const defaults = StyleSpec(
+    defaults = StyleSpec(
         fg: normalizeDefault(theme.defaultFg),
         bg: normalizeDefault(theme.defaultBg));
+}
+
+/**
+Resolves `theme` against `labels` into a freshly allocated `ResolvedTheme`.
+
+Configure-time only (allocates the table once); see $(LREF resolveThemeInto)
+for the `@nogc` caller-buffer variant this delegates to.
+*/
+ResolvedTheme resolveTheme(in Theme theme, LabelSet labels) pure nothrow
+{
+    auto styles = new StyleSpec[](labels.length);
+    StyleSpec defaults;
+    resolveThemeInto(theme, labels, styles, defaults);
     return ResolvedTheme(labels, styles.idup, defaults);
 }
 
@@ -154,6 +173,47 @@ unittest
     const labels = LabelSet.standard();
     const resolved = resolveTheme(theme, labels);
     assert(resolved[labels.find("string")].empty);
+}
+
+@("theme.resolveThemeInto.nogc")
+@safe pure nothrow @nogc
+unittest
+{
+    // Resolves into a stack buffer with no GC — the interactive-previewer path.
+    ThemeRule[1] rules = [ThemeRule("string", StyleSpec(fg: Color.fromPalette(2)))];
+    const theme = Theme(name: "t", defaultFg: Color.fromPalette(7), rules: rules[]);
+    const labels = LabelSet.standard();
+
+    StyleSpec[128] buf = void;
+    assert(labels.length <= buf.length);
+    StyleSpec defaults;
+    resolveThemeInto(theme, labels, buf[0 .. labels.length], defaults);
+
+    assert(buf[labels.find("string").value] == StyleSpec(fg: Color.fromPalette(2)));
+    assert(buf[labels.find("keyword").value] == StyleSpec.init);
+    assert(defaults.fg == Color.fromPalette(7));
+}
+
+@("theme.resolveThemeInto.matchesWrapper")
+@safe pure nothrow
+unittest
+{
+    // The caller-buffer path is identical to the GC wrapper, entry for entry.
+    const theme = Theme(name: "t", defaultBg: Color.fromPalette(235), rules: [
+        ThemeRule("string", StyleSpec(fg: Color.fromPalette(2))),
+        ThemeRule("string.special", StyleSpec(fg: Color.fromPalette(5))),
+        ThemeRule("comment", StyleSpec(fg: Color.fromPalette(8))),
+    ]);
+    const labels = LabelSet.standard();
+    const wrapped = resolveTheme(theme, labels);
+
+    auto buf = new StyleSpec[](labels.length);
+    StyleSpec defaults;
+    resolveThemeInto(theme, labels, buf, defaults);
+
+    foreach (i; 0 .. labels.length)
+        assert(buf[i] == wrapped.styles[i]);
+    assert(defaults == wrapped.defaults);
 }
 
 @("theme.StyleSpec.empty")

--- a/nix/packages/hue.nix
+++ b/nix/packages/hue.nix
@@ -1,0 +1,110 @@
+# `hue` — the interactive syntax-highlighting viewer / live theme previewer
+# (apps/hue), packaged for `nix run .#hue`. Built like the example derivations
+# (pkg-config + tree-sitter for the ImportC surface dub#3085 feeds to
+# `sparkles:syntax`), then wrapped so the tree-sitter grammar bundle is found
+# at runtime without the devshell: `sparkles:tree-sitter` dlopen()s grammars
+# from $SPARKLES_TS_GRAMMAR_PATH, so bake the `ts-grammars` linkFarm in.
+{ lib, ... }:
+{
+  perSystem =
+    { config, pkgs, ... }:
+    let
+      fs = lib.fileset;
+      root = ../..;
+      fromRoot = lib.path.append root;
+
+      isDubManifest =
+        file:
+        builtins.elem file.name [
+          "dub.sdl"
+          "dub.selections.json"
+        ];
+
+      src = fs.toSource {
+        inherit root;
+        fileset = fs.unions (
+          [
+            # Dub validates every sub-package declared in the root dub.sdl, so
+            # all sibling manifests must be present even when building only :hue.
+            (fs.fileFilter isDubManifest root)
+          ]
+          # hue's own sources plus the library closure it links against:
+          # syntax → {base, tree-sitter}; core-cli → {base, math}; and the impl
+          # runner sources base/core-cli import the `@…` attributes from
+          # unconditionally. `.c`/`.i` come along for the tree-sitter ImportC shim.
+          ++
+            map
+              (path: fs.fileFilter (file: file.hasExt "d" || file.hasExt "c" || file.hasExt "i") (fromRoot path))
+              [
+                "apps/hue/src"
+                "libs/base/src"
+                "libs/core-cli/src"
+                "libs/math/src"
+                "libs/syntax/src"
+                "libs/tree-sitter/src"
+                "libs/test-runner/src"
+                "libs/test-runner-impl/src"
+              ]
+        );
+      };
+    in
+    {
+      packages.hue = pkgs.buildDubPackage (finalAttrs: {
+        pname = "hue";
+        version = "0.1.0";
+
+        inherit src;
+        sourceRoot = "${finalAttrs.src.name}/apps/${finalAttrs.pname}";
+
+        # Shared with `ci`/`release` and the example derivations (./examples.nix).
+        dubLock = fromRoot "nix/dub-lock.json";
+        compiler = pkgs.ldc;
+
+        # pkg-config + the C library so dub#3085 feeds -P-I… to ImportC for
+        # <tree_sitter/api.h>; makeWrapper to inject the grammar bundle.
+        nativeBuildInputs = [
+          pkgs.pkg-config
+          pkgs.makeWrapper
+        ];
+        buildInputs = [ pkgs.tree-sitter ];
+
+        preBuild = ''chmod -R u+w "$NIX_BUILD_TOP"'';
+
+        # Phobos bakes store paths that must not leak into the runtime closure:
+        # ldc's separate `include` output (assert/`__FILE__` strings), the
+        # nixpkgs libcurl dlopen path, and tzdata — none reached at runtime. Same
+        # discipline as the example derivations (./examples.nix) and `release`.
+        disallowedReferences = [
+          pkgs.ldc
+          pkgs.ldc.include
+          pkgs.curl.out
+          pkgs.tzdata
+        ];
+
+        installPhase = ''
+          install -Dm755 build/${finalAttrs.pname} $out/bin/${finalAttrs.pname}
+        '';
+
+        # postFixup (after buildDubPackage's preFixup scrub): strip the baked
+        # phobos service paths, then wrap so grammars resolve outside the
+        # devshell. $SPARKLES_TS_GRAMMAR_PATH is only a *default* — a caller who
+        # exports their own still wins (--set-default).
+        postFixup = ''
+          find "$out" -type f -exec remove-references-to \
+            -t ${pkgs.ldc.include} -t ${pkgs.curl.out} -t ${pkgs.tzdata} '{}' +
+          wrapProgram $out/bin/${finalAttrs.pname} \
+            --set-default SPARKLES_TS_GRAMMAR_PATH ${config.packages.ts-grammars}
+        '';
+
+        meta = {
+          description = "Interactive syntax-highlighting viewer and live theme previewer";
+          mainProgram = finalAttrs.pname;
+        };
+      });
+
+      apps.hue = {
+        type = "app";
+        program = lib.getExe config.packages.hue;
+      };
+    };
+}


### PR DESCRIPTION
Promotes the syntax `highlight-file` demo to a first-class sparkles app,
**`apps/hue`** (`sparkles:hue`, `nix run .#hue`) — a syntax-highlighting file
viewer with an interactive live theme previewer whose render/output core is
`@nogc`.

> The benchmark + Nix-pinned foreign-highlighter panel that were originally
> here have moved to the stacked PR #114.

## Highlights

- **`apps/hue`** — `hue [--html] [--theme <name>] [path]`: the full precise-mode
  pipeline (tree-sitter parse → highlights → event stream → ANSI/HTML). In a tty
  it opens a live theme previewer (↑/↓ switch, Enter prints the whole file with
  the chosen theme). Exposed as a Nix package wrapped with the `ts-grammars`
  bundle so grammars `dlopen` outside the devshell.
- **`@nogc` interactive core** (`previewer.d`) — the whole per-frame path
  (`buildFrame` `@safe @nogc nothrow`, `runLoop` `@system @nogc nothrow`) builds
  one reused frame buffer and flushes it with a single `fwrite`; zero GC per
  frame (steady-state test proves it). Two small library enablers back it:
  `@nogc resolveThemeInto` (`sparkles:syntax`) and `@nogc` `KeySession`
  delegates (`sparkles:core-cli`).
- **Regression fixed** — the previewer used to re-highlight the whole file every
  keystroke; now it renders only the viewport (785µs → 69µs per frame; the
  benchmark that quantifies this is in #114).
- **Correctness fixes** — page-background fallback so the theme backdrop shows
  behind every token in ANSI; a latent `CtlSeq` string-enum bug (the TUI never
  actually entered the alt screen); and `import()`-embedded default source so
  the no-arg default works from any install location.

## Commits

12 commits: promote → renderer/backdrop/alt-screen → viewport perf → docs/lint →
`@nogc` enablers → `@nogc` core → `import()` default → print-on-Enter.