### PR TITLE
feat(ui.state): the pointer-shape seam + the line editor (B-2, B-4)

### DIFF
--- a/apps/hue/src/explorer.d
+++ b/apps/hue/src/explorer.d
@@ -30,8 +30,8 @@ import sparkles.ui.components.tree_widget : FlatTreeRow, flatten, TreeData,
 import sparkles.ui.display_list : buildDisplayList;
 import sparkles.ui.geometry : Rect, SizeSpec;
 import sparkles.ui.layout : layout;
-import sparkles.ui.state : DisclosureState, ScrollAxis, ScrollbarState, scrollbarThumb,
-    ScrollState;
+import sparkles.ui.state : DisclosureState, LineEditState, ScrollAxis,
+    ScrollbarState, scrollbarThumb, ScrollState;
 import sparkles.ui.style : Palette, Slot, TextStyle;
 import sparkles.ui.widget : Builder, Widget, WidgetKind;
 import sparkles.ui_tui : paintGrid;
@@ -145,15 +145,15 @@ struct ExplorerTui
     /// Whether this pane holds the workspace focus — the header title
     /// renders accented when focused, muted otherwise (like the viewer's).
     bool focused;
-    bool searching;
+    /// The live filter's editor — the one line-edit machine (STM10);
+    /// `filter.active` IS filter mode.
+    LineEditState filter;
     /// The scrollbar as one machine (STM9) — see the viewer's twin.
     ScrollbarState sb;
     /// The horizontal bar (IXB2): live when a visible label overflows the
     /// pane; scrolls the tree columns. Same machine, horizontal axis.
     ScrollbarState hsb = ScrollbarState(ScrollAxis.horizontal);
     int contentCols; // widest visible row, recomputed per rebuild
-    char[128] qbuf;
-    size_t qlen;
 
     // Visibility toggles (XPF2), state shown in the status bar: dotfiles are
     // hidden by default; git-ignored entries are listed (dimmed) by default.
@@ -206,8 +206,8 @@ struct ExplorerTui
         clamp();
     }
 
-    private const(char)[] query() const return @safe pure nothrow @nogc
-        => qbuf[0 .. qlen];
+    private const(char)[] query() const @safe pure nothrow @nogc
+        => filter.text;
 
     /// The live-filter query (for a host that paints its own input line —
     /// the GUI pane has no status bar of its own).
@@ -217,44 +217,44 @@ struct ExplorerTui
     /// The pane is consuming typed text (the workspace must not steal keys).
     bool inputActive() const @safe pure nothrow @nogc => searching;
 
+    /// Whether filter mode is capturing keys (the machine's `active`).
+    bool searching() const @safe pure nothrow @nogc => filter.active;
+
     // ── The live filter, drivable by either backend's input ───────────────
     /// `/`: enter filter mode (broot's tree-as-search-result — XPL/TRV5).
     void filterStart() @system
     {
-        searching = true;
-        qlen = 0;
+        filter = filter.started();
         rebuild();
     }
 
     /// ditto — a typed character narrows per keystroke.
     void filterInput(dchar c) @system
     {
-        if (c >= 32 && c < 127 && qlen < qbuf.length)
-        {
-            qbuf[qlen++] = cast(char) c;
-            rebuild();
-        }
+        const next = filter.typed(c);
+        if (next == filter)
+            return;
+        filter = next;
+        rebuild();
     }
 
     /// ditto
     void filterBackspace() @system
     {
-        if (qlen)
-            --qlen;
+        filter = filter.erased();
         rebuild();
     }
 
     /// Enter keeps the filtered tree; Esc clears it.
-    void filterAccept() @safe pure nothrow @nogc
+    void filterAccept() @safe pure nothrow
     {
-        searching = false;
+        filter = filter.accepted();
     }
 
     /// ditto
     void filterCancel() @system
     {
-        searching = false;
-        qlen = 0;
+        filter = filter.cancelled();
         rebuild();
     }
 
@@ -332,7 +332,7 @@ struct ExplorerTui
             }
         }
 
-        if (qlen == 0)
+        if (filter.text.length == 0)
             addChildren(root, uint.max, true);
         else
             addFiltered(root, uint.max);
