### PR TITLE
fix(ui.wrap): merge wrapped slices only within one span

### DIFF
--- a/libs/ui/src/sparkles/ui/wrap.d
+++ b/libs/ui/src/sparkles/ui/wrap.d
@@ -420,16 +420,19 @@ if (is(typeof(measure("")) : int))
     TextSpan[][] lines;
     TextSpan[] cur;
     int curW;
+    size_t lastSpan = size_t.max; // the span cur's last slice came from
     size_t pendingGlue = size_t.max; // index into frags of glue awaiting content
 
     void append(size_t fi)
     {
         const f = frags[fi];
         const w = measure(f.text);
-        // Merge into the previous slice when it continues the same span.
-        if (cur.length && cur[$ - 1].text.length
-            && &spans[f.span].text[0] <= &f.text[0]
-            && cur[$ - 1].slot == spans[f.span].slot
+        // Merge into the previous slice only when it continues the $(I same)
+        // span. Contiguity alone is not enough: a highlighted code line is
+        // adjacent same-slot spans slicing one buffer, and merging across
+        // the span boundary would paint the whole run in the first span's
+        // colors (each span carries its own resolved fg/bg/attrs).
+        if (cur.length && lastSpan == f.span && cur[$ - 1].text.length
             && isContiguous(cur[$ - 1].text, f.text))
         {
             cur[$ - 1].text = joinSlices(cur[$ - 1].text, f.text);
@@ -455,6 +458,7 @@ if (is(typeof(measure("")) : int))
             s.text = f.text;
             cur ~= s;
         }
+        lastSpan = f.span;
         curW += w;
     }
 
@@ -463,6 +467,7 @@ if (is(typeof(measure("")) : int))
         lines ~= cur;
         cur = null;
         curW = 0;
+        lastSpan = size_t.max;
         pendingGlue = size_t.max;
     }
 
@@ -544,6 +549,38 @@ private const(char)[] joinSlices(return scope const(char)[] a,
     assert(lines[0][0].text == "use the " && lines[0][1].text == "run");
     assert(lines[0][1].paintBackground);          // the pill's style survives
     assert(lines[1][0].text == "helper today");   // merged back into one slice
+}
+
+@("ui.wrap.spans.adjacentSpansKeepTheirColors")
+@safe pure nothrow unittest
+{
+    import sparkles.base.term_color : RgbColor;
+    import sparkles.ui.geometry : cellsOf;
+
+    static int cols2(scope const(char)[] s) @safe pure nothrow @nogc
+        => cast(int) cellsOf(s);
+
+    // A highlighted code line: same-slot spans slicing one contiguous
+    // buffer, each with its own resolved color. They must survive wrapping
+    // as separate slices — merging would repaint the run in the first
+    // span's color (the raw-view "syntax highlighting lost" regression).
+    static immutable src = "return true;";
+    const spans = [
+        TextSpan(src[0 .. 6], Slot.code, fg: RgbColor(0xff, 0, 0),
+            hasFg: true, srcStart: 0, srcEnd: 6),
+        TextSpan(src[6 .. 7], Slot.code, srcStart: 6, srcEnd: 7),
+        TextSpan(src[7 .. 11], Slot.code, fg: RgbColor(0, 0xff, 0),
+            hasFg: true, srcStart: 7, srcEnd: 11),
+        TextSpan(src[11 .. 12], Slot.code, srcStart: 11, srcEnd: 12),
+    ];
+    const lines = wrapSpans(spans, 80, &cols2);
+    assert(lines.length == 1);
+    assert(lines[0].length == 4);
+    assert(lines[0][0].text == "return" && lines[0][0].fg == RgbColor(0xff, 0, 0));
+    assert(lines[0][2].text == "true" && lines[0][2].fg == RgbColor(0, 0xff, 0));
+    assert(lines[0][3].text == ";" && !lines[0][3].hasFg);
+    // The identity channel survives per slice.
+    assert(lines[0][2].srcStart == 7 && lines[0][2].srcEnd == 11);
 }
 
 @("ui.wrap.spans.punctuationHugsThePill")

--- a/lychee.exclude
+++ b/lychee.exclude
@@ -102,3 +102,11 @@ apps/hue/twoslash
 # window-system-integration surveys) rather than all of x.org, since
 # www.x.org/wiki/ (uno-platform.md) does not redirect through the broken host.
 ^https?://([^/]+\.)?x\.org/releases/
+
+# nick-black.com's MediaWiki (/dankwiki/) returns HTTP 500 (verified directly with
+# curl on 2026-07-31, both locally and in CI), and the site root 301-redirects
+# into it — a real upstream outage, not checker flakiness. Scoped to the wiki +
+# the bare root; the static htp-notcurses.pdf on the same host still serves 200
+# and stays checked. Cited from research/tui-libraries/notcurses.md.
+^https?://nick-black\.com/$
+^https?://nick-black\.com/dankwiki/


### PR DESCRIPTION
Fixes the bisected regression from ddbb4d5f: syntax highlighting vanished from the raw code view (GUI and TUI) while code blocks inside markdown files stayed colored.

## The bug

`wrapSpans`' slice merge — "merge into the previous slice when it continues the same span" — actually checked only **slot equality + buffer contiguity**. A highlighted code line is exactly that: adjacent same-slot (`Slot.code`) spans slicing one contiguous source buffer, each carrying its own resolved fg/bg/attrs. So every fragment on a line merged into the line's first slice and the whole run rendered in that slice's color. On `vector.d`, 11 distinct foregrounds in the view collapsed to 4 in the display list.

ddbb4d5f is when the raw view started flowing through the wrapping widget pipeline, which is why the bisect lands there — the wrap-layer bug predates it. Markdown fences never wrap, so they took the unwrapped per-span emit path and kept their colors, which made the raw view the only visible casualty.

## The fix

The merge now requires the fragment to continue the **same span**, tracked by span index — what the comment always claimed. Same-span word + glue + word fragments still rejoin into one slice (the op-count optimization the merge exists for); cross-span merging is gone.

## Verification

- New `ui.wrap.spans.adjacentSpansKeepTheirColors` unit test: contiguous same-slot spans with distinct colors survive wrapping as separate slices, identity channel intact.
- `ci --test` across all sub-packages.
- xvfb captures: the raw view matches the pre-ddbb4d5f colors; the markdown preview is unchanged.

| before (regressed) | after (fixed) |
| --- | --- |
| everything in the default fg, only bold survives | keywords/types/strings/comments each in their theme color |

https://claude.ai/code/session_01WbniakDeFcv5CquF2pNFHx
