### PR TITLE
feat(syntax/bench): render-cost benchmark + nix-pinned foreign highlighter panel

### DIFF
--- a/apps/hue/dub.sdl
+++ b/apps/hue/dub.sdl
@@ -1,0 +1,42 @@
+name "hue"
+description "Interactive syntax-highlighting file viewer and live theme previewer (sparkles:syntax)"
+authors "Petar Kirov"
+copyright "Copyright © 2026, Petar Kirov"
+license "BSL-1.0"
+
+targetType "executable"
+targetName "hue"
+targetPath "build"
+mainSourceFile "src/app.d"
+
+dflags "-preview=in" "-preview=dip1000"
+
+// Resolved via pkg-config in dependents' builds (sparkles:syntax pulls in
+// sparkles:tree-sitter, whose ImportC surface needs <tree_sitter/api.h>).
+dependency "sparkles:syntax" path="../.."
+dependency "sparkles:core-cli" path="../.."
+
+configuration "application" {
+    targetType "executable"
+}
+
+configuration "unittest" {
+    targetType "library"
+    excludedSourceFiles "src/app.d"
+
+    // hue has no unittests of its own, but `dub test` still compiles its
+    // dependency sources with -unittest — and sparkles:syntax / sparkles:
+    // tree-sitter call `skipTest` (in the impl package) from their env-gated
+    // tests. Pulling the runner as a plain `dependency` links impl as a static
+    // archive positioned before those objects, so ld.bfd (single-pass) never
+    // pulls `skip.o` → undefined reference. Source-include the shim + impl
+    // instead (the cycle-safe recipe base/core-cli use) so `skipTest` compiles
+    // directly into this build.
+    sourcePaths "../../libs/test-runner/src" "../../libs/test-runner-impl/src"
+    importPaths "../../libs/test-runner/src" "../../libs/test-runner-impl/src"
+
+    dflags "-checkaction=context" "-allinst"
+    dflags "-defaultlib=libphobos2.so" "-L-fuse-ld=gold" platform="linux-dmd"
+    dflags "--link-defaultlib-shared" "--linker=gold" platform="linux-ldc"
+    lflags "--export-dynamic" platform="linux-ldc"
+}

--- a/apps/hue/dub.sdl
+++ b/apps/hue/dub.sdl
@@ -9,6 +9,11 @@ targetName "hue"
 targetPath "build"
 mainSourceFile "src/app.d"
 
+// `app.d` string-imports itself (`import("app.d")`) as the default sample to
+// highlight, so it works from any install location instead of relying on the
+// build-time __FILE_FULL_PATH__.
+stringImportPaths "src"
+
 dflags "-preview=in" "-preview=dip1000"
 
 // Resolved via pkg-config in dependents' builds (sparkles:syntax pulls in

--- a/apps/hue/dub.selections.json
+++ b/apps/hue/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"expected": "0.4.1",
+		"silly": "1.1.1"
+	}
+}

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -1,20 +1,13 @@
-#!/usr/bin/env dub
-/+ dub.sdl:
-    name "highlight-file"
-    dependency "sparkles:syntax" path="../../.."
-    dependency "sparkles:core-cli" path="../../.."
-    targetPath "build"
-+/
-
-// The full precise-mode pipeline: file → tree-sitter parse → highlights
-// query → event stream → ANSI (stdout) or HTML. Grammars come from the nix
-// bundle ($SPARKLES_TS_GRAMMAR_PATH, exported by the devshell); without it
-// the program degrades to plain text — the totality law in action.
+// `hue` — the `sparkles:syntax` precise-mode pipeline as an interactive app:
+// file → tree-sitter parse → highlights query → event stream → ANSI (stdout)
+// or HTML. Grammars come from the nix bundle ($SPARKLES_TS_GRAMMAR_PATH,
+// exported by the devshell and baked into the nix package); without it the
+// program degrades to plain text — the totality law in action.
 //
-// Usage: highlight-file [--html] [--theme <theme>] [path] (defaults to this file itself)
+// Usage: hue [--html] [--theme <theme>] [path] (defaults to this file itself)
 //   Interactive TUI (tty, no --html): ↑/↓ to switch themes live; any other key quits.
 
-module highlight_file;
+module app;
 
 import std.array : appender;
 import std.file : exists, readText;

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -39,6 +39,22 @@ void writeCtl(CtlSeq seq)
     write(cast(string) seq);
 }
 
+// The first `n` lines of `s` (including the newline that ends line `n`), or all
+// of `s` when it has fewer. The previewer only ever shows the top of the file,
+// so slicing here keeps the highlight fold O(visible lines) instead of
+// O(file) — the difference between a 40-line viewport and a multi-thousand-line
+// source on every keystroke.
+const(char)[] firstLines(return scope const(char)[] s, size_t n) @safe pure nothrow @nogc
+{
+    if (n == 0)
+        return s;
+    size_t seen = 0;
+    foreach (i, char c; s)
+        if (c == '\n' && ++seen == n)
+            return s[0 .. i + 1];
+    return s;
+}
+
 int main(string[] args)
 {
     const cli = args.parseCliArgs!CliParams(
@@ -152,30 +168,49 @@ void main()
         write(sgr[]);
     }
 
+    // Color depth is a stable property of the session — probe once, not per
+    // frame. Resolved themes are memoized: switching revisits themes, and each
+    // resolveTheme allocates a fresh label→style table.
+    const depth = detectColorDepth();
+    ResolvedTheme[string] resolvedCache;
+
+    ref const(ResolvedTheme) resolveCached(string name)
+    {
+        if (auto r = name in resolvedCache)
+            return *r;
+        auto tp = name in builtinThemes;
+        resolvedCache[name] = resolveTheme(tp ? *tp : builtinDark, labels);
+        return resolvedCache[name];
+    }
+
     string lastRendered;
     while (true)
     {
         const cur = names[idx];
-        auto tp = cur in builtinThemes;
-        const(Theme)* thp = tp ? tp : &builtinDark;
-        const resolved = resolveTheme(*thp, labels);
-        const depth = detectColorDepth();
+        const resolved = resolveCached(cur);
         const chrome = StyleSpec(fg: resolved.defaults.fg, bg: resolved.defaults.bg);
 
-        import sparkles.base.smallbuffer : SmallBuffer;
-        SmallBuffer!(char, 8192) buf;
-        renderAnsi(source, events[], resolved, buf,
-            AnsiOptions(depth: depth, italics: true, emitBackground: true));
-        lastRendered = buf[].idup;
-
-        import std.string : splitLines;
         import std.algorithm.comparison : min;
-        auto codeLines = lastRendered.splitLines();
         const sz = terminalSize();
         enum win = 7;
         const reserved = 4u + win; // header + hint + 2 separators + theme list
         const maxCode = (sz.height > reserved) ? sz.height - reserved : 10;
-        auto view = codeLines.length > maxCode ? codeLines[0 .. maxCode] : codeLines;
+
+        // Render only the visible slice: highlighting the whole file every frame
+        // and then discarding all but `maxCode` lines was the theme-switch
+        // regression (O(file) render + idup + splitLines per keystroke).
+        // renderAnsi clamps spans to the sliced length, so the shared event
+        // stream needs no filtering.
+        const shown = source.firstLines(maxCode);
+
+        import sparkles.base.smallbuffer : SmallBuffer;
+        SmallBuffer!(char, 8192) buf;
+        renderAnsi(shown, events[], resolved, buf,
+            AnsiOptions(depth: depth, italics: true, emitBackground: true));
+        lastRendered = buf[].idup;
+
+        import std.string : splitLines;
+        auto view = lastRendered.splitLines();
 
         writeCtl(CtlSeq.syncBegin);
         // Open the theme's fg/bg before erasing: terminals with "back color

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -6,6 +6,9 @@
 //
 // Usage: hue [--html] [--theme <theme>] [path] (defaults to this file itself)
 //   Interactive TUI (tty, no --html): ↑/↓ to switch themes live; any other key quits.
+//
+// Startup here is GC (CLI parse, file read, tree-sitter parse, theme list); the
+// interactive render/output core lives in `previewer.d` and is @nogc.
 
 module app;
 
@@ -18,8 +21,10 @@ import sparkles.syntax;
 import sparkles.core_cli.args;
 
 import sparkles.base.term_control : CtlSeq;
-import sparkles.core_cli.key_input : Key, stdioKeySession;
-import sparkles.core_cli.term_caps : isTerminal, StdStream, terminalSize;
+import sparkles.core_cli.key_input : stdioKeySession;
+import sparkles.core_cli.term_caps : isTerminal, StdStream;
+
+import previewer : Previewer, runLoop, TermOut;
 
 struct CliParams
 {
@@ -30,36 +35,11 @@ struct CliParams
     string theme = "catppuccin-mocha";
 }
 
-// `CtlSeq` is a `string`-based enum; `std.stdio.write` formats enums by their
-// symbolic member name (e.g. "enterAltScreen"), not the underlying escape
-// sequence, so writing one directly silently prints garbage instead of
-// control codes. Route every use through an explicit cast to `string`.
-void writeCtl(CtlSeq seq)
-{
-    write(cast(string) seq);
-}
-
-// The first `n` lines of `s` (including the newline that ends line `n`), or all
-// of `s` when it has fewer. The previewer only ever shows the top of the file,
-// so slicing here keeps the highlight fold O(visible lines) instead of
-// O(file) — the difference between a 40-line viewport and a multi-thousand-line
-// source on every keystroke.
-const(char)[] firstLines(return scope const(char)[] s, size_t n) @safe pure nothrow @nogc
-{
-    if (n == 0)
-        return s;
-    size_t seen = 0;
-    foreach (i, char c; s)
-        if (c == '\n' && ++seen == n)
-            return s[0 .. i + 1];
-    return s;
-}
-
 int main(string[] args)
 {
     const cli = args.parseCliArgs!CliParams(
         HelpInfo(
-            "highlight-file",
+            "hue",
             "The full precise-mode pipeline: file -> tree-sitter parse -> highlights query -> event stream -> ANSI (stdout) or HTML.",
             null
         )
@@ -132,9 +112,15 @@ void main()
         return 0;
     }
 
-    string[] names = builtinThemes.keys.dup;
+    // Sorted theme names, plus the parallel theme values the previewer indexes
+    // per frame (avoids per-frame GC AA lookups; `.keys` already returns a
+    // fresh array, so no `.dup`).
+    string[] names = builtinThemes.keys;
     import std.algorithm.sorting : sort;
+    import std.algorithm.iteration : map;
+    import std.array : array;
     sort(names);
+    immutable(Theme)[] themes = names.map!(n => *(n in builtinThemes)).array;
 
     size_t idx = 0;
     foreach (i, n; names) if (n == themeName) { idx = i; break; }
@@ -151,113 +137,28 @@ void main()
     auto sess = sessFactory();
     scope (exit) sess.finish();
 
-    writeCtl(CtlSeq.enterAltScreen);
-    writeCtl(CtlSeq.hideCursor);
-    scope (exit)
-    {
-        writeCtl(CtlSeq.showCursor);
-        writeCtl(CtlSeq.exitAltScreen);
-    }
-
-    // Emits the SGR transition from `from` to `to` directly to stdout.
-    void emitSgr(in StyleSpec from, in StyleSpec to, ColorDepth depth)
-    {
-        import sparkles.base.smallbuffer : SmallBuffer;
-        SmallBuffer!(char, 64) sgr;
-        writeStyleTransition(sgr, from, to, depth);
-        write(sgr[]);
-    }
-
-    // Color depth is a stable property of the session — probe once, not per
-    // frame. Resolved themes are memoized: switching revisits themes, and each
-    // resolveTheme allocates a fresh label→style table.
     const depth = detectColorDepth();
-    ResolvedTheme[string] resolvedCache;
+    auto prev = Previewer(
+        title: baseName(sourcePath),
+        source: source,
+        events: events[],
+        labels: labels,
+        names: names,
+        themes: themes,
+    );
 
-    ref const(ResolvedTheme) resolveCached(string name)
-    {
-        if (auto r = name in resolvedCache)
-            return *r;
-        auto tp = name in builtinThemes;
-        resolvedCache[name] = resolveTheme(tp ? *tp : builtinDark, labels);
-        return resolvedCache[name];
-    }
+    auto sink = TermOut.standard();
+    sink.put(CtlSeq.enterAltScreen);
+    sink.put(CtlSeq.hideCursor);
+    sink.flush();
 
-    string lastRendered;
-    while (true)
-    {
-        const cur = names[idx];
-        const resolved = resolveCached(cur);
-        const chrome = StyleSpec(fg: resolved.defaults.fg, bg: resolved.defaults.bg);
+    runLoop(prev, sink, sess, idx, depth);
 
-        import std.algorithm.comparison : min;
-        const sz = terminalSize();
-        enum win = 7;
-        const reserved = 4u + win; // header + hint + 2 separators + theme list
-        const maxCode = (sz.height > reserved) ? sz.height - reserved : 10;
-
-        // Render only the visible slice: highlighting the whole file every frame
-        // and then discarding all but `maxCode` lines was the theme-switch
-        // regression (O(file) render + idup + splitLines per keystroke).
-        // renderAnsi clamps spans to the sliced length, so the shared event
-        // stream needs no filtering.
-        const shown = source.firstLines(maxCode);
-
-        import sparkles.base.smallbuffer : SmallBuffer;
-        SmallBuffer!(char, 8192) buf;
-        renderAnsi(shown, events[], resolved, buf,
-            AnsiOptions(depth: depth, italics: true, emitBackground: true));
-        lastRendered = buf[].idup;
-
-        import std.string : splitLines;
-        auto view = lastRendered.splitLines();
-
-        writeCtl(CtlSeq.syncBegin);
-        // Open the theme's fg/bg before erasing: terminals with "back color
-        // erase" (xterm, kitty, alacritty, ghostty, iTerm2, Windows Terminal —
-        // effectively universal) fill erased cells with the *current* SGR
-        // background, so the whole alt-screen viewport picks up the theme's
-        // backdrop with no per-line padding needed.
-        emitSgr(StyleSpec.init, chrome, depth);
-        writeCtl(CtlSeq.eraseDisplay);
-        writeCtl(CtlSeq.cursorHome);
-
-        writef(" %s  —  %s (%d/%d)\n", baseName(sourcePath), cur, idx + 1, names.length);
-        write(" ↑/↓ switch   any other key quits\n");
-        const sepLen = sz.width ? min(60, sz.width) : 60;
-        foreach (_; 0 .. sepLen) write('─');
-        write('\n');
-
-        // Code lines already carry their own per-span (incl. background)
-        // styling — start them from a clean slate rather than the chrome
-        // style above.
-        emitSgr(chrome, StyleSpec.init, depth);
-        foreach (l; view) write(l, "\n");
-        emitSgr(StyleSpec.init, chrome, depth);
-
-        foreach (_; 0 .. sepLen) write('─');
-        write('\n');
-
-        size_t vs = (idx < win / 2) ? 0 : idx - win / 2;
-        vs = (vs + win > names.length) ? (names.length > win ? names.length - win : 0) : vs;
-        foreach (i; vs .. (vs + win > names.length ? names.length : vs + win))
-            write(i == idx ? "❯ " : "  ", names[i], "\n");
-
-        emitSgr(chrome, StyleSpec.init, depth);
-        writeCtl(CtlSeq.syncEnd);
-
-        final switch (sess.next())
-        {
-            case Key.up:   idx = (idx == 0) ? names.length - 1 : idx - 1; break;
-            case Key.down: idx = (idx + 1 == names.length) ? 0 : idx + 1; break;
-            case Key.enter, Key.cancel, Key.other:
-                goto done;
-        }
-    }
-done:;
-
-    writeCtl(CtlSeq.showCursor);
-    writeCtl(CtlSeq.exitAltScreen);
-    write(lastRendered);
+    // Restore the terminal, then leave the last highlighted frame on the primary
+    // screen (the alt screen's contents are discarded on exit).
+    sink.put(CtlSeq.showCursor);
+    sink.put(CtlSeq.exitAltScreen);
+    sink.put(prev.lastCode());
+    sink.flush();
     return 0;
 }

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -13,7 +13,7 @@
 module app;
 
 import std.array : appender;
-import std.file : exists, readText;
+import std.file : readText;
 import std.path : baseName, extension;
 import std.stdio : stderr, write, writef, writeln;
 
@@ -48,21 +48,13 @@ int main(string[] args)
     bool html = cli.html;
     string themeName = cli.theme;
 
-    string sourcePath = args.length > 1 ? args[1] : __FILE_FULL_PATH__;
-    string source = (args.length > 1 || sourcePath.exists) ? readText(sourcePath) : q{
-module sample;
-
-import std.stdio : writeln;
-
-void main()
-{
-    writeln("Hello, syntax!");
-    int x = 42;
-    if (x > 0)
-        writeln("positive");
-}
-};
-    sourcePath = (args.length <= 1 && !sourcePath.exists) ? "sample.d" : sourcePath;
+    // With a path argument, highlight that file; otherwise highlight hue's own
+    // source, embedded at compile time via `import()`. That works from any
+    // install location — the build-time `__FILE_FULL_PATH__` would not exist in
+    // a released (nix-packaged or copied) binary.
+    const hasFile = args.length > 1;
+    const sourcePath = hasFile ? args[1] : "app.d";
+    const source = hasFile ? readText(sourcePath) : import("app.d");
     const lang = canonicalLanguage(sourcePath.extension.length ? sourcePath.extension[1 .. $] : "");
 
     const labels = LabelSet.standard();

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -30,6 +30,15 @@ struct CliParams
     string theme = "catppuccin-mocha";
 }
 
+// `CtlSeq` is a `string`-based enum; `std.stdio.write` formats enums by their
+// symbolic member name (e.g. "enterAltScreen"), not the underlying escape
+// sequence, so writing one directly silently prints garbage instead of
+// control codes. Route every use through an explicit cast to `string`.
+void writeCtl(CtlSeq seq)
+{
+    write(cast(string) seq);
+}
+
 int main(string[] args)
 {
     const cli = args.parseCliArgs!CliParams(
@@ -101,7 +110,7 @@ void main()
         }
         else
             renderAnsi(source, events[], theme, output,
-                AnsiOptions(depth: detectColorDepth(), italics: true));
+                AnsiOptions(depth: detectColorDepth(), italics: true, emitBackground: true));
 
         write(output[]);
         return 0;
@@ -119,19 +128,28 @@ void main()
     {
         auto output = appender!string;
         renderAnsi(source, events[], theme, output,
-            AnsiOptions(depth: detectColorDepth(), italics: true));
+            AnsiOptions(depth: detectColorDepth(), italics: true, emitBackground: true));
         write(output[]);
         return 0;
     }
     auto sess = sessFactory();
     scope (exit) sess.finish();
 
-    write(CtlSeq.enterAltScreen);
-    write(CtlSeq.hideCursor);
+    writeCtl(CtlSeq.enterAltScreen);
+    writeCtl(CtlSeq.hideCursor);
     scope (exit)
     {
-        write(CtlSeq.showCursor);
-        write(CtlSeq.exitAltScreen);
+        writeCtl(CtlSeq.showCursor);
+        writeCtl(CtlSeq.exitAltScreen);
+    }
+
+    // Emits the SGR transition from `from` to `to` directly to stdout.
+    void emitSgr(in StyleSpec from, in StyleSpec to, ColorDepth depth)
+    {
+        import sparkles.base.smallbuffer : SmallBuffer;
+        SmallBuffer!(char, 64) sgr;
+        writeStyleTransition(sgr, from, to, depth);
+        write(sgr[]);
     }
 
     string lastRendered;
@@ -141,24 +159,33 @@ void main()
         auto tp = cur in builtinThemes;
         const(Theme)* thp = tp ? tp : &builtinDark;
         const resolved = resolveTheme(*thp, labels);
+        const depth = detectColorDepth();
+        const chrome = StyleSpec(fg: resolved.defaults.fg, bg: resolved.defaults.bg);
 
         import sparkles.base.smallbuffer : SmallBuffer;
         SmallBuffer!(char, 8192) buf;
         renderAnsi(source, events[], resolved, buf,
-            AnsiOptions(depth: detectColorDepth(), italics: true));
+            AnsiOptions(depth: depth, italics: true, emitBackground: true));
         lastRendered = buf[].idup;
 
         import std.string : splitLines;
         import std.algorithm.comparison : min;
         auto codeLines = lastRendered.splitLines();
         const sz = terminalSize();
-        const reserved = 9u;
+        enum win = 7;
+        const reserved = 4u + win; // header + hint + 2 separators + theme list
         const maxCode = (sz.height > reserved) ? sz.height - reserved : 10;
         auto view = codeLines.length > maxCode ? codeLines[0 .. maxCode] : codeLines;
 
-        write(CtlSeq.syncBegin);
-        write(CtlSeq.eraseDisplay);
-        write(CtlSeq.cursorHome);
+        writeCtl(CtlSeq.syncBegin);
+        // Open the theme's fg/bg before erasing: terminals with "back color
+        // erase" (xterm, kitty, alacritty, ghostty, iTerm2, Windows Terminal —
+        // effectively universal) fill erased cells with the *current* SGR
+        // background, so the whole alt-screen viewport picks up the theme's
+        // backdrop with no per-line padding needed.
+        emitSgr(StyleSpec.init, chrome, depth);
+        writeCtl(CtlSeq.eraseDisplay);
+        writeCtl(CtlSeq.cursorHome);
 
         writef(" %s  —  %s (%d/%d)\n", baseName(sourcePath), cur, idx + 1, names.length);
         write(" ↑/↓ switch   any other key quits\n");
@@ -166,18 +193,23 @@ void main()
         foreach (_; 0 .. sepLen) write('─');
         write('\n');
 
+        // Code lines already carry their own per-span (incl. background)
+        // styling — start them from a clean slate rather than the chrome
+        // style above.
+        emitSgr(chrome, StyleSpec.init, depth);
         foreach (l; view) write(l, "\n");
+        emitSgr(StyleSpec.init, chrome, depth);
 
         foreach (_; 0 .. sepLen) write('─');
         write('\n');
 
-        enum win = 7;
         size_t vs = (idx < win / 2) ? 0 : idx - win / 2;
         vs = (vs + win > names.length) ? (names.length > win ? names.length - win : 0) : vs;
         foreach (i; vs .. (vs + win > names.length ? names.length : vs + win))
             write(i == idx ? "❯ " : "  ", names[i], "\n");
 
-        write(CtlSeq.syncEnd);
+        emitSgr(chrome, StyleSpec.init, depth);
+        writeCtl(CtlSeq.syncEnd);
 
         final switch (sess.next())
         {
@@ -189,6 +221,8 @@ void main()
     }
 done:;
 
