### PR TITLE
feat(ci): add --ci-stats GitHub Actions usage-statistics subcommand

### DIFF
--- a/apps/ci/dub.sdl
+++ b/apps/ci/dub.sdl
@@ -13,3 +13,5 @@ dflags "-preview=in" "-preview=dip1000"
 
 dependency "sparkles:base" path="../.."
 dependency "sparkles:core-cli" path="../.."
+dependency "expected" version="~>0.4.1"
+dependency "sparkles:wired" path="../.."

--- a/apps/ci/dub.selections.json
+++ b/apps/ci/dub.selections.json
@@ -1,7 +1,9 @@
 {
 	"fileVersion": 1,
 	"versions": {
+		"bolts": "1.3.1",
 		"expected": "0.4.1",
+		"optional": "1.3.1",
 		"silly": "1.1.1"
 	}
 }

--- a/apps/ci/src/app.d
+++ b/apps/ci/src/app.d
@@ -176,6 +176,35 @@ struct CliParams
 
     @CliOption(`check-vcs-urls`, "Check tracked markdown files (or specified files) for github.com and raw.githubusercontent.com URLs, ensuring they reference a specific git commit.")
     bool checkVcsUrls;
+
+    @CliOption(`C|ci-stats`,
+        "Compute GitHub Actions CI job timing statistics and runner-type aggregates. "
+        ~ "See docs/specs/ci/stats/ for the full specification.")
+    bool ciStats;
+
+    @CliOption(`g|github-token`,
+        "GitHub token for API access (Bearer auth). Falls back to $GITHUB_TOKEN.")
+    string githubToken;
+
+    @CliOption(`r|repo`,
+        "Target repository as owner/repo (e.g. PetarKirov/sparkles).")
+    string repo;
+
+    @CliOption(`l|limit`,
+        "Maximum number of recent workflow runs to analyze (default 100).")
+    int limit = 100;
+
+    @CliOption(`S|since`,
+        "Only include runs created on/after this date (YYYY-MM-DD or ISO).")
+    string since;
+
+    @CliOption(`w|workflow`,
+        "Filter to runs/jobs matching this workflow name or path substring.")
+    string workflow;
+
+    @CliOption(`c|conclusion`,
+        "Only jobs with this conclusion (e.g. success, failure).")
+    string conclusion;
 }
 
 enum ProgramMode
@@ -189,6 +218,7 @@ enum ProgramMode
     fixReferenceLinks,
     checkCommitScope,
     checkVcsUrls,
+    ciStats,
 }
 
 struct Example
@@ -294,6 +324,9 @@ int main(string[] args)
     if (mode == ProgramMode.runDubTests)
         return runDubTestsMode(cli.failFast);
 
+    if (mode == ProgramMode.ciStats)
+        return runCiStatsMode(cli);
+
     auto inputFiles = collectInputFiles(cli, mode);
 
     if (inputFiles.length == 0)
@@ -362,11 +395,18 @@ private string validateCliMode(
     if (cli.test && (cli.dedupReferenceLinks || cli.fixReferenceLinks))
         return "--test cannot be combined with reference deduplication modes (--dedup-reference-links/--fix-reference-links)";
 
-    if (cli.checkCommitScope && (cli.verify || cli.update || cli.exampleFiles || cli.test || cli.dedupReferenceLinks || cli.fixReferenceLinks || cli.checkVcsUrls))
+    if (cli.checkCommitScope && (cli.verify || cli.update || cli.exampleFiles || cli.test || cli.dedupReferenceLinks || cli.fixReferenceLinks || cli.checkVcsUrls || cli.ciStats))
         return "--check-commit-scope cannot be combined with other modes";
 
-    if (cli.checkVcsUrls && (cli.verify || cli.update || cli.exampleFiles || cli.test || cli.dedupReferenceLinks || cli.fixReferenceLinks || cli.checkCommitScope))
+    if (cli.checkVcsUrls && (cli.verify || cli.update || cli.exampleFiles || cli.test || cli.dedupReferenceLinks || cli.fixReferenceLinks || cli.checkCommitScope || cli.ciStats))
         return "--check-vcs-urls cannot be combined with other modes";
+
+    if (cli.ciStats && (cli.verify || cli.update || cli.exampleFiles || cli.test
+            || cli.dedupReferenceLinks || cli.fixReferenceLinks || cli.checkCommitScope || cli.checkVcsUrls))
+        return "--ci-stats cannot be combined with other modes";
+
+    if (cli.ciStats && cli.limit <= 0)
+        return "--limit must be a positive integer";
 
     if (cli.checkCommitScope && positionalArgs.length > 1)
         return "--check-commit-scope accepts at most one argument (a path or '-' for stdin)";
@@ -382,6 +422,9 @@ private string validateCliMode(
 
 private ProgramMode resolveProgramMode(in CliParams cli)
 {
+    if (cli.ciStats)
+        return ProgramMode.ciStats;
+
     if (cli.exampleFiles)
         return ProgramMode.runExampleFiles;
 
@@ -826,6 +869,9 @@ private int runExamplesForFiles(string[] mdFiles, in ProgramMode mode, bool fail
             case ProgramMode.checkCommitScope:
             case ProgramMode.checkVcsUrls:
                 rc = 1;
+                break;
+            case ProgramMode.ciStats:
+                rc = 1;   // handled earlier in main(); should never reach here
                 break;
         }
 
@@ -2528,4 +2574,41 @@ private void displaySummary(size_t total, size_t failures)
             styledText(i"{dim $(passed)/$(total) passed}"),
         ].drawBox(styledText(i"{red Results}")));
     }
+}
+
+// ---------------------------------------------------------------------------
+// ci-stats (GitHub Actions usage) — M1 skeleton; real implementation in M2+
+// (see docs/specs/ci/stats/)
+// ---------------------------------------------------------------------------
+
+private int runCiStatsMode(in CliParams cli)
+{
+    import std.process : environment;
+    import std.stdio : writeln;
+
+    import ci_stats : CiStatsOptions, fetchAndDeserializeJson, runCiStats;
+
+    string token = cli.githubToken;
+    if (token.length == 0)
+        token = environment.get("GITHUB_TOKEN", "");
+
+    auto opts = CiStatsOptions(
+        repo: cli.repo,
+        token: token,
+        limit: cli.limit,
+        since: cli.since,
+        workflowFilter: cli.workflow,
+        conclusionFilter: cli.conclusion,
+    );
+
+    auto res = runCiStats!fetchAndDeserializeJson(opts);
+    if (res.hasError)
+    {
+        import sparkles.base.logger : error;
+        string errMsg = res.error;
+        error(i"ci-stats failed: $(errMsg)");
+        return 1;
+    }
+
+    return 0;
 }

