### PR TITLE
fix(tui.render): emit downward hardware scrolls as IL — zellij ignores SD

### DIFF
--- a/apps/hue/src/explorer.d
+++ b/apps/hue/src/explorer.d
@@ -141,6 +141,9 @@ struct ExplorerTui
     /// drag, and the thumb all share one scroll space.
     int chromeRows = 2;
 
+    /// Whether this pane holds the workspace focus — the header title
+    /// renders accented when focused, muted otherwise (like the viewer's).
+    bool focused;
     bool searching;
     bool sbDragging; // a scrollbar grab owns the pointer until release
     int sbGrab;      // pointer offset within the grabbed thumb
@@ -472,7 +475,7 @@ struct ExplorerTui
         // viewport-sliced (guides are per-row, so slicing is safe).
         auto b = Builder();
         const name = b.add(Widget(kind: WidgetKind.text, text: root,
-            slot: Slot.chromeAccent));
+            slot: focused ? Slot.chromeAccent : Slot.gutter));
         import std.conv : text;
         const pos = b.add(Widget(kind: WidgetKind.text,
             text: text(rows.length ? sel + 1 : 0, "/", rows.length),
@@ -1198,7 +1201,20 @@ unittest
     if (root.exists)
         rmdirRecurse(root);
     mkdirRecurse(buildPath(root, "build"));
-    scope (exit) rmdirRecurse(root);
+    // The async git-status refresh may hold a transient `.git/index.lock`
+    // while teardown iterates — retry once after it settles.
+    scope (exit)
+    {
+        import core.thread : Thread;
+        import core.time : msecs;
+        import std.exception : collectException;
+
+        if (collectException(rmdirRecurse(root)) !is null)
+        {
+            Thread.sleep(200.msecs);
+            collectException(rmdirRecurse(root));
+        }
+    }
     write(buildPath(root, ".env"), "");
     write(buildPath(root, "keep.d"), "int k;\n");
     write(buildPath(root, "noise.log"), "");

--- a/apps/hue/src/explorer.d
+++ b/apps/hue/src/explorer.d
@@ -143,6 +143,7 @@ struct ExplorerTui
 
     bool searching;
     bool sbDragging; // a scrollbar grab owns the pointer until release
+    int sbGrab;      // pointer offset within the grabbed thumb
     char[128] qbuf;
     size_t qlen;
 
@@ -557,11 +558,15 @@ struct ExplorerTui
                         && p.pos.y <= bodyRows)
                     || (p.action == PointerAction.drag && sbDragging))
                 {
+                    // Grab-relative (STM2): a press on the handle grabs in
+                    // place, on the track it jumps; drags move the thumb
+                    // relative to the grab point.
+                    top = p.action == PointerAction.press && !sbDragging
+                        ? ScrollState(top).pressedAt(p.pos.y - 1,
+                            rows.length, bodyRows, bodyRows, sbGrab).offset
+                        : ScrollState(top).draggedTo(p.pos.y - 1,
+                            rows.length, bodyRows, bodyRows, sbGrab).offset;
                     sbDragging = true;
-                    top = ScrollState(top)
-                        .draggedTo(p.pos.y - 1, rows.length, bodyRows,
-                            bodyRows)
-                        .offset;
                     scrollBy(0); // clamp top without moving the selection
                     return true;
                 }
@@ -918,22 +923,37 @@ unittest
     x.rebuild();
     assert(cast(long) x.rows.length > x.bodyRows);
 
-    // A press on the scrollbar column grabs the thumb: the selection stays,
-    // nothing activates, and the view jumps by the STM2 inverse mapping.
+    // A press on the TRACK (below the thumb) jumps: the selection stays,
+    // nothing activates, and the view lands by the STM2 inverse mapping.
     assert(x.handle(Event(PointerEvent(button: PointerButton.left,
-        action: PointerAction.press, pos: Point(49, 2)))));
+        action: PointerAction.press, pos: Point(49, 5)))));
     assert(x.sbDragging);
     assert(x.sel == 0, "a scrollbar press never selects a row");
-    assert(x.top > 0, "the thumb jumped to the pointer");
+    assert(x.top > 0, "a track press jumped to the pointer");
 
     // The drag owns the pointer even off the column — still no row clicks.
     const grabbed = x.top;
     assert(x.handle(Event(PointerEvent(button: PointerButton.left,
-        action: PointerAction.drag, pos: Point(20, 6)))));
-    assert(x.top > grabbed && x.sel == 0);
+        action: PointerAction.drag, pos: Point(20, 3)))));
+    assert(x.top < grabbed && x.sel == 0, "the drag kept scrolling off-column");
     assert(x.handle(Event(PointerEvent(button: PointerButton.left,
-        action: PointerAction.release, pos: Point(20, 6)))));
+        action: PointerAction.release, pos: Point(20, 3)))));
     assert(!x.sbDragging);
+
+    // A press ON the handle grabs it in place — no jump — and the drag
+    // then moves it relative to the grab point.
+    import sparkles.ui.state : scrollbarThumb;
+    const t0 = scrollbarThumb(x.rows.length, x.bodyRows, x.top, x.bodyRows);
+    const inThumb = cast(int) t0.start + (t0.extent > 1 ? 1 : 0);
+    const before = x.top;
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(49, inThumb + 1)))));
+    assert(x.top == before, "a click on the handle must not move it");
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(49, inThumb + 2)))));
+    assert(x.top > before, "the drag moved the thumb relative to the grab");
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.release, pos: Point(49, inThumb + 2)))));
 
     // Off the scrollbar, a press is still a row click.
     const want = x.top + 1;

--- a/apps/hue/src/explorer.d
+++ b/apps/hue/src/explorer.d
@@ -22,14 +22,15 @@ import sparkles.syntax : LabelSet, ResolvedTheme, resolveTheme, RgbColor,
     Theme, toRgb;
 import sparkles.tui : CellStyle, Color, Grid;
 import sparkles.tui.input : EndOfInput, Event, isEndOfInput, Key, KeyEvent,
-    match, PointerAction, PointerButton, PointerEvent, ResizeEvent, WheelEvent;
+    match, Point, PointerAction, PointerButton, PointerEvent, ResizeEvent,
+    WheelEvent;
 import sparkles.ui.components.chrome : headerBar;
 import sparkles.ui.components.tree_widget : FlatTreeRow, flatten, TreeData,
     TreeGlyphs, treeView;
 import sparkles.ui.display_list : buildDisplayList;
 import sparkles.ui.geometry : SizeSpec;
 import sparkles.ui.layout : layout;
-import sparkles.ui.state : DisclosureState, scrollbarThumb;
+import sparkles.ui.state : DisclosureState, scrollbarThumb, ScrollState;
 import sparkles.ui.style : Slot;
 import sparkles.ui.widget : Builder, Widget, WidgetKind;
 import sparkles.ui_tui : paintGrid;
@@ -141,6 +142,7 @@ struct ExplorerTui
     int chromeRows = 2;
 
     bool searching;
+    bool sbDragging; // a scrollbar grab owns the pointer until release
     char[128] qbuf;
     size_t qlen;
 
@@ -538,8 +540,32 @@ struct ExplorerTui
                 return true;
             },
             (in PointerEvent p) {
-                if (p.button == PointerButton.left
-                    && p.action == PointerAction.press && p.pos.y >= 1
+                if (p.button != PointerButton.left)
+                    return true;
+                if (p.action == PointerAction.release)
+                {
+                    sbDragging = false;
+                    return true;
+                }
+                // The scrollbar column (last, only when the tree overflows):
+                // a press there grabs the thumb — it is never a row click —
+                // and the grab owns the pointer until release, wherever the
+                // drag strays (STM2's inverse mapping, like the viewer's).
+                const overflows = cast(long) rows.length > bodyRows;
+                if ((p.action == PointerAction.press && overflows
+                        && p.pos.x == width - 1 && p.pos.y >= 1
+                        && p.pos.y <= bodyRows)
+                    || (p.action == PointerAction.drag && sbDragging))
+                {
+                    sbDragging = true;
+                    top = ScrollState(top)
+                        .draggedTo(p.pos.y - 1, rows.length, bodyRows,
+                            bodyRows)
+                        .offset;
+                    scrollBy(0); // clamp top without moving the selection
+                    return true;
+                }
+                if (p.action == PointerAction.press && p.pos.y >= 1
                     && p.pos.y <= bodyRows)
                 {
                     const i = top + (p.pos.y - 1);
@@ -866,6 +892,56 @@ unittest
     assert(!x.activate());
     assert(x.picked.canFind("app.d"));
 }
+@("explorer.pointer.scrollbarGrabIsNotARowClick")
+@system
+unittest
+{
+    import std.conv : text;
+    import std.file : mkdirRecurse, rmdirRecurse, tempDir, write;
+    import std.path : buildPath;
+    import sparkles.syntax : builtinDark, LabelSet;
+
+    // Enough files to overflow the pane, so the scrollbar exists.
+    const root = buildPath(tempDir(), "hue-explorer-sb-test");
+    mkdirRecurse(root);
+    scope (exit) rmdirRecurse(root);
+    foreach (i; 0 .. 12)
+        write(buildPath(root, text("f", i, ".d")), "int x;\n");
+
+    static immutable Theme dark = builtinDark;
+    ExplorerTui x;
+    x.root = root;
+    x.themeValue = &dark;
+    x.theme = resolveTheme(dark, LabelSet.standard());
+    x.width = 50;
+    x.height = 8; // bodyRows = 6 < 12 rows → the scrollbar is live
+    x.rebuild();
+    assert(cast(long) x.rows.length > x.bodyRows);
+
+    // A press on the scrollbar column grabs the thumb: the selection stays,
+    // nothing activates, and the view jumps by the STM2 inverse mapping.
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(49, 2)))));
+    assert(x.sbDragging);
+    assert(x.sel == 0, "a scrollbar press never selects a row");
+    assert(x.top > 0, "the thumb jumped to the pointer");
+
+    // The drag owns the pointer even off the column — still no row clicks.
+    const grabbed = x.top;
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(20, 6)))));
+    assert(x.top > grabbed && x.sel == 0);
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.release, pos: Point(20, 6)))));
+    assert(!x.sbDragging);
+
+    // Off the scrollbar, a press is still a row click.
+    const want = x.top + 1;
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(5, 2)))));
+    assert(x.sel == want, text(x.sel, " vs ", want));
+}
+
 @("explorer.currentDoc.rowBandAndAccent")
 @system
 unittest

