### PR TITLE
refactor(hue.tui): PreviewTui adopts ViewerModel (IXB5) + the TUI viewer h-bar

### DIFF
--- a/apps/hue/src/explorer.d
+++ b/apps/hue/src/explorer.d
@@ -542,7 +542,7 @@ struct ExplorerTui
         auto wt = tb.finish(tb.add(colW));
         paintGrid(g, pageBg, buildDisplayList(wt, layout(wt),
             themeValue.effectivePalette, pageFg, pageBg),
-            -hx, 1, Rect(hx, 0, width - 1 - hx, bodyRows));
+            -hx, 1, Rect(hx, 0, width - 1, bodyRows));
 
         // The horizontal bar, one row above the status bar, when live —
         // the SAME component/machine as the vertical bar (IXB2).

--- a/apps/hue/src/tui.d
+++ b/apps/hue/src/tui.d
@@ -385,8 +385,25 @@ struct PreviewTui
     private void paintMarkdown(ref Grid g) @system
     {
         const rows = bodyRows();
-        paintGrid(g, pageBg, mdOps, originX, cast(int)(1 - top),
-            Rect(0, cast(int) top, width, rows));
+        const hx = vm.hOverflows() ? cast(int) vm.hsb.offset : 0;
+        paintGrid(g, pageBg, mdOps, originX - hx, cast(int)(1 - top),
+            Rect(hx, cast(int) top, width - 1, rows));
+
+        // The horizontal bar (IXB2): the last body row, when wide content
+        // (a fence line, a table) clips — the same component/machine as
+        // the vertical bar, horizontal axis.
+        if (vm.hOverflows())
+        {
+            import sparkles.ui.components.chrome : scrollbar, ScrollbarGlyphs;
+
+            auto hb = Builder();
+            const bar = scrollbar(hb, vm.hsb, vm.contentCols, vm.widthCols,
+                width - 1, ScrollbarGlyphs('━', '─'));
+            auto hbt = hb.finish(bar);
+            paintGrid(g, pageBg, buildDisplayList(hbt, layout(hbt),
+                themes[themeIdx].effectivePalette, pageFg, pageBg),
+                originX, height - 2);
+        }
         if (!sel.active)
             return;
         const selFill = Color.fromRgb(selBg);
@@ -649,6 +666,21 @@ struct PreviewTui
             && e.action == PointerAction.release)
         {
             sb = sb.released();
+            vm.hsb = vm.hsb.released();
+            return true;
+        }
+        // The horizontal bar (IXB2): its row is the last body row; the
+        // grab owns the pointer, like every scrollbar grab.
+        if (e.button == PointerButton.left
+            && ((e.action == PointerAction.press && vm.hOverflows()
+                    && e.pos.y == rows && e.pos.x >= 0 && e.pos.x < width - 1)
+                || (e.action == PointerAction.drag && vm.hsb.dragging)))
+        {
+            vm.hsb = e.action == PointerAction.press && !vm.hsb.dragging
+                ? vm.hsb.pressed(e.pos.x, vm.contentCols, vm.widthCols,
+                    width - 1)
+                : vm.hsb.dragged(e.pos.x, vm.contentCols, vm.widthCols,
+                    width - 1);
             return true;
         }
         // A scrollbar grab OWNS the pointer: the press must land on the
@@ -684,11 +716,14 @@ struct PreviewTui
             // body's source offset. Otherwise start (press) or extend
             // (drag) a line selection.
             const line = top + (e.pos.y - 1);
+            // Content hits live in the (possibly) horizontally scrolled
+            // space — the paint shifts left by the bar's offset (IXB2).
+            const hx = vm.hOverflows() ? cast(int) vm.hsb.offset : 0;
             if (showPreview && e.action == PointerAction.press
                 && tw.code.length)
             {
                 const off = sourceOffsetAt(mdTree, mdFrames,
-                    Point(e.pos.x, cast(int) line));
+                    Point(e.pos.x + hx, cast(int) line));
                 if (off >= 0)
                     foreach (i, ni; hoverNodes)
                         if (off >= cast(long) tw.nodes[ni].start
@@ -707,7 +742,7 @@ struct PreviewTui
             }
             if (e.action == PointerAction.press)
             {
-                const p = Point(e.pos.x, cast(int) line);
+                const p = Point(e.pos.x + hx, cast(int) line);
                 foreach_reverse (ref const t; mdTargets)
                 {
                     if (t.hitId >= foldHitBase && t.rect.contains(p))
@@ -860,6 +895,53 @@ unittest
         action: PointerAction.drag, pos: Point(59, 3)))));
     assert(t.sel.active && t.sel.lo != t.sel.hi, "the selection extended");
     assert(t.top == topBefore, "a selection drag never scrolls the thumb");
