### PR TITLE
docs(apps/hue): track GUI mouse-drag-over-decoration bugs + E2E research

### DIFF
--- a/docs/apps/hue/index.md
+++ b/docs/apps/hue/index.md
@@ -14,7 +14,8 @@ dub run :hue -- --gui file.md           # raylib window + markdown preview
 ```
 
 The full, traceable feature inventory lives in the
-[hue feature spec](../../specs/hue/).
+[hue feature spec](../../specs/hue/). Known issues and deferred work are tracked in
+[open issues](./open-issues.md).
 
 ## Twoslash overlay
 

--- a/docs/apps/hue/open-issues.md
+++ b/docs/apps/hue/open-issues.md
@@ -1,0 +1,64 @@
+# hue — open issues
+
+Known issues and deferred work for [hue](./index.md), with pointers to the
+research or design notes that cover them.
+
+## GUI mouse-drag over the window decoration
+
+**Status: open (not fixed).** The raylib [`--gui`](../../specs/hue/gui.md) window —
+and, identically, `apps/terminal` — does **not hold a pointer grab** during a mouse
+drag. On GNOME/Wayland the apps run through **XWayland**, and its compositor routes
+pointer events that land on the window decoration (or fall outside the window) to
+the _decoration_ / away from the app rather than to the app. Two symptoms follow
+from that one cause:
+
+1. **A drag released on a title-bar button triggers that button.** Start a text
+   selection or scrollbar drag, move the cursor over the **close / minimize /
+   maximize** button, release — and the window closes / minimizes / maximizes. The
+   mouse-up is delivered to the decoration, so the WM button fires.
+2. **A drag that leaves the content loses its mouse-up.** Release over the title
+   bar or outside the window and the app never sees the button go up, so the
+   selection keeps extending. Conversely, a scrollbar drag _should_ keep working
+   while the button is held **outside** the window (standard behaviour) — but the
+   app receives no motion events out there, so it can't.
+
+### Why the obvious app-level fixes don't work
+
+Two mitigations were tried and **reverted** (they didn't fix it and one regressed
+real behaviour):
+
+- **Veto the close** (`glfwSetWindowShouldClose(handle, false)` when a close fires
+  mid-drag) — structurally can't help **minimize/maximize** (those aren't
+  `WindowShouldClose` events), and is defeated by the self-heal below clearing the
+  drag state before the release even arrives.
+- **Self-heal on cursor-exit** (end the drag when `!IsCursorOnScreen()`) — breaks
+  the legitimate "drag the scrollbar / extend the selection while the button is
+  held outside the window" behaviour, and prevents resume on re-entry.
+- **`GLFW_CURSOR_CAPTURED`** (confine the cursor to the content on mouse-down) — is
+  **ignored** on this XWayland/mutter setup, so the cursor still reaches the
+  decoration.
+
+The decisive events (the WM-button activation, the swallowed mouse-up) happen in
+the **window manager**, not in app code, so no app-level state check can reliably
+reconstruct them.
+
+### The correct fix (needs validation)
+
+Hold a real **active pointer grab** for the duration of the drag, so every pointer
+event — motion and button-release, including over a decoration or outside the
+window — is delivered to the app, and the cursor is confined to the content (can't
+reach the WM buttons):
+
+- **X11 / XWayland:** `XGrabPointer(confine_to = content window, owner_events,
+  ButtonReleaseMask | PointerMotionMask, …)` on mouse-down and `XUngrabPointer` on
+  mouse-up, via GLFW's native handles (`glfwGetX11Display` / `glfwGetX11Window`).
+  This is stronger than GLFW's passive `CURSOR_CAPTURED`.
+- **Native Wayland (future):** a `zwp_pointer_constraints` locked/confined pointer
+  plus the compositor's implicit grab.
+
+This is unverified against the actual compositor, and this bug class evades
+in-process tests entirely — so the fix should be developed against the end-to-end
+harness described in
+[**End-to-end testing the windowing layer**](../../research/window-system-integration/e2e-testing.md),
+which reproduces the drag-over-decoration gesture under a real headless WM before
+trusting any fix.

--- a/docs/research/window-system-integration/e2e-testing.md
+++ b/docs/research/window-system-integration/e2e-testing.md
@@ -1,0 +1,128 @@
+# End-to-end testing the windowing layer
+
+A design note on how to catch **input-behaviour** bugs in the raylib GUI apps
+(`hue --gui`, `apps/terminal`) — the class of bug that only appears once a real
+window manager and real pointer-event routing are in the loop, and is therefore
+structurally invisible to in-process unit tests.
+
+It is written against a concrete case study (mouse-drag-over-decoration bugs,
+below), motivates why the usual test layers miss them, and specifies an automated
+end-to-end harness that would catch them. Building the harness is **deferred** (see
+[status](#status)). See also the windowing [concepts](./concepts.md) and the
+[platform comparison](./comparison.md).
+
+## Case study: drag bugs that escaped every test
+
+On GNOME/Wayland the raylib apps run through **XWayland** (GLFW's X11 backend —
+a GLFW window under mutter only gets a title bar + close/minimize/maximize buttons
+via X11; native Wayland under GNOME is decorationless). The apps hold **no pointer
+grab** during a drag, and XWayland/mutter routes a pointer event that lands on the
+decoration (or off the window) to the _decoration_, not the app. That single cause
+produces several symptoms:
+
+1. **A drag released on a title-bar button triggers it** — releasing a text
+   selection or scrollbar drag over **close / minimize / maximize** fires that WM
+   button (the window closes / minimizes / maximizes).
+2. **A drag that leaves the content loses its mouse-up** — the app never sees the
+   release, so a selection keeps extending; and a scrollbar drag, which _should_
+   keep working while the button is held **outside** the window, can't, because no
+   motion events arrive out there.
+
+## Why in-process tests can't catch this
+
+The decisive events happen **outside** the application:
+
+- A WM-button activation (close/minimize/maximize) is performed by the **window
+  manager**, not app code. `WindowShouldClose()` (only for close) is observed
+  _after the fact_; minimize/maximize aren't even visible as app events.
+- The lost mouse-up is a compositor **routing** decision. No app-visible event is
+  generated to assert on — and worse, GLFW's button state can stay stuck "down".
+
+A pure logic test — inject a scripted `down → move → up` at the raylib-call seam,
+assert the selection range / `shouldClose` — validates the *app-side contract* but
+**cannot** reproduce any of these: the bug lives in event delivery the mock
+supplies by fiat. This was confirmed the hard way: app-level mitigations (veto a
+mid-drag close; end the drag when the cursor leaves the content) both passed
+review and built green, yet the first can't touch minimize/maximize and the second
+broke legitimate outside-window scrollbar dragging — neither would have been caught
+without a real WM in the loop. Catching this class requires a test with (a) a real
+decorating window manager and (b) synthetic pointer events routed by that WM.
+
+## The approach: real headless WM + synthetic input + observe
+
+A layered strategy; only the outer layer catches this class.
+
+### Layer 1 — input-logic seam (fast, in-process, deterministic)
+
+Put an *input provider* behind a small interface (`isMouseButtonPressed`,
+`getMousePosition`, `isCursorOnScreen`, `windowShouldClose`, …): the real impl
+calls raylib; the test impl replays a scripted event list. Unit-test the
+frame-handler's state transitions and *intents*. `@nogc`-clean, matches the repo's
+design-by-introspection style, locks the app-side contract — but does **not**
+exercise WM routing.
+
+### Layer 2 — windowing E2E (slow, real, gated) — the one that catches it
+
+A D harness (per the repo "scripts in D" rule) that:
+
+1. Stands up a **headless display with real decorations** — the load-bearing part:
+   - **X11 / XWayland (the apps' actual path today):** `Xvfb :N` + a decorating WM
+     (`metacity` / `openbox`), or a nested `mutter --x11` for mutter-faithful
+     routing. Launch `hue --gui` / `apps/terminal` on `:N`.
+   - **Native Wayland (future):** a headless compositor (`labwc` / `weston
+     --backend=headless` / `sway --headless`) plus the `wlr-virtual-pointer`
+     protocol (or `ydotool` / `wtype` via `/dev/uinput`).
+2. Reads the window's frame geometry (`xdotool` / `xwininfo`; `swaymsg -t
+   get_tree`) and locates each title-bar button.
+3. Drives the exact failing gestures via **OS-level** input (`xdotool` XTEST on
+   X11; `ydotool` / `wtype` on Wayland — no app hook needed): `mousedown` in
+   content → `mousemove` onto the close/minimize/maximize button (and off the
+   window entirely) → `mouseup` → `mousemove` back.
+4. Asserts the observable outcome: the window is still open / not minimized /
+   not maximized; the selection ended (or, for the scrollbar, *continued* while
+   the button was held outside — see [observability](#observability-the-app-must-expose-state)).
+   Inverse guards: a *real* click on each button still works; a normal in-content
+   drag still selects.
+5. `skipTest("no headless WM")` when the display / WM / input tool is absent
+   (mirrors the repo's `skipTest` idiom).
+
+## Observability: the app must expose state
+
+"Window alive / minimized / maximized" is observable via the WM. "Did the selection
+end / did the scrollbar keep dragging" is not, from outside. Add an env-gated debug
+sink — e.g. `HUE_GUI_DEBUG_STATE=/path` — that dumps `selecting`, the selection
+byte range, scroll offset, and window state each frame. That turns behavioural
+assertions into file reads instead of pixel-diffing. The GUI already has golden
+**screenshot** capture (`TakeScreenshot`) as a fallback for "does it *look* right".
+
+## Fidelity and CI
+
+- **The bug is WM-specific.** `openbox` may honour the X11 implicit grab and *not*
+  reproduce the mutter/XWayland leak. The harness must **first prove it reproduces
+  the bug** before it is trusted as a regression gate; if a light WM does not, use
+  nested `mutter`. "Confirm the test has teeth" is non-negotiable for this class.
+- **Matrix on the routing layer.** X11 vs XWayland vs native-Wayland route pointer
+  events differently; the same code passes on one and fails on another.
+- **Isolation.** Run in a throwaway display, never the developer's live session —
+  synthetic clicks and cursor warps are disruptive.
+- **Packaging.** A dedicated nix flake check / CI job provides `Xvfb` + a WM +
+  `xdotool` (all in nixpkgs), gated and separate from the fast tests.
+
+## The essential principle
+
+> To catch "a drag that ends on a decoration fires a WM button / loses the
+> mouse-up", the test must contain a real window manager drawing decorations **and**
+> synthetic pointer events routed by that WM. Everything short of that — mocked
+> raylib, in-process state assertions — structurally cannot see it, because the
+> decisive event is produced outside the application.
+
+## Status
+
+- **Harness: deferred.** This note is the design; no harness is built yet.
+- **Fix: open.** The proper fix is a real **active pointer grab** for the duration
+  of the drag (X11: `XGrabPointer(confine_to = content, owner_events,
+  ButtonRelease | PointerMotion)` via GLFW's native handles; native-Wayland:
+  `zwp_pointer_constraints`), so every event reaches the app and the cursor can't
+  reach the decorations. It is unverified against the actual compositor — exactly
+  what the Layer-2 harness is for. Tracked in
+  [hue open issues](../../apps/hue/open-issues.md).

--- a/docs/research/window-system-integration/index.md
+++ b/docs/research/window-system-integration/index.md
@@ -243,6 +243,10 @@ platform" — the [Flutter][flutter] and [MAUI][maui] story.
   cheat sheet, cross-linked to the deep-dive that hit each one.
 - **[Recommendations][recommendations]** — the resolved position on every fork and a
   prioritized roadmap for the cross-platform Sparkles windowing layer.
+- **[End-to-end testing the windowing layer](./e2e-testing.md)** — why input-behaviour
+  bugs (a drag released on the window decoration) evade in-process tests, and the
+  real-WM + synthetic-input harness that catches them. Motivated by raylib
+  `hue --gui` / `apps/terminal` drag bugs.
 
 ### Library deep-dives
 


### PR DESCRIPTION
The raylib GUIs (`hue --gui`, `apps/terminal`) have two mouse-drag input bugs, both from the app holding **no pointer grab** during a drag while XWayland/mutter routes decoration/off-window pointer events away from the app:

1. A drag (text selection or scrollbar) **released over a title-bar button** fires it — **close / minimize / maximize**.
2. A drag that **leaves the content loses its mouse-up** — the selection sticks, and a scrollbar drag can't keep working while the button is held outside the window.

Two app-level mitigations were attempted and **reverted** — a `WindowShouldClose` veto can't cover minimize/maximize (and was defeated by the self-heal), the cursor-exit self-heal broke legitimate outside-window dragging, and GLFW's `CURSOR_CAPTURED` is ignored on this compositor. So the apps keep their **original behaviour** and this PR just **tracks the bugs** with the correct fix direction.

- `docs/apps/hue/open-issues.md` — the bugs, why the app-level fixes fail, and the correct fix (an active `XGrabPointer` / `zwp_pointer_constraints` grab), to be validated against the harness below.
- `docs/research/window-system-integration/e2e-testing.md` — why this class evades in-process tests and the real-WM + synthetic-input E2E harness that catches it.

No code changes; original GUI behaviour is unchanged.

https://claude.ai/code/session_01DJnNeuo1QLbqZyU4kASfQ8