--- a/apps/hue/src/explorer.d
+++ b/apps/hue/src/explorer.d
@@ -31,7 +31,7 @@ import sparkles.ui.display_list : buildDisplayList;
 import sparkles.ui.geometry : SizeSpec;
 import sparkles.ui.layout : layout;
 import sparkles.ui.state : DisclosureState, scrollbarThumb, ScrollState;
-import sparkles.ui.style : Slot;
+import sparkles.ui.style : Slot, TextStyle;
 import sparkles.ui.widget : Builder, Widget, WidgetKind;
 import sparkles.ui_tui : paintGrid;
 
@@ -439,6 +439,12 @@ struct ExplorerTui
 
     /// Scrolls the viewport by `dy` rows (the wheel), leaving the cursor
     /// where it is; the next cursor move re-snaps the view to it.
+    /// Whether pane-local `(x, y)` sits on the live scrollbar column — the
+    /// workspace's pointer-shape hover check.
+    bool overScrollbar(int x, int y) const @safe pure nothrow @nogc
+        => cast(long) rows.length > bodyRows && x == width - 1
+            && y >= 1 && y <= bodyRows;
+
     void scrollBy(long dy) @safe pure nothrow @nogc
     {
         top += dy;
@@ -475,12 +481,13 @@ struct ExplorerTui
         // viewport-sliced (guides are per-row, so slicing is safe).
         auto b = Builder();
         const name = b.add(Widget(kind: WidgetKind.text, text: root,
-            slot: focused ? Slot.chromeAccent : Slot.gutter));
+            slot: focused ? Slot.chromeAccent : Slot.gutter,
+            textStyle: TextStyle(bold: focused)));
         import std.conv : text;
         const pos = b.add(Widget(kind: WidgetKind.text,
             text: text(rows.length ? sel + 1 : 0, "/", rows.length),
             slot: Slot.gutter));
-        const hdr = headerBar(b, [name], null, [pos]);
+        const hdr = headerBar(b, [name], null, [pos], focused);
 
         const first = cast(size_t) top;
         const last = first + bodyRows > rows.length ? rows.length

--- a/apps/hue/src/tui.d
+++ b/apps/hue/src/tui.d
@@ -123,6 +123,11 @@ struct PreviewTui
     private RgbColor[quoteBarCycle] bars;
     private RgbColor sbTrack, sbThumb; // scrollbar track / thumb (theme-tinted)
 
+    /// Whether this pane holds the workspace focus (a standalone viewer is
+    /// always focused). The header title renders accented when focused,
+    /// muted otherwise — the at-a-glance focus indicator.
+    bool focused = true;
+
     // Incremental search (`/`): `searching` is input mode; `qbuf[0 .. qlen]` is
     // the query, reused by `n`/`N`.
     private bool searching;
@@ -524,7 +529,7 @@ struct PreviewTui
 
         auto b = Builder();
         const name = b.add(Widget(kind: WidgetKind.text, text: title,
-            slot: Slot.chromeAccent));
+            slot: focused ? Slot.chromeAccent : Slot.gutter));
         const mid = b.add(Widget(kind: WidgetKind.text, text: text(
             names[themeIdx], " (", themeIdx + 1, "/", names.length, ")  ·  ",
             (showPreview && model.present) ? "preview" : "raw")));

--- a/apps/hue/src/tui.d
+++ b/apps/hue/src/tui.d
@@ -189,6 +189,10 @@ struct PreviewTui
     /// explorer pane when ←/→ cycles the theme (`XPL5`).
     size_t themeIndex() const @safe pure nothrow @nogc => themeIdx;
 
+    /// The active line selection, read-only — the workspace (and its tests)
+    /// observe it to verify pointer-capture routing.
+    Selection!long selection() const @safe pure nothrow @nogc => sel;
+
     /// Sets the pane size in cells (the workspace arranges; `relayout` after).
     void resize(int w, int h) @safe pure nothrow @nogc
     {

--- a/apps/hue/src/tui.d
+++ b/apps/hue/src/tui.d
@@ -111,6 +111,7 @@ struct PreviewTui
     private size_t themeIdx;
     private long top;               // first visible visual line
     private bool sbDragging;        // a scrollbar grab owns the pointer
+    private int sbGrab;             // pointer offset within the grabbed thumb
     private bool showPreview;       // preview vs raw source (Tab)
     private int width, height;      // pane size in cells
     /// Grid column of the pane's left edge — 0 when full-screen; the split
@@ -782,12 +783,16 @@ struct PreviewTui
                     && e.pos.y >= 1 && e.pos.y <= rows)
                 || (e.action == PointerAction.drag && sbDragging)))
         {
+            // The STM2 inverse mapping, grab-relative: a press on the
+            // handle grabs it in place (never jumps), a press on the track
+            // jumps the leading edge to the pointer, and drags move the
+            // thumb relative to the grab point.
+            top = e.action == PointerAction.press && !sbDragging
+                ? ScrollState(top).pressedAt(e.pos.y - 1,
+                    cast(size_t) lineCount, rows, rows, sbGrab).offset
+                : ScrollState(top).draggedTo(e.pos.y - 1,
+                    cast(size_t) lineCount, rows, rows, sbGrab).offset;
             sbDragging = true;
-            // The STM2 inverse mapping: thumb-aware, so a drag lands the
-            // thumb's leading edge where the pointer is.
-            top = ScrollState(top)
-                .draggedTo(e.pos.y - 1, cast(size_t) lineCount, rows, rows)
-                .offset;
             clampTop();
             return true;
         }

--- a/apps/hue/src/tui.d
+++ b/apps/hue/src/tui.d
@@ -38,7 +38,8 @@ import sparkles.ui.layout : Frame, layout;
 import sparkles.ui.state : DisclosureState, DocRow, documentRows, HoverTarget,
     hoverTargets, scrollbarThumb, ScrollState, Selection, selectionRects,
     sourceOffsetAt;
-import sparkles.ui.style : defaultTwoslashPalette, schemeForBackground, Slot;
+import sparkles.ui.style : defaultTwoslashPalette, schemeForBackground, Slot,
+    TextStyle;
 import sparkles.ui.widget : Builder, Widget, WidgetKind, WidgetTree;
 import sparkles.ui_tui : paintGrid;
 
@@ -110,7 +111,8 @@ struct PreviewTui
 
     private size_t themeIdx;
     private long top;               // first visible visual line
-    private bool sbDragging;        // a scrollbar grab owns the pointer
+    bool sbDragging;                // a scrollbar grab owns the pointer
+                                    // (the workspace's pointer-shape check)
     private int sbGrab;             // pointer offset within the grabbed thumb
     private bool showPreview;       // preview vs raw source (Tab)
     private int width, height;      // pane size in cells
@@ -198,6 +200,12 @@ struct PreviewTui
     /// The active line selection, read-only — the workspace (and its tests)
     /// observe it to verify pointer-capture routing.
     Selection!long selection() const @safe pure nothrow @nogc => sel;
+
+    /// Whether pane-local `(x, y)` sits on the live scrollbar column — the
+    /// workspace's pointer-shape hover check.
+    bool overScrollbar(int x, int y) const @safe pure nothrow @nogc
+        => lineCount > bodyRows && x == width - 1
+            && y >= 1 && y <= bodyRows;
 
     /// Sets the pane size in cells (the workspace arranges; `relayout` after).
     void resize(int w, int h) @safe pure nothrow @nogc
@@ -511,9 +519,9 @@ struct PreviewTui
     // `y` through the full widget pipeline: view → layout → display list →
     // the ui-tui GridCanvas. The slots resolve against the theme's palette.
     private void paintBar(ref Grid g, int y, uint[] leading, uint[] center,
-        uint[] trailing, ref Builder b) @system
+        uint[] trailing, ref Builder b, bool focusedBar = false) @system
     {
-        const bar = headerBar(b, leading, center, trailing);
+        const bar = headerBar(b, leading, center, trailing, focusedBar);
         Widget colW = Widget(kind: WidgetKind.column, children: [bar],
             width: SizeSpec.fixed(width));
         const col = b.add(colW);
@@ -529,13 +537,14 @@ struct PreviewTui
 
         auto b = Builder();
         const name = b.add(Widget(kind: WidgetKind.text, text: title,
-            slot: focused ? Slot.chromeAccent : Slot.gutter));
+            slot: focused ? Slot.chromeAccent : Slot.gutter,
+            textStyle: TextStyle(bold: focused)));
         const mid = b.add(Widget(kind: WidgetKind.text, text: text(
             names[themeIdx], " (", themeIdx + 1, "/", names.length, ")  ·  ",
             (showPreview && model.present) ? "preview" : "raw")));
         const pos = b.add(Widget(kind: WidgetKind.text,
             text: text(top + 1, "/", lineCount), slot: Slot.gutter));
-        paintBar(g, 0, [name], [mid], [pos], b);
+        paintBar(g, 0, [name], [mid], [pos], b, focused);
     }
 
     private void paintStatus(ref Grid g) @system