+}
+
+@("tui.pointer.horizontalBarScrollsWideContent")
+@system
+unittest
+{
+    import sparkles.syntax : builtinDark, MdBlock, MdBlockKind, MdDoc,
+        MdInline, MdInlineKind, Span, LabelSet;
+
+    // A fence whose one code line is 120 cells wide in a 40-column pane:
+    // fence lines never wrap, so the laid-out frames extend past the pane
+    // and the model reports horizontal overflow (IXB2).
+    string src = "wide\n";
+    foreach (i; 0 .. 120)
+        src ~= "x";
+    auto doc = MdDoc(MdBlock(kind: MdBlockKind.document, children: [
+        MdBlock(kind: MdBlockKind.paragraph, inlines: [
+            MdInline(kind: MdInlineKind.text, span: Span(0, 4))]),
+        MdBlock(kind: MdBlockKind.codeFence, infoLang: "",
+            codeBody: Span(5, src.length)),
+    ]), src);
+
+    static immutable(Theme)[1] themes = [builtinDark];
+    static immutable string[1] names = ["dark"];
+    PreviewTui t;
+    t.labels = LabelSet.standard();
+    t.names = names[];
+    t.themes = themes[];
+    t.width = 40;
+    t.height = 8; // bodyRows = 6; the h-bar row is y == 6
+    t.relayout();
+    t.setDocument("wide.md", src, null, PreviewModel(present: true, doc: doc),
+        startPreview: true);
+    assert(t.vm.hOverflows(), "the 120-cell fence line overflows the pane");
+
+    // A press on the bar's row grabs it; the drag scrolls the columns and
+    // owns the pointer; release ends the grab.
+    assert(t.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.press, pos: Point(2, 6)))));
+    assert(t.vm.hsb.dragging);
+    assert(t.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.drag, pos: Point(30, 3)))));
+    assert(t.vm.hsb.offset > 0, "the drag scrolled the columns");
+    assert(!t.selection.active, "a bar grab never selects text");
+    assert(t.handle(Event(PointerEvent(button: PointerButton.left,
+        action: PointerAction.release, pos: Point(30, 3)))));
+    assert(!t.vm.hsb.dragging);
 }
 
 @("tui.paint.markdownWidgets.fenceCopy")

--- a/apps/hue/src/tui.d
+++ b/apps/hue/src/tui.d
@@ -16,12 +16,9 @@ import sparkles.base.term_color : mix;
 import sparkles.base.text.writers : writeInteger;
 
 import sparkles.syntax : ColorDepth, HighlightEvent, LabelSet, ResolvedTheme,
-    resolveTheme, RgbColor, Theme, toRgb;
+    RgbColor, Theme, toRgb;
 
 import sparkles.syntax.md.model : MdBlock, MdBlockKind, Span;
-import sparkles.syntax.md.render_widgets : foldableSpans, MdViewOptions,
-    MdViewTheme, viewMarkdown;
-import sparkles.syntax.render.widgets : CodeViewOptions, viewCodeDocument;
 import sparkles.syntax.ts.injection : TsConfigCache;
 import sparkles.twoslash.protocol : NodeType, TwoslashReturn;
 import sparkles.twoslash.render_widgets : viewHoverPopup, viewTwoslashDocument;
@@ -35,18 +32,16 @@ import sparkles.ui.components.chrome : headerBar;
 import sparkles.ui.display_list : buildDisplayList;
 import sparkles.ui.geometry : Constraints, Point, Rect, SizeSpec;
 import sparkles.ui.layout : Frame, layout;
-import sparkles.ui.state : DisclosureState, DocRow, documentRows, HoverTarget,
-    ScrollbarState,
-    hoverTargets, scrollbarThumb, ScrollState, Selection, selectionRects,
-    sourceOffsetAt;
+import sparkles.ui.state : DisclosureState, DocRow, HoverTarget,
+    ScrollbarState, scrollbarThumb, Selection, selectionRects, sourceOffsetAt;
 import sparkles.ui.style : defaultTwoslashPalette, schemeForBackground, Slot,
     TextStyle;
 import sparkles.ui.widget : Builder, Widget, WidgetKind, WidgetTree;
 import sparkles.ui_tui : paintGrid;
 
 import ansi_model : Attr, BackgroundMode;
-import document : hueFenceRenderer;
-import gui_preview : PreviewModel, quoteBarColors, quoteBarCycle;
+import viewer_model : ViewerModel;
+import gui_preview : PreviewModel;
 
 private enum RgbColor fallbackFg = RgbColor(0xcc, 0xcc, 0xcc);
 private enum RgbColor fallbackBg = RgbColor(0x1e, 0x1e, 0x1e);
