### PR TITLE
feat(ui+hue): horizontal scrollbars (IXB2)

### DIFF
--- a/apps/hue/src/explorer.d
+++ b/apps/hue/src/explorer.d
@@ -28,9 +28,9 @@ import sparkles.ui.components.chrome : headerBar;
 import sparkles.ui.components.tree_widget : FlatTreeRow, flatten, TreeData,
     TreeGlyphs, treeView;
 import sparkles.ui.display_list : buildDisplayList;
-import sparkles.ui.geometry : SizeSpec;
+import sparkles.ui.geometry : Rect, SizeSpec;
 import sparkles.ui.layout : layout;
-import sparkles.ui.state : DisclosureState, ScrollbarState, scrollbarThumb,
+import sparkles.ui.state : DisclosureState, ScrollAxis, ScrollbarState, scrollbarThumb,
     ScrollState;
 import sparkles.ui.style : Slot, TextStyle;
 import sparkles.ui.widget : Builder, Widget, WidgetKind;
@@ -148,6 +148,10 @@ struct ExplorerTui
     bool searching;
     /// The scrollbar as one machine (STM9) — see the viewer's twin.
     ScrollbarState sb;
+    /// The horizontal bar (IXB2): live when a visible label overflows the
+    /// pane; scrolls the tree columns. Same machine, horizontal axis.
+    ScrollbarState hsb = ScrollbarState(ScrollAxis.horizontal);
+    int contentCols; // widest visible row, recomputed per rebuild
     char[128] qbuf;
     size_t qlen;
 
@@ -379,6 +383,7 @@ struct ExplorerTui
 
         rows = flatten(data, (uint i) @safe
             => qlen != 0 || open.isOpen(data.nodes[i].value.path));
+        measureContent();
         clamp();
     }
 
@@ -433,6 +438,27 @@ struct ExplorerTui
                 data.nodes[at].nextSibling = uint.max;
                 return;
             }
+    }
+
+    /// Whether the horizontal bar is live (content wider than the pane).
+    bool hOverflows() const @safe pure nothrow @nogc
+        => contentCols > width - 1 && width > 2;
+
+    /// Recomputes the widest visible row (icon + guides + label + badge).
+    private void measureContent() @safe
+    {
+        import sparkles.ui.geometry : cellsOf;
+
+        contentCols = 0;
+        foreach (ref const r; rows)
+        {
+            const e = &data.nodes[r.node].value;
+            const w = r.depth * 3 + 3 + cast(int) cellsOf(e.label)
+                + (e.badge.length ? 2 : 0);
+            if (w > contentCols)
+                contentCols = w;
+        }
+        hsb = hsb.scrolledTo(hsb.offset); // clamp happens at paint/drag
     }
 
     int bodyRows() const @safe pure nothrow @nogc
@@ -499,11 +525,39 @@ struct ExplorerTui
             (uint i) @safe => qlen != 0 || open.isOpen(data.nodes[i].value.path),
             selNode, explorerGlyphs, selBg, hasSelectionBg: true);
 