--- a/apps/hue/src/tui.d
+++ b/apps/hue/src/tui.d
@@ -110,6 +110,7 @@ struct PreviewTui
 
     private size_t themeIdx;
     private long top;               // first visible visual line
+    private bool sbDragging;        // a scrollbar grab owns the pointer
     private bool showPreview;       // preview vs raw source (Tab)
     private int width, height;      // pane size in cells
     /// Grid column of the pane's left edge — 0 when full-screen; the split
@@ -761,71 +762,84 @@ struct PreviewTui
     private bool handlePointer(in PointerEvent e) @system
     {
         const rows = bodyRows();
+        if (e.button == PointerButton.left
+            && e.action == PointerAction.release)
+        {
+            sbDragging = false;
+            return true;
+        }
+        // A scrollbar grab OWNS the pointer: the press must land on the
+        // last column, but the drag tracks wherever the pointer strays
+        // (never falling into the selection branch) until release —
+        // and symmetrically, a selection drag crossing the last column
+        // never jumps the scroll.
+        if (e.button == PointerButton.left
+            && ((e.action == PointerAction.press && e.pos.x == width - 1
+                    && e.pos.y >= 1 && e.pos.y <= rows)
+                || (e.action == PointerAction.drag && sbDragging)))
+        {
+            sbDragging = true;
+            // The STM2 inverse mapping: thumb-aware, so a drag lands the
+            // thumb's leading edge where the pointer is.
+            top = ScrollState(top)
+                .draggedTo(e.pos.y - 1, cast(size_t) lineCount, rows, rows)
+                .offset;
+            clampTop();
+            return true;
+        }
         // 0-based cells: row 0 is the header, the body spans rows 1 .. rows.
         if (e.button == PointerButton.left
             && (e.action == PointerAction.press || e.action == PointerAction.drag)
             && e.pos.y >= 1 && e.pos.y <= rows)
         {
-            if (e.pos.x == width - 1) // the scrollbar column (last)
+            // Body — a click on a fence header band copies its body (and
+            // doesn't select): the hit targets are in document cell
+            // coordinates, topmost last, and a fence's id encodes its
+            // body's source offset. Otherwise start (press) or extend
+            // (drag) a line selection.
+            const line = top + (e.pos.y - 1);
+            if (showPreview && e.action == PointerAction.press
+                && tw.code.length)
             {
-                // The STM2 inverse mapping: thumb-aware, so a drag lands the
-                // thumb's leading edge where the pointer is.
-                top = ScrollState(top)
-                    .draggedTo(e.pos.y - 1, cast(size_t) lineCount, rows, rows)
-                    .offset;
-                clampTop();
-            }
-            else
-            {
-                // Body — a click on a fence header band copies its body (and
-                // doesn't select): the hit targets are in document cell
-                // coordinates, topmost last, and a fence's id encodes its
-                // body's source offset. Otherwise start (press) or extend
-                // (drag) a line selection.
-                const line = top + (e.pos.y - 1);
-                if (showPreview && e.action == PointerAction.press
-                    && tw.code.length)
+                const off = sourceOffsetAt(mdTree, mdFrames,
+                    Point(e.pos.x, cast(int) line));
+                if (off >= 0)
+                    foreach (i, ni; hoverNodes)
+                        if (off >= cast(long) tw.nodes[ni].start
+                            && off < cast(long)(tw.nodes[ni].start
+                                + tw.nodes[ni].length))
+                        {
+                            hoverSel = hoverSel == cast(int) i
+                                ? -1 : cast(int) i;
+                            return true;
+                        }
+                if (hoverSel >= 0)
                 {
-                    const off = sourceOffsetAt(mdTree, mdFrames,
-                        Point(e.pos.x, cast(int) line));
-                    if (off >= 0)
-                        foreach (i, ni; hoverNodes)
-                            if (off >= cast(long) tw.nodes[ni].start
-                                && off < cast(long)(tw.nodes[ni].start
-                                    + tw.nodes[ni].length))
-                            {
-                                hoverSel = hoverSel == cast(int) i
-                                    ? -1 : cast(int) i;
-                                return true;
-                            }
-                    if (hoverSel >= 0)
+                    hoverSel = -1; // a click elsewhere dismisses the popup
+                    return true;
+                }
+            }
+            if (e.action == PointerAction.press)
+            {
+                const p = Point(e.pos.x, cast(int) line);
+                foreach_reverse (ref const t; mdTargets)
+                {
+                    if (t.hitId >= foldHitBase && t.rect.contains(p))
                     {
-                        hoverSel = -1; // a click elsewhere dismisses the popup
+                        folds = folds.toggled(t.hitId - foldHitBase);
+                        rebuildMd();
+                        return true;
+                    }
+                    if (t.hitId >= fenceHitBase && t.rect.contains(p))
+                    {
+                        copyFenceAt(t.hitId - fenceHitBase);
                         return true;
                     }
                 }
-                if (e.action == PointerAction.press)
-                {
-                    const p = Point(e.pos.x, cast(int) line);
-                    foreach_reverse (ref const t; mdTargets)
-                    {
-                        if (t.hitId >= foldHitBase && t.rect.contains(p))
-                        {
-                            folds = folds.toggled(t.hitId - foldHitBase);
-                            rebuildMd();
-                            return true;
-                        }
-                        if (t.hitId >= fenceHitBase && t.rect.contains(p))
-                        {
-                            copyFenceAt(t.hitId - fenceHitBase);
-                            return true;
-                        }
-                    }
-                }
-                sel = e.action == PointerAction.press
-                    ? Selection!long.started(line) : sel.extended(line);
-                clampSel();
             }
+            sel = e.action == PointerAction.press
+                ? Selection!long.started(line) : sel.extended(line);
+            clampSel();
         }
         return true;
     }
@@ -908,6 +922,58 @@ unittest
     assert(row(0).canFind("raw"), row(0));    // header: view mode
     assert(row(1).canFind("hello"), row(1));  // first source line, painted into the grid
     assert(row(2).canFind("world"), row(2));  // second source line
+}
+
+@("tui.pointer.scrollbarGrabOwnsThePointer")
+@system
+unittest
+{
+    import sparkles.syntax : builtinDark, HighlightEvent, LabelSet;
+
+    string src;
+    foreach (i; 0 .. 40)
+        src ~= "line\n";
+    HighlightEvent[1] ev = [HighlightEvent.sourceSpan(0, src.length)];
+    static immutable(Theme)[1] themes = [builtinDark];
+    static immutable string[1] names = ["dark"];
+
+    PreviewTui t;
+    t.title = "doc.d";
+    t.source = src;
+    t.events = ev[];
+    t.labels = LabelSet.standard();
+    t.names = names[];
+    t.themes = themes[];
+    t.width = 60;
+    t.height = 6; // bodyRows = 4
+    t.relayout();
+
+    // A press on the scrollbar column grabs the thumb...
+    assert(t.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(59, 3)))));
+    assert(t.sbDragging);
+    const grabbed = t.top;
+    assert(!t.sel.active, "a scrollbar press never starts a selection");
+
+    // ...and the drag keeps scrolling even off the column — no selection.
+    assert(t.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(10, 4)))));
+    assert(t.top > grabbed, "the drag kept scrolling off the column");
+    assert(!t.sel.active, "a scrollbar drag never selects text");
+    assert(t.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.release, pos: Point(10, 4)))));
+    assert(!t.sbDragging);
+
+    // Symmetrically: a selection drag crossing the scrollbar column keeps
+    // selecting and never jumps the scroll.
+    const topBefore = t.top;
+    assert(t.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(5, 2)))));
+    assert(t.sel.active);
+    assert(t.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(59, 3)))));
+    assert(t.sel.active && t.sel.lo != t.sel.hi, "the selection extended");
+    assert(t.top == topBefore, "a selection drag never scrolls the thumb");
 }
 
 @("tui.paint.markdownWidgets.fenceCopy")

--- a/apps/hue/src/workspace.d
+++ b/apps/hue/src/workspace.d
@@ -69,6 +69,12 @@ struct WorkspaceTui
     SplitState split = SplitState(32);
     private enum minTreeCols = 12;
 
+    // Pointer capture: the pane that took the press owns every drag until
+    // release, so a grab (a scrollbar thumb, a selection) never leaks into
+    // the neighbouring pane when the drag crosses the divider.
+    private bool pointerDown;
+    private bool pointerOnTree;
+
     /// Recomputes the pane geometry for the current terminal size.
     void arrange(int w, int h) @system
     {
@@ -256,19 +262,29 @@ struct WorkspaceTui
                 return true;
         }
 
-        // Pointer events pick their pane by position (click-to-focus) and
-        // arrive pane-local; everything else goes to the focused pane.
+        // Pointer events pick their pane by position on PRESS (click-to-
+        // focus) and arrive pane-local; the press captures the pointer, so
+        // drags stay with the owning pane across the divider until release.
+        // Everything else goes to the focused pane.
         bool toTree = treeFocused;
         Event ev = e;
         e.match!((in PointerEvent p) {
-            toTree = treeVisible && p.pos.x < tree.width;
+            if (p.action == PointerAction.press || !pointerDown)
+            {
+                pointerOnTree = treeVisible && p.pos.x < tree.width;
+                pointerDown = p.action != PointerAction.release;
+                if (p.action == PointerAction.press)
+                    treeFocused = pointerOnTree;
+            }
+            else if (p.action == PointerAction.release)
+                pointerDown = false;
+            toTree = pointerOnTree;
             if (!toTree && viewer.originX > 0)
             {
                 PointerEvent q = p;
                 q.pos = Point(p.pos.x - viewer.originX, p.pos.y);
                 ev = Event(q);
             }
-            treeFocused = toTree;
         }, (_) {});
 
         if (toTree && treeVisible)