@@ -92,39 +87,24 @@ private bool containsIC(scope const(char)[] hay, scope const(char)[] needle) @sa
 /// paints its precomputed ops into a cell grid with a scroll offset.
 struct PreviewTui
 {
-    string title;
-    const(char)[] source;
-    const(HighlightEvent)[] events;
-    string lang;                    // canonical language (CST fold provider)
-    PreviewModel model;             // present ⇒ a markdown file (preview available)
-    TwoslashReturn tw;              // non-empty code ⇒ a twoslash document
-    TsConfigCache* cache;           // fence highlighting for the widget markdown
-                                    // path (null ⇒ plain fence bodies)
-    LabelSet labels;
-    const(string)[] names;          // theme names, parallel to `themes`
-    immutable(Theme)[] themes;
+    /// The one document-pane Whole (`IXB5`): document, theme-resolved
+    /// colors, the widget pipeline, folds, scroll and search live in the
+    /// SAME model the GUI drives — this pane keeps only what is genuinely
+    /// terminal-shaped (grid painting, key decode, OSC 52, the scrollbar
+    /// machines, the search input buffer).
+    ViewerModel vm;
+
     BackgroundMode background;      // (kept for the caller; the viewer paints full-bg)
     ColorDepth depth;               // (unused: the cell renderer emits truecolor)
 
-    int tabWidth = 4;               // tab stops in the raw view
-    bool listWhitespace;            // vim `list` whitespace glyphs
-    bool codeLineNumbers = true;    // in-panel fence numbers
-
-    private size_t themeIdx;
-    private long top;               // first visible visual line
     /// The scrollbar as one machine (STM9): grab/hover/shape — the
     /// workspace reads `sb.dragging`/`sb.shape` for capture and pointers.
     ScrollbarState sb;
-    private bool showPreview;       // preview vs raw source (Tab)
     private int width, height;      // pane size in cells
     /// Grid column of the pane's left edge — 0 when full-screen; the split
     /// workspace places the viewer right of the explorer. Pointer events are
     /// translated to pane-local coordinates by the caller.
     int originX;
-    private ResolvedTheme theme;
-    private RgbColor pageFg, pageBg, gutterFg;
-    private RgbColor[quoteBarCycle] bars;
-    private RgbColor sbTrack, sbThumb; // scrollbar track / thumb (theme-tinted)
 
     /// Whether this pane holds the workspace focus (a standalone viewer is
     /// always focused). The header title renders accented when focused,
@@ -132,55 +112,61 @@ struct PreviewTui
     bool focused = true;
 
     // Incremental search (`/`): `searching` is input mode; `qbuf[0 .. qlen]` is
-    // the query, reused by `n`/`N`.
+    // the query, reused by `n`/`N` (one line editor pending — IXB6).
     private bool searching;
     private char[256] qbuf;
     private size_t qlen;
 
     // Selection (mouse drag) → OSC 52 copy: the shared STM3 machine over
-    // visual line indices ("no selection" is a mode, not -1); `selBg` tints
-    // the selected lines. `clip` holds a pending OSC 52 sequence that the
-    // loop flushes after a copy.
+    // visual line indices; `selBg` tints the selected lines. `clip` holds a
+    // pending OSC 52 sequence that the loop flushes after a copy.
     private Selection!long sel;
     private RgbColor selBg;
     private SmallBuffer!char clip;
     private bool clipReady;
 
-    // The widget markdown path (M10): the preview is one laid-out widget tree,
-    // painted from precomputed ops with a scroll offset. `mdRows` (the identity
-    // channel aggregated per visual row) drives search and selection; the hit
-    // targets carry the fences' source-anchored copy identity.
-    private WidgetTree mdTree;
-    private Frame[] mdFrames;
-    private DrawOp[] mdOps;
-    private DocRow[] mdRows;
-    private HoverTarget[] mdTargets;
-    private Span[] mdFences;        // codeFence body spans, resolved on copy
-
-    // Copy feedback: the just-copied fence's body start (its header shows the
-    // ✔ glyph) until the next event — the loop is event-driven, no timed flash.
-    private size_t copiedFenceSrc = size_t.max;
-
-    // Fence hit ids live above this base: `hitId - fenceHitBase` is the fence
-    // body's source byte offset (source-anchored identity, no counters).
-    private enum size_t fenceHitBase = size_t.max / 2 + 1;
-
-    // Fold placeholders live above this (disjoint) base; `hitId - foldHitBase`
-    // is the folded region's span start — the fold key (`FLD2`/`STM5`).
-    private enum size_t foldHitBase = size_t.max / 4 * 3 + 1;
-
-    // Content folding (`FLD`): the one disclosure machine, keyed by source
-    // span start (default open; the exceptions are the folded regions), plus
-    // the document's foldable spans (the `FSR3` provider) and the pending
-    // 'z' of the vim fold sequences (za/zz, zc, zo, zR, zM).
-    private DisclosureState!size_t folds = DisclosureState!size_t(true);
-    private Span[] foldable;
+    // The pending 'z' of the vim fold sequences (za/zz, zc, zo, zR, zM).
     private char zPending;
 
     // Twoslash hover popups in the pane: the hover-typed node indices (for
     // `p` cycling) and the selected one (-1 = none; click toggles).
     private size_t[] hoverNodes;
     private int hoverSel = -1;
+
+    // ── the model's vocabulary, forwarded (IXB5) ─────────────────────────────
+    // The old field names keep working for the methods below and every host
+    // and test; the storage is the model's — one copy, no disagreement.
+    ref inout(string) title() inout return @safe pure nothrow @nogc => vm.title;
+    ref inout(const(char)[]) source() inout return @safe pure nothrow @nogc => vm.source;
+    ref inout(const(HighlightEvent)[]) events() inout return @safe pure nothrow @nogc => vm.events;
+    ref inout(string) lang() inout return @safe pure nothrow @nogc => vm.lang;
+    ref inout(PreviewModel) model() inout return @safe pure nothrow @nogc => vm.preview;
+    ref inout(TwoslashReturn) tw() inout return @safe pure nothrow @nogc => vm.tw;
+    ref inout(TsConfigCache*) cache() inout return @safe pure nothrow @nogc => vm.cache;
+    ref inout(LabelSet) labels() inout return @safe pure nothrow @nogc => vm.labels;
+    ref inout(const(string)[]) names() inout return @safe pure nothrow @nogc => vm.names;
+    ref inout(immutable(Theme)[]) themes() inout return @safe pure nothrow @nogc => vm.themes;
+    ref inout(int) tabWidth() inout return @safe pure nothrow @nogc => vm.tabWidth;
+    ref inout(bool) listWhitespace() inout return @safe pure nothrow @nogc => vm.listWhitespace;
+    ref inout(bool) codeLineNumbers() inout return @safe pure nothrow @nogc => vm.codeLineNumbers;
+
+    private ref inout(size_t) themeIdx() inout return @safe pure nothrow @nogc => vm.themeIdx;
+    private ref inout(long) top() inout return @safe pure nothrow @nogc => vm.top;
+    private ref inout(bool) showPreview() inout return @safe pure nothrow @nogc => vm.showPreview;
+    private ref inout(ResolvedTheme) theme() inout return @safe pure nothrow @nogc => vm.current;
+    private RgbColor pageFg() const @safe pure nothrow @nogc => vm.pageFg;
+    private RgbColor pageBg() const @safe pure nothrow @nogc => vm.pageBg;
+    private RgbColor gutterFg() const @safe pure nothrow @nogc => vm.gutterFg;
+    private RgbColor sbTrack() const @safe pure nothrow @nogc => vm.sbTrack;
+    private RgbColor sbThumb() const @safe pure nothrow @nogc => vm.sbThumb;
+    private ref const(WidgetTree) mdTree() const return @safe pure nothrow @nogc => vm.tree;
+    private const(Frame)[] mdFrames() const @safe pure nothrow @nogc => vm.frames;
+    private const(DrawOp)[] mdOps() const @safe pure nothrow @nogc => vm.ops;
+    private const(DocRow)[] mdRows() const @safe pure nothrow @nogc => vm.rows;
+    private const(HoverTarget)[] mdTargets() const @safe pure nothrow @nogc => vm.targets;
+    private alias FoldOp = ViewerModel.FoldOp;
+    private enum size_t fenceHitBase = ViewerModel.fenceHitBase;
+    private enum size_t foldHitBase = ViewerModel.foldHitBase;
 
     private const(char)[] query() const return @safe pure nothrow @nogc => qbuf[0 .. qlen];
 
@@ -230,104 +216,29 @@ struct PreviewTui
         => cast(long) mdRows.length;
 
     /// Rebuild the laid-out lines for the current theme / width / view mode (GC;
-    /// run on a theme, resize, or toggle change — never per frame).
+    /// run on a theme, resize, or toggle change — never per frame). One column
+    /// narrower than the pane — the last column holds the scrollbar.
     void relayout() @system
     {
-        theme = resolveTheme(themes[themeIdx], labels);
-        pageFg = toRgb(theme.defaults.fg, fallbackFg);
-        pageBg = toRgb(theme.defaults.bg, fallbackBg);
-        gutterFg = mix(pageFg, pageBg, 0.5); // muted leader / decorations
-        bars = quoteBarColors(theme, pageFg, pageBg);
-        // Scrollbar chrome + selection: tint toward the theme link color (gui.d).
+        vm.inlineFoldMarker = true; // the placeholder ▸ is the TUI affordance
+        vm.widthCols = width < 9 ? 8 : width - 1;
+        vm.applyTheme(themeIdx);
+        // Selection tint: toward the theme link color, like the scrollbars.
         const linkC = toRgb(theme[theme.labels.resolve("markup.link")].fg, pageFg);
-        sbTrack = mix(pageBg, linkC, 0.22);
-        sbThumb = mix(pageBg, linkC, 0.5);
         selBg = mix(pageBg, linkC, 0.4);
-        rebuildMd();
+        refreshHover();
         clampTop();
     }
 
-    // Rebuild the active view's widget pipeline: view → layout → display
-    // list, plus the derived row index (search/selection) and hit targets
-    // (fence copy). Lays out one column narrower — the last column holds the
-    // scrollbar.
-    private void rebuildMd() @system
+    // The twoslash hover-typed node indices (for `p` cycling) follow the
+    // document; the model owns everything else the rebuild derives.
+    private void refreshHover() @safe pure nothrow
     {
-        const w = width < 9 ? 8 : width - 1;
-        if (!showPreview || (!model.present && !tw.code.length))
-        {
-            // The raw view: the highlighted source as the same widget
-            // pipeline (one painter for every view kind). Fold ranges come
-            // from the CST provider (FSR1/FSR2) when a grammar is known.
-            import sparkles.syntax.ts.folds : foldableSpansCst;
-            import sparkles.ui.wrap : TextWrap;
-
-            foldable = cache !is null && lang.length
-                ? foldableSpansCst(*cache, lang, source) : null;
-            Span[] closed;
-            foreach (sp; foldable)
-                if (!folds.isOpen(sp.start))
-                    closed ~= sp;
-            mdTree = viewCodeDocument(source, events, &theme, pageFg,
-                CodeViewOptions(foldedRegions: closed,
-                    foldHitBase: foldHitBase, tabWidth: tabWidth,
-                    listWhitespace: listWhitespace,
-                    whitespaceFg: gutterFg, hasWhitespaceFg: true));
-            mdFrames = layout(mdTree, Constraints(maxW: w));
-            mdOps = buildDisplayList(mdTree, mdFrames,
-                themes[themeIdx].effectivePalette, pageFg, pageBg);
-            mdRows = documentRows(mdTree, mdFrames);
-            mdTargets = hoverTargets(mdTree, mdFrames);
-            mdFences.length = 0;
-            hoverNodes.length = 0;
-            return;
-        }
-        if (tw.code.length)
-        {
-            // A twoslash document: the whole-document widget view (code as
-            // resolved spans + fused decorations + interleaved blocks).
-            mdTree = viewTwoslashDocument(tw, events, &theme, pageFg, cache);
-            mdFrames = layout(mdTree, Constraints(maxW: w));
-            mdOps = buildDisplayList(mdTree, mdFrames,
-                defaultTwoslashPalette(schemeForBackground(pageBg)),
-                pageFg, pageBg);
-            mdRows = documentRows(mdTree, mdFrames);
-            mdTargets = hoverTargets(mdTree, mdFrames);
-            mdFences.length = 0;
-            foldable = null;
-            hoverNodes.length = 0;
+        hoverNodes.length = 0;
+        if (tw.code.length && showPreview)
             foreach (ni, ref const n; tw.nodes)
                 if (n.type == NodeType.hover)
                     hoverNodes ~= ni;
-            return;
-        }
-        MdViewOptions opt = {
-            theme: MdViewTheme.derive(theme, pageFg, pageBg),
-            fenceHitBase: fenceHitBase,
-            copiedFence: copiedFenceSrc,
-            foldedSpans: folds.exceptions,
-            foldHitBase: foldHitBase,
-            codeLineNumbers: codeLineNumbers,
-        };
-        foldable = foldableSpans(model.doc);
-        if (cache !is null)
-            opt.fenceRenderer = hueFenceRenderer(cache, &theme, pageFg);
-        mdTree = viewMarkdown(model.doc, opt);
-        mdFrames = layout(mdTree, Constraints(maxW: w));
-        mdOps = buildDisplayList(mdTree, mdFrames,
-            themes[themeIdx].effectivePalette, pageFg, pageBg);
-        mdRows = documentRows(mdTree, mdFrames);
-        mdTargets = hoverTargets(mdTree, mdFrames);
-        mdFences.length = 0;
-        collectFences(model.doc.root, mdFences);
-    }
-
-    private static void collectFences(in MdBlock b, ref Span[] fences) @safe
-    {
-        if (b.kind == MdBlockKind.codeFence)
-            fences ~= b.codeBody;
-        foreach (ref const c; b.children)
-            collectFences(c, fences);
     }
 
     private int bodyRows() const @safe pure nothrow @nogc
@@ -434,21 +345,22 @@ struct PreviewTui
         bool startPreview, TwoslashReturn tw_ = TwoslashReturn.init,
         string lang_ = null) @system
     {
-        title = title_;
-        source = source_;
-        events = events_;
-        model = model_;
-        tw = tw_;
-        lang = lang_;
         hoverSel = -1;
-        showPreview = startPreview && (model.present || tw.code.length != 0);
-        top = 0;
         sel = Selection!long.cleared;
         searching = false;
         qlen = 0;
-        copiedFenceSrc = size_t.max;
-        folds = DisclosureState!size_t(true);
-        relayout();
+        vm.inlineFoldMarker = true;
+        vm.widthCols = width < 9 ? 8 : width - 1;
+        if (vm.current.labels.length == 0 && themes.length)
+            vm.applyTheme(themeIdx); // first document: resolve the theme once
+        vm.setDocument(title_, null, source_, events_, model_, tw_, lang_);
+        if (!startPreview && vm.showPreview)
+        {
+            vm.showPreview = false;
+            vm.rebuild();
+        }
+        refreshHover();
+        clampTop();
     }
 
     /// Paint the whole frame into `g` (immediate mode). The library diffs it