@@ -392,7 +392,7 @@ struct ExplorerTui
             }
 
         rows = flatten(data, (uint i) @safe
-            => qlen != 0 || open.isOpen(data.nodes[i].value.path));
+            => filter.text.length != 0 || open.isOpen(data.nodes[i].value.path));
         measureContent();
         clamp();
     }
@@ -536,7 +536,7 @@ struct ExplorerTui
         const selNode = sel < cast(long) rows.length
             ? rows[cast(size_t) sel].node : uint.max;
         const tree = treeView(b, data, rows[first .. last],
-            (uint i) @safe => qlen != 0 || open.isOpen(data.nodes[i].value.path),
+            (uint i) @safe => filter.text.length != 0 || open.isOpen(data.nodes[i].value.path),
             selNode, explorerGlyphs, selBg, hasSelectionBg: true);
 
         // The header paints unshifted; the tree shifts left by the
@@ -549,7 +549,7 @@ struct ExplorerTui
             palette, pageFg, pageBg));
         auto tb = Builder();
         const tree2 = treeView(tb, data, rows[first .. last],
-            (uint i) @safe => qlen != 0 || open.isOpen(data.nodes[i].value.path),
+            (uint i) @safe => filter.text.length != 0 || open.isOpen(data.nodes[i].value.path),
             selNode, explorerGlyphs, selBg, hasSelectionBg: true);
         Widget colW = Widget(kind: WidgetKind.column, children: [tree2],
             width: SizeSpec.fixed(width + hx));
@@ -976,8 +976,7 @@ unittest
     assert(row(7).canFind("filter"), row(7)); // the status bar hints
 
     // The live filter: "app" keeps the match and the dir on the way to it.
-    x.qbuf[0 .. 3] = "app";
-    x.qlen = 3;
+    x.filter = LineEditState("app", true);
     x.rebuild();
     assert(x.rows.length == 2);
     assert(x.data.nodes[x.rows[0].node].value.name == "src");

--- a/apps/hue/src/explorer.d
+++ b/apps/hue/src/explorer.d
@@ -482,6 +482,10 @@ struct ExplorerTui
         => cast(long) rows.length > bodyRows && x == width - 1
             && y >= 1 && y <= bodyRows;
 