+    writeCtl(CtlSeq.showCursor);
+    writeCtl(CtlSeq.exitAltScreen);
     write(lastRendered);
     return 0;
 }

--- a/apps/hue/src/app.d
+++ b/apps/hue/src/app.d
@@ -144,13 +144,15 @@ int main(string[] args)
     sink.put(CtlSeq.hideCursor);
     sink.flush();
 
-    runLoop(prev, sink, sess, idx, depth);
+    const result = runLoop(prev, sink, sess, idx, depth);
 
-    // Restore the terminal, then leave the last highlighted frame on the primary
-    // screen (the alt screen's contents are discarded on exit).
+    // Restore the terminal (the alt screen's contents are discarded on exit).
+    // On selection (Enter), print the whole file highlighted with the chosen
+    // theme onto the primary screen; on quit/abort, print nothing.
     sink.put(CtlSeq.showCursor);
     sink.put(CtlSeq.exitAltScreen);
-    sink.put(prev.lastCode());
+    if (result.selected)
+        sink.put(prev.renderFull(result.idx, depth));
     sink.flush();
     return 0;
 }

--- a/apps/hue/src/previewer.d
+++ b/apps/hue/src/previewer.d
@@ -103,31 +103,51 @@ struct Previewer
     const(char)[] lastCode() const @safe pure nothrow @nogc
         => frame[][codeStart .. codeEnd];
 
-    /// Builds the whole frame for theme `idx` into `frame` (`@nogc nothrow`):
-    /// sync markers, the theme backdrop via back-color-erase, header, the
-    /// highlighted viewport, and the theme-list window. Re-resolves the theme
-    /// into `styleBuf` only when `idx` changed.
-    void buildFrame(size_t idx, ushort width, ushort height, ColorDepth depth)
-        @safe @nogc nothrow
+    /// Renders the $(I entire) source with theme `idx` into the frame buffer and
+    /// returns the bytes — used to print the whole highlighted file to the
+    /// primary screen once the user selects a theme (Enter), rather than the
+    /// viewport slice `buildFrame` shows. `@nogc` (the buffer spills to malloc,
+    /// never the GC, for a large file).
+    const(char)[] renderFull(size_t idx, ColorDepth depth) @safe @nogc nothrow
+    {
+        const theme = themeView(idx);
+        frame.clear();
+        renderAnsi(source, events, theme, frame,
+            AnsiOptions(depth: depth, italics: true, emitBackground: true));
+        return frame[];
+    }
+
+    /// Resolves theme `idx` into the reused `styleBuf` (only when it changed)
+    /// and returns a `ResolvedTheme` borrowing it. The borrow is sound because
+    /// renderAnsi takes `in ResolvedTheme` and never escapes the slice, and the
+    /// buffer is only rewritten on the next theme change.
+    private ResolvedTheme themeView(size_t idx) @safe @nogc nothrow
     in (idx < names.length)
     in (labels.length <= styleBuf.length, "label vocabulary larger than the style buffer")
     {
-        import std.algorithm.comparison : min;
-
         if (idx != resolvedIdx)
         {
             resolveThemeInto(themes[idx], labels, styleBuf[0 .. labels.length],
                 resolvedDefaults);
             resolvedIdx = idx;
         }
-        // A ResolvedTheme borrowing the reused (mutable) style table: sound
-        // because renderAnsi takes `in ResolvedTheme` and never escapes the
-        // slice, and the buffer is only rewritten on the next theme change.
-        const theme = () @trusted {
+        return () @trusted {
             return ResolvedTheme(labels,
                 cast(immutable(StyleSpec)[]) styleBuf[0 .. labels.length],
                 resolvedDefaults);
         }();
+    }
+
+    /// Builds the whole frame for theme `idx` into `frame` (`@nogc nothrow`):
+    /// sync markers, the theme backdrop via back-color-erase, header, the
+    /// highlighted viewport, and the theme-list window.
+    void buildFrame(size_t idx, ushort width, ushort height, ColorDepth depth)
+        @safe @nogc nothrow
+    in (idx < names.length)
+    {
+        import std.algorithm.comparison : min;
+
+        const theme = themeView(idx);
         const chrome = StyleSpec(fg: resolvedDefaults.fg, bg: resolvedDefaults.bg);
 
         enum win = 7;
@@ -155,7 +175,7 @@ struct Previewer
         frame.put("/");
         writeInteger(frame, names.length);
         frame.put(")\n");
-        frame.put(" ↑/↓ switch   any other key quits\n");
+        frame.put(" ↑/↓ switch   enter: print full file   any other key: quit\n");
         putSeparator(sepLen);
 
         // Code lines carry their own per-span styling — start from a clean slate.
@@ -193,11 +213,19 @@ struct Previewer
     const(char)[] frameBytes() const @safe pure nothrow @nogc => frame[];
 }
 
+/// How the previewer loop ended: the theme `idx` last shown, and whether the
+/// user `selected` it (pressed Enter) versus quit/aborted (any other key).
+struct LoopResult
+{
+    size_t idx;
+    bool selected;
+}
+
 /// The interactive core: repaint, flush, read a key, repeat — `@nogc nothrow`,
 /// so a theme switch allocates nothing. `@system` only because raw terminal I/O
-/// (the key delegate, `fwrite`) is inherently unsafe. Returns the last-shown
-/// theme index. `idx` starts at the caller's chosen theme.
-size_t runLoop(ref Previewer prev, ref TermOut sink, ref KeySession sess,
+/// (the key delegate, `fwrite`) is inherently unsafe. `idx` starts at the
+/// caller's chosen theme.
+LoopResult runLoop(ref Previewer prev, ref TermOut sink, ref KeySession sess,
     size_t idx, ColorDepth depth) @system @nogc nothrow
 {
     while (true)
@@ -215,8 +243,10 @@ size_t runLoop(ref Previewer prev, ref TermOut sink, ref KeySession sess,
             case Key.down:
                 idx = (idx + 1 == prev.themeCount()) ? 0 : idx + 1;
                 break;
-            case Key.enter, Key.cancel, Key.other:
-                return idx;
+            case Key.enter:
+                return LoopResult(idx, true);   // select → print the full file
+            case Key.cancel, Key.other:
+                return LoopResult(idx, false);  // quit → print nothing
         }
     }
 }
@@ -281,4 +311,33 @@ unittest
         prev.buildFrame(i % 2, 80, 24, ColorDepth.trueColor);
     const delta = GC.stats.allocatedInCurrentThread - before;
     assert(delta == 0, "buildFrame is not zero-GC in steady state");
+}
+
+@("previewer.renderFull.coversWholeFile")
+@system
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    // A source taller than a small viewport, with a distinctive last line.
+    static immutable src = "a0\na1\na2\na3\na4\na5\na6\na7\na8\nLAST_LINE\n";
+    static HighlightEvent[1] ev = [HighlightEvent.sourceSpan(0, src.length)];
+    static immutable(Theme)[1] themes = [builtinDark];
+    static immutable string[1] names = ["dark"];
+
+    Previewer prev;
+    prev.title = "t";
+    prev.source = src;
+    prev.events = ev[];
+    prev.labels = LabelSet.standard();
+    prev.names = names[];
+    prev.themes = themes[];
+
+    // height 14 → reserved 11 → maxCode 3 visible lines: the viewport truncates.
+    prev.buildFrame(0, 40, 14, ColorDepth.trueColor);
+    assert(!prev.lastCode().canFind("LAST_LINE"), "viewport should truncate");
+
+    const full = prev.renderFull(0, ColorDepth.trueColor);
+    assert(full.canFind("a0") && full.canFind("LAST_LINE"),
+        "renderFull must cover the whole file");
 }

--- a/apps/hue/src/previewer.d
+++ b/apps/hue/src/previewer.d
@@ -1,0 +1,284 @@
+// The interactive live theme previewer's allocation-free core.
+//
+// Startup (file read, tree-sitter parse, building the theme list) is GC and
+// lives in `app.d`; everything here — building a frame and pushing it to the
+// terminal, plus the key-driven loop — is `@nogc nothrow`, so a theme switch
+// never triggers a GC pause. The whole frame is assembled into one reused
+// `SmallBuffer` and flushed with a single `fwrite`; the theme is re-resolved
+// into one reused stack buffer on change (see `resolveThemeInto`).
+module previewer;
+
+import core.stdc.stdio : FILE, fflush, fwrite;
+
+import sparkles.base.smallbuffer : SmallBuffer;
+import sparkles.base.term_control : CtlSeq;
+import sparkles.base.text.writers : writeInteger;
+
+import sparkles.syntax : AnsiOptions, ColorDepth, HighlightEvent, LabelSet,
+    renderAnsi, ResolvedTheme, resolveThemeInto, StyleSpec, Theme,
+    writeStyleTransition;
+
+import sparkles.core_cli.key_input : Key, KeySession;
+import sparkles.core_cli.term_caps : StdStream, terminalSize;
+
+/// The first `n` lines of `s` (including the newline that ends line `n`), or all
+/// of `s` when it has fewer. The previewer only shows the top of the file, so
+/// slicing here keeps the highlight fold O(visible lines), not O(file).
+const(char)[] firstLines(return scope const(char)[] s, size_t n) @safe pure nothrow @nogc
+{
+    if (n == 0)
+        return s;
+    size_t seen = 0;
+    foreach (i, char c; s)
+        if (c == '\n' && ++seen == n)
+            return s[0 .. i + 1];
+    return s;
+}
+
+/// A minimal `@nogc` byte sink over a C `FILE*` (stdout). One `put` + `flush`
+/// per frame keeps the whole repaint to a single write; `fwrite` short-writes
+/// are looped over (mirrors `sparkles.base.logger`'s `fwriteAll`).
+struct TermOut
+{
+    private FILE* fp;
+
+    /// A sink writing to C stdout.
+    static TermOut standard() @trusted @nogc nothrow
+    {
+        import core.stdc.stdio : stdout;
+
+        return TermOut(stdout);
+    }
+
+    /// Writes all of `data`, looping over partial `fwrite`s.
+    void put(scope const(char)[] data) @trusted @nogc nothrow
+    {
+        size_t off = 0;
+        while (off < data.length)
+        {
+            const n = fwrite(data.ptr + off, 1, data.length - off, fp);
+            if (n == 0)
+                break; // write error; nothing a nothrow sink can do
+            off += n;
+        }
+    }
+
+    /// Emits a fixed control sequence (a `string`-typed enum).
+    void put(CtlSeq seq) @trusted @nogc nothrow
+    {
+        put(cast(string) seq);
+    }
+
+    void flush() @trusted @nogc nothrow
+    {
+        fflush(fp);
+    }
+}
+
+/// The reusable previewer state: parsed source + events, the theme list, and
+/// the reused frame/style buffers. Built once at startup, then driven by
+/// `runLoop`. `themes[idx]` and `names[idx]` are parallel.
+struct Previewer
+{
+    string title;                 /// file base name shown in the header
+    const(char)[] source;         /// the whole file (rendered viewport-sliced)
+    const(HighlightEvent)[] events; /// parsed once; re-rendered per frame
+    LabelSet labels;              /// the vocabulary `styleBuf` is sized against
+    const(string)[] names;        /// sorted theme names (parallel to `themes`)
+    immutable(Theme)[] themes;    /// theme data (parallel to `names`)
+
+    // Reused per-frame scratch — no per-frame heap (spills to malloc, never GC,
+    // only on very large terminals).
+    private SmallBuffer!(char, 16384) frame;
+    private StyleSpec[128] styleBuf = void; /// current resolved theme's table
+    private StyleSpec resolvedDefaults;
+    private size_t resolvedIdx = size_t.max; /// which theme is in styleBuf
+    private size_t codeStart, codeEnd;       /// the code slice within `frame`
+
+    /// The theme count (rows to page through).
+    size_t themeCount() const @safe pure nothrow @nogc => names.length;
+
+    /// The last-rendered highlighted code, sliced out of `frame` — written to
+    /// the primary screen after the alt screen is left.
+    const(char)[] lastCode() const @safe pure nothrow @nogc
+        => frame[][codeStart .. codeEnd];
+
+    /// Builds the whole frame for theme `idx` into `frame` (`@nogc nothrow`):
+    /// sync markers, the theme backdrop via back-color-erase, header, the
+    /// highlighted viewport, and the theme-list window. Re-resolves the theme
+    /// into `styleBuf` only when `idx` changed.
+    void buildFrame(size_t idx, ushort width, ushort height, ColorDepth depth)
+        @safe @nogc nothrow
+    in (idx < names.length)
+    in (labels.length <= styleBuf.length, "label vocabulary larger than the style buffer")
+    {
+        import std.algorithm.comparison : min;
+
+        if (idx != resolvedIdx)
+        {
+            resolveThemeInto(themes[idx], labels, styleBuf[0 .. labels.length],
+                resolvedDefaults);
+            resolvedIdx = idx;
+        }
+        // A ResolvedTheme borrowing the reused (mutable) style table: sound
+        // because renderAnsi takes `in ResolvedTheme` and never escapes the
+        // slice, and the buffer is only rewritten on the next theme change.
+        const theme = () @trusted {
+            return ResolvedTheme(labels,
+                cast(immutable(StyleSpec)[]) styleBuf[0 .. labels.length],
+                resolvedDefaults);
+        }();
+        const chrome = StyleSpec(fg: resolvedDefaults.fg, bg: resolvedDefaults.bg);
+
+        enum win = 7;
+        const reserved = 4u + win; // header + hint + 2 separators + theme list
+        const maxCode = (height > reserved) ? height - reserved : 10;
+        const shown = source.firstLines(maxCode);
+        const sepLen = width ? min(60, cast(size_t) width) : 60;
+
+        frame.clear();
+        frame.put(CtlSeq.syncBegin);
+        // Open the theme fg/bg before erasing: terminals with back-color-erase
+        // fill erased cells with the current SGR background, so the whole
+        // viewport picks up the theme backdrop with no per-line padding.
+        writeStyleTransition(frame, StyleSpec.init, chrome, depth);
+        frame.put(CtlSeq.eraseDisplay);
+        frame.put(CtlSeq.cursorHome);
+
+        // Header: " <file>  —  <theme> (i/n)".
+        frame.put(" ");
+        frame.put(title);
+        frame.put("  —  ");
+        frame.put(names[idx]);
+        frame.put(" (");
+        writeInteger(frame, idx + 1);
+        frame.put("/");
+        writeInteger(frame, names.length);
+        frame.put(")\n");
+        frame.put(" ↑/↓ switch   any other key quits\n");
+        putSeparator(sepLen);
+
+        // Code lines carry their own per-span styling — start from a clean slate.
+        writeStyleTransition(frame, chrome, StyleSpec.init, depth);
+        codeStart = frame[].length;
+        renderAnsi(shown, events, theme, frame,
+            AnsiOptions(depth: depth, italics: true, emitBackground: true));
+        codeEnd = frame[].length;
+        writeStyleTransition(frame, StyleSpec.init, chrome, depth);
+
+        putSeparator(sepLen);
+
+        // The scrolling theme-list window around `idx`.
+        size_t vs = (idx < win / 2) ? 0 : idx - win / 2;
+        vs = (vs + win > names.length) ? (names.length > win ? names.length - win : 0) : vs;
+        foreach (i; vs .. (vs + win > names.length ? names.length : vs + win))
+        {
+            frame.put(i == idx ? "❯ " : "  ");
+            frame.put(names[i]);
+            frame.put("\n");
+        }
+
+        writeStyleTransition(frame, chrome, StyleSpec.init, depth);
+        frame.put(CtlSeq.syncEnd);
+    }
+
+    private void putSeparator(size_t n) @safe @nogc nothrow
+    {
+        foreach (_; 0 .. n)
+            frame.put("─");
+        frame.put("\n");
+    }
+
+    /// The assembled frame bytes (valid until the next `buildFrame`).
+    const(char)[] frameBytes() const @safe pure nothrow @nogc => frame[];
+}
+
+/// The interactive core: repaint, flush, read a key, repeat — `@nogc nothrow`,
+/// so a theme switch allocates nothing. `@system` only because raw terminal I/O
+/// (the key delegate, `fwrite`) is inherently unsafe. Returns the last-shown
+/// theme index. `idx` starts at the caller's chosen theme.
+size_t runLoop(ref Previewer prev, ref TermOut sink, ref KeySession sess,
+    size_t idx, ColorDepth depth) @system @nogc nothrow
+{
+    while (true)
+    {
+        const sz = terminalSize(StdStream.stdout);
+        prev.buildFrame(idx, sz.width, sz.height, depth);
+        sink.put(prev.frameBytes());
+        sink.flush();
+
+        final switch (sess.next())
+        {
+            case Key.up:
+                idx = (idx == 0) ? prev.themeCount() - 1 : idx - 1;
+                break;
+            case Key.down:
+                idx = (idx + 1 == prev.themeCount()) ? 0 : idx + 1;
+                break;
+            case Key.enter, Key.cancel, Key.other:
+                return idx;
+        }
+    }
+}
+
+version (unittest)
+{
+    import sparkles.syntax : builtinDark;
+
+    // A minimal previewer over a tiny source and two (identical) themes.
+    private Previewer testPreviewer()
+    {
+        static immutable src = "module x;\nint y = 42;\n// note\n";
+        static HighlightEvent[1] ev = [HighlightEvent.sourceSpan(0, src.length)];
+        static immutable(Theme)[2] themes = [builtinDark, builtinDark];
+        static immutable string[2] names = ["catppuccin-mocha", "dracula"];
+
+        Previewer prev;
+        prev.title = "sample.d";
+        prev.source = src;
+        prev.events = ev[];
+        prev.labels = LabelSet.standard();
+        prev.names = names[];
+        prev.themes = themes[];
+        return prev;
+    }
+}
+
+@("previewer.buildFrame.structure")
+@system
+unittest
+{
+    import std.algorithm.searching : canFind;
+
+    auto prev = testPreviewer();
+    prev.buildFrame(0, 80, 24, ColorDepth.trueColor);
+    const f = prev.frameBytes();
+
+    assert(f.canFind("\x1b[?2026h"), "syncBegin missing");   // begin sync
+    assert(f.canFind("\x1b[?2026l"), "syncEnd missing");     // end sync
+    assert(f.canFind("\x1b[2J"), "eraseDisplay missing");    // back-color-erase
+    assert(f.canFind("catppuccin-mocha"), "theme name missing"); // header + list
+    assert(f.canFind("sample.d"), "title missing");
+    assert(prev.lastCode().length > 0, "no code slice recorded");
+    // The code slice sits inside the frame and highlights the source.
+    assert(f.canFind(prev.lastCode()));
+}
+
+@("previewer.buildFrame.steadyStateZeroAlloc")
+@system
+unittest
+{
+    import core.memory : GC;
+
+    auto prev = testPreviewer();
+
+    // Warm up: grow the frame buffer and resolve both themes once.
+    foreach (i; 0 .. 4)
+        prev.buildFrame(i % 2, 80, 24, ColorDepth.trueColor);
+
+    const before = GC.stats.allocatedInCurrentThread;
+    foreach (i; 0 .. 16)
+        prev.buildFrame(i % 2, 80, 24, ColorDepth.trueColor);
+    const delta = GC.stats.allocatedInCurrentThread - before;
+    assert(delta == 0, "buildFrame is not zero-GC in steady state");
+}

--- a/docs/libs/syntax/index.md
+++ b/docs/libs/syntax/index.md
@@ -32,8 +32,8 @@ renderAnsi(source, events[], resolveTheme(builtinDark, labels), ansi);
 
 Any engine failure is an `Expected` error value — the caller renders plain
 text instead (a highlighter's worst legal output is uncolored text, never a
-crash). The runnable version of this pipeline is
-[`libs/syntax/examples/highlight-file.d`][example].
+crash). The runnable version of this pipeline is the
+`hue` app (`apps/hue`).
 
 ## How this documentation is organised
 
@@ -61,7 +61,3 @@ crash). The runnable version of this pipeline is
 - The research this library reifies:
   [the syntax-highlighting cluster](../../research/parsing/syntax-highlighting.md)
   of the parsing survey.
-
-<!-- References -->
-
-[example]: https://github.com/PetarKirov/sparkles/blob/3cc01cfdc8ae867f0558e43c731885a004cb0130/libs/syntax/examples/highlight-file.d

--- a/docs/libs/syntax/tutorial/getting-started.md
+++ b/docs/libs/syntax/tutorial/getting-started.md
@@ -83,10 +83,7 @@ html ~= "</code></pre>";
 
 ## The whole program
 
-[`libs/syntax/examples/highlight-file.d`][example] is this tutorial as a
-runnable script — `dub run --single highlight-file.d` inside the devshell
-highlights its own source; `--html` switches backends.
-
-<!-- References -->
-
-[example]: https://github.com/PetarKirov/sparkles/blob/3cc01cfdc8ae867f0558e43c731885a004cb0130/libs/syntax/examples/highlight-file.d
+The `hue` app (`apps/hue`) is this tutorial as a runnable
+program — `dub run :hue` inside the devshell highlights its own source;
+`--html` switches backends, and in a tty it opens an interactive live
+theme previewer (↑/↓ to switch themes).

--- a/dub.sdl
+++ b/dub.sdl
@@ -7,6 +7,7 @@ license "BSL-1.0"
 targetPath "build"
 
 subPackage "apps/ci"
+subPackage "apps/hue"
 subPackage "apps/release"
 subPackage "apps/terminal"
 subPackage "libs/base"

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
         ./nix/packages/all.nix
         ./nix/packages/build-d-wasm-module.nix
         ./nix/packages/default.nix
+        ./nix/packages/hue.nix
         ./nix/packages/libghostty-vt.nix
         ./nix/packages/text-wasm.nix
         ./nix/packages/table-wasm.nix

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
         ./nix/packages/text-wasm.nix
         ./nix/packages/table-wasm.nix
         ./nix/packages/ts-grammars.nix
+        ./nix/packages/syntax-foreign.nix
         ./nix/packages/uwidth-rs.nix
         ./nix/packages/wired-bench-data.nix
         ./nix/packages/wired-bench-yyjson.nix

--- a/libs/core-cli/src/sparkles/core_cli/key_input.d
+++ b/libs/core-cli/src/sparkles/core_cli/key_input.d
@@ -25,8 +25,8 @@ enum Key { up, down, enter, cancel, other }
 /// enter/use/finish lifecycle).
 struct KeySession
 {
-    Key delegate() next;
-    void delegate() finish;
+    Key delegate() @nogc nothrow next;
+    void delegate() @nogc nothrow finish;
 }
 
 /// Begins a raw-mode key session on stdin, or `null` when arrow-key