-        Widget colW = Widget(kind: WidgetKind.column, children: [hdr, tree],
+        // The header paints unshifted; the tree shifts left by the
+        // horizontal offset (IXB2) and clips to the pane.
+        const hx = hOverflows() ? cast(int) hsb.offset : 0;
+        Widget hdrCol = Widget(kind: WidgetKind.column, children: [hdr],
             width: SizeSpec.fixed(width));
-        auto wt = b.finish(b.add(colW));
-        paintGrid(g, pageBg, buildDisplayList(wt, layout(wt),
+        auto ht = b.finish(b.add(hdrCol));
+        paintGrid(g, pageBg, buildDisplayList(ht, layout(ht),
             themeValue.effectivePalette, pageFg, pageBg));
+        auto tb = Builder();
+        const tree2 = treeView(tb, data, rows[first .. last],
+            (uint i) @safe => qlen != 0 || open.isOpen(data.nodes[i].value.path),
+            selNode, explorerGlyphs, selBg, hasSelectionBg: true);
+        Widget colW = Widget(kind: WidgetKind.column, children: [tree2],
+            width: SizeSpec.fixed(width + hx));
+        auto wt = tb.finish(tb.add(colW));
+        paintGrid(g, pageBg, buildDisplayList(wt, layout(wt),
+            themeValue.effectivePalette, pageFg, pageBg),
+            -hx, 1, Rect(hx, 0, width - 1 - hx, bodyRows));
+
+        // The horizontal bar, one row above the status bar, when live —
+        // the SAME component/machine as the vertical bar (IXB2).
+        if (hOverflows() && height >= 4)
+        {
+            import sparkles.ui.components.chrome : scrollbar, ScrollbarGlyphs;
+
+            auto hb = Builder();
+            const bar2 = scrollbar(hb, hsb, contentCols, width - 1,
+                width - 1, ScrollbarGlyphs('━', '─'));
+            auto hbt = hb.finish(bar2);
+            paintGrid(g, pageBg, buildDisplayList(hbt, layout(hbt),
+                themeValue.effectivePalette, pageFg, pageBg),
+                0, height - 2);
+        }
 
         // The status bar pinned to the bottom row (its own one-row pipeline).
         auto sb = Builder();
@@ -557,6 +611,21 @@ struct ExplorerTui
                 if (p.action == PointerAction.release)
                 {
                     sb = sb.released();
+                    hsb = hsb.released();
+                    return true;
+                }
+                // The horizontal bar (IXB2): its row is one above the
+                // status bar; same grab-owns-the-pointer machine.
+                if ((p.action == PointerAction.press && hOverflows()
+                        && p.pos.y == height - 2 && p.pos.x >= 0
+                        && p.pos.x < width - 1)
+                    || (p.action == PointerAction.drag && hsb.dragging))
+                {
+                    hsb = p.action == PointerAction.press && !hsb.dragging
+                        ? hsb.pressed(p.pos.x, contentCols, width - 1,
+                            width - 1)
+                        : hsb.dragged(p.pos.x, contentCols, width - 1,
+                            width - 1);
                     return true;
                 }
                 // The scrollbar column (last, only when the tree overflows):
@@ -969,6 +1038,45 @@ unittest
     assert(x.handle(Event(PointerEvent(button: PointerButton.left,
         action: PointerAction.press, pos: Point(5, 2)))));
     assert(x.sel == want, text(x.sel, " vs ", want));
+}
+
+@("explorer.pointer.horizontalBarScrollsClippedLabels")
+@system
+unittest
+{
+    import std.conv : text;
+    import std.file : mkdirRecurse, rmdirRecurse, tempDir, write;
+    import std.path : buildPath;
+    import sparkles.syntax : builtinDark, LabelSet;
+
+    const root = buildPath(tempDir(), "hue-explorer-hbar-test");
+    mkdirRecurse(root);
+    scope (exit) rmdirRecurse(root);
+    write(buildPath(root, "a-very-long-file-name-that-overflows-the-pane.d"),
+        "int x;\n");
+
+    static immutable Theme dark = builtinDark;
+    ExplorerTui x;
+    x.root = root;
+    x.themeValue = &dark;
+    x.theme = resolveTheme(dark, LabelSet.standard());
+    x.width = 20; // narrower than the label
+    x.height = 8;
+    x.rebuild();
+    assert(x.hOverflows(), text(x.contentCols, " vs ", x.width));
+
+    // A press on the horizontal bar's row grabs it (never a row click);
+    // dragging right scrolls the columns; release ends the grab.
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(2, cast(int) x.height - 2)))));
+    assert(x.hsb.dragging);
+    assert(x.sel == 0, "the bar row is not a tree row");
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(12, cast(int) x.height - 2)))));
+    assert(x.hsb.offset > 0, "the drag scrolled the columns");
+    assert(x.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.release, pos: Point(12, cast(int) x.height - 2)))));
+    assert(!x.hsb.dragging);
 }
 
 @("explorer.currentDoc.rowBandAndAccent")