+    /// ditto for the horizontal bar's row (above the status bar, when live).
+    bool overHScrollbar(int x, int y) const @safe pure nothrow @nogc
+        => hOverflows() && y == height - 2 && x >= 0 && x < width - 1;
+
     void scrollBy(long dy) @safe pure nothrow @nogc
     {
         top += dy;

--- a/apps/hue/src/gui.d
+++ b/apps/hue/src/gui.d
@@ -67,12 +67,12 @@ import sparkles.ui.geometry : Constraints, Point, Rect;
 import sparkles.ui.canvas : DrawOp, LineStyle, OpKind;
 import sparkles.ui.layout : layout;
 import sparkles.ui.state : ScrollAxis, ScrollbarState, scrollbarThumb,
-    selectionRects, sourceOffsetAt,
+    selectionRects, sourceOffsetAt, wantedPointerShape,
     SplitState, Timeline;
 import sparkles.ui.display_list : buildDisplayList;
 import sparkles.ui.interp.immediate : paint;
 import sparkles.ui_raylib : drawScrollbar, RaylibCanvas, ScrollbarAnim,
-    scrollbarLayout;
+    scrollbarLayout, toRaylibCursor;
 
 // The multi-document set the twoslash view navigates with `[`/`]` (`GNV1`), plus
 // the two entry points a navigation reload needs.
@@ -1109,22 +1109,10 @@ int runGui(
         // grabs outrank hover — a scrollbar drag straying over the divider
         // stays ns-resize, a divider drag stays ew-resize — then hover by
         // orientation, else the default arrow.
-        {
-            auto want = MouseCursor.MOUSE_CURSOR_DEFAULT;
-            if (split.dragging)
-                want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
-            else if (tree.hsb.dragging || vm.hsb.dragging)
-                want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
-            else if (docSb.dragging || treeVSb.dragging)
-                want = MouseCursor.MOUSE_CURSOR_RESIZE_NS;
-            else if (divZone)
-                want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
-            else if (tree.hsb.hovered || vm.hsb.hovered)
-                want = MouseCursor.MOUSE_CURSOR_RESIZE_EW;
-            else if (docSb.hovered || treeVSb.hovered)
-                want = MouseCursor.MOUSE_CURSOR_RESIZE_NS;
-            SetMouseCursor(want);
-        }
+        // The ONE shared decision (IXB4), mapped to the window cursor —
+        // the TUI writes the identical result as OSC 22.
+        SetMouseCursor(toRaylibCursor(wantedPointerShape(split, divZone,
+            vm.hsb, tree.hsb, docSb, treeVSb)));
 
         vm.top = vm.top < 0 ? 0 : (vm.top > maxTop ? maxTop : vm.top);
         const topLine = cast(size_t) vm.top;

--- a/apps/hue/src/tui.d
+++ b/apps/hue/src/tui.d
@@ -194,6 +194,10 @@ struct PreviewTui
         => lineCount > bodyRows && x == width - 1
             && y >= 1 && y <= bodyRows;
 
+    /// ditto for the horizontal bar's row (the last body row, when live).
+    bool overHScrollbar(int x, int y) const @safe pure nothrow @nogc
+        => vm.hOverflows() && y == bodyRows && x >= 0 && x < width - 1;
+
     /// Sets the pane size in cells (the workspace arranges; `relayout` after).
     void resize(int w, int h) @safe pure nothrow @nogc
     {

--- a/apps/hue/src/workspace.d
+++ b/apps/hue/src/workspace.d
@@ -25,7 +25,7 @@ import sparkles.tui : CellStyle, Color, Grid, PosixEvents, Terminal,
 import sparkles.tui.input : EndOfInput, Event, isEndOfInput, Key, KeyEvent,
     match, PointerAction, PointerButton, PointerEvent, ResizeEvent, WheelEvent;
 import sparkles.ui.geometry : Point;
-import sparkles.ui.state : SplitState;
+import sparkles.ui.state : SplitState, wantedPointerShape;
 import sparkles.ui.style : Slot;
 
 import ansi_model : BackgroundMode;
@@ -209,20 +209,20 @@ struct WorkspaceTui
             const grabbed = split.dragging || viewer.sb.dragging
                 || tree.sb.dragging || viewer.vm.hsb.dragging
                 || tree.hsb.dragging;
-            PointerShape want;
-            if (split.dragging)
-                want = PointerShape.ewResize;
-            else if (viewer.vm.hsb.dragging || tree.hsb.dragging)
-                want = PointerShape.ewResize;
-            else if (viewer.sb.dragging || tree.sb.dragging)
-                want = PointerShape.nsResize;
-            else if (treeVisible && p.pos.x == tree.width)
-                want = PointerShape.ewResize;
-            else if ((treeVisible && tree.overScrollbar(p.pos.x, p.pos.y))
-                || viewer.overScrollbar(p.pos.x - viewer.originX, p.pos.y))
-                want = PointerShape.nsResize;
-            else
-                want = PointerShape.default_;
+            // Hover lives on the machines; the ONE shared decision (IXB4)
+            // turns the grab/hover states into the wanted shape.
+            const vx = p.pos.x - viewer.originX;
+            viewer.sb = viewer.sb.hoveredNow(
+                viewer.overScrollbar(vx, p.pos.y));
+            viewer.vm.hsb = viewer.vm.hsb.hoveredNow(
+                viewer.overHScrollbar(vx, p.pos.y));
+            tree.sb = tree.sb.hoveredNow(
+                treeVisible && tree.overScrollbar(p.pos.x, p.pos.y));
+            tree.hsb = tree.hsb.hoveredNow(
+                treeVisible && tree.overHScrollbar(p.pos.x, p.pos.y));
+            const want = wantedPointerShape(split,
+                treeVisible && p.pos.x == tree.width,
+                viewer.vm.hsb, tree.hsb, viewer.sb, tree.sb);
             // Re-assert on every event while a grab is live: some terminals
             // and multiplexers reset the pointer themselves when a drag
             // starts, clobbering the OSC 22 shape — a repeated set is

--- a/libs/ui-raylib/src/sparkles/ui_raylib/scrollbar.d
+++ b/libs/ui-raylib/src/sparkles/ui_raylib/scrollbar.d
@@ -13,9 +13,10 @@ cell component resolves — one color authority.
 */
 module sparkles.ui_raylib.scrollbar;
 
-import raylib : Color, DrawRectangle;
+import raylib : Color, DrawRectangle, MouseCursor;
 
 import sparkles.base.term_color : RgbColor;
+import sparkles.base.term_control : PointerShape;
 import sparkles.ui.geometry : Rect;
 import sparkles.ui.state : ScrollAxis, ScrollbarState;
 
@@ -115,4 +116,21 @@ unittest
         anim, 200, 100, Rect(0, 0, 100, 50));
     assert(h.live && h.track == Rect(0, 42, 100, 8));
     assert(!scrollbarLayout(st, anim, 90, 100, Rect(0, 0, 100, 50)).live);
+}
+
+/// The raylib spelling of a toolkit $(REF PointerShape, sparkles,base,
+/// term_control) — the GUI half of the pointer-shape seam (`IXB4`); the
+/// TUI writes the same shapes as OSC 22.
+MouseCursor toRaylibCursor(PointerShape shape) @safe pure nothrow @nogc
+{
+    final switch (shape) with (PointerShape)
+    {
+        case default_: return MouseCursor.MOUSE_CURSOR_DEFAULT;
+        case text:     return MouseCursor.MOUSE_CURSOR_IBEAM;
+        case pointer:  return MouseCursor.MOUSE_CURSOR_POINTING_HAND;
+        case ewResize: return MouseCursor.MOUSE_CURSOR_RESIZE_EW;
+        case nsResize: return MouseCursor.MOUSE_CURSOR_RESIZE_NS;
+        case grab:     return MouseCursor.MOUSE_CURSOR_RESIZE_ALL;
+        case grabbing: return MouseCursor.MOUSE_CURSOR_RESIZE_ALL;
+    }
 }

--- a/libs/ui/src/sparkles/ui/state.d
+++ b/libs/ui/src/sparkles/ui/state.d
@@ -762,6 +762,74 @@ unittest
 }
 
 /**
+One line editor for every query / filter / goto input (`STM10`, `IXB6`):
+a Regular value — the buffer plus whether the editor is capturing input —
+advanced by transformations. Hosts render `text` and their own caret;
+`typed` appends any printable codepoint (UTF-8-encoded), `erased` drops a
+whole codepoint (not a byte — a multibyte character never leaves a torn
+tail), `accepted` keeps the text and stops capturing, `cancelled` clears.
+*/
+struct LineEditState
+{
+    string text;
+    bool active; /// capturing keystrokes (the host routes keys here)
+
+@safe pure nothrow:
+
+    /// Begins a fresh input session.
+    LineEditState started() const => LineEditState("", true);
+
+    /// `c` appended (printable codepoints only; controls are ignored).
+    LineEditState typed(dchar c) const
+    {
+        import std.utf : encode, isValidDchar;
+
+        if (c < 0x20 || c == 0x7f || !isValidDchar(c))
+            return this;
+        char[4] buf;
+        size_t n;
+        try
+            n = encode(buf, c);
+        catch (Exception)
+            return this;
+        return LineEditState(text ~ buf[0 .. n].idup, active);
+    }
+
+    /// Backspace: the LAST CODEPOINT removed (UTF-8-aware).
+    LineEditState erased() const
+    {
+        auto t = text;
+        if (!t.length)
+            return this;
+        size_t e = t.length - 1;
+        while (e > 0 && (t[e] & 0xC0) == 0x80)
+            --e;
+        return LineEditState(t[0 .. e], active);
+    }
+
+    /// Enter: the text stays, capture ends.
+    LineEditState accepted() const => LineEditState(text, false);
+
+    /// Escape: cleared and closed.
+    LineEditState cancelled() const => LineEditState("", false);
+}
+
+@("ui.state.lineEdit.typeEraseAcceptCancel")
+@safe pure nothrow
+unittest
+{
+    auto e = LineEditState.init.started();
+    assert(e.active && e.text.length == 0);
+    e = e.typed('a').typed('é').typed('\n'); // the control is ignored
+    assert(e.text == "aé");
+    e = e.erased(); // é is two UTF-8 bytes — erased whole
+    assert(e.text == "a");
+    assert(e.accepted() == LineEditState("a", false));
+    assert(e.cancelled() == LineEditState("", false));
+    assert(LineEditState("", true).erased().text.length == 0);
+}
+
+/**
 The one pointer-shape decision (`IXB4`): what the terminal/window pointer
 should look like given the workspace's interaction state. Live grabs
 outrank hover — a divider drag holds `ew-resize` and a grabbed bar holds

--- a/libs/ui/src/sparkles/ui/state.d
+++ b/libs/ui/src/sparkles/ui/state.d
@@ -762,6 +762,58 @@ unittest
 }
 
 /**
+The one pointer-shape decision (`IXB4`): what the terminal/window pointer
+should look like given the workspace's interaction state. Live grabs
+outrank hover — a divider drag holds `ew-resize` and a grabbed bar holds
+its axis shape wherever the pointer strays — then divider hover, then any
+hovered bar's shape. Pass the bars in priority order (horizontal before
+vertical keeps `ew-resize` winning ties, matching both shipped hosts).
+
+Every host consumes this ONE function: the TUI writes the result as
+OSC 22 (re-asserting mid-grab — terminals may reset the pointer when a
+drag starts), the GUI maps it to the window cursor.
+*/
+PointerShape wantedPointerShape(in SplitState split, bool overDivider,
+    scope const(ScrollbarState)[] bars...) @safe pure nothrow @nogc
+{
+    if (split.dragging)
+        return PointerShape.ewResize;
+    foreach (ref const b; bars)
+        if (b.dragging)
+            return b.shape;
+    if (overDivider)
+        return PointerShape.ewResize;
+    foreach (ref const b; bars)
+        if (b.hovered)
+            return b.shape;
+    return PointerShape.default_;
+}
+
+@("ui.state.wantedPointerShape.priority")
+@safe pure nothrow @nogc
+unittest
+{
+    const idleV = ScrollbarState(ScrollAxis.vertical);
+    const idleH = ScrollbarState(ScrollAxis.horizontal);
+    const split = SplitState(32);
+
+    assert(wantedPointerShape(split, false, idleH, idleV)
+        == PointerShape.default_);
+    // A live divider drag outranks everything.
+    assert(wantedPointerShape(split.started(32), true,
+        idleH.hoveredNow(true), idleV) == PointerShape.ewResize);
+    // A grabbed bar outranks divider hover; its axis picks the shape.
+    const grabbedV = idleV.pressed(0, 100, 10, 10);
+    assert(wantedPointerShape(split, true, idleH, grabbedV)
+        == PointerShape.nsResize);
+    // Divider hover outranks bar hover; bar hover wins over idle.
+    assert(wantedPointerShape(split, true, idleH.hoveredNow(true), idleV)
+        == PointerShape.ewResize);
+    assert(wantedPointerShape(split, false, idleH, idleV.hoveredNow(true))
+        == PointerShape.nsResize);
+}
+
+/**
 A selection as one Regular value (`STM3`): an `anchor` (where it started) and a
 `focus` (where it is now) over any ordered position type — `long` line numbers,
 byte offsets, or a comparable (line, column) pair. "No selection" is a $(B mode)


### PR DESCRIPTION
Stacked on #153 (→ #152). B-2 and B-4 from the approved plan — the two small STMs that close IXB4 and start IXB6.

## B-2 — `wantedPointerShape` (IXB4 complete)

The copy-pasted pointer-shape decision in `workspace.d` and `gui.d` collapses into one pure, unit-tested function in `sparkles.ui.state`: live grabs outrank hover (divider first, then any grabbed bar's axis shape), then divider hover, then any hovered bar's shape. Hover now lives on the machines in the TUI too (`hoveredNow` per event, with new `overHScrollbar` checks giving the TUI horizontal bars hover parity). Hosts no longer compute shapes — the TUI writes the result as OSC 22 (keeping the mid-grab re-assertion), the GUI maps it through the new `ui_raylib.toRaylibCursor` table. PTY-verified byte-identical shape traffic.

## B-4 — `LineEditState` (IXB6, first adopter)

STM10: every query/filter/goto input as one Regular machine — `started`/`typed`/`erased`/`accepted`/`cancelled`, printable-only input, and **UTF-8-aware backspace** (a whole codepoint, never a torn multibyte tail — a live bug in the byte-wise editors it replaces). The tree filter adopts it first (its `filter*` methods were already the 1:1 seam), which also makes non-ASCII filter input work. The viewer's search editor and the GUI's search/goto modes follow with M17's key unification.

Verified: new STM unit tests (shape priority; type/erase/accept/cancel incl. the multibyte erase), 255 ui + 56 hue tests green, both hue build configurations.

https://claude.ai/code/session_01WbniakDeFcv5CquF2pNFHx