@@ -58,7 +58,7 @@ unittest
 /// Classifies a single input byte; `readEscape` is only invoked for a lone
 /// ESC (`0x1b`), and decides between a bare Esc keypress and the start of a
 /// CSI/SS3 escape sequence (typically via a short read timeout).
-private Key classifyByte(char b, scope Key delegate() @safe nothrow readEscape) @safe nothrow
+private Key classifyByte(char b, scope Key delegate() @safe nothrow @nogc readEscape) @safe nothrow @nogc
 {
     switch (b)
     {
@@ -135,7 +135,7 @@ version (Posix)
         tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
 
         auto restored = false;
-        void finish()
+        void finish() @nogc nothrow
         {
             if (restored) return;
             restored = true;
@@ -147,7 +147,7 @@ version (Posix)
     /// Reads one byte, retrying on `EINTR` (a `SIGWINCH` resize — see
     /// `term_caps.d`'s handler — must not spuriously cancel the prompt).
     /// Returns `1` (byte read), `0` (real EOF), or `-1` (other error).
-    private ptrdiff_t readBytePosix(ref char b) @trusted nothrow
+    private ptrdiff_t readBytePosix(ref char b) @trusted nothrow @nogc
     {
         import core.stdc.errno : EINTR, errno;
         import core.sys.posix.unistd : read, STDIN_FILENO;
@@ -160,7 +160,7 @@ version (Posix)
         }
     }
 
-    private Key readKeyPosix() @trusted nothrow
+    private Key readKeyPosix() @trusted nothrow @nogc
     {
         char b;
         if (readBytePosix(b) != 1)
@@ -168,7 +168,7 @@ version (Posix)
         return classifyByte(b, () => decodeEscapePosix());
     }
 
-    private Key decodeEscapePosix() @trusted nothrow
+    private Key decodeEscapePosix() @trusted nothrow @nogc
     {
         import core.sys.posix.poll : poll, pollfd, POLLIN;
         import core.sys.posix.unistd : STDIN_FILENO;
@@ -217,7 +217,7 @@ version (Windows)
         SetConsoleMode(handle, raw);
 
         auto restored = false;
-        void finish()
+        void finish() @nogc nothrow
         {
             if (restored) return;
             restored = true;
@@ -227,7 +227,7 @@ version (Windows)
     }
 
     /// Returns `1` (byte read), `0`/`-1` on EOF/error (mirrors `readBytePosix`).
-    private ptrdiff_t readByteWindows(HANDLE handle, ref char b) @trusted nothrow
+    private ptrdiff_t readByteWindows(HANDLE handle, ref char b) @trusted nothrow @nogc
     {
         import core.sys.windows.windows : DWORD, ReadFile;
 
@@ -237,7 +237,7 @@ version (Windows)
         return n;
     }
 
-    private Key readKeyWindows(HANDLE handle) @trusted nothrow
+    private Key readKeyWindows(HANDLE handle) @trusted nothrow @nogc
     {
         char b;
         if (readByteWindows(handle, b) != 1)
@@ -245,7 +245,7 @@ version (Windows)
         return classifyByte(b, () => decodeEscapeWindows(handle));
     }
 
-    private Key decodeEscapeWindows(HANDLE handle) @trusted nothrow
+    private Key decodeEscapeWindows(HANDLE handle) @trusted nothrow @nogc
     {
         import core.sys.windows.windows : WAIT_OBJECT_0, WaitForSingleObject;
 

--- a/libs/syntax/bench/render/README.md
+++ b/libs/syntax/bench/render/README.md
@@ -1,0 +1,70 @@
+# `syntax-render-bench` — syntax-highlighting render-cost benchmark
+
+Measures `sparkles:syntax`'s render backends — **ANSI** (`renderAnsi`) and
+**HTML** (`renderHtml`) — head-to-head under `sparkles:test-runner`, across
+viewport sizes, a theme-switch scenario, and the page-background toggle. A
+Nix-pinned **foreign panel** (bat/syntect, chroma, pygments, shiki) runs the
+same corpus end-to-end for cross-library comparison. Structure mirrors
+[`libs/tui/bench/render`](../../../tui/bench/render/README.md) and
+[`libs/wired/bench/runtime`](../../../wired/bench/runtime/README.md).
+
+## What it measures
+
+Library-side render cost: the CPU + allocation cost to fold a **cached**
+highlight-event stream into styled bytes, into a reused in-memory buffer (no fd
+— a per-flush syscall would pollute the number). Parsing (tree-sitter) is done
+once per case in untimed setup, so the timed body is exactly the app's
+per-frame work: re-render (and, for `ansi-switch`, re-resolve the theme).
+
+| Column | Meaning                                                            |
+| ------ | ------------------------------------------------------------------ |
+| `B/s`  | throughput — **source** bytes highlighted ÷ iteration time (MB/s)  |
+| `B`    | **output** bytes per render (deterministic; balloons with `bg=on`) |
+| `bg`   | `AnsiOptions.emitBackground` — the page-background axis            |
+
+The `name` column is the compared dimension:
+
+| Case          | Body (timed)                                           |
+| ------------- | ------------------------------------------------------ |
+| `ansi`        | `renderAnsi` over cached events, one resolved theme    |
+| `ansi-switch` | per theme in a rotation: `resolveTheme` + `renderAnsi` |
+| `html`        | `renderHtml` over cached events                        |
+
+`ansi-switch` is the interactive **live theme previewer** hot path (`apps/hue`):
+one iteration walks the whole theme rotation, so its per-frame cost is the row
+median ÷ rotation length.
+
+## Running
+
+```sh
+# Canonical run (release, -mcpu=native; debug builds are meaningless under --bench):
+dub test -b bench --root=libs/syntax/bench/render -- --bench --group-by=size
+
+# Subsets (comma lists; empty = all):
+SYNTAX_BENCH_MODES=ansi,ansi-switch SYNTAX_BENCH_SIZES=40l \
+    dub test -b bench --root=libs/syntax/bench/render -- --bench
+
+# Snapshot for the record (absolute path — the test binary's cwd differs):
+dub test -b bench --root=libs/syntax/bench/render -- --bench \
+    --bench-json="$PWD/libs/syntax/bench/render/results/$(date -I)-$(hostname)-native.json"
+
+# Foreign panel (nix-pinned bat/chroma/pygments/shiki over the same corpus):
+libs/syntax/bench/render/foreign/run.sh
+```
+
+## The corpus
+
+Frozen real source under `corpus/` (ours, BSL — deterministic and
+cwd-independent via `stringImportPaths`). `size` labels take the first N lines
+to simulate a terminal viewport height (`24l`/`40l`/`51l`), plus `full` for a
+steady end-to-end throughput number. The foreign panel highlights the same
+files.
+
+## Interpreting `bg=on`
+
+ANSI has no background inheritance (unlike HTML's `<pre>` container), so with
+`emitBackground` on, every run that a theme styles fg-only still has to carry
+the page background explicitly. That is correct — it is how the theme's backdrop
+shows through in a terminal — but it inflates both output bytes and the per-run
+SGR transition count, which is why `bg=on` rows are slower. The benchmark keeps
+`bg` a first-class column so that cost stays legible.

--- a/libs/syntax/bench/render/corpus/sample.d
+++ b/libs/syntax/bench/render/corpus/sample.d
@@ -1,0 +1,1051 @@
+/**
+The theme layer: label selectors → styles, resolved once per vocabulary.
+
+A $(LREF Theme) is plain data — ordered $(LREF ThemeRule)s mapping dotted
+selectors to $(LREF StyleSpec)s. $(LREF resolveTheme) folds it against a
+`LabelSet` into a $(LREF ResolvedTheme): a flat `labelId → StyleSpec` table
+indexed in O(1) on the render path. Resolution is longest-dot-prefix (the
+same rule `LabelSet.resolve` applies to capture names), whole-spec-wins (no
+attribute cascade), and last-rule-wins among equal selectors.
+
+`ResolvedTheme` is public API for every backend — including future
+non-markup consumers (a GPU text renderer indexes it with `StyledSpan.label`
+directly). Theme files (TOML/JSON) are a future seam: only a parser
+producing `ThemeRule[]` is missing.
+*/
+module sparkles.syntax.theme;
+
+import sparkles.syntax.color : Color;
+import sparkles.syntax.event : LabelId;
+import sparkles.syntax.label : LabelSet;
+
+@safe:
+
+/// Font-style flags, backend-neutral (they select faces/decorations, not
+/// escape codes).
+enum FontStyle : ubyte
+{
+    none = 0,
+    bold = 1 << 0,
+    dim = 1 << 1,
+    italic = 1 << 2,
+    underline = 1 << 3,
+    strikethrough = 1 << 4,
+}
+
+/// `true` iff `flags` contains every bit of `bit`.
+bool hasFont(FontStyle flags, FontStyle bit) pure nothrow @nogc
+    => (flags & bit) == bit && bit != FontStyle.none;
+
+/// The style a theme assigns to one label: optional fore-/background colors
+/// plus font flags. `Color.Kind.unset` means "not specified".
+struct StyleSpec
+{
+    Color fg;       /// foreground; unset = unspecified
+    Color bg;       /// background; unset = unspecified
+    FontStyle font; /// font flags
+
+    /// `true` iff the spec specifies nothing at all (renders unstyled).
+    bool empty() const scope pure nothrow @nogc
+        => !fg.isSet && !bg.isSet && font == FontStyle.none;
+}
+
+/// One theme rule: a dotted label selector and the style it assigns.
+struct ThemeRule
+{
+    string selector; /// dotted label name, matched by longest-dot-prefix
+    StyleSpec style; /// the whole spec assigned on match (no cascade)
+}
+
+/// A theme as plain data. See the module header for resolution semantics.
+struct Theme
+{
+    string name;                             /// display name
+    Color defaultFg = Color.defaultColor;    /// unlabeled-text foreground
+    Color defaultBg = Color.defaultColor;    /// document background
+    ThemeRule[] rules;                       /// ordered; later wins among equal selectors
+}
+
+/**
+A theme resolved against a label vocabulary: `labelId → StyleSpec` in O(1).
+The single style bundle every backend takes.
+*/
+struct ResolvedTheme
+{
+    LabelSet labels;                 /// the vocabulary this was resolved against
+    immutable(StyleSpec)[] styles;   /// parallel to `labels`; `.init` if unmatched
+    StyleSpec defaults;              /// style of unlabeled text (`LabelId.none`)
+
+    /// The style for `id`; `defaults` for `LabelId.none`. Ids outside this
+    /// vocabulary (a producer configured against a different `LabelSet`)
+    /// render as defaults — renderers are total.
+    StyleSpec opIndex(LabelId id) const scope pure nothrow @nogc
+        => id && id.value < styles.length ? styles[id.value] : defaults;
+}
+
+/**
+Resolves `theme` against `labels`: for every vocabulary name, the longest
+rule selector that is a dot-prefix of the name wins (last rule wins among
+equal selectors); unmatched names get `StyleSpec.init`.
+
+Configure-time only (allocates the table once). A `defaultFg`/`defaultBg` of
+`Color.defaultColor` is normalized to unset in `defaults` — for a renderer,
+"the terminal default" and "unspecified" both mean "emit nothing".
+*/
+ResolvedTheme resolveTheme(in Theme theme, LabelSet labels) pure nothrow
+{
+    auto styles = new StyleSpec[](labels.length);
+    foreach (i; 0 .. labels.length)
+    {
+        const labelName = labels.name(LabelId(cast(ushort) i));
+        size_t bestLen = 0;
+        bool found = false;
+        StyleSpec best;
+        foreach (rule; theme.rules)
+        {
+            if (rule.selector.length >= bestLen && isDotPrefix(rule.selector, labelName))
+            {
+                bestLen = rule.selector.length;
+                best = rule.style;
+                found = true;
+            }
+        }
+        styles[i] = found ? best : StyleSpec.init;
+    }
+
+    const defaults = StyleSpec(
+        fg: normalizeDefault(theme.defaultFg),
+        bg: normalizeDefault(theme.defaultBg));
+    return ResolvedTheme(labels, styles.idup, defaults);
+}
+
+///
+@("theme.resolveTheme.longestPrefixLastWins")
+unittest
+{
+    const theme = Theme(
+        name: "test",
+        rules: [
+            ThemeRule("string", StyleSpec(fg: Color.fromPalette(2))),
+            ThemeRule("string.special", StyleSpec(fg: Color.fromPalette(5))),
+            ThemeRule("string", StyleSpec(fg: Color.fromPalette(3))), // last wins
+        ]);
+    const labels = LabelSet.standard();
+    const resolved = resolveTheme(theme, labels);
+
+    // longest prefix beats rule order
+    assert(resolved[labels.find("string.special.key")].fg == Color.fromPalette(5));
+    // last rule wins among equal selectors
+    assert(resolved[labels.find("string")].fg == Color.fromPalette(3));
+    assert(resolved[labels.find("string.escape")].fg == Color.fromPalette(3));
+    // unmatched label → empty spec
+    assert(resolved[labels.find("keyword")].empty);
+    // no-label text → defaults (normalized to unset here)
+    assert(resolved[LabelId.none].empty);
+}
+
+@("theme.resolveTheme.noPartialSegmentMatch")
+unittest
+{
+    // "str" must not match "string" — prefixes are whole dotted segments.
+    const theme = Theme(name: "test", rules: [
+        ThemeRule("str", StyleSpec(fg: Color.fromPalette(1))),
+    ]);
+    const labels = LabelSet.standard();
+    const resolved = resolveTheme(theme, labels);
+    assert(resolved[labels.find("string")].empty);
+}
+
+@("theme.StyleSpec.empty")
+pure nothrow @nogc
+unittest
+{
+    assert(StyleSpec.init.empty);
+    assert(!StyleSpec(fg: Color.fromPalette(1)).empty);
+    assert(!StyleSpec(font: FontStyle.bold).empty);
+    assert(!StyleSpec(fg: Color.defaultColor).empty); // default_ counts as set
+}
+
+@("theme.hasFont")
+pure nothrow @nogc
+unittest
+{
+    const flags = cast(FontStyle)(FontStyle.bold | FontStyle.italic);
+    assert(hasFont(flags, FontStyle.bold));
+    assert(hasFont(flags, FontStyle.italic));
+    assert(!hasFont(flags, FontStyle.underline));
+    assert(!hasFont(flags, FontStyle.none));
+}
+
+/// `prefix` matches `full` iff equal, or `full` continues with `.` right
+/// after `prefix` (whole-segment prefix matching).
+private bool isDotPrefix(scope const(char)[] prefix, scope const(char)[] full) pure nothrow @nogc
+{
+    import std.algorithm.searching : startsWith;
+
+    return full.startsWith(prefix)
+        && (full.length == prefix.length || full[prefix.length] == '.');
+}
+
+private Color normalizeDefault(Color c) pure nothrow @nogc
+    => c.kind == Color.Kind.default_ ? Color.init : c;
+
+// ---- color.d ----
+
+/**
+Theme colors and terminal color-depth folding.
+
+$(LREF Color) is a proper sum type for what highlighting themes actually
+express: an RGB value, a terminal-palette index, "the terminal's default", or
+"not specified". bat encodes the same four cases into `#RRGGBBAA` hex strings
+(alpha 0 ⇒ palette index in the red channel, alpha 1 ⇒ terminal default) —
+$(LREF parseHexColor) understands that convention at the boundary and turns
+it into structure instead of propagating the trick.
+
+The depth fold ($(LREF ansi256FromRgb), $(LREF ansi16FromRgb)) reifies bat's
+rendering tiers: themes author in 24-bit RGB; terminals that only speak 256
+or 16 colors get the nearest approximation. `Color.Kind.rgb` is also the
+GPU-usable kind — a future non-terminal backend consumes it directly and a
+`toRgb(Color, palette)` concretizer is the recorded seam for resolving the
+palette/default kinds against a concrete palette table.
+
+Detection is split per repo doctrine: the pure, testable classifier
+$(REF classifyColorDepth, sparkles,base,term_color) (re-exported here) picks the
+tier from `$COLORTERM`/`$TERM` values; $(LREF detectColorDepth) is the thin
+environment-reading wrapper an application calls at its edge.
+*/
+module sparkles.syntax.color;
+
+import sparkles.base.text.errors : ParseErrorCode, ParseExpected, parseErr, parseOk;
+import sparkles.base.text.readers : hexNibble, isHexDigit;
+
+// The color-depth tier lives in base so core-cli's TermCaps shares one
+// classifier; re-exported so `sparkles.syntax.color.ColorDepth` still resolves.
+public import sparkles.base.term_color : ColorDepth, classifyColorDepth;
+
+@safe:
+
+/// A 24-bit RGB color value.
+struct RgbColor
+{
+    ubyte r, g, b;
+}
+
+/**
+A theme color: one of four cases.
+
+$(LIST
+    * `unset` — the theme does not specify this channel (the default);
+    * `default_` — use the terminal's default fore-/background;
+    * `palette` — a terminal-palette index (0–255) in `index`;
+    * `rgb` — a 24-bit value in `rgb`.
+)
+*/
+struct Color
+{
+    /// Discriminates the four cases.
+    enum Kind : ubyte
+    {
+        unset,    /// not specified by the theme
+        default_, /// the terminal's default color
+        palette,  /// a terminal-palette index (`index`)
+        rgb,      /// a 24-bit value (`rgb`)
+    }
+
+    Kind kind;    /// which case this color is
+    ubyte index;  /// palette index (kind == palette)
+    RgbColor rgb; /// 24-bit value (kind == rgb)
+
+    /// The terminal-default color.
+    enum Color defaultColor = Color(Kind.default_);
+
+    /// Constructs an RGB color.
+    static Color fromRgb(ubyte r, ubyte g, ubyte b) pure nothrow @nogc
+        => Color(kind: Kind.rgb, rgb: RgbColor(r, g, b));
+
+    /// ditto
+    static Color fromRgb(RgbColor c) pure nothrow @nogc
+        => Color(kind: Kind.rgb, rgb: c);
+
+    /// Constructs a terminal-palette color.
+    static Color fromPalette(ubyte index) pure nothrow @nogc
+        => Color(kind: Kind.palette, index: index);
+
+    /// `true` iff the theme specified this color at all.
+    bool isSet() const scope pure nothrow @nogc
+        => kind != Kind.unset;
+}
+
+///
+@("color.Color.cases")
+pure nothrow @nogc
+unittest
+{
+    assert(!Color.init.isSet);
+    assert(Color.defaultColor.kind == Color.Kind.default_);
+
+    const c = Color.fromRgb(0x1e, 0x1e, 0x2e);
+    assert(c.kind == Color.Kind.rgb && c.rgb == RgbColor(0x1e, 0x1e, 0x2e));
+
+    const p = Color.fromPalette(4);
+    assert(p.kind == Color.Kind.palette && p.index == 4);
+}
+
+/**
+Parses `#RGB`, `#RRGGBB`, or `#RRGGBBAA` at the front of `input`, advancing
+it past the parsed color on success (the `readers.d` cursor convention).
+
+`#RGB` expands each nibble (`#fa0` ⇒ `#ffaa00`). `#RRGGBBAA` follows bat's
+alpha conventions: alpha `00` ⇒ palette index `RR`; alpha `01` ⇒ the
+terminal-default color; any other alpha ⇒ the RGB value (alpha discarded).
+*/
+ParseExpected!Color parseHexColor(ref scope const(char)[] input) pure nothrow @nogc
+{
+    if (input.length == 0)
+        return parseErr!Color(ParseErrorCode.emptyInput, 0);
+    if (input[0] != '#')
+        return parseErr!Color(ParseErrorCode.unexpectedCharacter, 0, "expected '#'");
+
+    size_t n = 1;
+    while (n < input.length && isHexDigit(input[n]))
+        ++n;
+
+    Color result;
+    switch (n - 1)
+    {
+        case 3:
+            result = Color.fromRgb(
+                cast(ubyte)(hexNibble(input[1]) * 17),
+                cast(ubyte)(hexNibble(input[2]) * 17),
+                cast(ubyte)(hexNibble(input[3]) * 17));
+            break;
+        case 6:
+            result = Color.fromRgb(hexByte(input[1], input[2]),
+                hexByte(input[3], input[4]), hexByte(input[5], input[6]));
+            break;
+        case 8:
+        {
+            const r = hexByte(input[1], input[2]);
+            const alpha = hexByte(input[7], input[8]);
+            if (alpha == 0)
+                result = Color.fromPalette(r);
+            else if (alpha == 1)
+                result = Color.defaultColor;
+            else
+                result = Color.fromRgb(r, hexByte(input[3], input[4]),
+                    hexByte(input[5], input[6]));
+            break;
+        }
+        default:
+            return parseErr!Color(ParseErrorCode.widthMismatch, 1,
+                "expected 3, 6, or 8 hex digits after '#'");
+    }
+
+    input = input[n .. $];
+    return parseOk(result);
+}
+
+///
+@("color.parseHexColor.forms")
+pure nothrow @nogc
+unittest
+{
+    const(char)[] s = "#fa0 rest";
+    auto short3 = parseHexColor(s);
+    assert(short3.hasValue && short3.value == Color.fromRgb(0xff, 0xaa, 0x00));
+    assert(s == " rest");
+
+    s = "#1e1e2e";
+    assert(parseHexColor(s).value == Color.fromRgb(0x1e, 0x1e, 0x2e));
+    assert(s.length == 0);
+
+    // bat alpha conventions
+    s = "#0400000f"; // alpha 0x0f: plain RGB, alpha discarded
+    assert(parseHexColor(s).value == Color.fromRgb(0x04, 0x00, 0x00));
+    s = "#04000000"; // alpha 00: palette index 0x04
+    assert(parseHexColor(s).value == Color.fromPalette(0x04));
+    s = "#00000001"; // alpha 01: terminal default
+    assert(parseHexColor(s).value == Color.defaultColor);
+}
+
+@("color.parseHexColor.rejects")
+pure nothrow @nogc
+unittest
+{
+    static ParseErrorCode errorOf(string text) pure nothrow @nogc
+    {
+        const(char)[] s = text;
+        return parseHexColor(s).error.code;
+    }
+
+    assert(errorOf("") == ParseErrorCode.emptyInput);
+    assert(errorOf("fff") == ParseErrorCode.unexpectedCharacter);
+    assert(errorOf("#") == ParseErrorCode.widthMismatch);
+    assert(errorOf("#ff") == ParseErrorCode.widthMismatch);
+    assert(errorOf("#ffff") == ParseErrorCode.widthMismatch);
+    assert(errorOf("#fffffff") == ParseErrorCode.widthMismatch);
+    assert(errorOf("#fffffffff") == ParseErrorCode.widthMismatch);
+
+    // failed parses must not advance the cursor
+    const(char)[] s = "#zz";
+    assert(parseHexColor(s).hasError);
+    assert(s == "#zz");
+}
+
+/**
+Nearest xterm-256 palette index for an RGB value: the 6×6×6 color cube
+(levels 0, 95, 135, 175, 215, 255; indices 16–231) or the 24-step grayscale
+ramp (values 8–238; indices 232–255), whichever is closer.
+*/
+ubyte ansi256FromRgb(in RgbColor c) pure nothrow @nogc
+{
+    static immutable ubyte[6] cubeLevels = [0, 95, 135, 175, 215, 255];
+
+    static size_t nearestCubeIndex(ubyte v) pure nothrow @nogc @safe
+    {
+        // midpoints between consecutive levels: 47.5, 115, 155, 195, 235
+        if (v < 48)
+            return 0;
+        if (v < 115)
+            return 1;
+        return (v - 35) / 40;
+    }
+
+    const ri = nearestCubeIndex(c.r);
+    const gi = nearestCubeIndex(c.g);
+    const bi = nearestCubeIndex(c.b);
+    const cube = RgbColor(cubeLevels[ri], cubeLevels[gi], cubeLevels[bi]);
+
+    const avg = (c.r + c.g + c.b) / 3;
+    const grayIndex = avg < 8 ? 0
+        : avg > 238 ? 23
+        : (avg - 3) / 10;
+    const grayValue = cast(ubyte)(8 + 10 * grayIndex);
+    const gray = RgbColor(grayValue, grayValue, grayValue);
+
+    return colorDistanceSq(c, cube) <= colorDistanceSq(c, gray)
+        ? cast(ubyte)(16 + 36 * ri + 6 * gi + bi)
+        : cast(ubyte)(232 + grayIndex);
+}
+
+///
+@("color.ansi256FromRgb.corners")
+pure nothrow @nogc
+unittest
+{
+    // cube corners
+    assert(ansi256FromRgb(RgbColor(0, 0, 0)) == 16);
+    assert(ansi256FromRgb(RgbColor(255, 255, 255)) == 231);
+    assert(ansi256FromRgb(RgbColor(255, 0, 0)) == 196);
+    assert(ansi256FromRgb(RgbColor(0, 255, 0)) == 46);
+    assert(ansi256FromRgb(RgbColor(0, 0, 255)) == 21);
+    // exact cube levels
+    assert(ansi256FromRgb(RgbColor(95, 135, 175)) == 16 + 36 * 1 + 6 * 2 + 3);
+    // grays land on the ramp, not the cube
+    assert(ansi256FromRgb(RgbColor(8, 8, 8)) == 232);
+    assert(ansi256FromRgb(RgbColor(128, 128, 128)) == 232 + 12);
+    assert(ansi256FromRgb(RgbColor(238, 238, 238)) == 255);
+}
+
+/// The xterm default values for the classic 16 palette entries.
+private static immutable RgbColor[16] base16Palette = [
+    RgbColor(0, 0, 0),       // black
+    RgbColor(205, 0, 0),     // red
+    RgbColor(0, 205, 0),     // green
+    RgbColor(205, 205, 0),   // yellow
+    RgbColor(0, 0, 238),     // blue
+    RgbColor(205, 0, 205),   // magenta
+    RgbColor(0, 205, 205),   // cyan
+    RgbColor(229, 229, 229), // white
+    RgbColor(127, 127, 127), // bright black
+    RgbColor(255, 0, 0),     // bright red
+    RgbColor(0, 255, 0),     // bright green
+    RgbColor(255, 255, 0),   // bright yellow
+    RgbColor(92, 92, 255),   // bright blue
+    RgbColor(255, 0, 255),   // bright magenta
+    RgbColor(0, 255, 255),   // bright cyan
+    RgbColor(255, 255, 255), // bright white
+];
+
+/**
+Nearest classic-16 palette index (0–15) for an RGB value, measured against
+the xterm default palette. Foreground SGR codes are `30 + i` (or `90 + i - 8`
+for the bright half); the ANSI renderer derives them.
+*/
+ubyte ansi16FromRgb(in RgbColor c) pure nothrow @nogc
+{
+    import std.algorithm.searching : minIndex;
+
+    // nearest palette entry by squared distance (first min wins on ties). The
+    // distances are materialised into a stack array rather than a lazy `map`
+    // over a `c`-capturing lambda, which would allocate a closure under @nogc.
+    uint[base16Palette.length] dists = void;
+    foreach (i, entry; base16Palette)
+        dists[i] = colorDistanceSq(c, entry);
+    return cast(ubyte) dists[].minIndex;
+}
+
+/**
+The RGB value behind an xterm-256 palette index (xterm defaults for the
+classic 16). Inverse of $(LREF ansi256FromRgb) on palette-exact values, and
+the concretization step a non-terminal (e.g. GPU) backend uses to resolve
+`Color.Kind.palette` against a concrete palette.
+*/
+RgbColor xterm256ToRgb(ubyte index) pure nothrow @nogc
+{
+    static immutable ubyte[6] cubeLevels = [0, 95, 135, 175, 215, 255];
+
+    if (index < 16)
+        return base16Palette[index];
+    if (index < 232)
+    {
+        const i = index - 16;
+        return RgbColor(cubeLevels[i / 36], cubeLevels[(i / 6) % 6], cubeLevels[i % 6]);
+    }
+    const gray = cast(ubyte)(8 + 10 * (index - 232));
+    return RgbColor(gray, gray, gray);
+}
+
+@("color.xterm256ToRgb.roundTrip")
+pure nothrow @nogc
+unittest
+{
+    // Every cube/gray entry maps back to itself through the nearest fold.
+    foreach (i; 16 .. 256)
+        assert(ansi256FromRgb(xterm256ToRgb(cast(ubyte) i)) == i);
+
+    assert(xterm256ToRgb(0) == RgbColor(0, 0, 0));
+    assert(xterm256ToRgb(196) == RgbColor(255, 0, 0));
+    assert(xterm256ToRgb(244) == RgbColor(128, 128, 128));
+}
+
+@("color.ansi16FromRgb.basics")
+pure nothrow @nogc
+unittest
+{
+    assert(ansi16FromRgb(RgbColor(0, 0, 0)) == 0);
+    assert(ansi16FromRgb(RgbColor(255, 0, 0)) == 9);
+    assert(ansi16FromRgb(RgbColor(200, 10, 10)) == 1);
+    assert(ansi16FromRgb(RgbColor(255, 255, 255)) == 15);
+    assert(ansi16FromRgb(RgbColor(120, 120, 120)) == 8);
+}
+
+/// Reads `$COLORTERM`/`$TERM` and classifies via
+/// $(REF classifyColorDepth, sparkles,base,term_color). The thin env-reading
+/// edge for standalone use; an app already holding a
+/// $(REF TermCaps, sparkles,core_cli,term_caps) reads `.colorDepth` instead.
+ColorDepth detectColorDepth()
+{
+    import std.process : environment;
+
+    return classifyColorDepth(environment.get("COLORTERM", ""), environment.get("TERM", ""));
+}
+
+private uint colorDistanceSq(in RgbColor a, in RgbColor b) pure nothrow @nogc
+{
+    const dr = cast(int) a.r - cast(int) b.r;
+    const dg = cast(int) a.g - cast(int) b.g;
+    const db = cast(int) a.b - cast(int) b.b;
+    return cast(uint)(dr * dr + dg * dg + db * db);
+}
+
+// isHexDigit / hexNibble come from sparkles.base.text.readers.
+private ubyte hexByte(char hi, char lo) pure nothrow @nogc
+    => cast(ubyte)(hexNibble(hi) * 16 + hexNibble(lo));
+
+// ---- render/ansi.d ----
+
+/**
+The ANSI rendering backend: folds a highlight-event stream into SGR-styled
+terminal output.
+
+Renders through $(REF byStyledSpan, sparkles,syntax,event) (maximal
+innermost-wins runs), emitting the $(B minimal SGR transition) between
+adjacent runs ($(LREF writeStyleTransition)) at the requested
+$(REF ColorDepth, sparkles,syntax,color) tier — 24-bit, 256-color, or
+classic-16, with palette colors kept palette-native so the user's terminal
+scheme is respected (the bat discipline).
+
+$(B Per-line validity:) any active style is reset before every `'\n'` and
+lazily re-established after it, so each output line carries its own styling
+and survives being sliced, paged, or reflowed line-wise. The invariant is
+verified in tests by re-scanning the output with
+`sparkles.base.text.ansi.SgrState`.
+
+Totality: the renderer never fails on any event stream; `ColorDepth.none`
+degrades to verbatim source passthrough.
+*/
+module sparkles.syntax.render.ansi;
+
+import std.range.primitives : put;
+
+import sparkles.base.text.writers : writeInteger;
+import sparkles.base.text.ansi : writeSgrReset;
+import sparkles.base.term_style : Style;
+
+import sparkles.syntax.color : Color, ColorDepth, RgbColor, ansi16FromRgb,
+    ansi256FromRgb, xterm256ToRgb;
+import sparkles.syntax.event : byStyledSpan, isHighlightEventRange;
+import sparkles.syntax.theme : FontStyle, ResolvedTheme, StyleSpec, hasFont;
+
+/// Options for $(LREF renderAnsi).
+struct AnsiOptions
+{
+    /// Color tier to emit. `none` = verbatim passthrough.
+    ColorDepth depth = ColorDepth.ansi256;
+
+    /// Emit per-run theme backgrounds. Off by default: respect the
+    /// terminal's own background.
+    bool emitBackground = false;
+
+    /// Emit italics. Off by default (bat's defensive gate — some terminals
+    /// render italics poorly); italic font flags are dropped when off.
+    bool italics = false;
+}
+
+/**
+Folds `events` over `source`, writing SGR-styled text to `w`.
+
+`w` is any `char` output range. Attributes infer: with a `@nogc` writer and
+event range the whole render path is `@safe pure nothrow @nogc`.
+*/
+ref Writer renderAnsi(Writer, Events)(
+    scope const(char)[] source,
+    Events events,
+    in ResolvedTheme theme,
+    return ref Writer w,
+    in AnsiOptions options = AnsiOptions(),
+)
+if (isHighlightEventRange!Events)
+{
+    import std.algorithm.comparison : min;
+    import std.algorithm.searching : countUntil;
+    import std.utf : byCodeUnit;
+
+    if (options.depth == ColorDepth.none)
+    {
+        put(w, source);
+        return w;
+    }
+
+    StyleSpec current;
+
+    void transitionTo(in StyleSpec target)
+    {
+        if (current != target)
+        {
+            writeStyleTransition(w, current, target, options.depth);
+            current = target;
+        }
+    }
+
+    foreach (span; byStyledSpan(events))
+    {
+        auto spec = theme[span.label];
+        if (!options.italics)
+            spec.font = cast(FontStyle)(spec.font & ~FontStyle.italic);
+        if (!options.emitBackground)
+            spec.bg = Color.init;
+
+        // Defensive clamp: a misbehaving producer must not crash a renderer.
+        const lo = min(span.start, source.length);
+        const hi = min(span.end, source.length);
+        const(char)[] text = lo < hi ? source[lo .. hi] : null;
+
+        while (text.length)
+        {
+            const nlPos = text.byCodeUnit.countUntil('\n');
+            if (nlPos < 0)
+            {
+                transitionTo(spec);
+                put(w, text);
+                break;
+            }
+
+            const nl = cast(size_t) nlPos;
+            if (nl > 0)
+            {
+                transitionTo(spec);
+                put(w, text[0 .. nl]);
+            }
+            // reset before the newline; re-open lazily at the next text
+            transitionTo(StyleSpec.init);
+            put(w, '\n');
+            text = text[nl + 1 .. $];
+        }
+    }
+
+    transitionTo(StyleSpec.init);
+    return w;
+}
+
+/**
+Emits the minimal SGR sequence transitioning the terminal from style `from`
+to style `to` at `depth`; nothing when they are equal, a single `ESC[0m`
+when `to` is empty.
+
+Font bits are diffed per flag (off-codes `22`/`23`/`24`/`29` for cleared
+bits, on-codes for set bits — `22` clears both bold and dim, so a surviving
+one is re-issued); colors are emitted only when changed, an unset/default
+target as `39`/`49`.
+*/
+void writeStyleTransition(Writer)(ref Writer w, in StyleSpec from, in StyleSpec to, ColorDepth depth)
+{
+    if (from == to)
+        return;
+    if (to.empty)
+    {
+        if (!from.empty)
+            writeSgrReset(w);
+        return;
+    }
+
+    put(w, "\x1b[");
+    bool first = true;
+
+    // Emit one `;`-separated SGR parameter. Codes are sourced from
+    // `base.term_style.Style` ([on, off] pairs) so the numbers have one home.
+    void pieceCode(uint code)
+    {
+        if (!first)
+            put(w, ';');
+        first = false;
+        writeInteger(w, code);
+    }
+
+    // bold/dim share the off-code 22 (Style.bold[1] == Style.dim[1]): if either
+    // is cleared, clear both and re-issue the survivor.
+    const fromBD = from.font & (FontStyle.bold | FontStyle.dim);
+    const toBD = to.font & (FontStyle.bold | FontStyle.dim);
+    if (fromBD != toBD)
+    {
+        if (fromBD & ~toBD)
+        {
+            pieceCode(Style.bold[1]);
+            if (toBD & FontStyle.bold)
+                pieceCode(Style.bold[0]);
+            if (toBD & FontStyle.dim)
+                pieceCode(Style.dim[0]);
+        }
+        else
+        {
+            if ((toBD & FontStyle.bold) && !(fromBD & FontStyle.bold))
+                pieceCode(Style.bold[0]);
+            if ((toBD & FontStyle.dim) && !(fromBD & FontStyle.dim))
+                pieceCode(Style.dim[0]);
+        }
+    }
+
+    static struct FlagCodes
+    {
+        FontStyle flag;
+        uint on, off;
+    }
+
+    static immutable FlagCodes[3] flagCodes = [
+        FlagCodes(FontStyle.italic, Style.italic[0], Style.italic[1]),
+        FlagCodes(FontStyle.underline, Style.underline[0], Style.underline[1]),
+        FlagCodes(FontStyle.strikethrough, Style.strikethrough[0], Style.strikethrough[1]),
+    ];
+
+    foreach (fc; flagCodes)
+    {
+        const had = hasFont(from.font, fc.flag);
+        const has = hasFont(to.font, fc.flag);
+        if (had != has)
+            pieceCode(has ? fc.on : fc.off);
+    }
+
+    if (from.fg != to.fg)
+    {
+        if (!first)
+            put(w, ';');
+        first = false;
+        writeSgrColor(w, to.fg, depth, background: false);
+    }
+    if (from.bg != to.bg)
+    {
+        if (!first)
+            put(w, ';');
+        first = false;
+        writeSgrColor(w, to.bg, depth, background: true);
+    }
+
+    put(w, 'm');
+}
+
+/**
+Emits the SGR parameter(s) selecting `color` (without the `ESC[`/`m`
+wrapper): `38;2;r;g;b` / `38;5;n` / classic codes by `depth`, `39`/`49` for
+unset or terminal-default, palette entries kept palette-native (indices
+0–15 as classic codes at any depth; 16–255 as `38;5;n`, downsampled through
+the xterm palette only when the terminal can't address them).
+*/
+void writeSgrColor(Writer)(ref Writer w, in Color color, ColorDepth depth, bool background)
+{
+    final switch (color.kind)
+    {
+        case Color.Kind.unset:
+        case Color.Kind.default_:
+            put(w, background ? "49" : "39");
+            return;
+
+        case Color.Kind.palette:
+            if (color.index < 16)
+                writeClassicCode(w, color.index, background);
+            else if (depth >= ColorDepth.ansi256)
+            {
+                put(w, background ? "48;5;" : "38;5;");
+                writeInteger(w, color.index);
+            }
+            else
+                writeClassicCode(w, ansi16FromRgb(xterm256ToRgb(color.index)), background);
+            return;
+
+        case Color.Kind.rgb:
+            final switch (depth)
+            {
+                case ColorDepth.none:
+                case ColorDepth.ansi16:
+                    writeClassicCode(w, ansi16FromRgb(color.rgb), background);
+                    return;
+                case ColorDepth.ansi256:
+                    put(w, background ? "48;5;" : "38;5;");
+                    writeInteger(w, ansi256FromRgb(color.rgb));
+                    return;
+                case ColorDepth.trueColor:
+                    put(w, background ? "48;2;" : "38;2;");
+                    writeInteger(w, color.rgb.r);
+                    put(w, ';');
+                    writeInteger(w, color.rgb.g);
+                    put(w, ';');
+                    writeInteger(w, color.rgb.b);
+                    return;
+            }
+    }
+}
+
+private void writeClassicCode(Writer)(ref Writer w, ubyte index, bool background)
+in (index < 16)
+{
+    const base = index < 8
+        ? (background ? 40 : 30) + index
+        : (background ? 100 : 90) + index - 8;
+    writeInteger(w, cast(uint) base);
+}
+
+version (unittest)
+{
+    import sparkles.base.smallbuffer : SmallBuffer, checkWriter;
+    import sparkles.syntax.event : HighlightEvent, LabelId;
+    import sparkles.syntax.label : LabelSet;
+    import sparkles.syntax.theme : Theme, ThemeRule, resolveTheme;
+
+    // A tiny fixed vocabulary/theme pair shared by the renderer tests.
+    private ResolvedTheme testTheme() @safe pure nothrow
+    {
+        const theme = Theme(
+            name: "test",
+            rules: [
+                ThemeRule("keyword", StyleSpec(
+                    fg: Color.fromRgb(0xcb, 0xa6, 0xf7), font: FontStyle.bold)),
+                ThemeRule("string", StyleSpec(fg: Color.fromRgb(0xa6, 0xe3, 0xa1))),
+                ThemeRule("comment", StyleSpec(
+                    fg: Color.fromPalette(8), font: FontStyle.italic)),
+            ]);
+        return resolveTheme(theme, LabelSet.standard());
+    }
+
+    private LabelId lbl(string name) @safe pure nothrow
+    {
+        const id = LabelSet.standard().find(name);
+        assert(id, name);
+        return id;
+    }
+}
+
+///
+@("render.ansi.basicRuns")
+@safe pure nothrow
+unittest
+{
+    const resolved = testTheme();
+    alias E = HighlightEvent;
+    const source = "if (x) // hi";
+    const events = [
+        E.pushLabel(lbl("keyword")),
+        E.sourceSpan(0, 2),
+        E.popLabel(),
+        E.sourceSpan(2, 7),
+        E.pushLabel(lbl("comment")),
+        E.sourceSpan(7, 12),
+        E.popLabel(),
+    ];
+
+    // trueColor: bold+fg for the keyword; palette 8 stays palette-native
+    // (classic bright-black 90) at every depth; comment italic gated off.
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.trueColor)))(
+        "\x1b[1;38;2;203;166;247mif\x1b[0m (x) \x1b[90m// hi\x1b[0m");
+
+    // ansi256: RGB folds to the nearest palette entry
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.ansi256)))(
+        "\x1b[1;38;5;183mif\x1b[0m (x) \x1b[90m// hi\x1b[0m");
+
+    // ansi16: RGB folds to the classic palette (0xcba6f7 → white, 37)
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.ansi16)))(
+        "\x1b[1;37mif\x1b[0m (x) \x1b[90m// hi\x1b[0m");
+
+    // none: verbatim passthrough
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.none)))(source);
+}
+
+@("render.ansi.italicsGateAndBackground")
+@safe pure nothrow
+unittest
+{
+    const resolved = testTheme();
+    alias E = HighlightEvent;
+    const source = "x";
+    const events = [
+        E.pushLabel(lbl("comment")),
+        E.sourceSpan(0, 1),
+        E.popLabel(),
+    ];
+
+    // italics off (default): only the color survives
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.ansi256)))(
+        "\x1b[90mx\x1b[0m");
+
+    // italics on: italic flag emitted
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.ansi256, italics: true)))(
+        "\x1b[3;90mx\x1b[0m");
+}
+
+@("render.ansi.adjacentRunsDiffMinimally")
+@safe pure nothrow
+unittest
+{
+    const resolved = testTheme();
+    alias E = HighlightEvent;
+    const source = "abcd";
+    // keyword then string: same-bold? no — keyword is bold, string is not:
+    // transition must clear bold (22) and change color in ONE sequence.
+    const events = [
+        E.pushLabel(lbl("keyword")),
+        E.sourceSpan(0, 2),
+        E.popLabel(),
+        E.pushLabel(lbl("string")),
+        E.sourceSpan(2, 4),
+        E.popLabel(),
+    ];
+
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.trueColor)))(
+        "\x1b[1;38;2;203;166;247mab\x1b[22;38;2;166;227;161mcd\x1b[0m");
+}
+
+@("render.ansi.perLineReset")
+@safe pure nothrow
+unittest
+{
+    import sparkles.base.text.ansi : SgrState, byAnsiToken;
+
+    const resolved = testTheme();
+    alias E = HighlightEvent;
+    const source = "aa\nbb\ncc";
+    const events = [
+        E.pushLabel(lbl("string")),
+        E.sourceSpan(0, 8), // one span across three lines
+        E.popLabel(),
+    ];
+
+    SmallBuffer!(char, 256) buf;
+    renderAnsi(source, events[], resolved, buf,
+        AnsiOptions(depth: ColorDepth.trueColor));
+
+    // style re-established after each newline
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.trueColor)))(
+        "\x1b[38;2;166;227;161maa\x1b[0m\n\x1b[38;2;166;227;161mbb\x1b[0m\n" ~
+        "\x1b[38;2;166;227;161mcc\x1b[0m");
+
+    // the machine-checked invariant: SGR state inactive at every newline
+    SgrState state;
+    foreach (token; byAnsiToken(buf[]))
+    {
+        if (token.isEscape)
+            state.apply(token.slice);
+        else
+        {
+            foreach (char ch; token.slice)
+                if (ch == '\n')
+                    assert(!state.active, "styled newline leaked");
+        }
+    }
+    assert(!state.active, "unterminated style at end of output");
+}
+
+@("render.ansi.nogcProof")
+@safe pure nothrow @nogc
+unittest
+{
+    // The whole render path is @nogc given @nogc inputs.
+    static immutable HighlightEvent[3] events = [
+        HighlightEvent.pushLabel(LabelId(0)),
+        HighlightEvent.sourceSpan(0, 4),
+        HighlightEvent.popLabel(),
+    ];
+    const ResolvedTheme theme; // empty: everything renders unstyled
+    SmallBuffer!(char, 64) buf;
+    renderAnsi("text", events[], theme, buf);
+    assert(buf[] == "text");
+}
+
+@("render.ansi.writeSgrColor")
+@safe pure nothrow @nogc
+unittest
+{
+    checkWriter!((ref w) => writeSgrColor(w, Color.init, ColorDepth.trueColor, false))("39");
+    checkWriter!((ref w) => writeSgrColor(w, Color.defaultColor, ColorDepth.trueColor, true))("49");
+    checkWriter!((ref w) => writeSgrColor(w, Color.fromPalette(3), ColorDepth.trueColor, false))("33");
+    checkWriter!((ref w) => writeSgrColor(w, Color.fromPalette(11), ColorDepth.ansi16, true))("103");
+    checkWriter!((ref w) => writeSgrColor(w, Color.fromPalette(114), ColorDepth.ansi256, false))("38;5;114");
+    // palette above 15 at ansi16: downsampled through the xterm palette
+    checkWriter!((ref w) => writeSgrColor(w, Color.fromPalette(196), ColorDepth.ansi16, false))("91");
+    checkWriter!((ref w) => writeSgrColor(w, Color.fromRgb(1, 2, 3), ColorDepth.trueColor, false))("38;2;1;2;3");
+    checkWriter!((ref w) => writeSgrColor(w, Color.fromRgb(255, 0, 0), ColorDepth.ansi256, true))("48;5;196");
+    checkWriter!((ref w) => writeSgrColor(w, Color.fromRgb(255, 0, 0), ColorDepth.ansi16, false))("91");
+}
+
+@("render.ansi.writeStyleTransition")
+@safe pure nothrow @nogc
+unittest
+{
+    const bold = StyleSpec(font: FontStyle.bold);
+    const boldDim = StyleSpec(font: cast(FontStyle)(FontStyle.bold | FontStyle.dim));
+    const dim = StyleSpec(font: FontStyle.dim);
+    const plainRed = StyleSpec(fg: Color.fromPalette(1));
+
+    // no-op
+    checkWriter!((ref w) => writeStyleTransition(w, bold, bold, ColorDepth.ansi256))("");
+    // to empty → single reset
+    checkWriter!((ref w) => writeStyleTransition(w, bold, StyleSpec.init, ColorDepth.ansi256))("\x1b[0m");
+    // from empty
+    checkWriter!((ref w) => writeStyleTransition(w, StyleSpec.init, bold, ColorDepth.ansi256))("\x1b[1m");
+    // bold→dim: 22 clears both, dim re-issued
+    checkWriter!((ref w) => writeStyleTransition(w, bold, dim, ColorDepth.ansi256))("\x1b[22;2m");
+    // bold→bold+dim: pure addition, no 22
+    checkWriter!((ref w) => writeStyleTransition(w, bold, boldDim, ColorDepth.ansi256))("\x1b[2m");
+    // bold+dim→bold: 22 then re-issue bold
+    checkWriter!((ref w) => writeStyleTransition(w, boldDim, bold, ColorDepth.ansi256))("\x1b[22;1m");
+    // color-only change
+    checkWriter!((ref w) => writeStyleTransition(w, StyleSpec.init, plainRed, ColorDepth.ansi256))("\x1b[31m");
+    // dropping the color while keeping nothing else → reset
+    checkWriter!((ref w) => writeStyleTransition(w, plainRed, StyleSpec.init, ColorDepth.ansi256))("\x1b[0m");
+}