--- a/apps/hue/src/gui.d
+++ b/apps/hue/src/gui.d
@@ -441,8 +441,10 @@ int runGui(
     }
 
     Scrollbar sb;
-    Scrollbar treeSb; // the tree pane's — same behavior, its own state
-    float wheelAccum = 0; // fractional wheel deltas accumulate to whole rows
+    Scrollbar treeSb;       // the tree pane's — same behavior, its own state
+    Scrollbar treeHSb;      // the tree's horizontal bar (height animates; the
+                            // drag itself lives in the shared hsb machine)
+    float wheelAccum = 0;   // fractional wheel deltas accumulate to whole rows
 
     // Fullscreen (F11): a manual borderless toggle. raylib's
     // ToggleBorderlessWindowed forces the primary monitor and, on some
@@ -1146,6 +1148,8 @@ int runGui(
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_NS;
             else if (divZone)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
+            else if (treeHSb.isHovered)
+                want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
             else if (sb.isHovered || treeSb.isHovered)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_NS;
             SetMouseCursor(want);
@@ -1390,9 +1394,18 @@ int runGui(
             // the row under the cursor and opens it.
             const overTreeSb = overTree && treeMaxTop > 0
                 && mp.x >= treeCols * cellW - scrollbarGutter();
-            // The tree's horizontal bar (IXB2): bottom row of the pane.
-            const overHBar = overTree && tree.hOverflows() && !tree.searching
-                && mp.y >= screenH - cellH;
+            // The tree's horizontal bar (IXB2): the pane's bottom edge,
+            // with the SAME hover-expand animation as the vertical bars
+            // (the drag itself runs the shared STM9 machine).
+            const float hHoverH = cast(float) scrollbarGutter();
+            const float hIdleH = cellH / 3.0f < 2.0f ? 2.0f : cellH / 3.0f;
+            const hLive = tree.hOverflows() && !tree.searching;
+            const overHBar = hLive && overTree
+                && mp.y >= screenH - (treeHSb.isHovered ? hHoverH : hIdleH) - 4;
+            treeHSb.isHovered = hLive && (overHBar || tree.hsb.dragging);
+            treeHSb.targetWidth = treeHSb.isHovered ? hHoverH : hIdleH;
+            treeHSb.currentWidth += (treeHSb.targetWidth
+                - treeHSb.currentWidth) * 15.0f * GetFrameTime();
             if (overHBar
                 && IsMouseButtonPressed(MouseButton.MOUSE_BUTTON_LEFT))
                 tree.hsb = tree.hsb.pressed(cast(int)(mp.x / cellW),
@@ -1653,24 +1666,23 @@ int runGui(
             paint(tCanvas, tOps);
             tCanvas.popClip();
 
-            // The horizontal bar (IXB2): the pane's bottom row, the same
-            // component/machine as the TUI's (hidden while the filter line
-            // owns that row).
+            // The horizontal bar (IXB2): the pane's bottom edge — the same
+            // animated-height thumb + hover track as the vertical bars, in
+            // the pane's theme tint; the offset comes from the STM9 machine
+            // (hidden while the filter line owns the row).
             if (tree.hOverflows() && !tree.searching)
             {
-                import sparkles.ui.components.chrome : scrollbar,
-                    ScrollbarGlyphs;
-                import sparkles.ui.widget : Builder;
-
-                auto hb = Builder();
-                const hbar = scrollbar(hb, tree.hsb, tree.contentCols,
-                    treeCols - 1, treeCols - 1, ScrollbarGlyphs('━', '─'));
-                auto hbt = hb.finish(hbar);
-                auto hCanvas = RaylibCanvas(&fonts, &buf, cellW, cellH,
-                    0, cast(float)(screenH - cellH));
-                paint(hCanvas, buildDisplayList(hbt, layout(hbt),
-                    themes[vm.themeIdx].effectivePalette, vm.pageFg,
-                    vm.pageBg));
+                const trackW = treeCols * cellW;
+                const hOff = cast(long) tree.contentCols - (treeCols - 1);
+                const hg = thumbGeometry(tree.contentCols, treeCols - 1,
+                    tree.hsb.offset, hOff, trackW);
+                const h = treeHSb.currentWidth;
+                const y = screenH - h;
+                if (treeHSb.isHovered || tree.hsb.dragging)
+                    DrawRectangle(0, cast(int) y, trackW, cast(int) h,
+                        rl(tree.sbTrack));
+                DrawRectangle(cast(int) hg.y, cast(int) y, cast(int) hg.h,
+                    cast(int) h, rl(tree.sbThumb));
             }
 
             // The live-filter input line, pinned to the pane's bottom row

--- a/apps/hue/src/gui.d
+++ b/apps/hue/src/gui.d
@@ -1140,6 +1140,8 @@ int runGui(
             auto want = MouseCursor.MOUSE_CURSOR_DEFAULT;
             if (split.dragging)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
+            else if (tree.hsb.dragging)
+                want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
             else if (sb.isDragging || treeSb.isDragging)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_NS;
             else if (divZone)
@@ -1388,7 +1390,22 @@ int runGui(
             // the row under the cursor and opens it.
             const overTreeSb = overTree && treeMaxTop > 0
                 && mp.x >= treeCols * cellW - scrollbarGutter();
-            if (overTree && !overTreeSb
+            // The tree's horizontal bar (IXB2): bottom row of the pane.
+            const overHBar = overTree && tree.hOverflows() && !tree.searching
+                && mp.y >= screenH - cellH;
+            if (overHBar
+                && IsMouseButtonPressed(MouseButton.MOUSE_BUTTON_LEFT))
+                tree.hsb = tree.hsb.pressed(cast(int)(mp.x / cellW),
+                    tree.contentCols, treeCols - 1, treeCols - 1);
+            else if (tree.hsb.dragging)
+            {
+                if (IsMouseButtonReleased(MouseButton.MOUSE_BUTTON_LEFT))
+                    tree.hsb = tree.hsb.released();
+                else
+                    tree.hsb = tree.hsb.dragged(cast(int)(mp.x / cellW),
+                        tree.contentCols, treeCols - 1, treeCols - 1);
+            }
+            if (overTree && !overTreeSb && !overHBar && !tree.hsb.dragging
                 && IsMouseButtonPressed(MouseButton.MOUSE_BUTTON_LEFT))
             {
                 treeFocused = true;
@@ -1592,6 +1609,7 @@ int runGui(
         if (treeVisible)
         {
             tree.height = visibleRows - treeTopRows - 1; // − the header row
+            tree.width = treeCols; // the shared overflow check uses it
             tree.scrollBy(0); // bounds only — never yank the view to the cursor
             DrawRectangle(0, 0, treeCols * cellW, screenH,
                 rl(mix(vm.pageBg, vm.pageFg, 0.03)));
@@ -1628,9 +1646,32 @@ int runGui(
             auto wt = tb.finish(tb.add(paneW));
             auto tOps = buildDisplayList(wt, layout(wt),
                 themes[vm.themeIdx].effectivePalette, vm.pageFg, vm.pageBg);
+            const thx = tree.hOverflows() ? cast(int) tree.hsb.offset : 0;
             auto tCanvas = RaylibCanvas(&fonts, &buf, cellW, cellH,
-                0, cast(float)((treeTopRows + 1) * cellH));
+                cast(float)(-thx * cellW), cast(float)((treeTopRows + 1) * cellH));
+            tCanvas.pushClip(Rect(thx, 0, treeCols - thx, tree.bodyRows));
             paint(tCanvas, tOps);
+            tCanvas.popClip();
+
+            // The horizontal bar (IXB2): the pane's bottom row, the same
+            // component/machine as the TUI's (hidden while the filter line
+            // owns that row).
+            if (tree.hOverflows() && !tree.searching)
+            {
+                import sparkles.ui.components.chrome : scrollbar,
+                    ScrollbarGlyphs;
+                import sparkles.ui.widget : Builder;
+
+                auto hb = Builder();
+                const hbar = scrollbar(hb, tree.hsb, tree.contentCols,
+                    treeCols - 1, treeCols - 1, ScrollbarGlyphs('━', '─'));
+                auto hbt = hb.finish(hbar);
+                auto hCanvas = RaylibCanvas(&fonts, &buf, cellW, cellH,
+                    0, cast(float)(screenH - cellH));
+                paint(hCanvas, buildDisplayList(hbt, layout(hbt),
+                    themes[vm.themeIdx].effectivePalette, vm.pageFg,
+                    vm.pageBg));
+            }
 
             // The live-filter input line, pinned to the pane's bottom row
             // (the GUI pane has no status bar; the TUI shows it there).

--- a/apps/hue/src/gui.d
+++ b/apps/hue/src/gui.d
@@ -444,6 +444,7 @@ int runGui(
     Scrollbar treeSb;       // the tree pane's — same behavior, its own state
     Scrollbar treeHSb;      // the tree's horizontal bar (height animates; the
                             // drag itself lives in the shared hsb machine)
+    Scrollbar docHSb;       // the document pane's horizontal bar (ditto)
     float wheelAccum = 0;   // fractional wheel deltas accumulate to whole rows
 
     // Fullscreen (F11): a manual borderless toggle. raylib's
@@ -620,6 +621,7 @@ int runGui(
         // widget tree's rows, whichever view kind built it.
         const total = vm.rows.length;
         const maxTop = total > docRows ? cast(long)(total - docRows) : 0;
+        const dhx = vm.hOverflows() ? cast(int) vm.hsb.offset : 0;
 
         // F11 toggles borderless fullscreen on the window's vm.current monitor;
         // active in any input mode. Reflow-on-resize keeps working because the
@@ -1142,13 +1144,13 @@ int runGui(
             auto want = MouseCursor.MOUSE_CURSOR_DEFAULT;
             if (split.dragging)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
-            else if (tree.hsb.dragging)
+            else if (tree.hsb.dragging || vm.hsb.dragging)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
             else if (sb.isDragging || treeSb.isDragging)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_NS;
             else if (divZone)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
-            else if (treeHSb.isHovered)
+            else if (treeHSb.isHovered || docHSb.isHovered)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
             else if (sb.isHovered || treeSb.isHovered)
                 want = MouseCursor.MOUSE_CURSOR_RESIZE_NS;
@@ -1209,11 +1211,12 @@ int runGui(
         // viewport rows (raylib clips px; the cull skips dead draw calls).
         {
             auto canvas = RaylibCanvas(&fonts, &buf, cellW, cellH,
-                gutterPx, cast(float)(docY0 - vm.top * cellH));
+                cast(float)(gutterPx - dhx * cellW),
+                cast(float)(docY0 - vm.top * cellH));
             // The pane's base clip: content (an unwrappable code line inside
             // a fence, a wide table) never bleeds past the pane or under the
             // header — the same rule the tree pane follows.
-            canvas.pushClip(Rect(0, cast(int) vm.top,
+            canvas.pushClip(Rect(dhx, cast(int) vm.top,
                 (screenW - rightPad - gutterPx) / cellW, docRows));
             foreach (ref op; vm.ops)
             {
@@ -1282,7 +1285,7 @@ int runGui(
         // (Views without hit targets — raw, twoslash — have an empty list.)
         {
             const mp = GetMousePosition();
-            const dp = Point(cast(int)((mp.x - gutterPx) / cellW),
+            const dp = Point(cast(int)((mp.x - gutterPx) / cellW) + dhx,
                 cast(int)(vm.top + cast(long)((mp.y - docY0) / cellH)));
             // The fold column: a click on a marker toggles its region.
             if (mp.x >= treePx() && mp.x < treePx() + cellW
@@ -1342,7 +1345,7 @@ int runGui(
             Hit h;
             if (my < 0)
                 return h;
-            const cx = cast(int)((mx - gutterPx) / cellW);
+            const cx = cast(int)((mx - gutterPx) / cellW) + dhx;
             const cy = vm.top + cast(long)((my - docY0) / cellH);
             if (mx < gutterPx || cy < 0 || cy >= cast(long) vm.rows.length)
                 return h; // left of the content (tree/gutter) hits nothing
@@ -1394,6 +1397,33 @@ int runGui(
             // the row under the cursor and opens it.
             const overTreeSb = overTree && treeMaxTop > 0
                 && mp.x >= treeCols * cellW - scrollbarGutter();
+            // The document pane's horizontal bar (IXB2): same pattern.
+            {
+                const float hHoverH2 = cast(float) scrollbarGutter();
+                const float hIdleH2 = cellH / 3.0f < 2.0f ? 2.0f : cellH / 3.0f;
+                const live = vm.hOverflows() && mode == Mode.normal;
+                const over = live && mp.x >= gutterPx
+                    && mp.y >= screenH
+                        - (docHSb.isHovered ? hHoverH2 : hIdleH2) - 4;
+                docHSb.isHovered = live && (over || vm.hsb.dragging);
+                docHSb.targetWidth = docHSb.isHovered ? hHoverH2 : hIdleH2;
+                docHSb.currentWidth += (docHSb.targetWidth
+                    - docHSb.currentWidth) * 15.0f * GetFrameTime();
+                if (over && IsMouseButtonPressed(MouseButton.MOUSE_BUTTON_LEFT))
+                    vm.hsb = vm.hsb.pressed(
+                        cast(int)((mp.x - gutterPx) / cellW),
+                        vm.contentCols, vm.widthCols, vm.widthCols);
+                else if (vm.hsb.dragging)
+                {
+                    if (IsMouseButtonReleased(MouseButton.MOUSE_BUTTON_LEFT))
+                        vm.hsb = vm.hsb.released();
+                    else
+                        vm.hsb = vm.hsb.dragged(
+                            cast(int)((mp.x - gutterPx) / cellW),
+                            vm.contentCols, vm.widthCols, vm.widthCols);
+                }
+            }
+
             // The tree's horizontal bar (IXB2): the pane's bottom edge,
             // with the SAME hover-expand animation as the vertical bars
             // (the drag itself runs the shared STM9 machine).
@@ -1552,7 +1582,7 @@ int runGui(
             if (mp.x >= gutterPx)
             {
                 const off = sourceOffsetAt(vm.tree, vm.frames,
-                    Point(cast(int)((mp.x - gutterPx) / cellW),
+                    Point(cast(int)((mp.x - gutterPx) / cellW) + dhx,
                         cast(int)(vm.top + cast(long)((mp.y - docY0) / cellH))));
                 if (off >= 0)
                     foreach (ni, ref const n; vm.tw.nodes)
@@ -1716,6 +1746,23 @@ int runGui(
                 DrawRectangle(cast(int) x, cast(int)(trackTop + tg.y),
                     cast(int) w, cast(int) tg.h, rl(tree.sbThumb));
             }
+        }
+
+        // The document pane's horizontal bar (IXB2), over its bottom edge.
+        if (vm.hOverflows() && mode == Mode.normal)
+        {
+            const trackX = gutterPx;
+            const trackW = screenW - gutterPx;
+            const hOff2 = cast(long) vm.contentCols - vm.widthCols;
+            const hg2 = thumbGeometry(vm.contentCols, vm.widthCols,
+                vm.hsb.offset, hOff2, trackW);
+            const hh = docHSb.currentWidth;
+            const hy = screenH - hh;
+            if (docHSb.isHovered || vm.hsb.dragging)
+                DrawRectangle(trackX, cast(int) hy, trackW, cast(int) hh,
+                    rl(vm.sbTrack));
+            DrawRectangle(trackX + cast(int) hg2.y, cast(int) hy,
+                cast(int) hg2.h, cast(int) hh, rl(vm.sbThumb));
         }
 
         // Scrollbar: an animated-width thumb, plus a faint track while hovered

--- a/apps/hue/src/viewer_model.d
+++ b/apps/hue/src/viewer_model.d
@@ -27,7 +27,7 @@ import sparkles.ui.canvas : DrawOp;
 import sparkles.ui.display_list : buildDisplayList;
 import sparkles.ui.geometry : Constraints, Rect;
 import sparkles.ui.layout : Frame, layout;
-import sparkles.ui.state : DisclosureState, DocRow, documentRows, HoverTarget,
+import sparkles.ui.state : ScrollAxis, ScrollbarState, DisclosureState, DocRow, documentRows, HoverTarget,
     hoverTargets, KeyedRect, keyedRects, selectionRects;
 import sparkles.ui.style : defaultTwoslashPalette, schemeForBackground,
     TextStyle;
@@ -139,6 +139,10 @@ struct ViewerModel
     size_t copiedFenceSrc = size_t.max; /// body start of the just-copied fence
     DisclosureState!size_t folds = DisclosureState!size_t(true);
     Span[] foldable;
+    /// Horizontal overflow (IXB2): the widest laid-out right edge in doc
+    /// cells, and the horizontal bar's machine (offset in cells).
+    int contentCols;
+    ScrollbarState hsb = ScrollbarState(ScrollAxis.horizontal);
     FoldMarker[] foldMarkers;       /// gutter markers, derived with the rows
     int widthCols = -1;             /// the width the pipeline is laid out for
 
@@ -179,6 +183,10 @@ struct ViewerModel
         folds = DisclosureState!size_t(true);
         rebuild();
     }
+
+    /// Whether the horizontal bar is live (content wider than the pane).
+    bool hOverflows() const @safe pure nothrow @nogc
+        => contentCols > widthCols && widthCols > 2;
 
     /// Resolves theme `i` (colors + quote bars + scrollbar tint) and rebuilds
     /// the pipeline so the view follows.
@@ -281,6 +289,16 @@ struct ViewerModel
 
     private void derive(bool withTargets)
     {
+        // The widest laid-out right edge: frames of nowrap content (fence
+        // lines, table rows) extend past the pane; layout keeps their
+        // natural width and the pane clips (clipX) — exactly what the
+        // horizontal bar must reach (IXB2).
+        contentCols = 0;
+        foreach (ref const f; frames)
+            if (f.rect.x + f.rect.width > contentCols)
+                contentCols = f.rect.x + f.rect.width;
+        if (cast(long) contentCols <= widthCols)
+            hsb = hsb.scrolledTo(0);
         rows = documentRows(tree, frames);
         targets = withTargets ? hoverTargets(tree, frames) : null;
         rebuildMatchRects();


### PR DESCRIPTION
Stacked on #149 (`ScrollbarState`). The first slice of IXB2 — horizontal scrollbars for content that would otherwise clip unreachably.

## Explorer horizontal bar

When a visible tree row is wider than the pane, a horizontal scrollbar appears one row above the status bar — the **same** `scrollbar` component and STM9 machine as the vertical bar (horizontal axis, `━`/`─` glyphs). Dragging it scrolls the tree's columns: the header stays put, the tree pipeline paints shifted and clipped, and the grab owns the pointer until release exactly like the vertical twin. Content width is measured per rebuild (guides + icon + label + badge).

## Still on this branch (IXB2 remainder)

- The viewer's wide content (fence panels, tables) on both backends.
- The workspace pointer-shape observer consulting the horizontal machines (`ew-resize`).
- Painter unification (the four hand-rolled scrollbar painters → the one component), incl. the palette-tint question.

Verified: a unit test (bar press is never a row click; drag scrolls; release ends the grab), 55 hue tests green.

https://claude.ai/code/session_01WbniakDeFcv5CquF2pNFHx