--- a/apps/ci/src/ci_stats.d
+++ b/apps/ci/src/ci_stats.d
@@ -1,0 +1,688 @@
+/++
+`ci --ci-stats` — GitHub Actions CI usage statistics subcommand.
+
+See `docs/specs/ci/stats/SPEC.md` (normative contract) and `PLAN.md` (milestones).
+
+This module owns:
+- Domain data models (`Job`, `JobStats`, `RunnerAggregate` …)
+- The injectable fetch policy (`fetchAndDeserializeJson` seam)
+- Pure statistical pipelines (std.algorithm + std.range only)
+- Rendering (LiveRegion / TaskReporter + drawTable* + SmallBuffer durations)
+
+All non-trivial data transformation after the JSON→domain boundary must be range pipelines.
++/
+module ci_stats;
+
+import std.algorithm.iteration : fold, map, filter;
+import std.algorithm.searching : canFind, minElement, maxElement;
+import std.algorithm.sorting : sort;
+import std.array : array, join;
+import std.conv : to, text;
+import std.datetime : SysTime;
+import std.json : parseJSON;
+import std.net.curl : HTTP;
+import std.range : drop, isInputRange, walkLength, take, ElementType;
+import std.range.primitives : empty, front;
+import std.stdio : writeln;
+import std.string : strip;
+import std.typecons : Nullable, tuple;
+import std.uri : encodeComponent;
+
+import core.time : Duration;
+
+import expected : Expected, ok, err;
+
+import sparkles.base.smallbuffer : SmallBuffer;
+import sparkles.base.styled_template : styledWriteln;
+import sparkles.base.text.writers : writeDuration, writeFixedPoint, writeInteger;
+
+import sparkles.core_cli.term_caps : detectTermCaps;
+import sparkles.core_cli.ui.live : stdoutLiveRegion;
+import sparkles.core_cli.ui.table : drawTable, drawTableLines, TableProps;
+import sparkles.core_cli.ui.tasklist : TaskReporter;
+import sparkles.core_cli.ui.theme : makeTheme, Theme;
+
+import sparkles.wired : fromJSON, WireName;
+
+// ---------------------------------------------------------------------------
+// Result vocabulary (mirrors the release app pattern for consistency)
+// ---------------------------------------------------------------------------
+
+alias Result(T) = Expected!(T, string);
+
+Result!T success(T)(T value) => ok!string(value);
+Result!T failure(T)(string message) => err!T(message);
+
+// ---------------------------------------------------------------------------
+// Domain models (pure, minimal, wired-decodable response models are private)
+// ---------------------------------------------------------------------------
+
+struct Job
+{
+    string name;
+    string workflow;
+    Duration duration;
+    string[] labels;
+    string runnerName;
+    string conclusion;
+}
+
+struct JobStats
+{
+    size_t count;
+    Duration total;
+    Duration min;
+    Duration max;
+    Duration mean;
+    Duration median;
+    Duration p95;
+}
+
+struct RunnerAggregate
+{
+    string runnerType;
+    JobStats stats;
+    // No stored double minutes. "CI minutes" display values are derived from
+    // stats.total at render time (using Duration-based writers or scaled
+    // fixed-point). This keeps all aggregates in Duration.
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API response models (for wired deserialization)
+// ---------------------------------------------------------------------------
+
+struct GhWorkflowRun
+{
+    long id;
+    // GitHub marks `name` nullable (e.g. old or startup-failure runs); a plain
+    // `string` would abort the whole page decode on a null. `path` is always present.
+    Nullable!string name;
+    string path;
+    @WireName("workflow_name") Nullable!string workflowName;
+}
+
+struct GhRunsResponse
+{
+    long total_count;
+    @WireName("workflow_runs") GhWorkflowRun[] workflowRuns;
+}
+
+struct GhJob
+{
+    long id;
+    string name;
+    Nullable!string conclusion;
+    @WireName("started_at") Nullable!string startedAt;
+    @WireName("completed_at") Nullable!string completedAt;
+    string[] labels;
+    @WireName("runner_name") Nullable!string runnerName;
+}
+
+struct GhJobsResponse
+{
+    long total_count;
+    GhJob[] jobs;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch policy (the seam that enables mocking)
+//
+// Real code passes `fetchAndDeserializeJson`.
+// Tests pass a local template that returns pre-built T values directly.
+// ---------------------------------------------------------------------------
+
+/// Signature for a typed fetch+deserialize step.
+/// method is "GET" (REST) or "POST" (GraphQL with body).
+/// Implementations must honour the GitHub required headers and token policy.
+alias FetchJson(T) = Result!T delegate(
+    string url,
+    string method = "GET",
+    string body = null,
+    string[string] extraHeaders = null,
+);
+
+/// Truncate `s` to at most `maxBytes` bytes without splitting a UTF-8 code
+/// point (backs off the cut while it lands on a `0x80–0xBF` continuation byte),
+/// appending an ellipsis when anything was dropped.
+string truncateUtf8(string s, size_t maxBytes) @safe pure nothrow
+{
+    if (s.length <= maxBytes)
+        return s;
+    size_t cut = maxBytes;
+    while (cut > 0 && (s[cut] & 0xC0) == 0x80)
+        --cut;
+    return s[0 .. cut] ~ "…";
+}
+
+/// Production implementation using std.net.curl + wired deserialization.
+/// Supports REST (GET) and GraphQL (POST with JSON body).
+/// Caller must supply Authorization header content if needed (via extraHeaders or separate).
+///
+/// Uses the low-level `HTTP` + `perform` API rather than the free `get`/`post`
+/// functions: those throw `HTTPStatusException` on any non-2xx status *before*
+/// returning content, which would discard GitHub's explanatory error body.
+/// `perform` only throws on transport-level failures (still handled by the catch).
+Result!T fetchAndDeserializeJson(T)(
+    string url,
+    string method = "GET",
+    string body = null,
+    string[string] extraHeaders = null,
+)
+{
+    try
+    {
+        auto http = HTTP(url);
+        http.method = (method == "POST" ? HTTP.Method.post : HTTP.Method.get);
+
+        http.addRequestHeader("Accept", "application/vnd.github+json");
+        http.addRequestHeader("X-GitHub-Api-Version", "2022-11-28");
+        http.addRequestHeader("User-Agent", "sparkles-ci/0.1");
+
+        foreach (k, v; extraHeaders)
+            http.addRequestHeader(k, v);
+
+        if (method == "POST" && body.length)
+            http.setPostData(body, "application/json");
+
+        ubyte[] buf;
+        http.onReceive = (ubyte[] data) { buf ~= data; return data.length; };
+        http.perform();
+
+        const status = http.statusLine.code;
+        string responseText = cast(string) buf;
+        if (status < 200 || status >= 300)
+        {
+            string msg = "GitHub API HTTP " ~ status.to!string ~ ": "
+                ~ truncateUtf8(responseText.strip, 200);
+            // Rate-limit responses carry a reset epoch (SPEC §4) — surface it.
+            if (status == 403 || status == 429)
+                if (auto reset = "x-ratelimit-reset" in http.responseHeaders)
+                {
+                    try
+                        msg ~= " (rate limit resets at "
+                            ~ SysTime.fromUnixTime((*reset).to!long).toUTC.toISOExtString ~ ")";
+                    catch (Exception) { /* leave message as-is on a malformed header */ }
+                }
+            return failure!T(msg);
+        }
+
+        auto dom = parseJSON(responseText);
+        auto decoded = fromJSON!T(dom);
+        if (decoded.hasError)
+            return failure!T("JSON decode error: " ~ decoded.error.msg);
+
+        return success(decoded.value);
+    }
+    catch (Exception e)
+    {
+        return failure!T("HTTP/fetch error: " ~ e.msg);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure statistics (everything after domain objects uses range pipelines)
+// ---------------------------------------------------------------------------
+
+string normalizeRunnerKey(scope const(string)[] labels) @safe pure nothrow
+{
+    import std.algorithm.searching : canFind;
+    import std.algorithm.sorting : sort;
+    import std.array : array, join;
+
+    if (labels.canFind("self-hosted"))
+    {
+        auto rest = labels
+            .filter!(l => l != "self-hosted")
+            .array
+            .dup
+            .sort
+            .release;
+        return "self-hosted" ~ (rest.length ? "+" ~ rest.join("+") : "");
+    }
+    return labels.length ? labels[0].idup : "(unknown)";
+}
+
+/// Compute min/max/mean/median/p95 etc. from a range of Jobs (or Durations).
+JobStats computeStats(R)(R jobs)
+if (isInputRange!R)
+{
+    import std.algorithm.iteration : map, filter;
+    import std.algorithm.searching : minElement, maxElement;
+    import std.array : array;
+    import std.range : walkLength, take, drop;
+
+    auto durs = jobs
+        .filter!(j => j.duration > Duration.zero)
+        .map!(j => j.duration)
+        .array;
+
+    if (durs.length == 0)
+        return JobStats.init;
+
+    auto sorted = durs.dup;
+    sorted.sort();
+
+    JobStats s;
+    s.count = durs.length;
+    s.total = durs.fold!((a, b) => a + b)(Duration.zero);
+    s.min = sorted.minElement;
+    s.max = sorted.maxElement;
+    s.mean = s.total / s.count;
+
+    // median
+    auto mid = s.count / 2;
+    s.median = (s.count % 2 == 1)
+        ? sorted[mid]
+        : (sorted[mid-1] + sorted[mid]) / 2;
+
+    // p95 (simple index; good enough for the spec)
+    size_t p95Idx = cast(size_t)(0.95 * (s.count - 1));
+    s.p95 = sorted[p95Idx < sorted.length ? p95Idx : $ - 1];
+
+    return s;
+}
+
+RunnerAggregate[] aggregateByRunner(R)(R jobs) @safe pure
+if (isInputRange!R && is(ElementType!R == Job))
+{
+    import std.algorithm.sorting : sort;
+    import std.array : array;
+    import std.typecons : tuple;
+
+    // Use sort + manual consecutive grouping (library group had type issues in this context;
+    // the accumulation is small and followed by range post-processing for the result).
+    auto keyed = jobs
+        .map!(j => tuple(normalizeRunnerKey(j.labels), j))
+        .array
+        .sort!((a, b) => a[0] < b[0])
+        .release;
+
+    RunnerAggregate[] result;
+    if (keyed.empty) return result;
+
+    string currentKey = keyed.front[0];
+    auto group = [keyed.front[1]];
+    foreach (t; keyed.drop(1))
+    {
+        if (t[0] != currentKey)
+        {
+            auto st = computeStats(group);
+            result ~= RunnerAggregate(currentKey, st);
+            currentKey = t[0];
+            group = [t[1]];
+        }
+        else
+        {
+            group ~= t[1];
+        }
+    }
+    auto st = computeStats(group);
+    result ~= RunnerAggregate(currentKey, st);
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers (SmallBuffer + writers for durations, UI stack for tables)
+// ---------------------------------------------------------------------------
+
+// These `fmt*` return `string` because the table APIs (`string[][]` / `Cell`)
+// require owning string content for cells. They are thin adapters over the
+// project's writer primitives.
+//
+// Preferred style elsewhere (IES, task details, logs):
+//   SmallBuffer!(char, N) buf;
+//   writeDuration(buf, d);
+//   styledWriteln(i"... $(buf[]) ...");
+// or using the TaskReporter proxy for live output.
+//
+// See the direct buffer usage in the header stats and some task outputs below.
+
+string fmtDur(Duration d)
+{
+    SmallBuffer!(char, 32) buf;
+    writeDuration(buf, d);
+    return buf[].idup;
+}
+
+string fmtCount(size_t n)
+{
+    SmallBuffer!(char, 16) buf;
+    writeInteger(buf, n);
+    return buf[].idup;
+}
+
+string fmtMinutesFromTotal(Duration total)
+{
+    // Derive display minutes from Duration *only* at render time.
+    // We never store double minutes in RunnerAggregate / aggregates.
+    // Use scaled fixed-point + writeFixedPoint for clean 1-decimal bare number
+    // (the table column header already provides the "Minutes" unit).
+    double m = total.total!"seconds" / 60.0;
+    ulong scaled = cast(ulong)(m * 10.0 + 0.5);
+    SmallBuffer!(char, 16) buf;
+    writeFixedPoint(buf, scaled, 1);
+    return buf[].idup;
+}
+
+string[string] makeAuthHeaders(string authHeader)
+{
+    string[string] h;
+    if (authHeader.length)
+        h["Authorization"] = authHeader;
+    return h;
+}
+
+auto jobsWithDuration(R)(R jobs)
+{
+    return jobs.filter!(j => j.duration > Duration.zero);
+}
+
+Job[] topSlowJobs(R)(R jobs, size_t n = 5) @safe pure
+if (isInputRange!R && is(ElementType!R == Job))
+{
+    import std.algorithm.sorting : sort;
+    import std.range : take;
+
+    auto arr = jobs.array;
+    arr.sort!((a, b) => a.duration > b.duration);
+    return arr.take(n).array;
+}
+
+void renderReport(in JobStats overall, in RunnerAggregate[] byRunner, Job[] slowJobs, in Theme theme)
+{
+    import std.stdio : writeln;
+    import sparkles.core_cli.ui.header : drawHeader, HeaderProps, HeaderStyle;
+
+    writeln();
+    writeln(drawHeader("CI Usage Statistics", HeaderProps(style: HeaderStyle.banner)));
+
+    // Overall stats: use direct SmallBuffer + writers + slice in IES.
+    // This avoids fmt* allocation for temporary display values.
+    {
+        SmallBuffer!(char, 32) totalBuf, minBuf, maxBuf, avgBuf, medBuf, p95Buf;
+        writeDuration(totalBuf, overall.total);
+        writeDuration(minBuf, overall.min);
+        writeDuration(maxBuf, overall.max);
+        writeDuration(avgBuf, overall.mean);
+        writeDuration(medBuf, overall.median);
+        writeDuration(p95Buf, overall.p95);
+
+        styledWriteln(i"Jobs: $(overall.count)   Total: $(totalBuf[])");
+        styledWriteln(i"Min: $(minBuf[])  Max: $(maxBuf[])  Avg: $(avgBuf[])  Median: $(medBuf[])  p95: $(p95Buf[])");
+    }
+
+    // Runner aggregates table - richer with per-runner stats (using range style data prep)
+    string[][] runnerRows = [["Runner Type", "Jobs", "Total", "Avg", "Min", "Max", "Minutes"]];
+    foreach (r; byRunner)
+    {
+        auto s = r.stats;
+        runnerRows ~= [
+            r.runnerType,
+            fmtCount(s.count),
+            fmtDur(s.total),
+            fmtDur(s.mean),
+            fmtDur(s.min),
+            fmtDur(s.max),
+            fmtMinutesFromTotal(r.stats.total)
+        ];
+    }
+
+    writeln();
+    writeln(drawTable(runnerRows, TableProps(headerRows: 1, title: "By Runner Type")));
+
+    if (!slowJobs.empty)
+    {
+        string[][] slowRows = [["#", "Job", "Workflow", "Duration", "Runner"]];
+        foreach (i, j; slowJobs)
+        {
+            slowRows ~= [
+                fmtCount(i + 1),
+                j.name,
+                j.workflow,
+                fmtDur(j.duration),
+                j.runnerName.length ? j.runnerName : "-"
+            ];
+        }
+        writeln();
+        writeln(drawTable(slowRows, TableProps(headerRows: 1, title: "Top Slow Jobs")));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock support demonstration (for unit testing the pure logic)
+// As required: the fetcher is template param, so domain can be tested with
+// direct T returns, no network.
+// ---------------------------------------------------------------------------
+
+@("ci_stats.runCiStats.injectablePathCompiles")
+@system unittest
+{
+    // Compile-only check that the injectable fetch seam type-checks. We must NOT
+    // *run* runCiStats here: it spins up a real stdout live region and would paint
+    // a stray failed-task frame into every `dub test :ci`. `__traits(compiles)`
+    // instantiates the whole path (semantic3) without executing it.
+    auto dummyFetch(T)(string, string = "GET", string = null, string[string] = null)
+        => failure!T("mock not populated in this compile-test");
+    auto o = CiStatsOptions("owner/repo", "", 5);
+    static assert(__traits(compiles, runCiStats!dummyFetch(o)));
+}
+
+// ---------------------------------------------------------------------------
+// Core orchestration (templated on fetcher for testability)
+// ---------------------------------------------------------------------------
+
+struct CiStatsOptions
+{
+    string repo;
+    string token;
+    int limit = 100;
+    string since;
+    string workflowFilter;
+    string conclusionFilter;
+}
+
+/// High-level entry: templated so callers (or tests) can inject a fetcher
+/// that directly returns T without network.
+Result!Report runCiStats(alias fetchJson)(in CiStatsOptions opts)
+{
+    import std.algorithm.comparison : min;
+    import std.conv : to;
+
+    if (opts.repo.length == 0)
+        return failure!Report("repo is required (owner/repo)");
+
+    // Primary validation is in app.d's validateCliMode (pre-network); this guards
+    // the templated entry that tests/other callers invoke directly. A non-positive
+    // limit would otherwise promote to a huge size_t in the loop/slice below.
+    if (opts.limit <= 0)
+        return failure!Report("--limit must be a positive integer");
+
+    string authHeader = opts.token.length ? "Bearer " ~ opts.token : null;
+
+    auto region = stdoutLiveRegion();
+    scope (exit) region.finish();
+
+    const theme = makeTheme(detectTermCaps());
+    auto tasks = TaskReporter(&region, theme);
+
+    // 1. Fetch runs (paginated)
+    const runsId = tasks.add("fetch workflow runs");
+    tasks.start(runsId);
+
+    GhWorkflowRun[] runs;
+    bool[long] seenRuns;  // dedup by run.id: created-desc pages shift when runs start mid-fetch
+    int page = 1;
+    const perPage = 100;
+    string baseUrl = "https://api.github.com/repos/" ~ opts.repo ~ "/actions/runs";
+
+    while (runs.length < opts.limit)
+    {
+        string url = baseUrl ~ "?per_page=" ~ perPage.to!string ~ "&page=" ~ page.to!string;
+        if (opts.since.length)
+            url ~= "&created=" ~ encodeComponent(">=" ~ opts.since);
+
+        auto r = fetchJson!GhRunsResponse(url, "GET", null, makeAuthHeaders(authHeader));
+        if (r.hasError)
+        {
+            tasks.fail(runsId, r.error);
+            return failure!Report(r.error);
+        }
+
+        auto rawPage = r.value.workflowRuns;
+        if (rawPage.length == 0)
+            break;
+
+        foreach (run; rawPage)
+        {
+            if (run.id in seenRuns)
+                continue;
+            seenRuns[run.id] = true;
+
+            if (opts.workflowFilter.length)
+            {
+                const nameMatch = !run.name.isNull && run.name.get.canFind(opts.workflowFilter);
+                if (!nameMatch && !run.path.canFind(opts.workflowFilter))
+                    continue;
+            }
+
+            runs ~= run;
+            if (runs.length >= opts.limit)
+                break;
+        }
+
+        tasks.output(runsId).writeStyled(i"$(runs.length) runs so far");
+
+        // Break on the RAW page length — a short *filtered* page is not the last page.
+        if (rawPage.length < perPage)
+            break;
+        ++page;
+    }
+
+    runs = runs[0 .. min($, opts.limit)];
+    tasks.succeed(runsId, text(runs.length, " runs"));
+
+    if (runs.length == 0)
+        return success(Report.init);
+
+    // 2. For each run, fetch jobs (with progress)
+    const jobsId = tasks.add("fetch jobs for runs");
+    tasks.start(jobsId);
+
+    Job[] allJobs;
+    size_t failedRuns;  // runs whose jobs could not be fetched — stats would be incomplete
+    foreach (i, run; runs)
+    {
+        // The run's display name (workflow_name, else the run name) — used for every job.
+        const wf = run.workflowName.isNull
+            ? (run.name.isNull ? "" : run.name.get)
+            : run.workflowName.get;
+
+        // Paginate the jobs endpoint (SPEC §6.1): a large matrix can exceed one page.
+        GhJob[] runJobs;
+        int jobsPage = 1;
+        bool runFailed = false;
+        while (true)
+        {
+            string jobsUrl = "https://api.github.com/repos/" ~ opts.repo
+                ~ "/actions/runs/" ~ run.id.to!string
+                ~ "/jobs?per_page=" ~ perPage.to!string ~ "&page=" ~ jobsPage.to!string;
+
+            auto jr = fetchJson!GhJobsResponse(jobsUrl, "GET", null, makeAuthHeaders(authHeader));
+            if (jr.hasError)
+            {
+                runFailed = true;
+                break;
+            }
+
+            runJobs ~= jr.value.jobs;
+            if (jr.value.jobs.length < perPage)
+                break;
+            ++jobsPage;
+        }
+
+        if (runFailed)
+        {
+            ++failedRuns;
+            tasks.output(jobsId).writeStyled(i"warning: failed jobs for run $(run.id)");
+            continue;
+        }
+
+        foreach (ghJob; runJobs)
+        {
+            Duration dur;
+            if (!ghJob.startedAt.isNull && !ghJob.completedAt.isNull)
+            {
+                try
+                {
+                    auto start = SysTime.fromISOExtString(ghJob.startedAt.get);
+                    auto end = SysTime.fromISOExtString(ghJob.completedAt.get);
+                    dur = end - start;
+                }
+                catch (Exception) { /* ignore bad timestamp */ }
+            }
+
+            string rname = ghJob.runnerName.isNull ? "" : ghJob.runnerName.get;
+            string concl = ghJob.conclusion.isNull ? "" : ghJob.conclusion.get;
+
+            allJobs ~= Job(
+                name: ghJob.name,
+                workflow: wf,
+                duration: dur,
+                labels: ghJob.labels,
+                runnerName: rname,
+                conclusion: concl,
+            );
+        }
+
+        tasks.output(jobsId).writeStyled(i"$(i + 1) / $(runs.length) runs");
+
+        // Live summary of current aggregates (range pipeline)
+        auto currentPositive = jobsWithDuration(allJobs);
+        auto currentBy = aggregateByRunner(currentPositive);
+        {
+            auto w = tasks.output(jobsId);
+            w.put("runners: ");
+            bool first = true;
+            foreach (r; currentBy)
+            {
+                if (!first) w.put(", ");
+                first = false;
+                w.put(r.runnerType);
+                w.put(":");
+                writeInteger(w, r.stats.count);
+            }
+            if (first) w.put("-");
+        }
+    }
+
+    // Graduate a persistent summary via succeed's detail (the ephemeral tail is
+    // cleared on completion). Surface any incomplete-data warning on a follow-up line.
+    string jobsDetail = text(jobsWithDuration(allJobs).walkLength, " jobs with duration");
+    if (failedRuns > 0)
+        jobsDetail ~= text("\n⚠ ", failedRuns, " run(s) failed to fetch — stats may be incomplete");
+    tasks.succeed(jobsId, jobsDetail);
+
+    // 3. Pure pipeline processing.
+    // No workflow re-filter here: runs were already filtered on name/path at fetch
+    // time (SPEC §3), and Job.workflow holds only the display name.
+    auto filtered = jobsWithDuration(allJobs).array;
+
+    if (opts.conclusionFilter.length)
+        filtered = filtered.filter!(j => j.conclusion == opts.conclusionFilter).array;
+
+    auto overall = computeStats(filtered);
+    auto byRunner = aggregateByRunner(filtered);
+    auto slowJobs = topSlowJobs(filtered, 5);
+
+    // 4. Render with live-style final output (for now static tables; live during fetch above)
+    renderReport(overall, byRunner, slowJobs, theme);
+
+    return success(Report(overall, byRunner, slowJobs));
+}
+
+struct Report
+{
+    JobStats overall;
+    RunnerAggregate[] byRunner;
+    Job[] slowJobs;
+}

--- a/docs/specs/ci/stats/PLAN.md
+++ b/docs/specs/ci/stats/PLAN.md
@@ -1,0 +1,88 @@
+# `ci --ci-stats` — Delivery plan
+
+_Companion to [SPEC.md](./SPEC.md). Each milestone is independently green (builds, tests, lints, style). The SPEC is the contract; this document is the schedule._
+
+## M0 — Specification
+
+- Create `docs/specs/ci/stats/`.
+- Write `SPEC.md` (normative overview, CLI, data model, fetch policy seam, live progress contract, error model, pure-vs-IO separation).
+- Write `PLAN.md` (this file) with milestone table and explicit gates.
+- Commit both before any `.d` implementation that realises the feature.
+
+Gate: files exist, follow the style of `docs/specs/release/{SPEC,PLAN}.md` and `docs/specs/core-cli/tui-components/PLAN.md`, and have been reviewed for clarity.
+
+## M1 — Infrastructure in `apps/ci`
+
+- Add `dependency "expected" version="~>0.4.1"` and `dependency "sparkles:wired" path="../.."` (plus matching selections/lock updates) to `apps/ci/dub.sdl`.
+- Extend `CliParams` with the new flags (`--ci-stats`, `--github-token`, `--repo`, `--limit`, `--since`, `--workflow`, `--conclusion`, `--json`, `--no-live`).
+- Extend `ProgramMode`, `validateCliMode`, `resolveProgramMode`, and the dispatch in `main`.
+- Basic `--help` and conflict/error paths work and are consistent with other modes.
+
+Gate: `dub build :ci` succeeds; `dub run :ci -- --ci-stats --help` renders the new options cleanly; invalid combinations are rejected before any network work.
+
+## M2 — Injectable fetch layer (`std.net.curl` + wired)
+
+- Implement `fetchAndDeserializeJson!T` (or small policy type) that performs GET (REST) and POST (GraphQL), sets the required GitHub headers, and returns `Result!T` using `parseJSON` + `fromJSON`.
+- Token handling: `--github-token` > `GITHUB_TOKEN` env, with clear error when missing for private data.
+- Pagination helper (Link header or page loop) capped by effective limit.
+- The seam is exposed so that `runCiStats!(fetchJson)(...)` (or equivalent) accepts the fetcher as a template/alias parameter.
+
+Gate:
+
+- `dub run :ci -- --ci-stats --repo microsoft/vscode --limit 3` succeeds on a public repo (or with token).
+- Error paths (bad token, rate limit, malformed JSON) produce friendly `Result` failures.
+- Unit-testable: a local template returning a literal `T` can be passed instead of the real fetcher.
+
+## M3 — Pure domain logic (range pipelines only)
+
+- `Job` / `JobStats` / `RunnerAggregate` types.
+- `normalizeRunnerKey` (pure, @nogc).
+- `parseJobDuration` (small boundary).
+- `computeStats`, `aggregateByRunner`, top-N, filters — all expressed with `std.algorithm` / `std.range` (map/filter/fold/reduce/sort/groupBy/take etc.).
+- Duration formatting exclusively via `SmallBuffer` + `writeDuration`.
+- All statistical functions are `@safe pure nothrow` (or the maximal safe subset) and have tagged unit tests that use mock data.
+
+Gate: pure tests pass (`dub test :ci` or direct compile with `-unittest`); no hand-rolled accumulation loops remain in the stats path; `checkWriter` / SmallBuffer style used where appropriate.
+
+## M4 — Live TUI rendering + integration
+
+- Use `stdoutLiveRegion` + `TaskReporter` for fetch progress ("Fetching runs 12/30", "Jobs for run 12345").
+- Optional live aggregate / slow-job table updated via `drawTableLines` + `LiveRegion.update` (following `table-leaderboard.d`).
+- Final human output uses `drawHeader` + `drawTable` (with named `TableProps` arguments).
+- Non-tty degradation is clean (no control sequences) — verified by piping to `cat`.
+- `--no-live` forces plain output.
+
+Gate:
+
+- In a real terminal the progress UI repaints in place and graduates lines.
+- Piped output is a readable progressive log.
+- Matches the observable behaviour of `libs/core-cli/examples/live-tasklist.d` and `table-leaderboard.d`.
+
+## M5 — Polish, docs, extraction candidates, release
+
+- `--json` output shape stabilised and documented in SPEC.
+- Good error messages for all common failure modes (token, network, empty result set, no completed jobs).
+- Update top-level `ci` usage text and any relevant README / research note.
+- List in the PR / commit any hand-rolled pieces that are candidates for promotion to sparkles libs (`base`, `core-cli`, `build-primitives`) and any duplication with `apps/release` remote parsing that should later move per the dman effort (`docs/specs/dman/vcs-backend.md`).
+- Optional: small reusable helpers (fetch shell, paged list adaptor, duration stats) are proposed as PRs against the appropriate library.
+
+Gate:
+
+- `nix run .#ci -- --ci-stats ...` works.
+- `nix run .#ci -- --test --fail-fast` (ci package at minimum) is green.
+- Full style / editorconfig / guideline audit passes.
+- SPEC and PLAN are updated with any behavioural adjustments discovered during implementation.
+- Feature branch (in dedicated worktree) is ready for review.
+
+## Milestone summary table
+
+| #   | Deliverable                              | Key files / changes                   | Gate                              | Status |
+| --- | ---------------------------------------- | ------------------------------------- | --------------------------------- | ------ |
+| M0  | SPEC + PLAN written                      | `docs/specs/ci/stats/{SPEC,PLAN}.md`  | Files committed before .d code    | —      |
+| M1  | CLI surface + dispatch in `ci`           | `apps/ci/dub.sdl`, `app.d`            | `--help` + conflicts work         | —      |
+| M2  | curl + wired + injectable fetch          | `ci_stats.d` (fetch layer)            | Real + mock paths; token handling | —      |
+| M3  | Pure stats with range pipelines          | stats functions + unit tests          | Pure tests green, no hand loops   | —      |
+| M4  | Live TUI (TaskReporter + drawTableLines) | rendering + live paths                | tty + piped behaviour correct     | —      |
+| M5  | Polish, docs, extraction notes           | SPEC/PLAN updates, top-level help, PR | Full CI green + audit             | —      |
+
+Each milestone above is the unit of review and merge where practical.

--- a/docs/specs/ci/stats/SPEC.md
+++ b/docs/specs/ci/stats/SPEC.md
@@ -1,0 +1,167 @@
+# `ci --ci-stats` — GitHub Actions CI usage statistics
+
+_Audience: developers and coding agents building against or consuming the `ci` tool. This document is normative — it states what the `--ci-stats` subcommand does (and, for sections marked as targets, what it is specified to do once the corresponding PLAN milestone lands). For the delivery plan see [PLAN.md](./PLAN.md)._
+
+Sections describing unimplemented behaviour carry an explicit **(target — Mn)** marker.
+
+## 1. Overview
+
+`ci --ci-stats` queries the GitHub REST (and optionally GraphQL) API to produce human-readable statistics on CI job execution for a repository:
+
+- Overall per-job timing: count, min, max, mean, median, p95, total wall-clock time.
+- Aggregated "CI minutes" (and optionally ceiling-to-minute billed minutes) broken down by runner type (derived from job `labels`).
+- Supporting views: top slow jobs, per-workflow breakdowns where useful, and live progress during fetch.
+
+The command is a subcommand of the existing `sparkles:ci` tool (invoked as `dub run :ci -- --ci-stats ...` or `nix run .#ci -- --ci-stats ...`). It follows the same logging, pre-flight, and output conventions as other `ci` modes.
+
+All network I/O uses `std.net.curl`. Auth is via `--github-token` (with `GITHUB_TOKEN` environment fallback). No dependency on the `gh` CLI binary is required.
+
+Pure computation (filtering, duration derivation, statistical aggregation, runner key normalisation) is expressed with `std.algorithm` + `std.range` pipelines and is unit-testable via an injectable fetch policy.
+
+Live terminal progress uses the `LiveRegion` / `TaskReporter` + `drawTableLines` stack (see the idioms in `libs/core-cli/examples/{live-tasklist.d,table-leaderboard.d,streaming-box.d}`).
+
+## 2. Package and module layout
+
+| Identifier      | Value                  |
+| --------------- | ---------------------- |
+| Dub sub-package | `ci` (executable)      |
+| Source root     | `apps/ci/src/`         |
+| Entry point     | `src/app.d` (extended) |
+
+| Module / file                                | Responsibility                                                                                                                          |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/ci/src/app.d`                          | CLI surface extension, mode dispatch, top-level orchestration for `--ci-stats`                                                          |
+| `apps/ci/src/ci_stats.d` (or `ci_stats/*.d`) | Data models, `fetchAndDeserializeJson` policy, REST/GraphQL call helpers, pure stats pipelines, rendering, the `--ci-stats` entry point |
+| (future) promoted helpers                    | Any generally-useful pieces (fetch shell, duration stats, remote helpers) moved to `sparkles:base` / `core-cli` / `build-primitives`    |
+
+Pure logic is separated from I/O: JSON→domain transformations and all statistical functions are standalone `@safe` (or attribute-inferred) functions. Only thin wrappers perform curl requests.
+
+## 3. CLI surface
+
+```text
+ci --ci-stats
+   [--repo OWNER/REPO]
+   [--github-token TOKEN | $GITHUB_TOKEN]
+   [--limit N] [--since YYYY-MM-DD]
+   [--workflow NAME] [--conclusion success|failure|...]
+   [--json] [--no-live]
+   [--log-level trace|info|...]
+```
+
+| Flag / env                        | Default                         | Meaning                                                                                       |
+| --------------------------------- | ------------------------------- | --------------------------------------------------------------------------------------------- |
+| `--repo`                          | discovered (future) or required | `owner/repo` (case-insensitive on GitHub)                                                     |
+| `--github-token` / `GITHUB_TOKEN` | (none)                          | Bearer token. Precedence: flag > env. Sent as `Authorization: Bearer ...`.                    |
+| `--limit`                         | 100                             | Maximum workflow runs to consider (client-side cap after pagination).                         |
+| `--since`                         | (none)                          | Only runs created on or after this date (`created>=...` query param).                         |
+| `--workflow`                      | (all)                           | Substring filter on `name` or workflow filename.                                              |
+| `--conclusion`                    | (all completed)                 | Filter jobs by conclusion (`success`, `failure`, `cancelled`, ...).                           |
+| `--json`                          | off                             | Emit machine-readable JSON (structure defined in §6.3) instead of (or in addition to) tables. |
+| `--no-live`                       | off                             | Disable in-place live updates (force plain progressive output).                               |
+| `--log-level`                     | `info`                          | Standard sparkles logger levels.                                                              |
+
+Conflicts and errors are reported before any network work (consistent with other `ci` modes).
+
+When neither `--repo` nor discovery succeeds, a clear actionable error is printed.
+
+## 4. Authentication & production requirements
+
+- Token is never logged.
+- `User-Agent: sparkles-ci` (or similar) is always sent.
+- Required headers: `Accept: application/vnd.github+json`, `X-GitHub-Api-Version: 2022-11-28`.
+- Public repositories may succeed without a token; private repositories or high-volume usage require one.
+- Rate-limit responses (403/429 with `x-ratelimit-*` headers) are surfaced as friendly errors containing reset time when available.
+
+## 5. Data model (domain types)
+
+(These are internal but appear in the JSON output and are the vocabulary of the pure functions.)
+
+```d
+struct Job {
+    string id;
+    string name;
+    string workflow;      // workflow name or path
+    Duration duration;    // completed_at - started_at (0 when incomplete)
+    string[] labels;      // raw GitHub labels
+    string runnerName;
+    string conclusion;    // success | failure | ...
+    SysTime startedAt;
+    SysTime completedAt;
+}
+
+struct JobStats { size_t count; Duration total, min, max, mean, median, p95; }
+
+struct RunnerAggregate {
+    string runnerType;    // normalised key (see §6.2)
+    size_t jobCount;
+    Duration total;
+    double minutes;       // total / 60.0
+    // + per-runner JobStats subset
+}
+```
+
+Only jobs that possess both `started_at` and `completed_at` contribute a positive duration.
+
+## 6. Behaviour
+
+### 6.1 Fetch policy (the injectable seam)
+
+The command accepts an injectable fetcher:
+
+```d
+alias FetchJson(T) = Result!T delegate(string url, string method = "GET",
+                                       string body = null, string[string] extraHeaders = null);
+
+Result!Report runCiStats(alias fetchJson)(string repo, in Options opts) { ... }
+```
+
+- Real implementation: `fetchAndDeserializeJson!T` built on `std.net.curl.HTTP` + `parseJSON` + `fromJSON!T` (via `sparkles.wired`).
+- Test implementation: a local template that ignores the URL and returns a pre-built `T`.
+- REST list endpoints use GET + query parameters.
+- GraphQL (when used) uses POST with `{"query": "..."}` body and appropriate `Content-Type`.
+
+Pagination for `/actions/runs` and `/actions/runs/{id}/jobs` respects `per_page=100` and either follows `Link` headers or performs simple page loops up to the effective `--limit`.
+
+### 6.2 Runner type normalisation (pure)
+
+- If `labels` contains `"self-hosted"`, the key is `"self-hosted"` plus the remaining labels sorted and joined by `+` (example: `self-hosted+linux+x64`).
+- Otherwise the first label is used (typical values: `ubuntu-latest`, `ubuntu-22.04`, `macos-14`, `windows-latest`).
+- The resulting key is used for `groupBy` / associative aggregation.
+
+### 6.3 Output
+
+**Human (default):**
+
+- Header via `drawHeader`.
+- Overall `JobStats` summary (durations via `writeDuration` into `SmallBuffer`).
+- Table of runner aggregates (runner type, jobs, total, avg, min, max, minutes).
+- Optional "Top slow jobs" table.
+- Live progress during fetch using `TaskReporter` + detail lines; optional live-updating aggregate table via `drawTableLines` + `LiveRegion.update`.
+
+**Machine (`--json`):**
+
+A single JSON object containing the report (exact shape defined in the implementation but stable across minor versions; contains `generatedAt`, `repo`, `filters`, `overall`, `byRunner[]`, `slowJobs[]`).
+
+Non-tty output never emits terminal control sequences.
+
+### 6.4 Error model
+
+All fallible operations return a `Result!T` (alias to `Expected!(T, string)`) following the pattern in `apps/release/src/sparkles/release/result.d`.
+
+Top-level errors produce a single-line message on stderr and exit code 1 (or richer structured output under `--json`).
+
+## 7. Limits & quality
+
+- Default `--limit 100` (two pages of 100). Higher values are allowed but documented as potentially hitting secondary rate limits.
+- Only completed jobs (both timestamps present) are counted for timing stats.
+- Durations are rendered exclusively with `sparkles.base.text.writers.writeDuration`.
+- All statistical reductions after the domain objects exist are expressed with range pipelines (`map`, `filter`, `fold`/`reduce`, `sort` + indexing for median/p95, `groupBy` after sort, etc.).
+
+## 8. Future work (non-normative)
+
+- Automatic repo discovery from git remote (may reuse/extend logic from `build-primitives` or the dman VCS backend).
+- Billing-rate multipliers (Windows ×2, macOS ×10, self-hosted ×0).
+- Persistent caching of recent results.
+- Export to CSV / Prometheus.
+
+(See [PLAN.md](./PLAN.md) for what is actually scheduled.)

--- a/libs/core-cli/src/sparkles/core_cli/ui/tasklist.d
+++ b/libs/core-cli/src/sparkles/core_cli/ui/tasklist.d
@@ -182,6 +182,50 @@ struct TaskReporter
         repaint();
     }
 
+    /// Returns a short-lived writer for live output on this task.
+    /// You can call `.put` or `.writeStyled(i"...")` on it.
+    /// On destruction it flushes the accumulated content via the normal output path.
+    ///
+    /// Example (reduces SmallBuffer boilerplate):
+    ///   tasks.output(jobsId).writeStyled(i"$(i + 1) / $(runs.length) runs");
+    auto output(this This)(size_t id)
+    in (id < _items.length)
+    {
+        import sparkles.base.smallbuffer : SmallBuffer;
+
+        static struct OutputWriter
+        {
+            This* r;
+            size_t id;
+            SmallBuffer!(char, 256) b;
+
+            // The dtor flushes the accumulated buffer, so a copy would flush twice.
+            // The proxy is meant to be used as a short-lived temporary/local (moved,
+            // never copied); disable copying to make an accidental copy a compile error.
+            @disable this(this);
+
+            void put(const(char)[] s) { b ~= s; }
+
+            void writeStyled(Args...)(Args args)
+            {
+                import sparkles.base.styled_template : writeStyled;
+                import sparkles.base.term_color : ColorDepth;
+                // Honor the wrapped reporter's theme, like every other render path —
+                // a colors-off theme must not emit raw ANSI into the tail pane.
+                const depth = r._theme.colors ? ColorDepth.trueColor : ColorDepth.none;
+                writeStyled(b, depth, args);
+            }
+
+            ~this()
+            {
+                if (b.length > 0)
+                    r.output(id, b[]);
+            }
+        }
+
+        return OutputWriter(cast(This*)&this, id);
+    }
+
     /// The items (for tests / summaries).
     const(TaskItem)[] items() const @safe pure nothrow @nogc => _items;
 


### PR DESCRIPTION
Adds `ci --ci-stats`: query the GitHub Actions REST API for a repository's recent workflow runs and their jobs, then report per-job timing statistics and per-runner-type aggregates (CI minutes, top slow jobs) with live progress. The pure statistics pipeline is separated from I/O behind an injectable fetch seam, so the orchestration is unit- and mock-testable without network.

## Commits
- **docs(ci)** — normative SPEC + delivery PLAN under `docs/specs/ci/stats/`.
- **feat(core-cli)** — `TaskReporter.output(id)` buffered live-output writer (theme-aware, non-copyable flushing dtor, bounds-checked).
- **feat(ci)** — the `--ci-stats` subcommand (`apps/ci/src/ci_stats.d` + CLI wiring), depending on `sparkles:wired` for JSON decoding.

## Correctness properties (validated via the mock fetch seam)
- Runs **and** per-run jobs are both paginated (`per_page=100`) up to the effective `--limit`; runs are deduplicated by id (mid-fetch inserts don't double-count), and pagination stops on the **raw** page length rather than the workflow-filtered length.
- GitHub-nullable fields (run `name`) decode via `Nullable`, so a single such run can't abort a whole page.
- Non-2xx responses surface GitHub's error body (and the rate-limit reset time on 403/429) instead of a generic transport error.
- `--since` is percent-encoded; `--workflow` filters runs on name or path; `--conclusion` matches the exact conclusion value; `--limit` is rejected if non-positive before any network work.

Built on top of an xhigh multi-agent review of the initial implementation; all 15 verified findings are folded into these commits.

https://claude.ai/code/session_012LvDqwURerXvhPmR8kenPe