@@ -506,7 +418,7 @@ struct PreviewTui
         // With a grammar cache the signature renders as resolved-color spans
         // inside the widget model (the same mapping the GUI uses).
         TextSpan[] sig = cache !is null
-            ? signatureSpans(*cache, (() @trusted => &theme)(), pageFg,
+            ? signatureSpans(*cache, (() @trusted => &vm.current)(), pageFg,
                 withoutQuickinfoPrefix(n.text)) : null;
         auto tree = viewHoverPopup(tw, hoverNodes[hoverSel], sig);
         auto frames = layout(tree);
@@ -586,95 +498,46 @@ struct PreviewTui
     // source-anchored hit id, and rebuild so its header shows the ✔ glyph.
     private void copyFenceAt(size_t bodyStart) @system
     {
-        foreach (sp; mdFences)
-            if (sp.start == bodyStart && sp.end <= source.length)
+        foreach (ref const f; vm.fences)
+            if (f.body.start == bodyStart && f.body.end <= source.length)
             {
-                writeClipboard(source[sp.start .. sp.end]);
-                copiedFenceSrc = bodyStart;
-                rebuildMd();
+                writeClipboard(source[f.body.start .. f.body.end]);
+                vm.markCopied(bodyStart);
                 return;
             }
     }
 
-    /// The fold family's directed op (`FLD5`, mirroring the GUI's).
-    enum FoldOp : ubyte
-    {
-        toggle, /// `za`/`zz`: unfold the innermost folded region, else fold
-        close,  /// `zc`: fold the innermost still-open foldable region
-        open,   /// `zo`: unfold the innermost folded region
-    }
-
     // Applies `op` at the selection (else the top row), over the row's
-    // source identity.
+    // source identity — the model owns the innermost-region policy (FLD5).
     private void foldAt(FoldOp op) @system
     {
         const rowIdx = sel.active ? sel.lo : top;
         if (rowIdx < 0 || rowIdx >= cast(long) mdRows.length
             || mdRows[cast(size_t) rowIdx].srcStart == size_t.max)
             return;
-        const off = mdRows[cast(size_t) rowIdx].srcStart;
-
-        size_t innermost(bool wantOpen)
-        {
-            size_t best = size_t.max, bestLen = size_t.max;
-            foreach (sp; foldable)
-                if (folds.isOpen(sp.start) == wantOpen && off >= sp.start
-                    && off < sp.end && sp.end - sp.start < bestLen)
-                {
-                    best = sp.start;
-                    bestLen = sp.end - sp.start;
-                }
-            return best;
-        }
-
-        size_t best = op == FoldOp.close ? innermost(true) : innermost(false);
-        if (best == size_t.max && op == FoldOp.toggle)
-            best = innermost(true);
-        if (best == size_t.max)
-            return;
-        folds = folds.toggled(best);
-        rebuildMd();
+        vm.foldAt(cast(long) mdRows[cast(size_t) rowIdx].srcStart, op);
         clampTop();
     }
 
     // `zR` / `zM`: open every fold, or fold every foldable region.
     private void setAllFolds(bool folded) @system
     {
-        folds = DisclosureState!size_t(true);
-        if (folded)
-            foreach (sp; foldable)
-                folds = folds.closed(sp.start);
-        rebuildMd();
+        vm.setAllFolds(folded);
         clampTop();
     }
 
-    // `z1`–`z9`: fold to nesting level (vim's foldlevel) — regions nested
-    // `level` deep or deeper fold, shallower ones open. Depth via an
-    // enclosing-ends stack over the source-ordered, properly nested regions.
+    // `z1`-`z9`: fold to nesting level (vim's foldlevel).
     private void foldToLevel(int level) @system
     {
-        folds = DisclosureState!size_t(true);
-        size_t[] ends;
-        foreach (sp; foldable)
-        {
-            while (ends.length && ends[$ - 1] <= sp.start)
-                ends = ends[0 .. $ - 1];
-            if (cast(int) ends.length >= level)
-                folds = folds.closed(sp.start);
-            ends ~= sp.end;
-        }
-        rebuildMd();
+        vm.foldToLevel(level);
         clampTop();
     }
 
     /// Apply an event; returns false to quit.
     bool handle(in Event e) @system
     {
-        if (copiedFenceSrc != size_t.max)
-        {
-            copiedFenceSrc = size_t.max; // the ✔ flash lasts until the next event
-            rebuildMd();
-        }
+        if (vm.copiedFenceSrc != size_t.max)
+            vm.clearCopied(); // the copy flash lasts until the next event
         if (searching)
             return handleSearch(e);
         return e.match!(
@@ -849,8 +712,8 @@ struct PreviewTui
                 {
                     if (t.hitId >= foldHitBase && t.rect.contains(p))
                     {
-                        folds = folds.toggled(t.hitId - foldHitBase);
-                        rebuildMd();
+                        vm.folds = vm.folds.toggled(t.hitId - foldHitBase);
+                        vm.rebuild();
                         return true;
                     }
                     if (t.hitId >= fenceHitBase && t.rect.contains(p))

--- a/apps/hue/src/viewer_model.d
+++ b/apps/hue/src/viewer_model.d
@@ -23,7 +23,7 @@ import sparkles.syntax.ts.injection : TsConfigCache;
 import sparkles.twoslash.protocol : TwoslashReturn;
 import sparkles.twoslash.render_widgets : viewTwoslashDocument;
 
-import sparkles.ui.canvas : DrawOp;
+import sparkles.ui.canvas : DrawOp, OpKind;
 import sparkles.ui.display_list : buildDisplayList;
 import sparkles.ui.geometry : Constraints, Rect;
 import sparkles.ui.layout : Frame, layout;
@@ -292,14 +292,16 @@ struct ViewerModel
 
     private void derive(bool withTargets)
     {
-        // The widest laid-out right edge: frames of nowrap content (fence
-        // lines, table rows) extend past the pane; layout keeps their
-        // natural width and the pane clips (clipX) — exactly what the
-        // horizontal bar must reach (IXB2).
+        // The widest painted right edge: TEXT ops carry their natural
+        // extent even where the pane clips them (a fence line, a table row
+        // — emitSpanRow advances past the clamp and the scissor crops), so
+        // the display list, not the frames, knows what the horizontal bar
+        // must reach (IXB2).
         contentCols = 0;
-        foreach (ref const f; frames)
-            if (f.rect.x + f.rect.width > contentCols)
-                contentCols = f.rect.x + f.rect.width;
+        foreach (ref const op; ops)
+            if ((op.kind == OpKind.textRun || op.kind == OpKind.glyph)
+                && op.rect.x + op.rect.width > contentCols)
+                contentCols = op.rect.x + op.rect.width;
         if (cast(long) contentCols <= widthCols)
             hsb = hsb.scrolledTo(0);
         rows = documentRows(tree, frames);

--- a/apps/hue/src/viewer_model.d
+++ b/apps/hue/src/viewer_model.d
@@ -118,6 +118,9 @@ struct ViewerModel
     int tabWidth = 4;               /// tab stops in the raw view (--tab-width)
     bool listWhitespace;            /// vim `list` (--list-whitespace)
     bool codeLineNumbers = true;    /// in-panel fence numbers ('c' toggles)
+    /// Fold placeholders keep their inline `▸ ` prefix — the TUI's one fold
+    /// affordance; the GUI leaves this false (its gutter column carries it).
+    bool inlineFoldMarker;
 
     // ── theme-resolved values ───────────────────────────────────────────────
     size_t themeIdx;
@@ -256,7 +259,7 @@ struct ViewerModel
                     foldHitBase: foldHitBase, tabWidth: tabWidth,
                     listWhitespace: listWhitespace,
                     whitespaceFg: gutterFg, hasWhitespaceFg: true,
-                    inlineFoldMarker: false)); // the GUI's fold column
+                    inlineFoldMarker: inlineFoldMarker));
             frames = layout(tree, Constraints(maxW: widthCols));
             ops = buildDisplayList(tree, frames,
                 themes[themeIdx].effectivePalette, pageFg, pageBg);
@@ -274,7 +277,7 @@ struct ViewerModel
             fenceRenderer: fenceRenderer(),
             foldedSpans: folds.exceptions,
             foldHitBase: foldHitBase,
-            inlineFoldMarker: false, // the GUI's fold column carries the ▸
+            inlineFoldMarker: inlineFoldMarker,
             codeLineNumbers: codeLineNumbers,
         };
         foldable = foldableSpans(preview.doc);