@@ -540,6 +556,79 @@ unittest
     assert(w.tree.width == 50, "clamped at half the screen");
     w.handle(Event(PointerEvent(button: PointerButton.left,
         action: PointerAction.release, pos: Point(99, 4))));
+}
+
+@("workspace.pointerCapture.grabsStayWithTheirPane")
+@system
+unittest
+{
+    import std.conv : text;
+    import std.file : mkdirRecurse, rmdirRecurse, tempDir, write;
+    import std.path : buildPath;
+    import sparkles.syntax : builtinDark, LabelSet;
+
+    // Enough files that the tree overflows its pane (its scrollbar is live)
+    // and a long document in the viewer.
+    const root = buildPath(tempDir(), "hue-workspace-capture-test");
+    mkdirRecurse(root);
+    scope (exit) rmdirRecurse(root);
+    foreach (i; 0 .. 20)
+        write(buildPath(root, text("f", i, ".d")), "int x;\n");
+    string src;
+    foreach (i; 0 .. 40)
+        src ~= "int line;\n";
+    write(buildPath(root, "long.d"), src);
+
+    static immutable(Theme)[1] themes = [builtinDark];
+    static immutable string[1] names = ["dark"];
+    WorkspaceTui w;
+    w.loadDoc = delegate WorkspaceDoc(string path) @system {
+        import std.file : readText;
+        import std.path : baseName;
+
+        const s = readText(path);
+        return WorkspaceDoc(baseName(path), s,
+            [HighlightEvent.sourceSpan(0, s.length)], PreviewModel.init);
+    };
+    w.tree.root = root;
+    w.tree.themeValue = &themes[0];
+    w.tree.theme = resolveTheme(themes[0], LabelSet.standard());
+    w.viewer.names = names[];
+    w.viewer.themes = themes[];
+    w.viewer.labels = LabelSet.standard();
+    w.treeVisible = true;
+    w.tree.rebuild();
+    w.arrange(100, 12);
+    w.openDoc(buildPath(root, "long.d"));
+    assert(cast(long) w.tree.rows.length > w.tree.bodyRows);
+
+    // A grab on the tree's scrollbar stays with the tree when the drag
+    // crosses the divider into the document pane — no text selection.
+    const sbCol = w.tree.width - 1;
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(sbCol, 2)))));
+    assert(w.tree.sbDragging);
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(60, 6)))));
+    assert(w.tree.sbDragging, "the tree kept the grab across the divider");
+    assert(!w.viewer.selection.active, "no text selection from a tree-owned drag");
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.release, pos: Point(60, 6)))));
+    assert(!w.tree.sbDragging);
+
+    // Symmetrically: a selection started in the document keeps extending
+    // when the drag crosses into the tree pane — and never steals focus.
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(60, 2)))));
+    assert(w.viewer.selection.active);
+    assert(!w.treeFocused, "the press focused the viewer");
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(5, 5)))));
+    assert(w.viewer.selection.active && w.viewer.selection.lo != w.viewer.selection.hi,
+        "the selection extended across the divider");
+    assert(!w.treeFocused, "a drag never steals focus");
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.release, pos: Point(5, 5)))));
 }
 
 @("workspace.wheel.scrollsThePaneUnderTheCursor")

--- a/apps/hue/src/workspace.d
+++ b/apps/hue/src/workspace.d
@@ -16,6 +16,7 @@ version (Posix):
 import core.time : msecs;
 import std.path : dirName;
 
+import sparkles.base.term_control : PointerShape;
 import sparkles.syntax : HighlightEvent, LabelSet, resolveTheme, RgbColor,
     Theme, toRgb;
 import sparkles.syntax.ts.injection : TsConfigCache;
@@ -76,11 +77,12 @@ struct WorkspaceTui
     private bool pointerDown;
     private bool pointerOnTree;
 
-    // Divider hover: over the divider column (or mid divider-drag) the
-    // terminal pointer becomes `ew-resize` (OSC 22); leaving restores
-    // `default`. The loop drains `takeCursorShape` after each event and
-    // writes it out of band — only transitions emit.
-    private bool resizeCursor;
+    // Pointer shape (OSC 22): grab state first — an active divider or
+    // scrollbar grab HOLDS its shape until release, wherever the pointer
+    // strays — then hover (the divider column → ew-resize, a scrollbar
+    // column → ns-resize). The loop drains `takeCursorShape` after each
+    // event and writes it out of band — only transitions emit.
+    private PointerShape curShape = PointerShape.default_;
     private const(char)[] pendingCursor;
 
     /// The pointer-shape sequence to write to the terminal, if the hover
@@ -200,16 +202,26 @@ struct WorkspaceTui
     /// Applies one event; returns false to quit.
     bool handle(in Event e) @system
     {
-        // Divider hover (observes only — never consumes): the resize cursor
-        // shows over the divider column and stays for the whole drag.
+        // Pointer shape (observes only — never consumes). Grabs outrank
+        // hover, so the shape holds through the whole drag no matter where
+        // the pointer strays; the scrollbars are vertical → ns-resize.
         e.match!((in PointerEvent p) {
-            const want = treeVisible
-                && (split.dragging || p.pos.x == tree.width);
-            if (want != resizeCursor)
+            PointerShape want;
+            if (split.dragging)
+                want = PointerShape.ewResize;
+            else if (viewer.sbDragging || tree.sbDragging)
+                want = PointerShape.nsResize;
+            else if (treeVisible && p.pos.x == tree.width)
+                want = PointerShape.ewResize;
+            else if ((treeVisible && tree.overScrollbar(p.pos.x, p.pos.y))
+                || viewer.overScrollbar(p.pos.x - viewer.originX, p.pos.y))
+                want = PointerShape.nsResize;
+            else
+                want = PointerShape.default_;
+            if (want != curShape)
             {
-                resizeCursor = want;
-                pendingCursor = want
-                    ? "\x1b]22;ew-resize\x1b\\" : "\x1b]22;default\x1b\\";
+                curShape = want;
+                pendingCursor = "\x1b]22;" ~ cast(string) want ~ "\x1b\\";
             }
         }, (_) {});
 
@@ -685,11 +697,22 @@ unittest
     const root = buildPath(tempDir(), "hue-workspace-chrome-test");
     mkdirRecurse(root);
     scope (exit) rmdirRecurse(root);
-    write(buildPath(root, "a.d"), "int a;\n");
+    string src;
+    foreach (i; 0 .. 40)
+        src ~= "int line;\n";
+    write(buildPath(root, "long.d"), src);
 
     static immutable(Theme)[1] themes = [builtinDark];
     static immutable string[1] names = ["dark"];
     WorkspaceTui w;
+    w.loadDoc = delegate WorkspaceDoc(string path) @system {
+        import std.file : readText;
+        import std.path : baseName;
+
+        const s = readText(path);
+        return WorkspaceDoc(baseName(path), s,
+            [HighlightEvent.sourceSpan(0, s.length)], PreviewModel.init);
+    };
     w.tree.root = root;
     w.tree.themeValue = &themes[0];
     w.tree.theme = resolveTheme(themes[0], LabelSet.standard());
@@ -700,6 +723,7 @@ unittest
     w.treeFocused = true;
     w.tree.rebuild();
     w.arrange(100, 12);
+    w.openDoc(buildPath(root, "long.d"));
 
     // OSC 22 divider hover: entering emits ew-resize, leaving restores the
     // default, and no-transition motion emits nothing.
@@ -714,8 +738,27 @@ unittest
         pos: Point(60, 6)))));
     assert(w.takeCursorShape() == "\x1b]22;default\x1b\\");
 
+    // The viewer's scrollbar column hovers as ns-resize (vertical), and a
+    // grab HOLDS the shape wherever the drag strays — no revert mid-drag.
+    assert(w.handle(Event(PointerEvent(action: PointerAction.move,
+        pos: Point(99, 4)))));
+    assert(w.takeCursorShape() == "\x1b]22;ns-resize\x1b\\");
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(99, 4)))));
+    assert(w.viewer.sbDragging);
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(60, 6)))));
+    assert(w.takeCursorShape().length == 0,
+        "the grab held the shape through the stray drag");
+    assert(w.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.release, pos: Point(60, 6)))));
+    assert(w.handle(Event(PointerEvent(action: PointerAction.move,
+        pos: Point(60, 6)))));
+    assert(w.takeCursorShape() == "\x1b]22;default\x1b\\");
+
     // Focus indication: paint stamps the focused pane; the hidden-tree
     // viewer is always focused (the standalone look).
+    w.treeFocused = true; // (openDoc handed focus to the viewer)
     Grid g;
     g.resize(100, 12);
     w.paint(g);

--- a/apps/hue/src/workspace.d
+++ b/apps/hue/src/workspace.d
@@ -19,7 +19,8 @@ import std.path : dirName;
 import sparkles.syntax : HighlightEvent, LabelSet, resolveTheme, RgbColor,
     Theme, toRgb;
 import sparkles.syntax.ts.injection : TsConfigCache;
-import sparkles.tui : CellStyle, Color, Grid, PosixEvents, Terminal;
+import sparkles.tui : CellStyle, Color, Grid, PosixEvents, Terminal,
+    TerminalOptions;
 import sparkles.tui.input : EndOfInput, Event, isEndOfInput, Key, KeyEvent,
     match, PointerAction, PointerButton, PointerEvent, ResizeEvent, WheelEvent;
 import sparkles.ui.geometry : Point;
@@ -75,6 +76,22 @@ struct WorkspaceTui
     private bool pointerDown;
     private bool pointerOnTree;
 