--- a/libs/syntax/bench/render/corpus/sample.py
+++ b/libs/syntax/bench/render/corpus/sample.py
@@ -1,0 +1,98 @@
+# Representative Python corpus for the sparkles:syntax foreign benchmark panel.
+# Original BSL-1.0 code (ours) — a small, self-contained event-stream folder that
+# mirrors the shape of the D corpus (comments, strings, numbers, classes,
+# decorators, comprehensions, f-strings) so highlighters have realistic work.
+"""A tiny highlight-event model and an ANSI folder, in pure Python.
+
+The point is not correctness but *texture*: enough distinct token classes on
+every line that a TextMate/Pygments/chroma grammar has something to colour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Iterable, Iterator
+
+
+class EventKind(Enum):
+    """The three shapes a highlight event can take."""
+
+    PUSH = auto()
+    POP = auto()
+    SPAN = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class Event:
+    kind: EventKind
+    label: str = ""
+    start: int = 0
+    end: int = 0
+
+    @property
+    def length(self) -> int:
+        return max(0, self.end - self.start)
+
+    def __str__(self) -> str:  # noqa: D105
+        return f"<{self.kind.name} {self.label!r} {self.start}:{self.end}>"
+
+
+SGR = {
+    "keyword": "\x1b[35m",
+    "string": "\x1b[32m",
+    "number": "\x1b[33m",
+    "comment": "\x1b[90m",
+}
+RESET = "\x1b[0m"
+
+
+@dataclass
+class Folder:
+    """Folds an event stream + source into styled ANSI bytes."""
+
+    source: str
+    _stack: list[str] = field(default_factory=list)
+
+    def _style(self) -> str:
+        for label in reversed(self._stack):
+            if label in SGR:
+                return SGR[label]
+        return ""
+
+    def fold(self, events: Iterable[Event]) -> str:
+        out: list[str] = []
+        for ev in events:
+            if ev.kind is EventKind.PUSH:
+                self._stack.append(ev.label)
+            elif ev.kind is EventKind.POP:
+                if self._stack:
+                    self._stack.pop()
+            else:
+                text = self.source[ev.start : ev.end]
+                style = self._style()
+                out.append(f"{style}{text}{RESET}" if style else text)
+        return "".join(out)
+
+
+def spans(source: str, labels: dict[str, tuple[int, int]]) -> Iterator[Event]:
+    """Yield PUSH/SPAN/POP triples for each labelled slice, in order."""
+    for label, (start, end) in sorted(labels.items(), key=lambda kv: kv[1][0]):
+        yield Event(EventKind.PUSH, label, start, end)
+        yield Event(EventKind.SPAN, label, start, end)
+        yield Event(EventKind.POP, label, start, end)
+
+
+def demo() -> str:
+    src = 'x = 0xFF + 12_000  # comment: the "answer"'
+    labels = {
+        "number": (4, 8),
+        "comment": (19, len(src)),
+    }
+    folded = Folder(src).fold(spans(src, labels))
+    total = sum(ev.length for ev in spans(src, labels) if ev.kind is EventKind.SPAN)
+    return f"{folded}\n-- highlighted {total} bytes across {len(labels)} spans --"
+
+
+if __name__ == "__main__":
+    print(demo())

--- a/libs/syntax/bench/render/corpus/sample.ts
+++ b/libs/syntax/bench/render/corpus/sample.ts
@@ -1,0 +1,99 @@
+// Representative TypeScript corpus for the sparkles:syntax foreign benchmark
+// panel. Original BSL-1.0 code (ours) — a small highlight-event model + HTML
+// folder mirroring the D/Python corpora, dense with token classes (types,
+// generics, template literals, enums, decorators-in-comment, regex, numbers)
+// so TextMate/Pygments/chroma grammars have realistic work.
+
+/** The three shapes a highlight event can take. */
+export const enum EventKind {
+  Push = 'push',
+  Pop = 'pop',
+  Span = 'span',
+}
+
+export interface Event {
+  readonly kind: EventKind;
+  readonly label: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+const SGR: Readonly<Record<string, string>> = {
+  keyword: 'color:#c586c0',
+  string: 'color:#ce9178',
+  number: 'color:#b5cea8',
+  comment: 'color:#6a9955',
+};
+
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, c => {
+    switch (c) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      default:
+        return '&#39;';
+    }
+  });
+}
+
+/** Folds an event stream + source into styled HTML. */
+export class HtmlFolder {
+  private readonly stack: string[] = [];
+
+  constructor(private readonly source: string) {}
+
+  private style(): string {
+    for (let i = this.stack.length - 1; i >= 0; i--) {
+      const label = this.stack[i];
+      if (label in SGR) return SGR[label];
+    }
+    return '';
+  }
+
+  fold(events: Iterable<Event>): string {
+    const out: string[] = ['<pre><code>'];
+    for (const ev of events) {
+      if (ev.kind === EventKind.Push) {
+        this.stack.push(ev.label);
+      } else if (ev.kind === EventKind.Pop) {
+        this.stack.pop();
+      } else {
+        const text = escapeHtml(this.source.slice(ev.start, ev.end));
+        const style = this.style();
+        out.push(style ? `<span style="${style}">${text}</span>` : text);
+      }
+    }
+    out.push('</code></pre>');
+    return out.join('');
+  }
+}
+
+function* spans(
+  labels: ReadonlyMap<string, readonly [number, number]>,
+): Iterator<Event> {
+  const sorted = [...labels.entries()].sort((a, b) => a[1][0] - b[1][0]);
+  for (const [label, [start, end]] of sorted) {
+    yield { kind: EventKind.Push, label, start, end };
+    yield { kind: EventKind.Span, label, start, end };
+    yield { kind: EventKind.Pop, label, start, end };
+  }
+}
+
+export function demo(): string {
+  const src = `x = 0xff + 12_000; // the "answer"`;
+  const labels = new Map<string, readonly [number, number]>([
+    ['number', [4, 8]],
+    ['comment', [18, src.length]],
+  ]);
+  return new HtmlFolder(src).fold({ [Symbol.iterator]: () => spans(labels) });
+}
+
+if (typeof require !== 'undefined' && require.main === module) {
+  console.log(demo());
+}

--- a/libs/syntax/bench/render/dub.sdl
+++ b/libs/syntax/bench/render/dub.sdl
@@ -1,0 +1,36 @@
+name "syntax-render-bench"
+description "Syntax-highlighting render-cost benchmark (ANSI + HTML, sizes, theme-switch) on sparkles:test-runner, with a nix-pinned foreign panel"
+authors "Petar Kirov"
+copyright "Copyright © 2026, Petar Kirov"
+license "BSL-1.0"
+
+targetType "library"
+targetPath "build"
+
+dflags "-preview=in" "-preview=dip1000"
+
+// `runner.d` imports sparkles.test_runner.* at module scope, so the runner is an
+// unconditional dependency (mirrors libs/tui/bench/render). `sparkles:syntax`
+// pulls in tree-sitter (ImportC) and base; the corpus is parsed once per case in
+// untimed setup, then the renderers are timed over the cached event stream.
+dependency "sparkles:syntax" path="../../../.."
+dependency "sparkles:test-runner" path="../../../.."
+
+// The frozen corpus files are string-imported (cwd-independent, deterministic).
+stringImportPaths "corpus"
+
+configuration "unittest" {
+    dflags "-checkaction=context" "-allinst"
+    dflags "-defaultlib=libphobos2.so" "-L-fuse-ld=gold" platform="linux-dmd"
+    dflags "--link-defaultlib-shared" "--linker=gold" platform="linux-ldc"
+    lflags "--export-dynamic" platform="linux-ldc"
+}
+
+// Real numbers need release codegen: dub's stock `unittest` build is a debug
+// build (the runner warns under --bench), so benchmarks run via
+// `dub test -b bench -- --bench …`. `unittests` is load-bearing — without it
+// `dub test` registers zero tests. Copied from libs/tui/bench/render.
+buildType "bench" {
+    buildOptions "unittests" "releaseMode" "optimize" "inline"
+    dflags "-mcpu=native" "-O3" "-allinst" platform="ldc"
+}

--- a/libs/syntax/bench/render/dub.selections.json
+++ b/libs/syntax/bench/render/dub.selections.json
@@ -1,0 +1,8 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"expected": "0.4.1",
+		"silly": "1.1.1",
+		"sparkles": {"path":"../../../../"}
+	}
+}

--- a/libs/syntax/bench/render/foreign/README.md
+++ b/libs/syntax/bench/render/foreign/README.md
@@ -1,0 +1,73 @@
+# `syntax-foreign-bench` — foreign highlighter panel
+
+Runs four **other** syntax highlighters over the same corpus as the in-process
+[`syntax-render-bench`](../README.md) and reports **MB/s of source highlighted**,
+so `sparkles:syntax`'s ANSI/HTML renderers can be placed against the field on
+identical input.
+
+| Tool         | Engine / grammars           | ANSI | HTML | Source            |
+| ------------ | --------------------------- | :--: | :--: | ----------------- |
+| `bat`        | syntect / Sublime-syntax    |  ✓   |      | `pkgs.bat`        |
+| `chroma`     | Go, Pygments-derived        |  ✓   |  ✓   | `pkgs.chroma`     |
+| `pygmentize` | Pygments                    |  ✓   |  ✓   | `pygments`        |
+| `shiki-html` | TextMate / VS Code grammars |      |  ✓   | `buildNpmPackage` |
+
+The tools are Nix-pinned in
+[`nix/packages/syntax-foreign.nix`](../../../../../nix/packages/syntax-foreign.nix)
+as the `syntax-foreign` linkFarm (`result/bin/{bat,chroma,pygmentize,shiki-html}`).
+
+## What it measures — and what it does NOT
+
+> [!IMPORTANT]
+> These are **end-to-end wall-clock** numbers. Each timed run **spawns the tool**,
+> which pays process startup + grammar/theme load + a full parse + render, every
+> time. That is deliberately **not** comparable to the in-process `ansi`/`html`
+> rows in the parent bench (those parse once and re-render a cached event stream —
+> pure render cost). It **is** comparable:
+>
+> - among the foreign tools (same methodology), and
+> - to our own **end-to-end** path (read file → tree-sitter parse → render),
+>   which is the honest apples-to-apples comparison.
+
+To keep spawn cost from dominating, each corpus file is **concatenated ×N to
+~1.5 MB** before highlighting, so the wall time is mostly the highlighter's
+throughput, not `fork`/`exec`. The reported rate is `input_bytes ÷ median_wall_time`.
+
+## Languages
+
+The runner is **language-aware**: it only runs a `(tool, language)` cell when the
+tool advertises a grammar for it, and it treats a non-zero exit or empty output
+during the warmup run as "unsupported" and skips the cell rather than failing.
+
+Corpus (under [`../corpus/`](../corpus/)): `sample.d` (the shared D corpus),
+plus `sample.py` and `sample.ts` — **original BSL-1.0 code (ours)**, authored to
+mirror the D corpus's token texture so every tool (and shiki in particular, whose
+D grammar we also exercise) has representative work. No third-party source is
+vendored.
+
+## Running
+
+```sh
+# 1. Build the pinned tool panel.
+nix build .#syntax-foreign          # -> ./result/bin/{bat,chroma,pygmentize,shiki-html}
+
+# 2. Run the panel (bin dir via $SYNTAX_FOREIGN or as argv[1]).
+SYNTAX_FOREIGN="$PWD/result/bin" \
+    dub run --root=libs/syntax/bench/render/foreign
+
+# or point it explicitly:
+dub run --root=libs/syntax/bench/render/foreign -- "$PWD/result/bin"
+```
+
+Environment knobs:
+
+| Variable                | Default                              | Meaning                               |
+| ----------------------- | ------------------------------------ | ------------------------------------- |
+| `SYNTAX_FOREIGN`        | (argv[1], then `$PATH`)              | bin dir with the four wrappers        |
+| `SYNTAX_FOREIGN_REPS`   | `5`                                  | timed runs per cell (median reported) |
+| `SYNTAX_FOREIGN_TARGET` | `1500000`                            | concatenated input size, bytes        |
+| `SYNTAX_FOREIGN_LANGS`  | (all present)                        | comma list to restrict languages      |
+| `SYNTAX_FOREIGN_JSON`   | `results/<date>-<host>-foreign.json` | JSON snapshot path                    |
+
+The run prints a comparison table and writes a JSON snapshot under
+[`results/`](./results/) for the record.

--- a/libs/syntax/bench/render/foreign/dub.sdl
+++ b/libs/syntax/bench/render/foreign/dub.sdl
@@ -1,0 +1,17 @@
+name "syntax-foreign-bench"
+description "End-to-end throughput comparison of foreign syntax highlighters (bat/chroma/pygments/shiki) on the sparkles:syntax render corpus"
+authors "Petar Kirov"
+copyright "Copyright © 2026, Petar Kirov"
+license "BSL-1.0"
+
+targetType "executable"
+targetName "syntax-foreign-bench"
+targetPath "build"
+mainSourceFile "src/app.d"
+
+dflags "-preview=in" "-preview=dip1000"
+
+// Pure Phobos: it shells out to the pinned foreign tools (found via
+// $SYNTAX_FOREIGN or argv) and times them. No sparkles deps — the corpus is
+// read at runtime as plain files, not string-imported, so non-D languages can
+// be added without touching the D bench.

--- a/libs/syntax/bench/render/foreign/results/2026-07-13-petar-kirov-minisforum-bd790i0-se-002-foreign.json
+++ b/libs/syntax/bench/render/foreign/results/2026-07-13-petar-kirov-minisforum-bd790i0-se-002-foreign.json
@@ -1,0 +1,190 @@
+{
+  "date": "2026-07-13",
+  "host": "host",
+  "note": "end-to-end wall clock (spawn+parse+render); comparable among these tools, not to in-process rows",
+  "reps": 3,
+  "results": [
+    {
+      "format": "ansi",
+      "inputBytes": 804012,
+      "lang": "d",
+      "mbPerSec": 1.2441,
+      "medianMs": 646.238,
+      "ok": true,
+      "outputBytes": 3670326,
+      "tool": "bat"
+    },
+    {
+      "format": "ansi",
+      "inputBytes": 801856,
+      "lang": "python",
+      "mbPerSec": 0.9148,
+      "medianMs": 876.57,
+      "ok": true,
+      "outputBytes": 4055792,
+      "tool": "bat"
+    },
+    {
+      "format": "ansi",
+      "inputBytes": 802944,
+      "lang": "typescript",
+      "mbPerSec": 0.5046,
+      "medianMs": 1591.254,
+      "ok": true,
+      "outputBytes": 4768416,
+      "tool": "bat"
+    },
+    {
+      "format": "ansi",
+      "inputBytes": 804012,
+      "lang": "d",
+      "mbPerSec": 1.0426,
+      "medianMs": 771.151,
+      "ok": true,
+      "outputBytes": 3605338,
+      "tool": "chroma"
+    },
+    {
+      "format": "html",
+      "inputBytes": 804012,
+      "lang": "d",
+      "mbPerSec": 1.0677,
+      "medianMs": 753.066,
+      "ok": true,
+      "outputBytes": 4696772,
+      "tool": "chroma"
+    },
+    {
+      "format": "ansi",
+      "inputBytes": 801856,
+      "lang": "python",
+      "mbPerSec": 0.6261,
+      "medianMs": 1280.727,
+      "ok": true,
+      "outputBytes": 4333232,
+      "tool": "chroma"
+    },
+    {
+      "format": "html",
+      "inputBytes": 801856,
+      "lang": "python",
+      "mbPerSec": 0.6311,
+      "medianMs": 1270.489,
+      "ok": true,
+      "outputBytes": 5563506,
+      "tool": "chroma"
+    },
+    {
+      "format": "ansi",
+      "inputBytes": 802944,
+      "lang": "typescript",
+      "mbPerSec": 1.0725,
+      "medianMs": 748.697,
+      "ok": true,
+      "outputBytes": 4745376,
+      "tool": "chroma"
+    },
+    {
+      "format": "html",
+      "inputBytes": 802944,
+      "lang": "typescript",
+      "mbPerSec": 1.0773,
+      "medianMs": 745.311,
+      "ok": true,
+      "outputBytes": 5887922,
+      "tool": "chroma"
+    },
+    {
+      "format": "ansi",
+      "inputBytes": 804012,
+      "lang": "d",
+      "mbPerSec": 1.2019,
+      "medianMs": 668.932,
+      "ok": true,
+      "outputBytes": 2111184,
+      "tool": "pygmentize"
+    },
+    {
+      "format": "html",
+      "inputBytes": 804012,
+      "lang": "d",
+      "mbPerSec": 1.2478,
+      "medianMs": 644.365,
+      "ok": true,
+      "outputBytes": 4700242,
+      "tool": "pygmentize"
+    },
+    {
+      "format": "ansi",
+      "inputBytes": 801856,
+      "lang": "python",
+      "mbPerSec": 0.6895,
+      "medianMs": 1162.984,
+      "ok": true,
+      "outputBytes": 2264670,
+      "tool": "pygmentize"
+    },
+    {
+      "format": "html",
+      "inputBytes": 801856,
+      "lang": "python",
+      "mbPerSec": 0.7092,
+      "medianMs": 1130.631,
+      "ok": true,
+      "outputBytes": 4334644,
+      "tool": "pygmentize"
+    },
+    {
+      "format": "ansi",
+      "inputBytes": 802944,
+      "lang": "typescript",
+      "mbPerSec": 0.8601,
+      "medianMs": 933.535,
+      "ok": true,
+      "outputBytes": 3140638,
+      "tool": "pygmentize"
+    },
+    {
+      "format": "html",
+      "inputBytes": 802944,
+      "lang": "typescript",
+      "mbPerSec": 0.9561,
+      "medianMs": 839.784,
+      "ok": true,
+      "outputBytes": 6267508,
+      "tool": "pygmentize"
+    },
+    {
+      "format": "html",
+      "inputBytes": 804012,
+      "lang": "d",
+      "mbPerSec": 0.2813,
+      "medianMs": 2858.128,
+      "ok": true,
+      "outputBytes": 4734123,
+      "tool": "shiki-html"
+    },
+    {
+      "format": "html",
+      "inputBytes": 801856,
+      "lang": "python",
+      "mbPerSec": 0.2863,
+      "medianMs": 2800.891,
+      "ok": true,
+      "outputBytes": 6877117,
+      "tool": "shiki-html"
+    },
+    {
+      "format": "html",
+      "inputBytes": 802944,
+      "lang": "typescript",
+      "mbPerSec": 0.2301,
+      "medianMs": 3488.886,
+      "ok": true,
+      "outputBytes": 7355661,
+      "tool": "shiki-html"
+    }
+  ],
+  "schema": "syntax-foreign/1",
+  "targetBytes": 800000
+}

--- a/libs/syntax/bench/render/foreign/src/app.d
+++ b/libs/syntax/bench/render/foreign/src/app.d
@@ -1,0 +1,438 @@
+/++
+Foreign syntax-highlighter benchmark panel for `sparkles:syntax`.
+
+Runs the Nix-pinned foreign highlighters (bat/syntect, chroma, pygments, shiki)
+over the same corpus as the in-process render benchmark and reports MB/s of
+*source* highlighted, so our ANSI/HTML renderers can be placed against other
+libraries on identical input.
+
+> [!IMPORTANT]
+> These are **end-to-end wall-clock** numbers: each measurement spawns the tool,
+> which pays process startup + grammar/theme load + full parse + render on every
+> run. That is deliberately *not* comparable to our in-process per-render `ansi`/
+> `html` rows (parse-once, re-render a cached event stream). It **is** comparable
+> among the foreign tools, and to our own end-to-end path (read file → parse →
+> render). To amortise spawn cost the corpus is concatenated ×N to ~1.5 MB, so
+> the number is dominated by highlight throughput, not `fork`/`exec`.
+
+Tool discovery: the four tool wrappers are found in a bin directory taken from
+(in order) the first CLI argument, `$SYNTAX_FOREIGN`, or `$PATH`. Build the bin
+dir with `nix build .#syntax-foreign` (its `result/bin`).
+
+Usage:
+
+    dub run --root=libs/syntax/bench/render/foreign -- [BIN_DIR]
+
+    # or, with the linkFarm on PATH already:
+    SYNTAX_FOREIGN=$PWD/result/bin \
+        dub run --root=libs/syntax/bench/render/foreign
+
+Environment:
+    SYNTAX_FOREIGN        bin dir holding bat/chroma/pygmentize/shiki-html
+    SYNTAX_FOREIGN_REPS   runs timed per (tool,lang,format) cell (default 5)
+    SYNTAX_FOREIGN_TARGET target concatenated input size in bytes (default 1500000)
+    SYNTAX_FOREIGN_LANGS  comma list to restrict languages (default all present)
+    SYNTAX_FOREIGN_JSON   output JSON path (default results/<date>-<host>-foreign.json)
++/
+module app;
+
+import std.algorithm : filter, map, sort, canFind;
+import std.array : appender, array, join, replicate;
+import std.conv : to;
+import std.datetime.stopwatch : StopWatch, AutoStart;
+import std.datetime.systime : Clock;
+import std.file : exists, read, readText, mkdirRecurse, write, thisExePath;
+import std.format : format;
+import std.path : buildPath, dirName, baseName;
+import std.process : execute, environment, Config;
+import std.stdio : writeln, writefln, stderr;
+
+// --- output formats --------------------------------------------------------
+
+enum Format
+{
+    ansi,
+    html,
+}
+
+string label(Format f) @safe pure nothrow
+{
+    return f == Format.ansi ? "ansi" : "html";
+}
+
+// --- corpus languages ------------------------------------------------------
+
+/// A language in the corpus: a display tag and the corpus file that backs it.
+/// The per-tool grammar name is looked up in `Tool.langName`; a `null` there
+/// means the tool cannot highlight that language, and the cell is skipped.
+struct Lang
+{
+    string tag; /// canonical tag, e.g. "d", "python", "typescript"
+    string file; /// corpus filename under corpus/
+}
+
+immutable Lang[] langs = [
+    Lang("d", "sample.d"),
+    Lang("python", "sample.py"),
+    Lang("typescript", "sample.ts"),
+];
+
+// --- tools -----------------------------------------------------------------
+
+/// A foreign highlighter: which formats it can emit, how it names each corpus
+/// language, and how to build its argv for a given format + input file.
+struct Tool
+{
+    string name; /// wrapper basename in the bin dir
+    Format[] formats; /// output formats this tool produces
+    string[string] langName; /// corpus tag -> the tool's grammar name (absent = unsupported)
+    string[] delegate(string bin, Format fmt, string lang, string file) argv;
+}
+
+Tool[] buildTools() @safe
+{
+    Tool[] tools;
+
+    // bat (syntect / Sublime-syntax) — ANSI only.
+    tools ~= Tool(
+        "bat",
+        [Format.ansi],
+        ["d": "d", "python": "python", "typescript": "typescript"],
+        (bin, fmt, lang, file) => [
+            bin, "--language", lang, "--color=always", "--style=plain",
+            "--paging=never", file
+        ],
+    );
+
+    // chroma (Go) — ANSI + HTML.
+    tools ~= Tool(
+        "chroma",
+        [Format.ansi, Format.html],
+        ["d": "d", "python": "python", "typescript": "typescript"],
+        (bin, fmt, lang, file) => [
+            bin, "--lexer", lang, "--formatter",
+            fmt == Format.ansi ? "terminal256" : "html", file
+        ],
+    );
+
+    // pygmentize (Pygments) — ANSI + HTML.
+    tools ~= Tool(
+        "pygmentize",
+        [Format.ansi, Format.html],
+        ["d": "d", "python": "python", "typescript": "typescript"],
+        (bin, fmt, lang, file) => [
+            bin, "-l", lang, "-f",
+            fmt == Format.ansi ? "terminal256" : "html", file
+        ],
+    );
+
+    // shiki (TextMate / VS Code grammars) — HTML only.
+    tools ~= Tool(
+        "shiki-html",
+        [Format.html],
+        ["d": "d", "python": "python", "typescript": "typescript"],
+        (bin, fmt, lang, file) => [bin, file, lang],
+    );
+
+    return tools;
+}
+
+// --- measurement -----------------------------------------------------------
+
+struct Result
+{
+    string tool;
+    string lang;
+    string format;
+    bool ok;
+    string skipReason;
+    size_t inputBytes;
+    size_t outputBytes;
+    double medianMs;
+    double mbPerSec;
+}
+
+double median(double[] xs) @safe
+{
+    if (xs.length == 0)
+        return 0;
+    auto s = xs.dup;
+    s.sort();
+    const n = s.length;
+    return n % 2 ? s[n / 2] : (s[n / 2 - 1] + s[n / 2]) / 2;
+}
+
+/// Time `argv` `reps` times (plus one warmup), returning the median wall time
+/// in milliseconds and the output byte count. `ok=false` with a reason when the
+/// tool exits non-zero or produces empty output (so an unsupported (tool,lang)
+/// pair is skipped rather than fatal).
+Result measure(string tool, string lang, Format fmt, string[] argv,
+    size_t inputBytes, size_t reps)
+{
+    Result r;
+    r.tool = tool;
+    r.lang = lang;
+    r.format = fmt.label;
+    r.inputBytes = inputBytes;
+
+    // Warmup — also our correctness gate: a tool that can't handle the language
+    // fails here and the cell is skipped.
+    auto warm = execute(argv, null, Config.none, size_t.max);
+    if (warm.status != 0)
+    {
+        r.skipReason = format("exit %d", warm.status);
+        return r;
+    }
+    if (warm.output.length == 0)
+    {
+        r.skipReason = "empty output";
+        return r;
+    }
+    r.outputBytes = warm.output.length;
+
+    auto samples = appender!(double[]);
+    foreach (_; 0 .. reps)
+    {
+        auto sw = StopWatch(AutoStart.yes);
+        auto res = execute(argv, null, Config.none, size_t.max);
+        sw.stop();
+        if (res.status != 0)
+        {
+            r.skipReason = format("exit %d (timed run)", res.status);
+            return r;
+        }
+        samples ~= sw.peek.total!"usecs" / 1000.0;
+    }
+
+    r.medianMs = median(samples[]);
+    r.ok = true;
+    r.mbPerSec = r.medianMs > 0
+        ? (cast(double) inputBytes / 1e6) / (r.medianMs / 1000.0) : 0;
+    return r;
+}
+
+// --- driver ----------------------------------------------------------------
+
+string resolveBinDir(string[] args) @safe
+{
+    if (args.length > 1 && args[1].length)
+        return args[1];
+    return environment.get("SYNTAX_FOREIGN", "");
+}
+
+/// Locate a tool: prefer `binDir/name`, else rely on `$PATH` (return the bare
+/// name and let `execute` resolve it), else empty if truly absent.
+string toolPath(string binDir, string name) @safe
+{
+    if (binDir.length)
+    {
+        const p = buildPath(binDir, name);
+        if (p.exists)
+            return p;
+    }
+    return name; // let execute() search $PATH
+}
+
+/// Build the ~target-byte concatenated input for a corpus file, written to a
+/// temp path, and return (path, byteCount, reps).
+struct Blown
+{
+    string path;
+    size_t bytes;
+    size_t reps;
+}
+
+Blown blowUp(string corpusFile, string tmpDir, size_t target)
+{
+    const src = readText(corpusFile);
+    size_t reps = src.length ? (target + src.length - 1) / src.length : 1;
+    if (reps < 1)
+        reps = 1;
+    // Join with a blank line so tokens from adjacent copies never fuse.
+    const unit = src ~ "\n\n";
+    auto buf = appender!string;
+    foreach (_; 0 .. reps)
+        buf ~= unit;
+    const outPath = buildPath(tmpDir, "blown-" ~ corpusFile.baseName);
+    write(outPath, buf[]);
+    return Blown(outPath, buf[].length, reps);
+}
+
+int main(string[] args)
+{
+    // corpus/ sits next to foreign/ under bench/render/. Resolve relative to
+    // this file's build layout: the exe lives in foreign/build/, corpus in
+    // foreign/../corpus.
+    const foreignDir = thisExePath.dirName.dirName; // .../foreign
+    const corpusDir = buildPath(foreignDir.dirName, "corpus");
+    if (!corpusDir.exists)
+    {
+        stderr.writefln("corpus dir not found: %s", corpusDir);
+        return 1;
+    }
+
+    const binDir = resolveBinDir(args);
+    if (binDir.length)
+        writefln("# foreign tools bin dir: %s", binDir);
+    else
+        writeln("# no SYNTAX_FOREIGN / argv bin dir — resolving tools on $PATH");
+
+    const reps = environment.get("SYNTAX_FOREIGN_REPS", "5").to!size_t;
+    const target = environment.get("SYNTAX_FOREIGN_TARGET", "1500000").to!size_t;
+
+    string[] langFilter;
+    if (auto lf = environment.get("SYNTAX_FOREIGN_LANGS", ""))
+        langFilter = lf.split(',');
+
+    // Scratch dir for the blown-up inputs.
+    const tmpDir = buildPath(environment.get("TMPDIR", "/tmp"),
+        "syntax-foreign-" ~ Clock.currTime.toUnixTime.to!string);
+    mkdirRecurse(tmpDir);
+
+    auto tools = buildTools();
+
+    // Pre-build blown-up input per present corpus language.
+    Blown[string] blown;
+    foreach (const ref l; langs)
+    {
+        if (langFilter.length && !langFilter.canFind(l.tag))
+            continue;
+        const cf = buildPath(corpusDir, l.file);
+        if (!cf.exists)
+        {
+            stderr.writefln("# skip lang %s — no corpus file %s", l.tag, l.file);
+            continue;
+        }
+        blown[l.tag] = blowUp(cf, tmpDir, target);
+    }
+
+    Result[] results;
+    foreach (ref t; tools)
+    {
+        const bin = toolPath(binDir, t.name);
+        foreach (const ref l; langs)
+        {
+            auto b = l.tag in blown;
+            if (b is null)
+                continue;
+            auto gn = l.tag in t.langName;
+            foreach (fmt; t.formats)
+            {
+                if (gn is null)
+                {
+                    results ~= Result(t.name, l.tag, fmt.label, false,
+                        "no grammar", b.bytes, 0, 0, 0);
+                    continue;
+                }
+                auto argv = t.argv(bin, fmt, *gn, b.path);
+                results ~= measure(t.name, l.tag, fmt, argv, b.bytes, reps);
+            }
+        }
+    }
+
+    printTable(results, reps, target);
+    const jsonPath = writeJson(results, foreignDir, reps, target);
+    writefln("\n# JSON snapshot: %s", jsonPath);
+    return 0;
+}
+
+string[] split(string s, char sep) @safe pure
+{
+    import std.algorithm : splitter;
+
+    return s.length ? s.splitter(sep).array : null;
+}
+
+// --- reporting -------------------------------------------------------------
+
+void printTable(Result[] results, size_t reps, size_t target)
+{
+    writefln("\n# Foreign syntax-highlighter panel — end-to-end wall clock");
+    writefln("# (spawn + parse + render per run; input ~%.1f MB; median of %d runs)",
+        target / 1e6, reps);
+    writefln("# NOT comparable to our in-process per-render rows — comparable among these.\n");
+
+    writefln("%-12s %-11s %-6s %10s %10s %12s", "tool", "lang", "fmt",
+        "MB/s", "med ms", "out KB");
+    writefln("%-12s %-11s %-6s %10s %10s %12s", "----", "----", "---",
+        "----", "------", "------");
+
+    foreach (const ref r; results)
+    {
+        if (r.ok)
+            writefln("%-12s %-11s %-6s %10.1f %10.2f %12.1f",
+                r.tool, r.lang, r.format, r.mbPerSec, r.medianMs,
+                r.outputBytes / 1024.0);
+        else
+            writefln("%-12s %-11s %-6s %10s %10s %12s   (%s)",
+                r.tool, r.lang, r.format, "-", "-", "-", r.skipReason);
+    }
+}
+
+string writeJson(Result[] results, string foreignDir, size_t reps, size_t target)
+{
+    import std.datetime.systime : SysTime;
+
+    const now = Clock.currTime;
+    const date = format("%04d-%02d-%02d", now.year, cast(int) now.month, now.day);
+    const host = environment.get("HOSTNAME", environment.get("HOST", "host"));
+
+    string jsonPath = environment.get("SYNTAX_FOREIGN_JSON", "");
+    if (jsonPath.length == 0)
+    {
+        const resultsDir = buildPath(foreignDir, "results");
+        mkdirRecurse(resultsDir);
+        jsonPath = buildPath(resultsDir, format("%s-%s-foreign.json", date, host));
+    }
+    else
+        mkdirRecurse(jsonPath.dirName);
+
+    auto j = appender!string;
+    j ~= "{\n";
+    j ~= format("  \"schema\": \"syntax-foreign/1\",\n");
+    j ~= format("  \"date\": \"%s\",\n", date);
+    j ~= format("  \"host\": %s,\n", jstr(host));
+    j ~= format("  \"reps\": %d,\n", reps);
+    j ~= format("  \"targetBytes\": %d,\n", target);
+    j ~= "  \"note\": \"end-to-end wall clock (spawn+parse+render); comparable among these tools, not to in-process rows\",\n";
+    j ~= "  \"results\": [\n";
+    foreach (i, const ref r; results)
+    {
+        j ~= "    {";
+        j ~= format("\"tool\": %s, \"lang\": %s, \"format\": %s, \"ok\": %s, ",
+            jstr(r.tool), jstr(r.lang), jstr(r.format), r.ok ? "true" : "false");
+        j ~= format("\"inputBytes\": %d, \"outputBytes\": %d, \"medianMs\": %.4f, \"mbPerSec\": %.4f",
+            r.inputBytes, r.outputBytes, r.medianMs, r.mbPerSec);
+        if (!r.ok)
+            j ~= format(", \"skip\": %s", jstr(r.skipReason));
+        j ~= i + 1 < results.length ? "},\n" : "}\n";
+    }
+    j ~= "  ]\n}\n";
+    write(jsonPath, j[]);
+    return jsonPath;
+}
+
+string jstr(string s) @safe pure
+{
+    auto o = appender!string;
+    o ~= '"';
+    foreach (char c; s)
+    {
+        switch (c)
+        {
+        case '"':
+            o ~= "\\\"";
+            break;
+        case '\\':
+            o ~= "\\\\";
+            break;
+        case '\n':
+            o ~= "\\n";
+            break;
+        default:
+            o ~= c;
+        }
+    }
+    o ~= '"';
+    return o[];
+}

--- a/libs/syntax/bench/render/results/2026-07-13-petar-kirov-minisforum-bd790i0-se-002-native.json
+++ b/libs/syntax/bench/render/results/2026-07-13-petar-kirov-minisforum-bd790i0-se-002-native.json
@@ -1,0 +1,443 @@
+{
+  "columns": [
+    {
+      "class": "quantitative",
+      "format": "count",
+      "header": "B/s",
+      "name": "B/s",
+      "source": "client"
+    },
+    {
+      "class": "quantitative",
+      "format": "count",
+      "header": "B",
+      "name": "B",
+      "source": "client"
+    }
+  ],
+  "meta": {
+    "arch": "x86_64",
+    "compiler": "LDC (front-end 2.111)",
+    "cpu": "AMD Ryzen 9 7940HX with Radeon Graphics",
+    "date": "2026-07-13",
+    "hostname": "petar-kirov-minisforum-bd790i0-se-002",
+    "minSampleTimeMs": 5,
+    "os": "linux",
+    "sampleCount": 32
+  },
+  "rows": [
+    {
+      "deviationNs": 802,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "off",
+        "lang": "d",
+        "size": "24l"
+      },
+      "maxNs": 20159,
+      "medianNs": 5280,
+      "metrics": {
+        "B": 2269,
+        "B/s": 190530000.0
+      },
+      "minNs": 4419,
+      "name": "ansi",
+      "samples": 923
+    },
+    {
+      "deviationNs": 30,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "on",
+        "lang": "d",
+        "size": "24l"
+      },
+      "maxNs": 46320,
+      "medianNs": 4989,
+      "metrics": {
+        "B": 2535,
+        "B/s": 201644000.0
+      },
+      "minNs": 4909,
+      "name": "ansi",
+      "samples": 948
+    },
+    {
+      "deviationNs": 1883.5,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "off",
+        "lang": "d",
+        "size": "24l"
+      },
+      "maxNs": 97449,
+      "medianNs": 86768.5,
+      "metrics": {
+        "B": 2103,
+        "B/s": 69564400.0
+      },
+      "minNs": 84134,
+      "name": "ansi-switch",
+      "samples": 58
+    },
+    {
+      "deviationNs": 1593,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "on",
+        "lang": "d",
+        "size": "24l"
+      },
+      "maxNs": 310424,
+      "medianNs": 91543,
+      "metrics": {
+        "B": 2376,
+        "B/s": 65936200.0
+      },
+      "minNs": 87600,
+      "name": "ansi-switch",
+      "samples": 52
+    },
+    {
+      "deviationNs": 50,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "lang": "d",
+        "size": "24l"
+      },
+      "maxNs": 69345,
+      "medianNs": 4569,
+      "metrics": {
+        "B": 3030,
+        "B/s": 220179000.0
+      },
+      "minNs": 4419,
+      "name": "html",
+      "samples": 987
+    },
+    {
+      "deviationNs": 59,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "off",
+        "lang": "d",
+        "size": "40l"
+      },
+      "maxNs": 30780,
+      "medianNs": 11672,
+      "metrics": {
+        "B": 4875,
+        "B/s": 122087000.0
+      },
+      "minNs": 11532,
+      "name": "ansi",
+      "samples": 422
+    },
+    {
+      "deviationNs": 90,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "on",
+        "lang": "d",
+        "size": "40l"
+      },
+      "maxNs": 24658,
+      "medianNs": 12975,
+      "metrics": {
+        "B": 5348,
+        "B/s": 109827000.0
+      },
+      "minNs": 12694,
+      "name": "ansi",
+      "samples": 370
+    },
+    {
+      "deviationNs": 1288,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "off",
+        "lang": "d",
+        "size": "40l"
+      },
+      "maxNs": 238494,
+      "medianNs": 126350,
+      "metrics": {
+        "B": 4466,
+        "B/s": 67668900.0
+      },
+      "minNs": 124742,
+      "name": "ansi-switch",
+      "samples": 38
+    },
+    {
+      "deviationNs": 836,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "on",
+        "lang": "d",
+        "size": "40l"
+      },
+      "maxNs": 326976,
+      "medianNs": 132492,
+      "metrics": {
+        "B": 4956,
+        "B/s": 64532000.0
+      },
+      "minNs": 131085,
+      "name": "ansi-switch",
+      "samples": 36
+    },
+    {
+      "deviationNs": 145.5,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "lang": "d",
+        "size": "40l"
+      },
+      "maxNs": 22835,
+      "medianNs": 10485.5,
+      "metrics": {
+        "B": 6110,
+        "B/s": 135902000.0
+      },
+      "minNs": 10169,
+      "name": "html",
+      "samples": 464
+    },
+    {
+      "deviationNs": 145,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "off",
+        "lang": "d",
+        "size": "51l"
+      },
+      "maxNs": 26080,
+      "medianNs": 16507,
+      "metrics": {
+        "B": 6693,
+        "B/s": 111407000.0
+      },
+      "minNs": 16301,
+      "name": "ansi",
+      "samples": 292
+    },
+    {
+      "deviationNs": 69,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "on",
+        "lang": "d",
+        "size": "51l"
+      },
+      "maxNs": 29317,
+      "medianNs": 17785,
+      "metrics": {
+        "B": 7306,
+        "B/s": 103402000.0
+      },
+      "minNs": 17585,
+      "name": "ansi",
+      "samples": 267
+    },
+    {
+      "deviationNs": 637,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "off",
+        "lang": "d",
+        "size": "51l"
+      },
+      "maxNs": 168157,
+      "medianNs": 155508,
+      "metrics": {
+        "B": 6133,
+        "B/s": 70954500.0
+      },
+      "minNs": 154331,
+      "name": "ansi-switch",
+      "samples": 32
+    },
+    {
+      "deviationNs": 1723,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "on",
+        "lang": "d",
+        "size": "51l"
+      },
+      "maxNs": 217192,
+      "medianNs": 163964,
+      "metrics": {
+        "B": 6769,
+        "B/s": 67295300.0
+      },
+      "minNs": 161805,
+      "name": "ansi-switch",
+      "samples": 32
+    },
+    {
+      "deviationNs": 3426.5,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "lang": "d",
+        "size": "51l"
+      },
+      "maxNs": 33645,
+      "medianNs": 18175.5,
+      "metrics": {
+        "B": 8234,
+        "B/s": 101180000.0
+      },
+      "minNs": 14428,
+      "name": "html",
+      "samples": 282
+    },
+    {
+      "deviationNs": 10450,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "off",
+        "lang": "d",
+        "size": "full"
+      },
+      "maxNs": 761090,
+      "medianNs": 551086,
+      "metrics": {
+        "B": 194051,
+        "B/s": 66312600.0
+      },
+      "minNs": 536433,
+      "name": "ansi",
+      "samples": 32
+    },
+    {
+      "deviationNs": 8486.5,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "on",
+        "lang": "d",
+        "size": "full"
+      },
+      "maxNs": 597623,
+      "medianNs": 582858,
+      "metrics": {
+        "B": 207630,
+        "B/s": 62697900.0
+      },
+      "minNs": 567053,
+      "name": "ansi",
+      "samples": 32
+    },
+    {
+      "deviationNs": 26972,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "off",
+        "lang": "d",
+        "size": "full"
+      },
+      "maxNs": 3415784,
+      "medianNs": 3198350.0,
+      "metrics": {
+        "B": 175601,
+        "B/s": 68555400.0
+      },
+      "minNs": 3101152,
+      "name": "ansi-switch",
+      "samples": 32
+    },
+    {
+      "deviationNs": 21712,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "bg": "on",
+        "lang": "d",
+        "size": "full"
+      },
+      "maxNs": 4415027,
+      "medianNs": 3351043,
+      "metrics": {
+        "B": 189417,
+        "B/s": 65431600.0
+      },
+      "minNs": 3266293,
+      "name": "ansi-switch",
+      "samples": 32
+    },
+    {
+      "deviationNs": 6888,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "lang": "d",
+        "size": "full"
+      },
+      "maxNs": 557474,
+      "medianNs": 531228,
+      "metrics": {
+        "B": 276827,
+        "B/s": 68791500.0
+      },
+      "minNs": 518298,
+      "name": "html",
+      "samples": 32
+    },
+    {
+      "deviationNs": 12094,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "frame": "whole",
+        "lang": "d"
+      },
+      "maxNs": 1003111,
+      "medianNs": 790573,
+      "metrics": {
+        "B": 207630,
+        "B/s": 46224700.0
+      },
+      "minNs": 728066,
+      "name": "app-frame",
+      "samples": 32
+    },
+    {
+      "deviationNs": 2274.5,
+      "error": "",
+      "iterations": 1,
+      "labels": {
+        "frame": "viewport",
+        "lang": "d"
+      },
+      "maxNs": 99824,
+      "medianNs": 68007,
+      "metrics": {
+        "B": 5348,
+        "B/s": 20953700.0
+      },
+      "minNs": 64205,
+      "name": "app-frame",
+      "samples": 72
+    }
+  ],
+  "schema": 2
+}

--- a/libs/syntax/bench/render/src/sparkles/syntax_render_bench/corpus.d
+++ b/libs/syntax/bench/render/src/sparkles/syntax_render_bench/corpus.d
@@ -1,0 +1,64 @@
+/++
+Frozen benchmark corpus + the parse-once setup shared by every case.
+
+The corpus files under `corpus/` are string-imported (deterministic,
+cwd-independent — the test binary's cwd differs from the repo root). Each is a
+real source file; `sized` takes the first `lines` lines to simulate a terminal
+viewport of a given height (the app renders only the visible slice per frame).
+
+`parse` runs the full tree-sitter precise pipeline (grammar from
+$SPARKLES_TS_GRAMMAR_PATH) exactly as `apps/hue` does, returning the cached
+`HighlightEvent[]`. Parsing is done once per case in untimed `setup`; the timed
+body only re-renders that event stream — which is precisely the app's
+theme-switch hot path (parse once, re-render per theme).
++/
+module sparkles.syntax_render_bench.corpus;
+
+import std.array : appender;
+
+import sparkles.syntax.event : HighlightEvent;
+import sparkles.syntax.label : LabelSet;
+import sparkles.syntax.ts.registry : GrammarRegistry, canonicalLanguage;
+import sparkles.syntax.ts.injection : TsConfigCache;
+import sparkles.syntax.ts.highlighter : highlightInjected;
+
+/// One corpus entry: a language tag (canonicalized on use) and its source.
+struct Corpus
+{
+    string lang; /// language tag, e.g. "d", "python", "typescript"
+    string source; /// the full frozen file
+}
+
+/// The frozen corpora, string-imported at compile time.
+immutable Corpus[] corpora = [
+    Corpus("d", import("sample.d")),
+];
+
+/// `corpus` truncated to its first `lines` lines (a viewport slice). `0` =
+/// the whole file.
+string sized(string corpus, size_t lines) @safe pure nothrow
+{
+    if (lines == 0)
+        return corpus;
+    size_t seen = 0;
+    foreach (i, char c; corpus)
+        if (c == '\n' && ++seen == lines)
+            return corpus[0 .. i + 1];
+    return corpus;
+}
+
+/// Parse `source` through the tree-sitter precise pipeline, returning the
+/// highlight-event stream (or a single passthrough span when no grammar is
+/// available). Runs once per case, untimed. `@system` (the highlighter is —
+/// it threads scope pointers through the ImportC boundary) and allocating (the
+/// event buffer, which is the point: the timed body reuses it).
+HighlightEvent[] parse(string lang, string source, LabelSet labels) @system
+{
+    auto events = appender!(HighlightEvent[]);
+    auto registry = GrammarRegistry.fromEnvironment();
+    auto cache = TsConfigCache.create(&registry, labels);
+    auto res = highlightInjected(cache, canonicalLanguage(lang), source, events);
+    if (res.hasError)
+        events ~= HighlightEvent.sourceSpan(0, source.length);
+    return events[];
+}

--- a/libs/syntax/bench/render/src/sparkles/syntax_render_bench/runner.d
+++ b/libs/syntax/bench/render/src/sparkles/syntax_render_bench/runner.d
@@ -1,0 +1,329 @@
+/++
+The `@benchmark` matrix: renderer × viewport-size × background, plus a
+theme-switch scenario.
+
+`name` is the varying dimension compared per row (the renderer / scenario);
+`size`, `bg`, and `lang` are labels (`--group-by=size,bg` gives one table per
+group). Metrics per row: throughput as MB/s of *source* highlighted
+(`Unit("B")` rate — comparable across renderers and against the foreign panel)
+and output bytes per render (`Unit("B")` level — this is what balloons when the
+page background is emitted, so it makes the regression legible).
+
+Cases:
+    - `ansi`        renderAnsi over the cached event stream (one theme). The
+        app's per-frame cost once events are parsed.
+    - `ansi-switch` for each theme in a rotation: resolveTheme + renderAnsi.
+        The interactive theme-switch hot path (what got slow).
+    - `html`        renderHtml over the cached event stream.
+
+The `bg` label toggles `AnsiOptions.emitBackground` — the exact axis the
+background-color feature flips, so baseline-vs-regression is one column.
+
+Subset with $SYNTAX_BENCH_MODES, $SYNTAX_BENCH_SIZES, $SYNTAX_BENCH_LANGS
+(comma lists; empty = all). Parsing (tree-sitter) is untimed setup. Run:
+
+    dub test -b bench --root=libs/syntax/bench/render -- --bench --group-by=size,bg
++/
+module sparkles.syntax_render_bench.runner;
+
+import std.array : Appender;
+
+import sparkles.test_runner.attributes : benchmark;
+import sparkles.test_runner.bench : benchCase, blackBox, Metric, Unit;
+
+import sparkles.syntax.color : ColorDepth;
+import sparkles.syntax.event : HighlightEvent;
+import sparkles.syntax.label : LabelSet;
+import sparkles.syntax.render.ansi : renderAnsi, AnsiOptions;
+import sparkles.syntax.render.html : renderHtml, HtmlOptions, HtmlMode;
+import sparkles.syntax.theme : ResolvedTheme, resolveTheme, Theme;
+import sparkles.syntax.themes : builtinThemes, builtinDark;
+
+import sparkles.syntax_render_bench.corpus : corpora, parse, sized;
+
+// Fixed color tier: the regression shows at any depth, and trueColor is what
+// modern terminals negotiate — pinning it keeps rows comparable and avoids the
+// env-dependent detectColorDepth().
+private enum ColorDepth depth = ColorDepth.trueColor;
+
+private struct SizeSpec
+{
+    size_t lines; // 0 = whole file
+    string label;
+}
+
+// Viewport heights (visible code lines) the app would render per frame, plus
+// the whole file for a steady end-to-end throughput number.
+private immutable SizeSpec[] sizes = [
+    SizeSpec(24, "24l"),
+    SizeSpec(40, "40l"),
+    SizeSpec(51, "51l"),
+    SizeSpec(0, "full"),
+];
+
+// The theme rotation for `ansi-switch` — a representative spread across the
+// builtin set. Missing names are skipped (kept resilient to theme renames).
+private immutable string[] switchThemes = [
+    "catppuccin-mocha", "catppuccin-latte", "dracula", "nord",
+    "gruvbox-dark", "solarized-dark", "tokyo-night", "one-dark",
+];
+
+@("render")
+@benchmark
+@system
+unittest
+{
+    const labels = LabelSet.standard();
+    bool any;
+    foreach (const ref c; corpora)
+    {
+        if (!envAllows("SYNTAX_BENCH_LANGS", c.lang))
+            continue;
+        foreach (const ref sz; sizes)
+        {
+            if (!envAllows("SYNTAX_BENCH_SIZES", sz.label))
+                continue;
+
+            const source = c.source.sized(sz.lines);
+            auto events = parse(c.lang, source, labels);
+
+            if (envAllows("SYNTAX_BENCH_MODES", "ansi"))
+                foreach (bg; [false, true])
+                {
+                    registerAnsi(c.lang, source, events, labels, sz, bg);
+                    any = true;
+                }
+            if (envAllows("SYNTAX_BENCH_MODES", "ansi-switch"))
+            {
+                foreach (bg; [false, true])
+                {
+                    registerSwitch(c.lang, source, events, labels, sz, bg);
+                    any = true;
+                }
+            }
+            if (envAllows("SYNTAX_BENCH_MODES", "html"))
+            {
+                registerHtml(c.lang, source, events, labels, sz);
+                any = true;
+            }
+            // The apps/hue per-frame path, measured both ways on the whole file:
+            // `whole` renders the entire source then slices (the theme-switch
+            // regression); `viewport` slices first (the fix). Only meaningful at
+            // full size, where "whole" ≫ "viewport".
+            if (sz.lines == 0 && envAllows("SYNTAX_BENCH_MODES", "app-frame"))
+            {
+                foreach (viewport; [false, true])
+                    registerAppFrame(c.lang, source, events, labels, viewport);
+                any = true;
+            }
+        }
+    }
+    if (!any)
+        benchCase(name: "(filtered out)", timed: () {}, after: () {});
+}
+
+// --- ansi: render cached events with one resolved theme --------------------
+
+private void registerAnsi(string lang, string source, HighlightEvent[] events,
+    LabelSet labels, in SizeSpec sz, bool bg)
+{
+    static struct St
+    {
+        string source;
+        HighlightEvent[] events;
+        ResolvedTheme theme;
+        AnsiOptions opts;
+        Appender!(char[]) sink;
+    }
+
+    auto st = new St;
+    st.source = source;
+    st.events = events;
+    st.theme = resolveNamed("catppuccin-mocha", labels);
+    st.opts = AnsiOptions(depth: depth, italics: true, emitBackground: bg);
+
+    const outBytes = renderedAnsiBytes(source, events, st.theme, st.opts);
+
+    benchCase(
+        name: "ansi",
+        timed: () {
+        st.sink.clear();
+        renderAnsi(st.source, st.events, st.theme, st.sink, st.opts);
+        blackBox(st.sink.data.length);
+    },
+        after: () {},
+        metrics: throughput(source.length, outBytes),
+        labels: ["lang": lang, "size": sz.label, "bg": bg ? "on" : "off"],
+    );
+}
+
+// --- ansi-switch: resolve + render, rotating themes (the hot path) ---------
+
+private void registerSwitch(string lang, string source, HighlightEvent[] events,
+    LabelSet labels, in SizeSpec sz, bool bg)
+{
+    static struct St
+    {
+        string source;
+        HighlightEvent[] events;
+        LabelSet labels;
+        immutable(Theme)*[] themes;
+        AnsiOptions opts;
+        Appender!(char[]) sink;
+    }
+
+    auto st = new St;
+    st.source = source;
+    st.events = events;
+    st.labels = labels;
+    st.opts = AnsiOptions(depth: depth, italics: true, emitBackground: bg);
+    foreach (n; switchThemes)
+        if (auto t = n in builtinThemes)
+            st.themes ~= t;
+    if (st.themes.length == 0)
+        st.themes ~= &builtinDark;
+
+    // Output bytes for the level metric: average across the rotation.
+    size_t total;
+    foreach (t; st.themes)
+        total += renderedAnsiBytes(source, events, resolveTheme(*t, labels), st.opts);
+    const outBytes = total / st.themes.length;
+
+    benchCase(
+        name: "ansi-switch",
+        timed: () {
+        foreach (t; st.themes)
+        {
+            // Exactly the app's per-frame work: re-resolve the theme, then
+            // render the cached events into a reused buffer.
+            const resolved = resolveTheme(*t, st.labels);
+            st.sink.clear();
+            renderAnsi(st.source, st.events, resolved, st.sink, st.opts);
+            blackBox(st.sink.data.length);
+        }
+    },
+        after: () {},
+        // Work per iteration = the whole rotation, so the rate is themes-worth
+        // of source bytes per second.
+        metrics: throughput(source.length * st.themes.length, outBytes),
+        labels: ["lang": lang, "size": sz.label, "bg": bg ? "on" : "off"],
+    );
+}
+
+// --- html: render cached events --------------------------------------------
+
+private void registerHtml(string lang, string source, HighlightEvent[] events,
+    LabelSet labels, in SizeSpec sz)
+{
+    static struct St
+    {
+        string source;
+        HighlightEvent[] events;
+        ResolvedTheme theme;
+        HtmlOptions opts;
+        Appender!(char[]) sink;
+    }
+
+    auto st = new St;
+    st.source = source;
+    st.events = events;
+    st.theme = resolveNamed("catppuccin-mocha", labels);
+    st.opts = HtmlOptions(mode: HtmlMode.cssClasses);
+
+    Appender!(char[]) probe;
+    renderHtml(source, events, st.theme, probe, st.opts);
+    const outBytes = probe.data.length;
+
+    benchCase(
+        name: "html",
+        timed: () {
+        st.sink.clear();
+        renderHtml(st.source, st.events, st.theme, st.sink, st.opts);
+        blackBox(st.sink.data.length);
+    },
+        after: () {},
+        metrics: throughput(source.length, outBytes),
+        labels: ["lang": lang, "size": sz.label],
+    );
+}
+
+// --- app-frame: the apps/hue per-frame path (render + idup + splitLines) ----
+
+private void registerAppFrame(string lang, string source, HighlightEvent[] events,
+    LabelSet labels, bool viewport)
+{
+    import std.string : splitLines;
+
+    static struct St
+    {
+        string source;
+        HighlightEvent[] events;
+        ResolvedTheme theme;
+        AnsiOptions opts;
+        Appender!(char[]) sink;
+    }
+
+    enum size_t viewportLines = 40; // a typical terminal height
+
+    auto st = new St;
+    // `viewport` slices to the visible lines first (the fix); `whole` renders
+    // the entire file then would slice (the regression). Events stay the full
+    // stream either way — renderAnsi clamps spans to the source length, exactly
+    // as the app does with its parse-once event buffer.
+    st.source = viewport ? source.sized(viewportLines) : source;
+    st.events = events;
+    st.theme = resolveNamed("catppuccin-mocha", labels);
+    st.opts = AnsiOptions(depth: depth, italics: true, emitBackground: true);
+
+    const outBytes = renderedAnsiBytes(st.source, events, st.theme, st.opts);
+
+    benchCase(
+        name: "app-frame",
+        timed: () {
+        st.sink.clear();
+        renderAnsi(st.source, st.events, st.theme, st.sink, st.opts);
+        // The app copies the render out and splits it into lines every frame —
+        // both are GC allocations the viewport fix shrinks by the same factor.
+        auto rendered = st.sink.data.idup;
+        auto lines = rendered.splitLines();
+        blackBox(lines.length);
+    },
+        after: () {},
+        metrics: throughput(st.source.length, outBytes),
+        labels: ["lang": lang, "frame": viewport ? "viewport" : "whole"],
+    );
+}
+
+// --- helpers ---------------------------------------------------------------
+
+private Metric[] throughput(size_t sourceBytes, size_t outBytes) @safe pure nothrow
+{
+    return [
+        Metric(unit: Unit("B"), amount: cast(double) sourceBytes, mode: Metric.Mode.rate),
+        Metric(unit: Unit("B"), amount: cast(double) outBytes, mode: Metric.Mode.level),
+    ];
+}
+
+private size_t renderedAnsiBytes(string source, HighlightEvent[] events,
+    in ResolvedTheme theme, in AnsiOptions opts) @safe
+{
+    Appender!(char[]) probe;
+    renderAnsi(source, events, theme, probe, opts);
+    return probe.data.length;
+}
+
+private ResolvedTheme resolveNamed(string name, LabelSet labels) @safe nothrow
+{
+    if (auto t = name in builtinThemes)
+        return resolveTheme(*t, labels);
+    return resolveTheme(builtinDark, labels);
+}
+
+private bool envAllows(string var, string name) @safe
+{
+    import std.algorithm : canFind, splitter;
+    import std.process : environment;
+
+    const v = environment.get(var, "");
+    return v.length == 0 || v.splitter(',').canFind(name);
+}

--- a/libs/syntax/examples/highlight-file.d
+++ b/libs/syntax/examples/highlight-file.d
@@ -12,16 +12,21 @@
 // the program degrades to plain text — the totality law in action.
 //
 // Usage: highlight-file [--html] [--theme <theme>] [path] (defaults to this file itself)
+//   Interactive TUI (tty, no --html): ↑/↓ to switch themes live; any other key quits.
 
 module highlight_file;
 
 import std.array : appender;
 import std.file : exists, readText;
 import std.path : baseName, extension;
-import std.stdio : stderr, write, writeln;
+import std.stdio : stderr, write, writef, writeln;
 
 import sparkles.syntax;
 import sparkles.core_cli.args;
+
+import sparkles.base.term_control : CtlSeq;
+import sparkles.core_cli.key_input : Key, stdioKeySession;
+import sparkles.core_cli.term_caps : isTerminal, StdStream, terminalSize;
 
 struct CliParams
 {
@@ -45,19 +50,8 @@ int main(string[] args)
     bool html = cli.html;
     string themeName = cli.theme;
 
-    string sourcePath;
-    string source;
-    if (args.length > 1) {
-        sourcePath = args[1];
-        source = readText(sourcePath);
-    } else {
-        sourcePath = __FILE_FULL_PATH__;
-        if (sourcePath.exists) {
-            source = readText(sourcePath);
-        } else {
-            // Fallback for packaged runs (e.g. nix run-all-examples) where the
-            // compile-time source path is not present at runtime.
-            source = q{
+    string sourcePath = args.length > 1 ? args[1] : __FILE_FULL_PATH__;
+    string source = (args.length > 1 || sourcePath.exists) ? readText(sourcePath) : q{
 module sample;
 
 import std.stdio : writeln;
@@ -70,64 +64,138 @@ void main()
         writeln("positive");
 }
 };
-            sourcePath = "sample.d";
-        }
-    }
+    sourcePath = (args.length <= 1 && !sourcePath.exists) ? "sample.d" : sourcePath;
     const lang = canonicalLanguage(sourcePath.extension.length ? sourcePath.extension[1 .. $] : "");
 
     const labels = LabelSet.standard();
 
-    const(Theme)* themeVal = &builtinDark;
-    if (auto t = themeName in builtinThemes)
-    {
-        themeVal = t;
-    }
-    else
-    {
-        stderr.writef("Warning: theme '%s' not found. Falling back to default dark theme.\n", themeName);
-    }
+    auto t = themeName in builtinThemes;
+    if (!t) stderr.writef("Warning: theme '%s' not found. Falling back to default dark theme.\n", themeName);
+    const(Theme)* themeVal = t ? t : &builtinDark;
     const theme = resolveTheme(*themeVal, labels);
 
-    // Engine side: any failure falls back to plain text.
+    // Engine side: any failure falls back to plain text. Use the injection-aware
+    // path so that markdown (and other languages with injections.scm) get their
+    // fenced code blocks / inline content highlighted by nested grammars.
     auto events = appender!(HighlightEvent[]);
     auto registry = GrammarRegistry.fromEnvironment();
+    auto cache = TsConfigCache.create(&registry, labels);
 
-    bool highlighted = false;
-    auto grammar = registry.grammar(lang);
-    auto queryText = registry.queryText(lang);
-    if (!grammar.hasError && !queryText.hasError)
-    {
-        TsError error;
-        auto config = TsHighlightConfig.create(grammar.value, queryText.value, error);
-        if (!error)
-        {
-            config.configure(labels);
-            highlighted = !highlight(config, source, events).hasError;
-        }
-    }
-    if (!highlighted)
+    auto res = highlightInjected(cache, lang, source, events);
+    if (res.hasError)
     {
         stderr.writeln("note: no grammar for '", lang, "' — plain text");
         events ~= HighlightEvent.sourceSpan(0, source.length);
     }
 
-    auto output = appender!string;
-    if (html)
+    const interactive = !html &&
+        isTerminal(StdStream.stdin) && isTerminal(StdStream.stdout);
+
+    if (!interactive)
     {
-        import std.format : format;
-        string bgStr = theme.defaults.bg.isSet ? format("background: #%02x%02x%02x;", theme.defaults.bg.rgb.r, theme.defaults.bg.rgb.g, theme.defaults.bg.rgb.b) : "";
-        string fgStr = theme.defaults.fg.isSet ? format("color: #%02x%02x%02x;", theme.defaults.fg.rgb.r, theme.defaults.fg.rgb.g, theme.defaults.fg.rgb.b) : "";
-        output ~= format("<style>\npre { %s %s padding: 1em; }\n", bgStr, fgStr);
-        writeThemeStylesheet(theme, output);
-        output ~= "</style>\n<pre><code>";
-        renderHtml(source, events[], theme, output,
-            HtmlOptions(mode: HtmlMode.cssClasses));
-        output ~= "</code></pre>\n";
+        auto output = appender!string;
+        if (html)
+        {
+            import std.format : format;
+            string bgStr = theme.defaults.bg.isSet ? format("background: #%02x%02x%02x;", theme.defaults.bg.rgb.r, theme.defaults.bg.rgb.g, theme.defaults.bg.rgb.b) : "";
+            string fgStr = theme.defaults.fg.isSet ? format("color: #%02x%02x%02x;", theme.defaults.fg.rgb.r, theme.defaults.fg.rgb.g, theme.defaults.fg.rgb.b) : "";
+            output ~= format("<style>\npre { %s %s padding: 1em; }\n", bgStr, fgStr);
+            writeThemeStylesheet(theme, output);
+            output ~= "</style>\n<pre><code>";
+            renderHtml(source, events[], theme, output,
+                HtmlOptions(mode: HtmlMode.cssClasses));
+            output ~= "</code></pre>\n";
+        }
+        else
+            renderAnsi(source, events[], theme, output,
+                AnsiOptions(depth: detectColorDepth(), italics: true));
+
+        write(output[]);
+        return 0;
     }
-    else
+
+    string[] names = builtinThemes.keys.dup;
+    import std.algorithm.sorting : sort;
+    sort(names);
+
+    size_t idx = 0;
+    foreach (i, n; names) if (n == themeName) { idx = i; break; }
+
+    auto sessFactory = stdioKeySession();
+    if (sessFactory is null)
+    {
+        auto output = appender!string;
         renderAnsi(source, events[], theme, output,
             AnsiOptions(depth: detectColorDepth(), italics: true));
+        write(output[]);
+        return 0;
+    }
+    auto sess = sessFactory();
+    scope (exit) sess.finish();
 
-    write(output[]);
+    write(CtlSeq.enterAltScreen);
+    write(CtlSeq.hideCursor);
+    scope (exit)
+    {
+        write(CtlSeq.showCursor);
+        write(CtlSeq.exitAltScreen);
+    }
+
+    string lastRendered;
+    while (true)
+    {
+        const cur = names[idx];
+        auto tp = cur in builtinThemes;
+        const(Theme)* thp = tp ? tp : &builtinDark;
+        const resolved = resolveTheme(*thp, labels);
+
+        import sparkles.base.smallbuffer : SmallBuffer;
+        SmallBuffer!(char, 8192) buf;
+        renderAnsi(source, events[], resolved, buf,
+            AnsiOptions(depth: detectColorDepth(), italics: true));
+        lastRendered = buf[].idup;
+
+        import std.string : splitLines;
+        import std.algorithm.comparison : min;
+        auto codeLines = lastRendered.splitLines();
+        const sz = terminalSize();
+        const reserved = 9u;
+        const maxCode = (sz.height > reserved) ? sz.height - reserved : 10;
+        auto view = codeLines.length > maxCode ? codeLines[0 .. maxCode] : codeLines;
+
+        write(CtlSeq.syncBegin);
+        write(CtlSeq.eraseDisplay);
+        write(CtlSeq.cursorHome);
+
+        writef(" %s  —  %s (%d/%d)\n", baseName(sourcePath), cur, idx + 1, names.length);
+        write(" ↑/↓ switch   any other key quits\n");
+        const sepLen = sz.width ? min(60, sz.width) : 60;
+        foreach (_; 0 .. sepLen) write('─');
+        write('\n');
+
+        foreach (l; view) write(l, "\n");
+
+        foreach (_; 0 .. sepLen) write('─');
+        write('\n');
+
+        enum win = 7;
+        size_t vs = (idx < win / 2) ? 0 : idx - win / 2;
+        vs = (vs + win > names.length) ? (names.length > win ? names.length - win : 0) : vs;
+        foreach (i; vs .. (vs + win > names.length ? names.length : vs + win))
+            write(i == idx ? "❯ " : "  ", names[i], "\n");
+
+        write(CtlSeq.syncEnd);
+
+        final switch (sess.next())
+        {
+            case Key.up:   idx = (idx == 0) ? names.length - 1 : idx - 1; break;
+            case Key.down: idx = (idx + 1 == names.length) ? 0 : idx + 1; break;
+            case Key.enter, Key.cancel, Key.other:
+                goto done;
+        }
+    }
+done:;
+
+    write(lastRendered);
     return 0;
 }

--- a/libs/syntax/src/sparkles/syntax/render/ansi.d
+++ b/libs/syntax/src/sparkles/syntax/render/ansi.d
@@ -37,8 +37,10 @@ struct AnsiOptions
     /// Color tier to emit. `none` = verbatim passthrough.
     ColorDepth depth = ColorDepth.ansi256;
 
-    /// Emit per-run theme backgrounds. Off by default: respect the
-    /// terminal's own background.
+    /// Emit per-run theme backgrounds — including the theme's page
+    /// background (`ResolvedTheme.defaults.bg`) for runs whose own rule
+    /// styles fg only. Off by default: respect the terminal's own
+    /// background.
     bool emitBackground = false;
 
     /// Emit italics. Off by default (bat's defensive gate — some terminals
@@ -89,6 +91,12 @@ if (isHighlightEventRange!Events)
             spec.font = cast(FontStyle)(spec.font & ~FontStyle.italic);
         if (!options.emitBackground)
             spec.bg = Color.init;
+        else if (!spec.bg.isSet)
+            // Most rules style fg only. Unlike HTML's `<pre>` container,
+            // ANSI has no background inheritance, so without this an unset
+            // per-span bg would render as the terminal's own default (`49`)
+            // instead of the theme's page background showing through.
+            spec.bg = theme.defaults.bg;
 
         // Defensive clamp: a misbehaving producer must not crash a renderer.
         const lo = min(span.start, source.length);
@@ -289,6 +297,7 @@ version (unittest)
     {
         const theme = Theme(
             name: "test",
+            defaultBg: Color.fromPalette(235), // page background; only consulted with emitBackground
             rules: [
                 ThemeRule("keyword", StyleSpec(
                     fg: Color.fromRgb(0xcb, 0xa6, 0xf7), font: FontStyle.bold)),
@@ -344,6 +353,34 @@ unittest
     // none: verbatim passthrough
     checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
         AnsiOptions(depth: ColorDepth.none)))(source);
+}
+
+@("render.ansi.emitBackgroundFallsBackToPageBackground")
+@safe pure nothrow
+unittest
+{
+    const resolved = testTheme();
+    alias E = HighlightEvent;
+    const source = "if x";
+    const events = [
+        E.pushLabel(lbl("keyword")),
+        E.sourceSpan(0, 2), // "if" — the keyword rule styles fg only
+        E.popLabel(),
+        E.sourceSpan(2, 4), // " x" — unlabeled gap
+    ];
+
+    // "if" has no rule-specified background, but still picks up the theme's
+    // page background (48;5;235) instead of resetting to the terminal
+    // default; the unlabeled gap already carried it via `defaults`, so no
+    // redundant background code is re-emitted when the run changes.
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.ansi256, emitBackground: true)))(
+        "\x1b[1;38;5;183;48;5;235mif\x1b[22;39m x\x1b[0m");
+
+    // emitBackground off (default): no page background leaks in at all.
+    checkWriter!((ref w) => renderAnsi(source, events[], resolved, w,
+        AnsiOptions(depth: ColorDepth.ansi256)))(
+        "\x1b[1;38;5;183mif\x1b[0m x");
 }
 
 @("render.ansi.italicsGateAndBackground")

--- a/libs/syntax/src/sparkles/syntax/theme.d
+++ b/libs/syntax/src/sparkles/syntax/theme.d
@@ -84,17 +84,23 @@ struct ResolvedTheme
 }
 
 /**
-Resolves `theme` against `labels`: for every vocabulary name, the longest
-rule selector that is a dot-prefix of the name wins (last rule wins among
-equal selectors); unmatched names get `StyleSpec.init`.
+Resolves `theme` into a caller-provided `styles` buffer (`@nogc`): for every
+vocabulary name, the longest rule selector that is a dot-prefix of the name
+wins (last rule wins among equal selectors); unmatched names get
+`StyleSpec.init`. `styles` must be exactly `labels.length` long and is written
+in full; `defaults` receives the normalized unlabeled-text style.
 
-Configure-time only (allocates the table once). A `defaultFg`/`defaultBg` of
-`Color.defaultColor` is normalized to unset in `defaults` — for a renderer,
-"the terminal default" and "unspecified" both mean "emit nothing".
+Allocation-free — the whole-table resolution logic without the array. A
+`@nogc nothrow` caller (e.g. an interactive previewer re-resolving on each
+theme switch into one reused buffer) can drive this directly; `resolveTheme`
+is the GC-allocating convenience wrapper. A `defaultFg`/`defaultBg` of
+`Color.defaultColor` is normalized to unset — for a renderer, "the terminal
+default" and "unspecified" both mean "emit nothing".
 */
-ResolvedTheme resolveTheme(in Theme theme, LabelSet labels) pure nothrow
+void resolveThemeInto(in Theme theme, LabelSet labels,
+    scope StyleSpec[] styles, out StyleSpec defaults) @safe pure nothrow @nogc
+in (styles.length == labels.length, "styles buffer must match the label vocabulary size")
 {
-    auto styles = new StyleSpec[](labels.length);
     foreach (i; 0 .. labels.length)
     {
         const labelName = labels.name(LabelId(cast(ushort) i));
@@ -113,9 +119,22 @@ ResolvedTheme resolveTheme(in Theme theme, LabelSet labels) pure nothrow
         styles[i] = found ? best : StyleSpec.init;
     }
 
-    const defaults = StyleSpec(
+    defaults = StyleSpec(
         fg: normalizeDefault(theme.defaultFg),
         bg: normalizeDefault(theme.defaultBg));
+}
+
+/**
+Resolves `theme` against `labels` into a freshly allocated `ResolvedTheme`.
+
+Configure-time only (allocates the table once); see $(LREF resolveThemeInto)
+for the `@nogc` caller-buffer variant this delegates to.
+*/
+ResolvedTheme resolveTheme(in Theme theme, LabelSet labels) pure nothrow
+{
+    auto styles = new StyleSpec[](labels.length);
+    StyleSpec defaults;
+    resolveThemeInto(theme, labels, styles, defaults);
     return ResolvedTheme(labels, styles.idup, defaults);
 }
 
@@ -154,6 +173,47 @@ unittest
     const labels = LabelSet.standard();
     const resolved = resolveTheme(theme, labels);
     assert(resolved[labels.find("string")].empty);
+}
+
+@("theme.resolveThemeInto.nogc")
+@safe pure nothrow @nogc
+unittest
+{
+    // Resolves into a stack buffer with no GC — the interactive-previewer path.
+    ThemeRule[1] rules = [ThemeRule("string", StyleSpec(fg: Color.fromPalette(2)))];
+    const theme = Theme(name: "t", defaultFg: Color.fromPalette(7), rules: rules[]);
+    const labels = LabelSet.standard();
+
+    StyleSpec[128] buf = void;
+    assert(labels.length <= buf.length);
+    StyleSpec defaults;
+    resolveThemeInto(theme, labels, buf[0 .. labels.length], defaults);
+
+    assert(buf[labels.find("string").value] == StyleSpec(fg: Color.fromPalette(2)));
+    assert(buf[labels.find("keyword").value] == StyleSpec.init);
+    assert(defaults.fg == Color.fromPalette(7));
+}
+
+@("theme.resolveThemeInto.matchesWrapper")
+@safe pure nothrow
+unittest
+{
+    // The caller-buffer path is identical to the GC wrapper, entry for entry.
+    const theme = Theme(name: "t", defaultBg: Color.fromPalette(235), rules: [
+        ThemeRule("string", StyleSpec(fg: Color.fromPalette(2))),
+        ThemeRule("string.special", StyleSpec(fg: Color.fromPalette(5))),
+        ThemeRule("comment", StyleSpec(fg: Color.fromPalette(8))),
+    ]);
+    const labels = LabelSet.standard();
+    const wrapped = resolveTheme(theme, labels);
+
+    auto buf = new StyleSpec[](labels.length);
+    StyleSpec defaults;
+    resolveThemeInto(theme, labels, buf, defaults);
+
+    foreach (i; 0 .. labels.length)
+        assert(buf[i] == wrapped.styles[i]);
+    assert(defaults == wrapped.defaults);
 }
 
 @("theme.StyleSpec.empty")

--- a/nix/packages/hue.nix
+++ b/nix/packages/hue.nix
@@ -1,0 +1,110 @@
+# `hue` — the interactive syntax-highlighting viewer / live theme previewer
+# (apps/hue), packaged for `nix run .#hue`. Built like the example derivations
+# (pkg-config + tree-sitter for the ImportC surface dub#3085 feeds to
+# `sparkles:syntax`), then wrapped so the tree-sitter grammar bundle is found
+# at runtime without the devshell: `sparkles:tree-sitter` dlopen()s grammars
+# from $SPARKLES_TS_GRAMMAR_PATH, so bake the `ts-grammars` linkFarm in.
+{ lib, ... }:
+{
+  perSystem =
+    { config, pkgs, ... }:
+    let
+      fs = lib.fileset;
+      root = ../..;
+      fromRoot = lib.path.append root;
+
+      isDubManifest =
+        file:
+        builtins.elem file.name [
+          "dub.sdl"
+          "dub.selections.json"
+        ];
+
+      src = fs.toSource {
+        inherit root;
+        fileset = fs.unions (
+          [
+            # Dub validates every sub-package declared in the root dub.sdl, so
+            # all sibling manifests must be present even when building only :hue.
+            (fs.fileFilter isDubManifest root)
+          ]
+          # hue's own sources plus the library closure it links against:
+          # syntax → {base, tree-sitter}; core-cli → {base, math}; and the impl
+          # runner sources base/core-cli import the `@…` attributes from
+          # unconditionally. `.c`/`.i` come along for the tree-sitter ImportC shim.
+          ++
+            map
+              (path: fs.fileFilter (file: file.hasExt "d" || file.hasExt "c" || file.hasExt "i") (fromRoot path))
+              [
+                "apps/hue/src"
+                "libs/base/src"
+                "libs/core-cli/src"
+                "libs/math/src"
+                "libs/syntax/src"
+                "libs/tree-sitter/src"
+                "libs/test-runner/src"
+                "libs/test-runner-impl/src"
+              ]
+        );
+      };
+    in
+    {
+      packages.hue = pkgs.buildDubPackage (finalAttrs: {
+        pname = "hue";
+        version = "0.1.0";
+
+        inherit src;
+        sourceRoot = "${finalAttrs.src.name}/apps/${finalAttrs.pname}";
+
+        # Shared with `ci`/`release` and the example derivations (./examples.nix).
+        dubLock = fromRoot "nix/dub-lock.json";
+        compiler = pkgs.ldc;
+
+        # pkg-config + the C library so dub#3085 feeds -P-I… to ImportC for
+        # <tree_sitter/api.h>; makeWrapper to inject the grammar bundle.
+        nativeBuildInputs = [
+          pkgs.pkg-config
+          pkgs.makeWrapper
+        ];
+        buildInputs = [ pkgs.tree-sitter ];
+
+        preBuild = ''chmod -R u+w "$NIX_BUILD_TOP"'';
+
+        # Phobos bakes store paths that must not leak into the runtime closure:
+        # ldc's separate `include` output (assert/`__FILE__` strings), the
+        # nixpkgs libcurl dlopen path, and tzdata — none reached at runtime. Same
+        # discipline as the example derivations (./examples.nix) and `release`.
+        disallowedReferences = [
+          pkgs.ldc
+          pkgs.ldc.include
+          pkgs.curl.out
+          pkgs.tzdata
+        ];
+
+        installPhase = ''
+          install -Dm755 build/${finalAttrs.pname} $out/bin/${finalAttrs.pname}
+        '';
+
+        # postFixup (after buildDubPackage's preFixup scrub): strip the baked
+        # phobos service paths, then wrap so grammars resolve outside the
+        # devshell. $SPARKLES_TS_GRAMMAR_PATH is only a *default* — a caller who
+        # exports their own still wins (--set-default).
+        postFixup = ''
+          find "$out" -type f -exec remove-references-to \
+            -t ${pkgs.ldc.include} -t ${pkgs.curl.out} -t ${pkgs.tzdata} '{}' +
+          wrapProgram $out/bin/${finalAttrs.pname} \
+            --set-default SPARKLES_TS_GRAMMAR_PATH ${config.packages.ts-grammars}
+        '';
+
+        meta = {
+          description = "Interactive syntax-highlighting viewer and live theme previewer";
+          mainProgram = finalAttrs.pname;
+        };
+      });
+
+      apps.hue = {
+        type = "app";
+        program = lib.getExe config.packages.hue;
+      };
+    };
+}

--- a/nix/packages/shiki-cli/cli.mjs
+++ b/nix/packages/shiki-cli/cli.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Tiny CLI over shiki's codeToHtml for the sparkles:syntax foreign benchmark
+// panel. Reads a source file + language from argv and prints highlighted HTML
+// to stdout — the end-to-end path (process startup + WASM oniguruma load +
+// TextMate tokenize + HTML render) the foreign benchmark measures.
+//
+//   shiki-html <file> <lang> [theme]
+//
+// Exit codes:
+//   0  success (HTML on stdout)
+//   2  unsupported language (stderr note) — the D runner skips such pairs
+//   1  any other error
+import { readFile } from 'node:fs/promises';
+import { codeToHtml, bundledLanguages } from 'shiki';
+
+async function main() {
+  const [, , file, lang, theme = 'catppuccin-mocha'] = process.argv;
+  if (!file || !lang) {
+    process.stderr.write('usage: shiki-html <file> <lang> [theme]\n');
+    process.exit(1);
+  }
+  if (!(lang in bundledLanguages)) {
+    process.stderr.write(`shiki: unsupported language '${lang}'\n`);
+    process.exit(2);
+  }
+  const code = await readFile(file, 'utf8');
+  const html = await codeToHtml(code, { lang, theme });
+  process.stdout.write(html);
+}
+
+main().catch(err => {
+  process.stderr.write(String(err?.stack ?? err) + '\n');
+  process.exit(1);
+});

--- a/nix/packages/shiki-cli/package-lock.json
+++ b/nix/packages/shiki-cli/package-lock.json
@@ -1,0 +1,544 @@
+{
+  "name": "shiki-html-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shiki-html-cli",
+      "version": "0.1.0",
+      "license": "BSL-1.0",
+      "dependencies": {
+        "shiki": "1.29.2"
+      },
+      "bin": {
+        "shiki-html": "cli.mjs"
+      }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
+      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
+      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "oniguruma-to-es": "^2.2.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
+      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
+      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
+      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
+      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
+      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^5.1.1",
+        "regex-recursion": "^5.1.1"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
+      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
+      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
+      "license": "MIT",
+      "dependencies": {
+        "regex": "^5.1.1",
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/shiki": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
+      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "1.29.2",
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/langs": "1.29.2",
+        "@shikijs/themes": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/nix/packages/shiki-cli/package.json
+++ b/nix/packages/shiki-cli/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "shiki-html-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Tiny CLI over shiki's codeToHtml for the sparkles:syntax foreign benchmark panel",
+  "license": "BSL-1.0",
+  "type": "module",
+  "bin": {
+    "shiki-html": "cli.mjs"
+  },
+  "dependencies": {
+    "shiki": "1.29.2"
+  }
+}

--- a/nix/packages/syntax-foreign.nix
+++ b/nix/packages/syntax-foreign.nix
@@ -1,0 +1,66 @@
+# Nix-pinned foreign syntax-highlighter panel for the sparkles:syntax render
+# benchmark (libs/syntax/bench/render/foreign). Four other highlighters run the
+# same corpus end-to-end so we can place our ANSI/HTML renderers against them:
+#
+#   bat        (syntect / Sublime-syntax)      ANSI only         — pkgs.bat
+#   chroma     (Go, Pygments-derived)          ANSI + HTML       — pkgs.chroma
+#   pygmentize (Pygments)                       ANSI + HTML       — pkgs.python3Packages.pygments
+#   shiki-html (TextMate / VS Code grammars)   HTML only         — buildNpmPackage below
+#
+# The first three are stock nixpkgs binaries; only shiki needs real packaging.
+# It is a tiny Node CLI (nix/packages/shiki-cli) over `codeToHtml`, built from a
+# checked-in package-lock.json so the whole grammar/theme set is pinned.
+#
+# Everything is collected into a single `packages.syntax-foreign` linkFarm whose
+# bin/ holds runnable wrappers: `bat`, `chroma`, `pygmentize`, `shiki-html`. The
+# D foreign runner discovers them via $SYNTAX_FOREIGN (the linkFarm's bin dir)
+# or an explicit path argument.
+{ lib, ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    let
+      # The shiki CLI: `shiki-html <file> <lang> [theme]` → HTML on stdout.
+      shiki-cli = pkgs.buildNpmPackage {
+        pname = "shiki-html-cli";
+        version = "0.1.0";
+        src = lib.fileset.toSource {
+          root = ./shiki-cli;
+          fileset = lib.fileset.unions [
+            ./shiki-cli/package.json
+            ./shiki-cli/package-lock.json
+            ./shiki-cli/cli.mjs
+          ];
+        };
+        npmDepsHash = "sha256-ZYgonGJURpRQ2Q+wKdlnkbkWy1JtAnPnztfZg55MFHA=";
+        # Pure-JS package: nothing to compile, and there is no build script.
+        dontNpmBuild = true;
+        meta.mainProgram = "shiki-html";
+      };
+
+      pygments = pkgs.python3Packages.pygments;
+    in
+    {
+      packages.syntax-foreign = pkgs.linkFarm "syntax-foreign" [
+        {
+          name = "bin/bat";
+          path = lib.getExe pkgs.bat;
+        }
+        {
+          name = "bin/chroma";
+          path = lib.getExe pkgs.chroma;
+        }
+        {
+          name = "bin/pygmentize";
+          path = "${pygments}/bin/pygmentize";
+        }
+        {
+          name = "bin/shiki-html";
+          path = lib.getExe shiki-cli;
+        }
+      ];
+
+      # Also expose shiki on its own so it can be built/debugged in isolation.
+      packages.syntax-foreign-shiki = shiki-cli;
+    };
+}


### PR DESCRIPTION
Stacked on #109 (the `apps/hue` interactive previewer). Split out of that PR so
the app work stays reviewable on its own.

## What

A benchmark for `sparkles:syntax`'s render backends, plus a Nix-pinned foreign
comparison panel.

1. **`feat(syntax/bench/render)` — harness.** A `sparkles:test-runner`
   `@benchmark` matrix over `renderAnsi`/`renderHtml`: renderer × viewport-size ×
   page-background, an `ansi-switch` theme-rotation case (the live-previewer hot
   path), and an `app-frame` case that pins the whole-file-vs-viewport render fix
   (785µs → 69µs per frame). Parsing is untimed setup; the timed body re-renders
   a cached event stream. Throughput as MB/s of source highlighted. Frozen
   ~1k-line D corpus, string-imported. Mirrors `libs/tui/bench/render`.

2. **`feat(syntax/bench/render)` — foreign panel.** bat (syntect), chroma,
   pygments, and shiki (packaged from a pinned `package-lock` via
   `buildNpmPackage`; it even bundles a D grammar) run the same corpus
   end-to-end via a pure-Phobos D runner (`nix build .#syntax-foreign`). These
   are end-to-end wall-clock numbers (spawn + parse + render) — comparable among
   the foreign tools and to our own end-to-end path, NOT to the in-process
   per-render rows. Foreign tools cluster at 0.2–1.4 MB/s; our in-process
   renderers do 60–140 MB/s. Adds representative BSL Python + TypeScript corpus
   files and records native + foreign result snapshots.

## Running

```sh
dub test -b bench --root=libs/syntax/bench/render -- --bench --group-by=size
nix build .#syntax-foreign && SYNTAX_FOREIGN=$PWD/result/bin \
    dub run --root=libs/syntax/bench/render/foreign
```

> Merge #109 first; GitHub will retarget this PR to `main` automatically.