--- a/apps/hue/src/workspace.d
+++ b/apps/hue/src/workspace.d
@@ -207,9 +207,12 @@ struct WorkspaceTui
         // the pointer strays; the scrollbars are vertical → ns-resize.
         e.match!((in PointerEvent p) {
             const grabbed = split.dragging || viewer.sb.dragging
-                || tree.sb.dragging;
+                || tree.sb.dragging || viewer.vm.hsb.dragging
+                || tree.hsb.dragging;
             PointerShape want;
             if (split.dragging)
+                want = PointerShape.ewResize;
+            else if (viewer.vm.hsb.dragging || tree.hsb.dragging)
                 want = PointerShape.ewResize;
             else if (viewer.sb.dragging || tree.sb.dragging)
                 want = PointerShape.nsResize;

--- a/lychee.exclude
+++ b/lychee.exclude
@@ -110,3 +110,9 @@ apps/hue/twoslash
 # and stays checked. Cited from research/tui-libraries/notcurses.md.
 ^https?://nick-black\.com/$
 ^https?://nick-black\.com/dankwiki/
+
+# git.launchpad.net (cgit; a Launchpad commit cited in the docs) times out
+# locally and 500s in CI (verified with curl on 2026-08-02) — a real upstream
+# outage/chronic slowness, not checker flakiness. Same class as the x.org
+# entry above.
+^https?://git\.launchpad\.net/


### PR DESCRIPTION
The interaction review's biggest split closes (IXB5), and the TUI viewer's horizontal bar falls out of it (IXB2 completion).

## `PreviewTui` adopts `ViewerModel`

The TUI document pane no longer re-implements the document Whole. The duplicated state — source/theme resolution, the widget pipeline (tree/frames/ops/rows/targets/fences), folds and the whole vim fold policy, scroll, the copied-fence flash — is deleted (−228 lines); `PreviewTui` holds the **same** `ViewerModel` the GUI drives and keeps only the genuinely terminal-shaped parts: grid painting, key decode, OSC 52, the scrollbar machines, the search input buffer (IXB6 later), and twoslash hover-node cycling. The old field names survive as forwarding accessors into the model, so every host call site and test compiles unchanged. `ViewerModel` gains the one knob the backends disagree on: `inlineFoldMarker` (the TUI placeholder keeps its `▸ `; the GUI's gutter column carries the affordance).

Every fold/fence/search/scroll fix now lands once, for both backends.

## The TUI viewer's horizontal scrollbar

The adoption's immediate payoff: the viewer inherits `vm.hsb`/`contentCols`, so the same bar the GUI grew appears on the last body row when wide content clips — shared component/machine, `━`/`─` glyphs, grab-owns-the-pointer, `ew-resize` held through horizontal grabs by the workspace observer.

Two correctness upgrades found on the way: **overflow is measured from the display list, not the frames** (layout clamps a clipped child's frame, but text ops keep their natural extent past the scissor — this also makes fence panels measurable in the GUI, which the frame scan missed); and body hit-testing (selection, fence/fold clicks, twoslash hover) maps into the horizontally scrolled space. The explorer's shifted-paint clip also no longer narrows with the offset.

## Verification

56 hue tests green (the suite exercises the adopted path end to end: paint, fence copy, folds, twoslash pane, both scrollbar grabs, the new wide-fence overflow test); PTY drives — G/k scrolling + Tab toggles replay correctly, and the bar renders under AGENTS.md's wide tables at 80 columns; full `ci --test` sweep 24/24.

https://claude.ai/code/session_01WbniakDeFcv5CquF2pNFHx