+    // Divider hover: over the divider column (or mid divider-drag) the
+    // terminal pointer becomes `ew-resize` (OSC 22); leaving restores
+    // `default`. The loop drains `takeCursorShape` after each event and
+    // writes it out of band — only transitions emit.
+    private bool resizeCursor;
+    private const(char)[] pendingCursor;
+
+    /// The pointer-shape sequence to write to the terminal, if the hover
+    /// state changed since the last take (empty otherwise).
+    const(char)[] takeCursorShape() return @safe pure nothrow @nogc
+    {
+        const s = pendingCursor;
+        pendingCursor = null;
+        return s;
+    }
+
     /// Recomputes the pane geometry for the current terminal size.
     void arrange(int w, int h) @system
     {
@@ -99,13 +116,21 @@ struct WorkspaceTui
         page.bg = Color.fromRgb(pageBg);
         g.clearTo(page);
 
+        // Focus indication: the focused pane's header renders accented, the
+        // other muted; with the tree hidden the viewer is always focused
+        // (the standalone look).
+        tree.focused = treeFocused;
+        viewer.focused = !treeFocused || !treeVisible;
+
         if (treeVisible)
         {
             tree.paint(g);
             // The divider: a full-height │ rule between the panes, tinted
-            // toward the focused side's chrome.
+            // toward the focused side — the tree's accent when the tree
+            // holds focus, the muted chrome color otherwise.
             CellStyle div = page;
-            div.fg = Color.fromRgb(toRgb(tree.theme.defaults.fg, pageFg));
+            div.fg = Color.fromRgb(treeFocused
+                ? tree.accent : toRgb(tree.theme.defaults.fg, pageFg));
             foreach (y; 0 .. g.rows)
                 g.putText(cast(ushort) tree.width, cast(ushort) y, "│", div);
         }
@@ -175,6 +200,19 @@ struct WorkspaceTui
     /// Applies one event; returns false to quit.
     bool handle(in Event e) @system
     {
+        // Divider hover (observes only — never consumes): the resize cursor
+        // shows over the divider column and stays for the whole drag.
+        e.match!((in PointerEvent p) {
+            const want = treeVisible
+                && (split.dragging || p.pos.x == tree.width);
+            if (want != resizeCursor)
+            {
+                resizeCursor = want;
+                pendingCursor = want
+                    ? "\x1b]22;ew-resize\x1b\\" : "\x1b]22;default\x1b\\";
+            }
+        }, (_) {});
+
         // The wheel scrolls the pane under the CURSOR, not the focused one —
         // both ways: over the tree it scrolls the tree, anywhere else it goes
         // to the viewer (whose wheel arm is position-blind), so a focused
@@ -365,7 +403,9 @@ int runWorkspace(string target, bool isDir, WorkspaceDoc initial,
     else if (!isDir && target.length)
         w.openDoc(target);
 
-    auto term = Terminal.open();
+    // Any-event tracking (1003): bare pointer motion reports too, so the
+    // divider can show a hover resize cursor.
+    auto term = Terminal.open(TerminalOptions(motion: true));
     if (!term.active)
         return 1;
     scope (exit) term.close();
@@ -386,6 +426,9 @@ int runWorkspace(string target, bool isDir, WorkspaceDoc initial,
         const clip = w.viewer.takeClipboard();
         if (clip.length)
             term.writeRaw(clip); // OSC 52 clipboard write (out of band)
+        const shape = w.takeCursorShape();
+        if (shape.length)
+            term.writeRaw(shape); // OSC 22 pointer shape (out of band)
 
         // While a git-status refresh is in flight, wait in short slices so
         // the finished snapshot paints without requiring a keypress; with
@@ -629,6 +672,62 @@ unittest
     assert(!w.treeFocused, "a drag never steals focus");
     assert(w.handle(Event(PointerEvent(button: PointerButton.left,
         action: PointerAction.release, pos: Point(5, 5)))));
+}
+
+@("workspace.chrome.hoverCursorAndFocusIndication")
+@system
+unittest
+{
+    import std.file : mkdirRecurse, rmdirRecurse, tempDir, write;
+    import std.path : buildPath;
+    import sparkles.syntax : builtinDark, LabelSet;
+
+    const root = buildPath(tempDir(), "hue-workspace-chrome-test");
+    mkdirRecurse(root);
+    scope (exit) rmdirRecurse(root);
+    write(buildPath(root, "a.d"), "int a;\n");
+
+    static immutable(Theme)[1] themes = [builtinDark];
+    static immutable string[1] names = ["dark"];
+    WorkspaceTui w;
+    w.tree.root = root;
+    w.tree.themeValue = &themes[0];
+    w.tree.theme = resolveTheme(themes[0], LabelSet.standard());
+    w.viewer.names = names[];
+    w.viewer.themes = themes[];
+    w.viewer.labels = LabelSet.standard();
+    w.treeVisible = true;
+    w.treeFocused = true;
+    w.tree.rebuild();
+    w.arrange(100, 12);
+
+    // OSC 22 divider hover: entering emits ew-resize, leaving restores the
+    // default, and no-transition motion emits nothing.
+    const div = w.tree.width;
+    assert(w.handle(Event(PointerEvent(action: PointerAction.move,
+        pos: Point(div, 4)))));
+    assert(w.takeCursorShape() == "\x1b]22;ew-resize\x1b\\");
+    assert(w.handle(Event(PointerEvent(action: PointerAction.move,
+        pos: Point(div, 6)))));
+    assert(w.takeCursorShape().length == 0, "no transition, no write");
+    assert(w.handle(Event(PointerEvent(action: PointerAction.move,
+        pos: Point(60, 6)))));
+    assert(w.takeCursorShape() == "\x1b]22;default\x1b\\");
+
+    // Focus indication: paint stamps the focused pane; the hidden-tree
+    // viewer is always focused (the standalone look).
+    Grid g;
+    g.resize(100, 12);
+    w.paint(g);
+    assert(w.tree.focused && !w.viewer.focused);
+    w.treeFocused = false;
+    w.paint(g);
+    assert(!w.tree.focused && w.viewer.focused);
+    w.treeVisible = false;
+    w.treeFocused = true; // stale focus flag must not defeat the fallback
+    w.arrange(100, 12);
+    w.paint(g);
+    assert(w.viewer.focused, "a lone viewer is always focused");
 }
 
 @("workspace.wheel.scrollsThePaneUnderTheCursor")

--- a/apps/hue/src/workspace.d
+++ b/apps/hue/src/workspace.d
@@ -206,6 +206,8 @@ struct WorkspaceTui
         // hover, so the shape holds through the whole drag no matter where
         // the pointer strays; the scrollbars are vertical → ns-resize.
         e.match!((in PointerEvent p) {
+            const grabbed = split.dragging || viewer.sbDragging
+                || tree.sbDragging;
             PointerShape want;
             if (split.dragging)
                 want = PointerShape.ewResize;
@@ -218,7 +220,11 @@ struct WorkspaceTui
                 want = PointerShape.nsResize;
             else
                 want = PointerShape.default_;
-            if (want != curShape)
+            // Re-assert on every event while a grab is live: some terminals
+            // and multiplexers reset the pointer themselves when a drag
+            // starts, clobbering the OSC 22 shape — a repeated set is
+            // idempotent and a few bytes, so keep re-applying it.
+            if (want != curShape || (grabbed && p.action == PointerAction.drag))
             {
                 curShape = want;
                 pendingCursor = "\x1b]22;" ~ cast(string) want ~ "\x1b\\";
@@ -748,8 +754,11 @@ unittest
     assert(w.viewer.sbDragging);
     assert(w.handle(Event(PointerEvent(button: PointerButton.left,
         action: PointerAction.drag, pos: Point(60, 6)))));
-    assert(w.takeCursorShape().length == 0,
-        "the grab held the shape through the stray drag");
+    // Mid-grab drags RE-ASSERT the held shape (never default): terminals /
+    // multiplexers may reset the pointer on drag start, so the idempotent
+    // re-set keeps the resize shape pinned.
+    assert(w.takeCursorShape() == "\x1b]22;ns-resize\x1b\\",
+        "the grab re-asserts its shape through the stray drag");
     assert(w.handle(Event(PointerEvent(button: PointerButton.left,
         action: PointerAction.release, pos: Point(60, 6)))));
     assert(w.handle(Event(PointerEvent(action: PointerAction.move,
@@ -763,6 +772,13 @@ unittest
     g.resize(100, 12);
     w.paint(g);
     assert(w.tree.focused && !w.viewer.focused);
+    // The focused pane's header title is BOLD on the accent band; the
+    // unfocused pane's is not (the at-a-glance indicator).
+    import sparkles.base.term_style : TextAttr;
+    assert(g[1, 0].style.attrs.has(TextAttr.bold),
+        "the focused tree title renders bold");
+    assert(!g[cast(ushort)(w.viewer.originX + 1), 0].style.attrs
+        .has(TextAttr.bold), "the unfocused viewer title stays regular");
     w.treeFocused = false;
     w.paint(g);
     assert(!w.tree.focused && w.viewer.focused);

--- a/apps/hue/src/workspace.d
+++ b/apps/hue/src/workspace.d
@@ -169,15 +169,18 @@ struct WorkspaceTui
     /// Applies one event; returns false to quit.
     bool handle(in Event e) @system
     {
-        // The wheel scrolls the pane under the CURSOR, not the focused one.
+        // The wheel scrolls the pane under the CURSOR, not the focused one —
+        // both ways: over the tree it scrolls the tree, anywhere else it goes
+        // to the viewer (whose wheel arm is position-blind), so a focused
+        // tree never swallows a wheel spun over the document.
         {
             bool done;
             e.match!((in WheelEvent wv) {
                 if (treeVisible && wv.pos.x < tree.width)
-                {
                     tree.scrollBy(3 * wv.dy);
-                    done = true;
-                }
+                else
+                    viewer.handle(e);
+                done = true;
             }, (_) {});
             if (done)
                 return true;
@@ -537,4 +540,72 @@ unittest
     assert(w.tree.width == 50, "clamped at half the screen");
     w.handle(Event(PointerEvent(button: PointerButton.left,
         action: PointerAction.release, pos: Point(99, 4))));
+}
+
+@("workspace.wheel.scrollsThePaneUnderTheCursor")
+@system
+unittest
+{
+    import std.algorithm.searching : canFind;
+    import std.file : mkdirRecurse, rmdirRecurse, tempDir, write;
+    import std.path : buildPath;
+    import sparkles.syntax : builtinDark, LabelSet;
+
+    const root = buildPath(tempDir(), "hue-workspace-wheel-test");
+    mkdirRecurse(root);
+    scope (exit) rmdirRecurse(root);
+    string src;
+    foreach (i; 0 .. 30)
+        src ~= "int line" ~ cast(char)('0' + i / 10) ~ cast(char)('0' + i % 10)
+            ~ ";\n";
+    write(buildPath(root, "long.d"), src);
+
+    static immutable(Theme)[1] themes = [builtinDark];
+    static immutable string[1] names = ["dark"];
+    WorkspaceTui w;
+    w.loadDoc = delegate WorkspaceDoc(string path) @system {
+        import std.file : readText;
+        import std.path : baseName;
+
+        const s = readText(path);
+        return WorkspaceDoc(baseName(path), s,
+            [HighlightEvent.sourceSpan(0, s.length)], PreviewModel.init);
+    };
+    w.tree.root = root;
+    w.tree.themeValue = &themes[0];
+    w.tree.theme = resolveTheme(themes[0], LabelSet.standard());
+    w.viewer.names = names[];
+    w.viewer.themes = themes[];
+    w.viewer.labels = LabelSet.standard();
+    w.treeVisible = true;
+    w.tree.rebuild();
+    w.arrange(100, 12);
+    w.openDoc(buildPath(root, "long.d"));
+
+    // The failing configuration: the TREE holds focus while the wheel spins
+    // over the DOCUMENT pane — the wheel must scroll the pane under the
+    // cursor, not be swallowed by the focused tree.
+    w.treeFocused = true;
+    Grid g;
+    g.resize(100, 12);
+    w.paint(g);
+    string row(ushort y)
+    {
+        string s;
+        foreach (x; 0 .. g.cols)
+            s ~= g[cast(ushort) x, y].grapheme;
+        return s;
+    }
+    assert(row(1)[w.viewer.originX .. $].canFind("int line00;"), row(1));
+
+    assert(w.handle(Event(WheelEvent(dy: 1, pos: Point(60, 5)))));
+    w.paint(g);
+    assert(row(1)[w.viewer.originX .. $].canFind("int line03;"),
+        "wheel over the document scrolled it despite tree focus: " ~ row(1));
+    assert(w.treeFocused, "the wheel does not steal focus");
+
+    // And back up.
+    assert(w.handle(Event(WheelEvent(dy: -1, pos: Point(60, 5)))));
+    w.paint(g);
+    assert(row(1)[w.viewer.originX .. $].canFind("int line00;"), row(1));
 }

--- a/libs/base/src/sparkles/base/term_control.d
+++ b/libs/base/src/sparkles/base/term_control.d
@@ -133,11 +133,26 @@ void writeEscapeSeq(DecMode mode, bool set, Writer)(ref Writer w)
 }
 
 /// Enable/disable SGR mouse reporting — button press/release (1000), drag (1002),
-/// and the SGR extended coordinate encoding (1006) — in a single `put`. The
-/// composite mode string is a compile-time constant selected by `on`.
-void writeMouseTracking(Writer)(ref Writer w, bool on)
+/// and the SGR extended coordinate encoding (1006) — in a single `put`. With
+/// `motion`, any-event tracking (1003) replaces 1002, so bare pointer motion
+/// reports too (hover affordances — e.g. a resize cursor over a divider).
+void writeMouseTracking(Writer)(ref Writer w, bool on, bool motion = false)
 {
-    put(w, on ? "\x1b[?1000;1002;1006h" : "\x1b[?1000;1002;1006l");
+    if (motion)
+        put(w, on ? "\x1b[?1000;1003;1006h" : "\x1b[?1000;1003;1006l");
+    else
+        put(w, on ? "\x1b[?1000;1002;1006h" : "\x1b[?1000;1002;1006l");
+}
+
+/// Set the terminal's pointer shape (xterm OSC 22; kitty, ghostty, wezterm
+/// and foot honor it, others ignore it): a CSS cursor keyword — `default`,
+/// `ew-resize`, `pointer`, `text`, … An empty/`default` shape restores the
+/// terminal's own choice.
+void writePointerShape(Writer)(ref Writer w, scope const(char)[] shape)
+{
+    put(w, "\x1b]22;");
+    put(w, shape);
+    put(w, "\x1b\\");
 }
 
 // ---------------------------------------------------------------------------
@@ -229,4 +244,12 @@ unittest
     b.clear();
     writeMouseTracking(b, false);
     assert(b[] == "\x1b[?1000;1002;1006l");
+    b.clear();
+    writeMouseTracking(b, true, motion: true);
+    assert(b[] == "\x1b[?1000;1003;1006h");
+
+    // Pointer shape (OSC 22).
+    b.clear();
+    writePointerShape(b, "ew-resize");
+    assert(b[] == "\x1b]22;ew-resize\x1b\\");
 }

--- a/libs/base/src/sparkles/base/term_control.d
+++ b/libs/base/src/sparkles/base/term_control.d
@@ -41,12 +41,30 @@ enum CtlSeq : string
 enum DecMode : ushort
 {
     autowrap       = 7,    /// Autowrap (DECAWM); reset so a full-width last cell can't wrap.
+    mouseButtons   = 1000, /// Mouse button press/release reporting.
+    mouseDrag      = 1002, /// Mouse motion reporting while a button is held.
+    mouseAnyMotion = 1003, /// Mouse motion reporting regardless of buttons (hover).
+    mouseSgr       = 1006, /// SGR extended mouse coordinate encoding.
     altScreen      = 1049, /// Alternate screen buffer.
     bracketedPaste = 2004, /// Bracketed paste.
     syncOutput     = 2026, /// Synchronized output (atomic frame flush).
     unicodeCore    = 2027, /// Grapheme-cluster width handling.
     colorScheme    = 2031, /// Light/dark color-scheme update reports.
     inBandResize   = 2048, /// In-band resize notifications.
+}
+
+/// Terminal pointer shapes (xterm OSC 22, the CSS `cursor` keywords —
+/// kitty, ghostty, wezterm and foot honor them, others ignore the OSC).
+/// `default_` restores the terminal's own pointer.
+enum PointerShape : string
+{
+    default_ = "default",   /// the terminal's normal pointer
+    text     = "text",      /// the I-beam over selectable text
+    pointer  = "pointer",   /// the link hand
+    ewResize = "ew-resize", /// horizontal resize (a vertical divider)
+    nsResize = "ns-resize", /// vertical resize (a horizontal divider)
+    grab     = "grab",      /// an open hand (draggable content)
+    grabbing = "grabbing",  /// a closed hand (a drag in progress)
 }
 
 // Every writer below emits nothing for a zero argument: CSI treats a missing/0
@@ -132,22 +150,55 @@ void writeEscapeSeq(DecMode mode, bool set, Writer)(ref Writer w)
     put(w, seq);
 }
 
-/// Enable/disable SGR mouse reporting — button press/release (1000), drag (1002),
-/// and the SGR extended coordinate encoding (1006) — in a single `put`. With
-/// `motion`, any-event tracking (1003) replaces 1002, so bare pointer motion
+/// Emit several DEC private modes as one composite set/reset
+/// (`CSI ? m1;m2;… h|l`), CTFE-collapsed into a single `put` — the composed
+/// counterpart of the one-mode overload above.
+void writeEscapeSeq(DecMode[] modes, bool set, Writer)(ref Writer w)
+if (modes.length > 0)
+{
+    enum string seq = () {
+        import std.conv : to;
+
+        string s = "\x1b[?";
+        foreach (i, m; modes)
+            s ~= (i ? ";" : "") ~ (cast(uint) m).to!string;
+        return s ~ (set ? "h" : "l");
+    }();
+    put(w, seq);
+}
+
+/// Emit an xterm OSC 22 pointer-shape set, CTFE-collapsed into a single
+/// `put` (see $(LREF PointerShape); unsupporting terminals ignore the OSC).
+void writeEscapeSeq(PointerShape shape, Writer)(ref Writer w)
+{
+    enum string seq = "\x1b]22;" ~ cast(string) shape ~ "\x1b\\";
+    put(w, seq);
+}
+
+/// Enable/disable SGR mouse reporting — button press/release, drag motion,
+/// and the SGR extended coordinate encoding — in a single `put`. With
+/// `motion`, any-event tracking replaces drag-only, so bare pointer motion
 /// reports too (hover affordances — e.g. a resize cursor over a divider).
 void writeMouseTracking(Writer)(ref Writer w, bool on, bool motion = false)
 {
-    if (motion)
-        put(w, on ? "\x1b[?1000;1003;1006h" : "\x1b[?1000;1003;1006l");
+    with (DecMode) if (motion)
+    {
+        if (on)
+            writeEscapeSeq!([mouseButtons, mouseAnyMotion, mouseSgr], true)(w);
+        else
+            writeEscapeSeq!([mouseButtons, mouseAnyMotion, mouseSgr], false)(w);
+    }
     else
-        put(w, on ? "\x1b[?1000;1002;1006h" : "\x1b[?1000;1002;1006l");
+    {
+        if (on)
+            writeEscapeSeq!([mouseButtons, mouseDrag, mouseSgr], true)(w);
+        else
+            writeEscapeSeq!([mouseButtons, mouseDrag, mouseSgr], false)(w);
+    }
 }
 
-/// Set the terminal's pointer shape (xterm OSC 22; kitty, ghostty, wezterm
-/// and foot honor it, others ignore it): a CSS cursor keyword — `default`,
-/// `ew-resize`, `pointer`, `text`, … An empty/`default` shape restores the
-/// terminal's own choice.
+/// Set the terminal's pointer shape from a runtime keyword (the CTFE
+/// $(LREF writeEscapeSeq) overload covers the static spellings).
 void writePointerShape(Writer)(ref Writer w, scope const(char)[] shape)
 {
     put(w, "\x1b]22;");
@@ -247,9 +298,15 @@ unittest
     b.clear();
     writeMouseTracking(b, true, motion: true);
     assert(b[] == "\x1b[?1000;1003;1006h");
-
-    // Pointer shape (OSC 22).
     b.clear();
-    writePointerShape(b, "ew-resize");
+    writeEscapeSeq!([DecMode.mouseButtons, DecMode.mouseSgr], true)(b);
+    assert(b[] == "\x1b[?1000;1006h");
+
+    // Pointer shape (OSC 22): the CTFE enum spelling and the runtime one.
+    b.clear();
+    writeEscapeSeq!(PointerShape.ewResize)(b);
     assert(b[] == "\x1b]22;ew-resize\x1b\\");
+    b.clear();
+    writePointerShape(b, "ns-resize");
+    assert(b[] == "\x1b]22;ns-resize\x1b\\");
 }

--- a/libs/tui/src/sparkles/tui/render.d
+++ b/libs/tui/src/sparkles/tui/render.d
@@ -179,15 +179,31 @@ struct Screen
         if (r1 - r0 + 1 <= absD)
             return;
 
-        // Set the scroll region, scroll it, reset the region.
+        // Set the scroll region, scroll it, reset the region. Upward is SU
+        // (`CSI n S`). Downward is NOT SD (`CSI n T`): zellij silently
+        // ignores SD — probably because `CSI Ps;…(5 params) T` doubles as
+        // xterm's highlight-mouse-tracking hijack — which desyncs the
+        // retained mirror and freezes every row the diff then trusts.
+        // `IL` at the region's top row has the identical effect (VT102
+        // baseline, no ambiguity, verified in zellij/ghostty/xterm).
         put(w, "\x1b[");
         writeInteger(w, cast(uint)(r0 + 1));
         put(w, ';');
         writeInteger(w, cast(uint)(r1 + 1));
         put(w, 'r');
-        put(w, "\x1b[");
-        writeInteger(w, cast(uint) absD);
-        put(w, bestD > 0 ? 'S' : 'T'); // SU / SD
+        if (bestD > 0)
+        {
+            put(w, "\x1b[");
+            writeInteger(w, cast(uint) absD);
+            put(w, 'S'); // SU
+        }
+        else
+        {
+            writeCursorTo(w, cast(uint)(r0 + 1), 1); // IL needs the cursor in-region
+            put(w, "\x1b[");
+            writeInteger(w, cast(uint) absD);
+            put(w, 'L'); // IL == SD-by-n with the cursor on the region's top row
+        }
         put(w, "\x1b[r"); // reset the scroll region to full screen
 
         // Mirror the terminal's shift in the retained grid (blank the vacated
@@ -314,4 +330,41 @@ unittest
     assert(s.canFind("\x1b[2S"), s);              // scroll up by 2 (SU)
     assert(s.canFind("nA") && s.canFind("nB"), s); // only the exposed rows are drawn
     assert(!s.canFind("r2") && !s.canFind("r7"), s); // preserved rows are NOT re-emitted
+}
+
+@("render.screen.downwardScrollEmitsIlNotSd")
+@safe nothrow
+unittest
+{
+    import sparkles.base.smallbuffer : SmallBuffer;
+    import sparkles.tui.cell : CellStyle;
+    import std.algorithm.searching : canFind;
+
+    static immutable string[8] labels = ["r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7"];
+    Grid g;
+    g.resize(6, 8);
+    foreach (ushort y; 0 .. 8)
+        g.putText(0, y, labels[y], CellStyle.init);
+
+    Screen scr;
+    SmallBuffer!char full;
+    scr.render(g, full); // first frame — full paint
+
+    // Scroll the whole grid down by 2 (the viewer scrolling up) and expose
+    // two new rows at the top.
+    g.scrollRect(0, 0, 6, 8, 2, CellStyle.init);
+    g.putText(0, 0, "nA", CellStyle.init);
+    g.putText(0, 1, "nB", CellStyle.init);
+
+    SmallBuffer!char diff;
+    scr.render(g, diff);
+    const s = diff[];
+    // Downward must be IL at the region top, NEVER SD (`CSI n T`): zellij
+    // silently ignores SD, which desyncs the retained mirror and leaves
+    // frozen rows on screen (the scroll-up-under-zellij regression).
+    assert(s.canFind("\x1b[1;8r"), s);             // DECSTBM region rows 1..8
+    assert(s.canFind("\x1b[1;1H\x1b[2L"), s);      // cursor to region top + IL 2
+    assert(!s.canFind("\x1b[2T"), s);              // no SD
+    assert(s.canFind("nA") && s.canFind("nB"), s); // only the exposed rows are drawn
+    assert(!s.canFind("r2") && !s.canFind("r5"), s); // preserved rows are NOT re-emitted
 }

--- a/libs/tui/src/sparkles/tui/terminal.d
+++ b/libs/tui/src/sparkles/tui/terminal.d
@@ -39,6 +39,10 @@ struct TerminalOptions
     bool altScreen = true;   /// switch to the alternate screen buffer
     bool hideCursor = true;  /// hide the cursor for the session
     bool mouse = true;       /// enable SGR mouse reporting (press + drag + wheel)
+    /// With `mouse`: any-event tracking (1003) instead of drag-only (1002),
+    /// so bare motion reports too (hover affordances — a divider's resize
+    /// cursor). Costs one input event per pointer move.
+    bool motion;
 }
 
 /// A raw-mode, alt-screen terminal session. Move-only; owns the restore.
@@ -91,7 +95,7 @@ struct Terminal
             writeEscapeSeq!(CtlSeq.hideCursor)(s);
         writeEscapeSeq!(DecMode.autowrap, false)(s); // a full-width cell must not wrap/scroll
         if (opts.mouse)
-            writeMouseTracking(s, true); // SGR mouse: click + drag + wheel
+            writeMouseTracking(s, true, opts.motion); // SGR mouse: click + drag + wheel
         writeAll(outFd, s[]);
         return t;
     }
@@ -114,7 +118,7 @@ struct Terminal
 
         SmallBuffer!char s;
         if (_opts.mouse)
-            writeMouseTracking(s, false);
+            writeMouseTracking(s, false, _opts.motion);
         writeEscapeSeq!(DecMode.autowrap, true)(s); // autowrap on
         if (_opts.hideCursor)
             writeEscapeSeq!(CtlSeq.showCursor)(s);

--- a/libs/ui-tui/src/sparkles/ui_tui/grid_canvas.d
+++ b/libs/ui-tui/src/sparkles/ui_tui/grid_canvas.d
@@ -30,7 +30,7 @@ import sparkles.ui.interp.cells : blend;
 import sparkles.ui.style : BorderStyle, Visual;
 
 import sparkles.base.term_color : Color, RgbColor, toRgb;
-import sparkles.base.term_style : UnderlineStyle;
+import sparkles.base.term_style : TextAttr, UnderlineStyle;
 
 @safe:
 
@@ -266,6 +266,10 @@ struct GridCanvas
         auto c = &cell(x, y);
         auto st = c.style; // keep bg / underline already composited here
         st.fg = Color.fromRgb(v.fg);
+        // The resolved text chrome: bold / italic / strikethrough travel as
+        // packed `TextAttr` bits — dropping them here silently un-bolds
+        // every widget-pipeline text run in the TUI.
+        st.attrs = TextAttr(cast(ubyte) v.styleBits);
         if (v.hasBg)
             st.bg = Color.fromRgb(blend(cellBg(st), v.bg, v.bgAlpha));
         c.setCodepoint(cp, w, st);

--- a/libs/ui/src/sparkles/ui/components/chrome.d
+++ b/libs/ui/src/sparkles/ui/components/chrome.d
@@ -76,14 +76,16 @@ leading, center and trailing segment groups separated by `grow` spacers — the
 spelling `LAY8` prescribes for distribution. Any of the groups may be empty.
 */
 uint headerBar(ref Builder b, uint[] leading, uint[] center = null,
-    uint[] trailing = null)
+    uint[] trailing = null, bool focused = false)
 {
     const s1 = b.add(Widget(kind: WidgetKind.box, width: SizeSpec.grow()));
     const s2 = b.add(Widget(kind: WidgetKind.box, width: SizeSpec.grow()));
     return b.add(Widget(
         kind: WidgetKind.row,
         children: leading ~ s1 ~ center ~ s2 ~ trailing,
-        slot: Slot.chrome,
+        // A focused pane's bar renders on the accented band, so the pane
+        // holding the input focus is visible at a glance.
+        slot: focused ? Slot.chromeFocused : Slot.chrome,
         paintBackground: true,
         stretch: true, // span the parent column edge-to-edge
         padding: Insets.symmetric(0, 1),

--- a/libs/ui/src/sparkles/ui/state.d
+++ b/libs/ui/src/sparkles/ui/state.d
@@ -547,17 +547,39 @@ struct ScrollState
         return ScrollState(o);
     }
 
-    /// Jumped so the thumb's leading edge lands at `trackPos` — the inverse
-    /// mapping a click/drag on the scrollbar track needs.
-    ScrollState draggedTo(int trackPos, long content, long viewport, int track) const
+    /// Jumped so the thumb's leading edge lands at `trackPos - grab` — the
+    /// inverse mapping a click/drag on the scrollbar needs. `grab` is the
+    /// pointer's offset within the thumb from $(LREF pressedAt), so a drag
+    /// moves the thumb relative to where it was grabbed instead of snapping
+    /// its leading edge under the pointer.
+    ScrollState draggedTo(int trackPos, long content, long viewport,
+        int track, int grab = 0) const
     {
         const limit = maxOffset(content, viewport);
         const thumb = scrollbarThumb(content, viewport, offset, track);
         const span = track - thumb.extent;
         if (span <= 0 || limit == 0)
             return ScrollState(0);
-        auto p = trackPos < 0 ? 0 : (trackPos > span ? span : trackPos);
+        const at = trackPos - grab;
+        auto p = at < 0 ? 0 : (at > span ? span : at);
         return ScrollState(cast(long) p * limit / span);
+    }
+
+    /// A scrollbar press: $(B inside the thumb) it grabs in place — the
+    /// state is unchanged and `grab` receives the pointer's offset within
+    /// the thumb (a click on the handle must not move it); $(B on the
+    /// track) it jumps the thumb's leading edge to the pointer (`grab` 0).
+    ScrollState pressedAt(int trackPos, long content, long viewport,
+        int track, out int grab) const
+    {
+        const thumb = scrollbarThumb(content, viewport, offset, track);
+        if (trackPos >= thumb.start && trackPos < thumb.start + thumb.extent)
+        {
+            grab = trackPos - thumb.start;
+            return this;
+        }
+        grab = 0;
+        return draggedTo(trackPos, content, viewport, track);
     }
 }
 
@@ -597,6 +619,28 @@ unittest
     // Dragging the thumb to the top / bottom of a 10-cell track.
     assert(s.draggedTo(0, 100, 10, 10).offset == 0);
     assert(ScrollState(0).draggedTo(10, 100, 10, 10).offset == 90);
+}
+
+@("ui.state.scrollState.thumbPressGrabsInPlace")
+@safe pure nothrow @nogc
+unittest
+{
+    // 40 units in a 10-unit viewport on a 10-cell track: thumb extent
+    // 10*10/40 = 2, at offset 12 it starts at 12*8/30 = 3 → cells [3, 5).
+    const s = ScrollState(12);
+    int grab;
+
+    // A press INSIDE the thumb grabs in place — the offset must not move.
+    assert(s.pressedAt(4, 40, 10, 10, grab).offset == 12);
+    assert(grab == 1);
+    // The drag then moves the thumb relative to the grab point: one cell
+    // down lands the leading edge at 4 → 4*30/8 = 15.
+    assert(s.draggedTo(5, 40, 10, 10, grab).offset == 15);
+
+    // A press on the TRACK jumps the leading edge to the pointer.
+    assert(s.pressedAt(8, 40, 10, 10, grab).offset == 30);
+    assert(grab == 0);
+    assert(s.pressedAt(0, 40, 10, 10, grab).offset == 0);
 }
 
 // ── Selection (STM3) ─────────────────────────────────────────────────────────

--- a/libs/ui/src/sparkles/ui/style.d
+++ b/libs/ui/src/sparkles/ui/style.d
@@ -61,6 +61,7 @@ enum Slot : ubyte
     track,           /// scrollbar track
     thumb,           /// scrollbar thumb
     selection,       /// selected-content tint (background only)
+    chromeFocused,   /// the focused pane's header band (accented background)
 }
 
 private enum slotCount = Slot.max + 1;
@@ -294,6 +295,10 @@ Palette defaultTwoslashPalette(ColorScheme scheme = ColorScheme.light) pure noth
         // characters) are the theme's glyph channel.
         p.bg[chrome] = Color.fromRgb(0x7f, 0x7f, 0x7f);
         p.bgAlpha[chrome] = 0x20;
+        // The focused pane's header band: the accent, translucent — clearly
+        // apart from the neutral `chrome` band at a glance.
+        p.bg[chromeFocused] = Color.fromRgb(0x37, 0x72, 0xcf);
+        p.bgAlpha[chromeFocused] = 0x48;
         p.fg[chromeAccent] = Color.fromRgb(0x37, 0x72, 0xcf);
         p.fg[gutter] = Color.fromRgb(0x88, 0x88, 0x88);
         p.fg[track] = Color.fromRgb(0x88, 0x88, 0x88);

--- a/lychee.ci.exclude
+++ b/lychee.ci.exclude
@@ -146,3 +146,8 @@
 # paper in manim/bluefish.md) times out under GitHub Actions' concurrency (live +
 # 200 locally). Surfaces on a cold lychee cache; same class as cs.cmu.edu above.
 ^https?://vis\.csail\.mit\.edu/
+# www.cl.cam.ac.uk (Cambridge Computer Laboratory techreports — Kennedy's
+# UCAM-CL-TR-391, cited across the units-of-measure theory pages) errors and
+# times out for GitHub Actions' shared IPs (22 errors in one CI run; live +
+# 200 locally). Same class as cs.cmu.edu / vis.csail.mit.edu above.
+^https?://(www\.)?cl\.cam\.ac\.uk/


### PR DESCRIPTION
Fixes the user-reported TUI artifact: scrolling **up** in the document pane under **zellij** leaves frozen rows that draw over the rest of the document (any emulator, zellij only; scroll-down unaffected; page-jumps unaffected).

## Root cause

`Screen.scrollOptimize` expresses a downward shift as `DECSTBM` + `CSI n T` (SD) and mirrors the shift into the retained `_prev` grid. **zellij silently ignores SD** — verified with a minimal probe (30 numbered rows, `CSI 5;20 r` + `CSI 3 T`, driven through a scripted zellij session and replayed into an off-screen libghostty VT): real terminals shift the band down 3; zellij's screen is left byte-identical. A plausible reason: `CSI Ps;…T` with five parameters doubles as xterm's highlight-mouse-tracking hijack, so conservative parsers drop the whole `T` family.

With the shift never applied but mirrored as applied, the per-cell diff skips every row it believes correct — those rows freeze on screen and overdraw the moving document. Scroll-down uses `SU` (`CSI n S`), which zellij implements correctly — hence the direction asymmetry. Page jumps shift too much for the optimization to trigger, hence their immunity.

## Fix

The downward branch now emits `DECSTBM` + `CUP` to the region's top row + **`IL n`** (insert lines) — the identical operation in VT102-baseline vocabulary with no parser ambiguity. Probes confirm zellij, ghostty, and xterm all implement region-clipped IL correctly. The upward branch keeps `SU`.

## Verification

- New `render.screen.downwardScrollEmitsIlNotSd` unit test (asserts `CUP`+`IL`, asserts no `CSI n T`, preserved rows not re-emitted).
- The scripted zellij repro (hue on README.md, `G` then 40× `k`) replayed through libghostty: **before** — the pane's lower half is stale/blank after the scroll-ups; **after** — coherent through the whole scroll-up.
- Plain-terminal regression: hue driven via a PTY (keys and SGR-1006 wheel, tree open and closed, 80×24 and 200×50), every synchronized frame replayed into the VT and validated against the viewed file's source lines — byte-correct before and after the change.
- `ci --test` green across all sub-packages.

Also fixed on this PR (second commit): the wheel did not scroll the document pane while the tree pane held focus — the wheel-under-cursor rule was only implemented for the tree side, so the focused tree swallowed wheels spun over the document. The wheel block now routes by position both ways, without moving focus (workspace unit test + PTY drive).

https://claude.ai/code/session_01WbniakDeFcv5CquF2pNFHx

**Third round (UAT):** two more TUI pointer bugs fixed on this PR — a press on the explorer's scrollbar column was a row click (selecting/expanding tree items) with no drag support at all; and the viewer's scrollbar drag didn't own the pointer, so mid-drag motion off the last column selected text. Both panes now treat a scrollbar press as a thumb grab that owns the pointer until release (STM2 inverse mapping), and a selection drag crossing the scrollbar column keeps selecting. Unit tests for both ownership directions + PTY drives.

**Fourth round (UAT):** three more TUI pointer refinements — a click on the scrollbar *handle* no longer jumps it (`ScrollState.pressedAt`: in-thumb presses grab in place, track presses jump; drags move grab-relative); hovering the pane divider shows the terminal's `ew-resize` pointer (OSC 22 + any-motion tracking 1003, held through the drag); and the focused pane is now visible at a glance — the focused header title renders accented, the other muted, and the divider tints toward the tree's accent while it holds focus.

**Fifth round (UAT):** pointer shapes are grab-state driven now — an active divider/scrollbar grab holds its shape until release wherever the drag strays (no revert mid-drag), scrollbars hover/drag as `ns-resize`, `term_control` gained the proper vocabulary (`DecMode` mouse modes + composed-modes CTFE `writeEscapeSeq` + `PointerShape`), and the focus indication is now unmissable: a new theme-driven `Slot.chromeFocused` accent band behind the focused pane's header plus a bold title (`headerBar(focused)` — reusable by every backend).

**Sixth round (UAT):** `GridCanvas` was dropping the resolved text attributes for every widget-pipeline text run — bold/italic/strikethrough now reach TUI cells (fixing the focused header's bold, and restoring attrs to the markdown/code views); and the OSC 22 shape re-asserts on every mid-grab drag event, so terminals/multiplexers that reset the pointer on drag start can't clobber the resize shape.
